### PR TITLE
Fix up validation on new user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,7 +37,7 @@ class User
 
   after_create :seed_aspects
 
-  before_validation_on_create :downcase_username
+  after_create :downcase_username
   
    def self.find_for_authentication(conditions={})
     if conditions[:username] =~ /^([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})$/i # email regex


### PR DESCRIPTION
When registering, `downcase_username` checks for a field which doesn't exist yet, since the object has not been saved. Better to downcase the username after the object exists, otherwise you'll get a NilClass error.

Thanks guys for the hard work!

Dan
