### PR TITLE
Support for running websocket on a different port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ gpg/diaspora-production/*.gpg
 gpg/*/random_seed
 public/uploads/*
 .rvmrc
+/bin

--- a/app/views/js/_websocket_js.haml
+++ b/app/views/js/_websocket_js.haml
@@ -9,7 +9,7 @@
   $(document).ready(function(){
     function debug(str){ $("#debug").append("<p>" +  str); };
 
-    ws = new WebSocket("ws://#{request.host}:8080/#{CGI::escape(current_user.id.to_s)}");
+    ws = new WebSocket("ws://#{request.host}:#{APP_CONFIG[:socket_port]}/#{CGI::escape(current_user.id.to_s)}");
 
   //Attach onmessage to websocket
     ws.onmessage = function(evt) {

--- a/config/initializers/socket.rb
+++ b/config/initializers/socket.rb
@@ -9,18 +9,26 @@ require "lib/diaspora/websocket"
   EM.next_tick {
     Diaspora::WebSocket.initialize_channels
 
-    EventMachine::WebSocket.start(
-                  :host => "0.0.0.0",
-                  :port => APP_CONFIG[:socket_port],
-                  :debug =>APP_CONFIG[:socket_debug]) do |ws|
-      ws.onopen {
+    begin
+      EventMachine::WebSocket.start(
+                    :host => "0.0.0.0",
+                    :port => APP_CONFIG[:socket_port],
+                    :debug =>APP_CONFIG[:socket_debug]) do |ws|
+        ws.onopen {
 
-        sid = Diaspora::WebSocket.subscribe(ws.request['Path'].gsub('/',''), ws)
+          sid = Diaspora::WebSocket.subscribe(ws.request['Path'].gsub('/',''), ws)
 
-        ws.onmessage { |msg| SocketsController.new.incoming(msg) }
+          ws.onmessage { |msg| SocketsController.new.incoming(msg) }
 
-        ws.onclose { Diaspora::WebSocket.unsubscribe(ws.request['Path'].gsub('/',''), sid) }
-      }
+          ws.onclose { Diaspora::WebSocket.unsubscribe(ws.request['Path'].gsub('/',''), sid) }
+        }
+      end
+    rescue RuntimeError => e
+      if e.message =~ /no acceptor/
+        raise RuntimeError, "Could not listen on port #{APP_CONFIG[:socket_port]}, perhaps another process is already using it?"
+      else
+        raise
+      end
     end
   }
 


### PR DESCRIPTION
This is a small patch that allows someone who already has something running on port 8080 to use Diaspora.

When you're running something on 8080 and try to start Diaspora, thin dies complaining that it can't connect to the socket, but doesn't tell you that it's actually trying to connect to 8080, not 3000.  This gives a better error message.

When you do change to a different port, this sets the js websocket helper to use that port.
