### PR TITLE
Fixed lack-of-user-profile-page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,7 +12,9 @@ class UsersController < ApplicationController
   def show
     @user         = User.find_by_id params[:id]
     @user_profile = @user.person.profile
-    respond_with @user
+    @person = @current_user
+    @posts = current_user.raw_visible_posts.paginate :page => params[:page], :order => 'created_at DESC'
+    respond_with @person
   end
 
   def edit

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,0 +1,39 @@
+-#   Copyright (c) 2010, Diaspora Inc.  This file is
+-#   licensed under the Affero General Public License version 3.  See
+-#   the COPYRIGHT file.
+
+
+- content_for :page_title do
+  = @person.real_name
+
+- content_for :left_pane do
+  #profile
+    .profile_photo
+      = person_image_link(@person)
+    %ul
+      -unless @posts.first.nil?
+        %li
+          %i= "last update: #{how_long_ago(@posts.first)}"
+      - if @person != current_user.person && current_user.friends.include?(@person)
+        %li
+          %i= "friends since: #{how_long_ago(@person)}"
+        %li
+          = form_tag move_friend_path
+          = select :to, :to,  @aspects_dropdown_array, :selected => @aspects_with_person.first.id
+          = hidden_field_tag :from, :from, :value => @aspects_with_person.first.id
+          = hidden_field_tag :friend_id, :friend_id, :value => @person.id
+          = submit_tag "save"
+
+    - if @person != current_user.person && current_user.friends.include?(@person)
+      = link_to 'remove friend', @person, :confirm => 'Are you sure?', :method => :delete, :class => "button"
+
+.span-20.last
+  
+  .span-19.last
+    - if @posts
+      %ul#stream
+        - for post in @posts
+          = render type_partial(post), :post => post unless post.class == Album
+        = will_paginate @posts
+    - else
+      %h3 no posts to display!

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,0 +1,26 @@
+#   Copyright (c) 2010, Diaspora Inc.  This file is
+#   licensed under the Affero General Public License version 3.  See
+#   the COPYRIGHT file.
+
+
+
+require File.dirname(__FILE__) + '/../spec_helper'
+
+describe UsersController do
+  render_views
+  before do
+    @user = Factory.create(:user)
+
+    sign_in :user, @user
+    @user.aspect(:name => "lame-os")
+  end
+
+
+
+  it 'should go to the current_user show page' do
+    get :show, :id => @user.id
+    
+    response.should render_template "users/show"
+    response.should be_success
+  end
+end


### PR DESCRIPTION
Assuming that users would want different functionality on their own profile page, added show page and supporting controller modifications to allow users to view their own profile/wall type thing.

Confirmed with new controller tests.
