### PR TITLE
Xss fix

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -10,6 +10,8 @@ class Comment
   include Encryptable
   include Diaspora::Socketable
 
+  include Haml::Helpers
+
   xml_accessor :text
   xml_accessor :person, :as => Person
   xml_accessor :post_id
@@ -26,6 +28,8 @@ class Comment
   validates_presence_of :text
 
   timestamps!
+
+  after_create :escape_text
 
   #ENCRYPTION
 
@@ -55,6 +59,12 @@ class Comment
 
   def signature_valid?
     verify_signature(creator_signature, person)
+  end
+
+  private
+
+  def escape_text
+    self.text = html_escape text
   end
 
 end

--- a/spec/models/comments_spec.rb
+++ b/spec/models/comments_spec.rb
@@ -32,6 +32,15 @@ describe Comment do
       StatusMessage.first.comments.first.person.should == @user.person
     end
 
+    it "should be escaped" do
+      status = Factory.create(:status_message, :person => @user.person)
+      status.comments.should == []
+
+      @user.comment "><p style='color:red'>lolol</p><", :on => status
+      StatusMessage.first.comments.first.text.should == "&gt;&lt;p style='color:red'&gt;lolol&lt;/p&gt;&lt;"
+    end
+    
+
     it 'should not send out comments when we have no people' do
       status = Factory.create(:status_message, :person => @user.person)
       User::QUEUE.should_not_receive(:add_post_request)


### PR DESCRIPTION
 Hey guys, I'm sorry about the myriad of fucked up pull requests. I won't let it happen again.

This makes sure that comments get properly escaped, to eliminate xss vulnerabilities.

The only thing that I don't like about this patch is that usually, I like to store unescaped info in the database, and escape it in the view. There seem to be no view tests or integration tests going on, though, and so I've just escaped it before storing it in the database. If this should be done at the view level, something like cucumber or rspec integration tests should be set up.
