### PR TITLE
dynamic photo upload destination

### DIFF
--- a/app/views/photos/_new_photo.haml
+++ b/app/views/photos/_new_photo.haml
@@ -9,7 +9,7 @@
         element: document.getElementById('file-upload'),
         params: {'album_id' : "#{@album.id}"},
         allowedExtensions: ['jpg', 'jpeg', 'png'],
-        action: "/photos"
+        action: "#{photos_path}"
     });           
   }
   window.onload = createUploader;      


### PR DESCRIPTION
i have diaspora on a sub-path myserver.com/diaspora. the destination for photo uploads is "/photos" which is incorrect. by using "#{photo_path}" it generates myserver.com/diaspora/photos which is correct. simple one line change.
