### PR TITLE
"Set up your environment section" for exports and platform-specifics

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,9 @@ If you have never used github before, their [help desk](http://help.github.com/)
 
 ## Running Diaspora
 
+### Set up you environment
+If you are running **Ubuntu**, run `export PATH=$PATH:/var/lib/gems/1.8/bin` to make the bundler binary accessible.
+
 ### Install required gems
 To start the app server for the first time, you need to use Bundler to install Diaspora's gem depencencies.  Run `bundle install` from Diaspora's root directory.  Bundler will also warn you if there is a new dependency and you need to bundle install again.
 


### PR DESCRIPTION
The first one adds bundler to the PATH on Ubuntu.

Note this is in the 'run' section because it must be done every time diaspora shall be started (from a new shell).
