### PR TITLE
Croatian i18n files

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,7 +28,7 @@ module ApplicationHelper
   end
 
   def how_long_ago(obj)
-    "#{time_ago_in_words(obj.created_at)} ago."
+    "#{time_ago_in_words(obj.created_at)}."
   end
 
   def person_url(person)

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,7 +37,7 @@ module Diaspora
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
+    config.i18n.default_locale = :en
 
     # Configure generators values. Many other options are available, be sure to check the documentation.
      config.generators do |g|

--- a/config/locales/devise.hr.yml
+++ b/config/locales/devise.hr.yml
@@ -1,0 +1,41 @@
+#   Copyright (c) 2010, Diaspora Inc.  This file is
+#   licensed under the Affero General Public License version 3.  See
+#   the COPYRIGHT file.
+
+
+hr:
+  errors:
+    messages:
+      not_found: "nije pronađen"
+      already_confirmed: "je već potvrđen"
+      not_locked: "nije bio zaključan"
+
+  devise:
+    failure:
+      unauthenticated: 'Trebaš se prijaviti ili registrirati da bi mogao nastavi dalje.'
+      unconfirmed: 'Trebaš potvrditi svoj korisnički račun da bi mogao nastaviti dalje.'
+      locked: 'Tvoj korisnički račun je zaključan.'
+      invalid: 'Neispravan email ili lozinka.'
+      invalid_token: 'Pogrešan autorizacijski token.'
+      timeout: 'Tvoja sesija je istekla, prijavi se da bi magao nastaviti dalje.'
+      inactive: 'Tvoj korisnički račun nije još aktiviran.'
+    sessions:
+      signed_in: 'Uspješno si se prijavio.'
+      signed_out: 'Uspješno si se odjavio.'
+    passwords:
+      send_instructions: 'Uskoro ćeš dobiti email s uputama kako resetirati lozinku.'
+      updated: 'Tvoja lozinka je uspješno promjenjena i prijavljen si.'
+    confirmations:
+      send_instructions: 'Uskoro ćeš dobiti email s uputama kako potvrditi svoj korisnički račun.'
+      confirmed: 'Tvoj korisnički račun je uspješno potvrđen i sada si prijavljen.'
+    registrations:
+      signed_up: 'Usješno si se registrirao, ako su potvrde aktivirane, uskoro ćeš dobiti email s potvrdom registracije.'
+      updated: 'Tvoj korisnički račun je uspješno uređen.'
+      destroyed: 'Doviđenja! Tvoj korisnički račun je otkazan, nadamo se da se vidimo ponovo.'
+    unlocks:
+      send_instructions: 'Uskoro ćeš dobiti email s uputama kako otključati svoj korisnički račun.'
+      unlocked: 'Tvoj korisnički račun je uspješno otključan i sada si prijavljen.'
+    mailer:
+      confirmation_instructions: 'Upute za potvrdu korisničkog računa'
+      reset_password_instructions: 'Upute za resetiranje lozinke'
+      unlock_instructions: 'Upute za otključavanje korisničkog računa'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,3 +8,47 @@
 
 en:
   hello: "Hello world"
+  
+  datetime:
+    distance_in_words:
+      half_a_minute: "half a minute ago"
+      less_than_x_seconds:
+        one:   "less than 1 second ago"
+        other: "less than %{count} seconds ago"
+      x_seconds:
+        one:   "1 second ago"
+        other: "%{count} seconds ago"
+      less_than_x_minutes:
+        one:   "less than a minute ago"
+        other: "less than %{count} minutes ago"
+      x_minutes:
+        one:   "1 minute ago"
+        other: "%{count} minutes ago"
+      about_x_hours:
+        one:   "about 1 hour ago"
+        other: "about %{count} hours ago"
+      x_days:
+        one:   "1 day ago"
+        other: "%{count} days ago"
+      about_x_months:
+        one:   "about 1 month ago"
+        other: "about %{count} months ago"
+      x_months:
+        one:   "1 month ago"
+        other: "%{count} months ago"
+      about_x_years:
+        one:   "about 1 year ago"
+        other: "about %{count} years ago"
+      over_x_years:
+        one:   "over 1 year ago"
+        other: "over %{count} years ago"
+      almost_x_years:
+        one:   "almost 1 year ago"
+        other: "almost %{count} years ago"
+    prompts:
+      year:   "Year"
+      month:  "Month"
+      day:    "Day"
+      hour:   "Hour"
+      minute: "Minute"
+      second: "Seconds"

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -1,0 +1,112 @@
+#   Copyright (c) 2010, Diaspora Inc.  This file is
+#   licensed under the Affero General Public License version 3.  See
+#   the COPYRIGHT file.
+
+
+# Sample localization file for English. Add more files in this directory for other locales.
+# See http://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
+
+hr:
+  hello: "Zdravo"
+  
+  date:
+    formats:
+      default: "%d/%m/%Y"
+      short: "%e %b"
+      long: "%B %e, %Y"
+      only_day: "%e"
+ 
+    day_names: [nedjelja, ponedjeljak, utorak, srijeda, četvrtak, petak, subota]
+    abbr_day_names: [ned, pon, uto, sri, čet, pet, sub]
+    month_names: [~, Siječanj, Veljača, Ožujak, Travanj, Svibanj, Lipanj, Srpanj, Kolovoz, Rujan, Listopad, Studeni, Prosinac]
+    abbr_month_names: [~, Sij, Velj, Ožu, Tra, Svi, Lip, Srp, Kol, Ruj, Lis, Stu, Pro]
+    order: [ :day, :month, :year ]
+    
+  number:
+    format:
+      precision: 3
+      separator: '.'
+      delimiter: ','
+    currency:
+      format:
+        unit: 'Kn'
+        precision: 2
+        format: '%n %u'
+ 
+  support:
+    array:
+      sentence_connector: "i"
+    
+  #TODO - fix some croatian's specific grammar casees
+  datetime:
+    formats:
+      default: "%Y-%m-%dT%H:%M:%S%Z"
+    distance_in_words:
+      half_a_minute: 'Prije pola minute'
+      less_than_x_seconds:
+        zero: 'Prije manje od 1 sekunde'
+        one: 'Prije manje od 1 sekunde'
+        few: 'Prije manje od %{count} sekunde'
+        other: 'Prije manje od %{count} sekundi'
+      x_seconds:
+        one: 'Prije 1 sekunde'
+        few: 'Prije %{count} sekunde'
+        other: '%{count} sekundi'
+      less_than_x_minutes:
+        zero: 'Prije manje оd minute'
+        one: 'Prije manje od minute'
+        other: 'Prije manje od %{count} minuta'
+      x_minutes:
+        one: 'Prije 1 minute'
+        other: 'Prije %{count} minuta'
+      about_x_hours:
+        one: 'Prije oko 1 sat'
+        few: 'Prije око %{count} sata'
+        other: 'Prije око %{count} sati'
+      x_days:
+        one: 'Prije 1 dan'
+        other: 'Prije %{count} dana'
+      about_x_months:
+        one: 'Prije око 1 mjesec'
+        few: 'Prije око %{count} mjeseca'
+        other: 'Prije око %{count} mjeseci'
+      x_months:
+        one: 'Prije 1 mjesec'
+        few: 'Prije %{count} mjeseca'
+        other: 'Prije %{count} mjeseci'
+      about_x_years:
+        one: 'Prije око 1 godine'
+        other: 'Prije око %{count} godine'
+      over_x_years:
+        one: 'Prije preko 1 godine'
+        other: 'Prije preko %{count} godine'
+        
+        
+  activerecord:                
+  errors:
+    template:
+      header:
+        one: 'Snimanje nije uspjelo'
+        few: 'Snimanje nije uspjelo'
+        other: 'Snimanje nije uspjelo'
+      body: "Provjerite sljedeća polja:"
+    messages:
+      inclusion: "nije u listi"
+      exclusion: "nije dostupno"
+      invalid: "nije ispravan"
+      confirmation: "se ne slaže sa svojom potvrdom"
+      accepted: "mora biti prihvaćeno"
+      empty: "mora biti upisan"
+      blank: "mora biti upisan"
+      too_long: "je predugačak (ne više od %{count} znakova)"
+      too_short: "је prekratak (ne manje od %{count} znakova)"
+      wrong_length: "nije odgovarajuće dužine (mora biti %{count} znakova)"
+      taken: "је zauzeto"
+      not_a_number: "nije broj"
+      greater_than: "mora biti veće od %{count}"
+      greater_than_or_equal_to: "mora biti veće ili jednako %{count}"
+      equal_to: "mora biti jednako %{count}"
+      less_than: "mora biti manje od %{count}"
+      less_than_or_equal_to: "mora biti manje ili jednako %{count}"
+      odd: "mora biti neparno"
+      even: "mora biti parno"


### PR DESCRIPTION
I add devise.hr.yml and hr.yml files for Croatian(hr) language and remove word 'ago' from application_helper method "how_long_ago" into locale files. I also edit en.yml and add datetime values, to get 'ago' in distance_in_words.
