### PR TITLE
S3 upload

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'magent', :git => 'http://github.com/dcu/magent.git'
 #File uploading
 gem 'carrierwave', :git => 'git://github.com/rsofaer/carrierwave.git' , :branch => 'master' #Untested mongomapper branch
 gem 'mini_magick'
+gem 'aws'
 
 group :test, :development do
   gem 'factory_girl_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,10 @@ GEM
     arel (1.0.1)
       activesupport (~> 3.0.0)
     autotest (4.3.2)
+    aws (2.3.21)
+      http_connection
+      uuidtools
+      xml-simple
     bcrypt-ruby (2.1.2)
     bson (1.0.7)
     bson_ext (1.0.7)
@@ -133,6 +137,7 @@ GEM
     haml (3.0.18)
     hashie (0.4.0)
     highline (1.6.1)
+    http_connection (1.3.1)
     i18n (0.4.1)
     json (1.4.6)
     linecache (0.43)
@@ -232,6 +237,7 @@ GEM
       rack (>= 1.0)
       rack-test (>= 0.5.3)
     will_paginate (3.0.pre2)
+    xml-simple (1.0.12)
 
 PLATFORMS
   ruby
@@ -239,6 +245,7 @@ PLATFORMS
 DEPENDENCIES
   addressable
   autotest
+  aws
   bson (= 1.0.7)
   bson_ext (= 1.0.7)
   bundler (= 1.0.0)

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -6,8 +6,6 @@
 class ImageUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
 
-  storage :file
-
   def store_dir
     "uploads/images"
   end

--- a/config/initializers/_mongo.rb
+++ b/config/initializers/_mongo.rb
@@ -2,13 +2,14 @@
 #   licensed under the Affero General Public License version 3.  See
 #   the COPYRIGHT file.
 
-if ENV['MONGOHQ_URL']
-  MongoMapper.config = {RAILS_ENV => {'uri' => ENV['MONGOHQ_URL']}}
+if ENV['MONGOHQ_URL']	
+  MongoMapper.config = {Rails.env => {'uri' => ENV['MONGOHQ_URL']}}
+  MongoMapper.connect(Rails.env)
+  Magent.connection = Mongo::Connection.from_uri(ENV['MONGOHQ_URL'])
 else
   MongoMapper.connection = Mongo::Connection.new('localhost', 27017)
+  MongoMapper.database = "diaspora-#{Rails.env}"	
 end
-
-MongoMapper.database = "diaspora-#{Rails.env}"
 
 if defined?(PhusionPassenger)
    PhusionPassenger.on_event(:starting_worker_process) do |forked|

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -4,5 +4,13 @@
 
 
 CarrierWave.configure do |config|
-  config.storage = :file
+  if ENV['S3_KEY'] && ENV['S3_SECRET'] && ENV['S3_BUCKET']
+    config.storage = :s3
+    config.s3_access_key_id = ENV['S3_KEY']
+    config.s3_secret_access_key = ENV['S3_SECRET']
+    config.s3_bucket = ENV['S3_BUCKET']
+    config.cache_dir = "#{Rails.root}/tmp/uploads"
+  else
+    config.storage = :file
+  end
 end


### PR DESCRIPTION
Since Carrierwave support uploads to S3, I do some changes in initializer to make photo uploading work under Heroku, if the ENV variables S3_KEY, S3_SECRET, S3_BUCKET are set the files are uploaded directly to S3. (I follow Heroku suggestions for ENV variables names: http://docs.heroku.com/config-vars)

I remove "storage :file" from ImageUploader because isn't required if you set it already in the initializer.

You can see working in live: http://diaspora-app.heroku.com
