### PR TITLE
Edit profile : previous profile picture does not appear as checked by default when editing the profile

### DIFF
--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -17,11 +17,10 @@
 
     %h3 Picture
     %div#image_picker
-      = p.hidden_field :image_url, :value => (@profile.image_url.sub(@user.url,'/') if @profile.image_url), :id => 'image_url_field'
-
+      = p.hidden_field :image_url, :value => (@profile.image_url.sub('http://' + @user.url,'').sub(/:\d*/,'') if @profile.image_url), :id => 'image_url_field'
       - unless @photos.nil? || @photos.empty?
         - for photo in @photos
-          - if @profile.image_url && (photo.url(:thumb_medium) == @profile.image_url.sub(@user.url,'/'))
+          - if @profile.image_url && (photo.url(:thumb_medium) == @profile.image_url.sub('http://' + @user.url,'').sub(/:\d*/,''))
             %div.small_photo{:id => photo.url(:thumb_medium), :class=>'selected'}
               = check_box_tag 'checked_photo', true, true
               = link_to image_tag(photo.url(:thumb_medium)), "#"


### PR DESCRIPTION
Fix to that bug :

Previous profile picture does not appear as checked by default when editing the profile.
When the user then clicks on "Update profile", it causes his profile picture to fail.
