### PR TITLE
Correcting the url in the diaspora username on the sign up page 

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -260,7 +260,7 @@ class User
   end
   
   def terse_url
-    terse = APP_CONFIG[:pod_url].gsub(/(https?:|www\.)\/\//, '')
+    terse = APP_CONFIG[:terse_pod_url]
     terse = terse.chop! if terse[-1, 1] == '/'
     terse
   end

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -10,7 +10,7 @@
       = f.label :username
       = f.text_field :username
     %p.user_network
-      ="@#{APP_CONFIG[:pod_url].gsub(/(http:\/\/)|(\/$)/,'')}"
+      ="@#{APP_CONFIG[:pod_url]}"
 
     %p
       = f.label :password

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -10,7 +10,7 @@
       = f.label :username
       = f.text_field :username
     %p.user_network
-      ="@#{APP_CONFIG[:pod_url]}"
+      ="@#{APP_CONFIG[:terse_pod_url]}"
 
     %p
       = f.label :password

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -10,7 +10,7 @@
       = f.label :username
       = f.text_field :username
     %p.user_network
-      ="@#{APP_CONFIG[:pod_url]}"
+      ="@#{APP_CONFIG[:pod_url].gsub(/(http:\/\/)|(\/$)/,'')}"
 
     %p
       = f.label :password


### PR DESCRIPTION
The diaspora user name is not user@http://example.domain.com/ but user@example.domain.com.
I use a regexp to remove 'http://'  the end slash if present in the pod_url parameter.
