### PR TITLE
Fixing MongoDB configuration for MongoHQ

### DIFF
--- a/config/initializers/_mongo.rb
+++ b/config/initializers/_mongo.rb
@@ -2,18 +2,18 @@
 #   licensed under the Affero General Public License version 3.  See
 #   the COPYRIGHT file.
 
-if ENV['MONGOHQ_URL']
-  MongoMapper.config = {RAILS_ENV => {'uri' => ENV['MONGOHQ_URL']}}
+if ENV['MONGOHQ_URL']	
+  MongoMapper.config = {Rails.env => {'uri' => ENV['MONGOHQ_URL']}}
+  MongoMapper.connect(Rails.env)
+  Magent.connection = Mongo::Connection.from_uri(ENV['MONGOHQ_URL'])
 else
   MongoMapper.connection = Mongo::Connection.new(APP_CONFIG['mongo_host'], APP_CONFIG['mongo_port'])
+  MongoMapper.database = "diaspora-#{Rails.env}"
+  Magent.connection  = Mongo::Connection.new(APP_CONFIG['mongo_host'], APP_CONFIG['mongo_port'])	
 end
-
-MongoMapper.database = "diaspora-#{Rails.env}"
 
 if defined?(PhusionPassenger)
    PhusionPassenger.on_event(:starting_worker_process) do |forked|
      MongoMapper.connection.connect_to_master if forked
    end
 end
-
-Magent.connection  = Mongo::Connection.new(APP_CONFIG['mongo_host'], APP_CONFIG['mongo_port'])


### PR DESCRIPTION
Current version of initializer still broken when ENV['MONGOHQ_URL'] is set.
