### PR TITLE
Mailing list link typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Ongoing discussion:
 More general info and updates about the project can be found on:
 [Our blog](http://joindiaspora.com),
 [and on Twitter](http://twitter.com/joindiaspora).
-Also, be sure to join the official [mailing list](http://http://eepurl.com/Vebk).
+Also, be sure to join the official [mailing list](http://eepurl.com/Vebk).
 
 If you wish to contact us privately about any exploits in Diaspora you may
 find, you can email


### PR DESCRIPTION
Fixed a typo (extra "http://" before link) in the mailing list link in the Readme file.
