### PR TITLE
Prevent error page when trying to add yourself as a friend

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -47,8 +47,13 @@ class RequestsController < ApplicationController
     begin
       @request = current_user.send_friend_request_to(rel_hash[:friend], aspect)
     rescue Exception => e
-      raise e unless e.message.include? "already"
-      flash[:notice] = I18n.t 'requests.create.already_friends', :destination_url => params[:request][:destination_url]
+      if e.message.include? "yourself"
+        flash[:notice] = I18n.t 'requests.create.yourself', :destination_url => params[:request][:destination_url]
+      elsif e.message.include? "already"
+        flash[:notice] = I18n.t 'requests.create.already_friends', :destination_url => params[:request][:destination_url]
+      else
+        raise e
+      end
       respond_with :location => aspect
       return
     end

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -225,6 +225,7 @@ en:
           ignore: "Ignored friend request."
       create:
           error: "No diaspora seed found with this email!"
+          yourself: "You cannot befriend yourself!"
           already_friends: "You are already friends with %{destination_url}!"
           success: "A friend request was sent to %{destination_url}."
           horribly_wrong: "Something went horribly wrong."

--- a/lib/diaspora/user/friending.rb
+++ b/lib/diaspora/user/friending.rb
@@ -7,6 +7,7 @@ module Diaspora
     module Friending
       def send_friend_request_to(desired_friend, aspect)
         # should have different exception types for these?
+        raise "You cannot befriend yourself" if desired_friend.nil? 
         raise "You have already sent a friend request to that person!" if self.pending_requests.detect{
           |x| x.destination_url == desired_friend.receive_url }
         raise "You are already friends with that person!" if self.friends.detect{

--- a/spec/controllers/requests_controller_spec.rb
+++ b/spec/controllers/requests_controller_spec.rb
@@ -1,0 +1,25 @@
+#   Copyright (c) 2010, Diaspora Inc.  This file is
+#   licensed under the Affero General Public License version 3 or later.  See
+#   the COPYRIGHT file.
+
+require 'spec_helper'
+
+describe RequestsController do
+  render_views
+  before do
+    @user = Factory.create(:user)
+
+    sign_in :user, @user
+    @user.aspect(:name => "lame-os")
+  end
+
+  it "should not error out when requesting to be friends with yourself" do
+    put("create", "request" => {
+      "destination_url" => @user.diaspora_handle,
+      "aspect_id" => @user.aspects[0].id 
+      } 
+    )
+    response.should redirect_to aspect_path(@user.aspects[0].id.to_s)
+  end
+
+end

--- a/spec/models/user/user_friending_spec.rb
+++ b/spec/models/user/user_friending_spec.rb
@@ -54,6 +54,11 @@ describe User do
       proc { user.send_friend_request_to(friend, aspect) }.should raise_error
     end
 
+    it 'should not be able to friend request yourself' do
+      proc { user.send_friend_request_to(nil, aspect) }.should raise_error(RuntimeError, /befriend yourself/)
+    end
+
+
     describe 'multiple users accepting/rejecting the same person' do
 
       before do


### PR DESCRIPTION
This diff and fix is mainly an excuse to get re-acquainted with Rails, TDD and the Diaspora code base.

I didn't touch the way that relationship_flow checks to see if you're referring to yourself, which leads to the error, but these tests should help with future refactoring of thislogic.
