### PR TITLE
328 profile image dead url

### DIFF
--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -62,10 +62,12 @@ class Photo < Post
   end
 
   def ensure_user_picture
-    users = Person.all('profile.image_url' => image.url(:thumb_medium) )
-    users.each{ |user|
-      user.profile.update_attributes!(:image_url => nil)
-    }
+    image_file = File.basename(image.url(:thumb_medium))
+    User.all.each do |user|
+      if image_file == File.basename(user.profile.image_url) 
+        user.profile.update_attributes!(:image_url => nil)
+      end
+    end
   end
 
   def thumb_hash


### PR DESCRIPTION
fixed #328 Profile image points to dead url on deletion

The issue here was that the ensure_user_picture method compared a
file path against a URL. The test does not reflect this.

Now filenames are compared assuming that profile pictures are
always local.

This solution might cause a performance issue, since the comparison
is not done in the DB anymore.
