### PR TITLE
441 failed aspect creation redirect

### DIFF
--- a/app/controllers/aspects_controller.rb
+++ b/app/controllers/aspects_controller.rb
@@ -24,7 +24,7 @@ class AspectsController < ApplicationController
       respond_with @aspect
     else
       flash[:error] = I18n.t('aspects.create.failure')
-      redirect_to aspects_manage_path
+      redirect_to :back
     end
   end
 

--- a/spec/controllers/aspects_controller_spec.rb
+++ b/spec/controllers/aspects_controller_spec.rb
@@ -16,6 +16,7 @@ describe AspectsController do
     friend_users(@user,@aspect, @user2, @aspect2)
     @contact = @user.contact_for(@user2.person)
     sign_in :user, @user
+    request.env["HTTP_REFERER"] = 'http://' + request.host
   end
 
   describe "#index" do
@@ -44,9 +45,9 @@ describe AspectsController do
         post :create, "aspect" => {"name" => ""}
         @user.reload.aspects.count.should == 2
       end
-      it "goes back to manage aspects" do
+      it "goes back to the page you came from" do
         post :create, "aspect" => {"name" => ""}
-        response.should redirect_to(aspects_manage_path)
+        response.should redirect_to(:back)
       end
     end
   end


### PR DESCRIPTION
Fixing bug 441 - failed aspect creation now redirects to the referring page instead of always redirecting to the manage page. Spec modified accordingly.
