### PR TITLE
365 fixed the app_config warning

### DIFF
--- a/config/initializers/_load_app_config.rb
+++ b/config/initializers/_load_app_config.rb
@@ -23,4 +23,4 @@ end
 APP_CONFIG[:terse_pod_url] = APP_CONFIG[:pod_url].gsub(/(https?:|www\.)\/\//, '')
 APP_CONFIG[:terse_pod_url].chop! if APP_CONFIG[:terse_pod_url][-1, 1] == '/'
 
-puts "WARNING: Please modify your app_config.yml to have a proper pod_url!" if APP_CONFIG[:terse_pod_url] == "example.org" && Rails.env != :test
+puts "WARNING: Please modify your app_config.yml to have a proper pod_url!" if APP_CONFIG[:terse_pod_url] == "example.org" && Rails.env != "test"


### PR DESCRIPTION
Very minor fix, but it should help the other newbies.  Rails.env is a string, not a symbol.
http://bugs.joindiaspora.com/issues/365  "Suppress APP_CONFIG warnings in rake spec"
