### PR TITLE
feature #336: render status messages using markdown syntax

### DIFF
--- a/app/helpers/status_messages_helper.rb
+++ b/app/helpers/status_messages_helper.rb
@@ -36,8 +36,8 @@ module StatusMessagesHelper
     end
 
     # markdown
-    message.gsub!(/([^\\]|^)\*\*(([^*]|([^*]\*[^*]))*[^\\])\*\*/, '\1<strong>\2</strong>')
-    message.gsub!(/([^\\]|^)__(([^_]|([^_]_[^_]))*[^\\])__/, '\1<strong>\2</strong>')
+    message.gsub!(/([^\\]|^)\*\*(([^*]|([^*]\*[^*]))*[^*\\])\*\*/, '\1<strong>\2</strong>')
+    message.gsub!(/([^\\]|^)__(([^_]|([^_]_[^_]))*[^_\\])__/, '\1<strong>\2</strong>')
     message.gsub!(/([^\\]|^)\*([^*]*[^\\])\*/, '\1<em>\2</em>')
     message.gsub!(/([^\\]|^)_([^_]*[^\\])_/, '\1<em>\2</em>')
     message.gsub!(/([^\\]|^)\*/, '\1')

--- a/app/helpers/status_messages_helper.rb
+++ b/app/helpers/status_messages_helper.rb
@@ -19,6 +19,9 @@ module StatusMessagesHelper
     # next line is important due to XSS! (h is rail's make_html_safe-function)
     message = h(message).html_safe
 
+    message.gsub!(/\[([^\[]+)\]\(([^ ]+) \&quot;(([^&]|(&[^q])|(&q[^u])|(&qu[^o])|(&quo[^t])|(&quot[^;]))+)\&quot;\)/, '<a href="\2" title="\3">\1</a>')
+    message.gsub!(/\[([^\[]+)\]\(([^ ]+)\)/, '<a href="\2">\1</a>')
+
     message.gsub!(/( |^)(www\.[^ ]+\.[^ ])/) do |m|
       res = "#{$1}http://#{$2}"
       res.gsub!(/^(\*|_)$/) { |m| "\\#{$1}" }
@@ -29,13 +32,16 @@ module StatusMessagesHelper
       res.gsub!(/(\*|_)/) { |m| "\\#{$1}" }
       res
     end
-    message.gsub!(/(https|http|ftp):\/\/([^ ]+)/) do |m|
-      res = %{<a target="_blank" href="#{$1}://#{$2}">#{$2}</a>}
-      res.gsub!(/(\*|_)/) { |m| "\\#{$1}" }
-      res
+    message.gsub!(/(<a href=")?(https|http|ftp):\/\/([^ ]+)/) do |m|
+      if $1 == '<a href="'
+        m
+      else
+        res = %{<a target="_blank" href="#{$2}://#{$3}">#{$3}</a>}
+        res.gsub!(/(\*|_)/) { |m| "\\#{$1}" }
+        res
+      end
     end
 
-    # markdown
     message.gsub!(/([^\\]|^)\*\*(([^*]|([^*]\*[^*]))*[^*\\])\*\*/, '\1<strong>\2</strong>')
     message.gsub!(/([^\\]|^)__(([^_]|([^_]_[^_]))*[^_\\])__/, '\1<strong>\2</strong>')
     message.gsub!(/([^\\]|^)\*([^*]*[^\\])\*/, '\1<em>\2</em>')

--- a/spec/helpers/status_messages_helper_spec.rb
+++ b/spec/helpers/status_messages_helper_spec.rb
@@ -99,6 +99,8 @@ describe StatusMessagesHelper do
         make_links(message).should == "<strong>this is <em>some</em> text</strong>"
         message = "*this is **some** text*"
         make_links(message).should == "<em>this is <strong>some</strong> text</em>"
+        message = "___some text___"
+        make_links(message).should == "<em><strong>some text</strong></em>"
       end
     end
 

--- a/spec/helpers/status_messages_helper_spec.rb
+++ b/spec/helpers/status_messages_helper_spec.rb
@@ -104,6 +104,18 @@ describe StatusMessagesHelper do
       end
     end
 
+    describe "links" do
+      it "should be recognized without title attribute" do
+        message = "[link text](http://someurl.com) [link text](http://someurl.com)"
+        make_links(message).should == '<a href="http://someurl.com">link text</a> <a href="http://someurl.com">link text</a>'
+      end
+
+      it "should be recognized with title attribute" do
+        message = '[link text](http://someurl.com "some title") [link text](http://someurl.com "some title")'
+        make_links(message).should == '<a href="http://someurl.com" title="some title">link text</a> <a href="http://someurl.com" title="some title">link text</a>'
+      end
+    end
+
     it "should allow escaping" do
       message = '*some text* \\*some text* \\**some text* _some text_ \\_some text_ \\__some text_'
       make_links(message).should == "<em>some text</em> *some text<em> *</em>some text <em>some text</em> _some text<em> _</em>some text"

--- a/spec/helpers/status_messages_helper_spec.rb
+++ b/spec/helpers/status_messages_helper_spec.rb
@@ -68,5 +68,45 @@ describe StatusMessagesHelper do
     make_links(url).should == "<a target=\"_blank\" href=\"http://"+url+"\">"+url+"</a>"
   end
 
+  describe "markdown" do
+    describe "weak emphasis" do
+      it "should be recognized (1/2)" do
+        message = "*some text* some text *some text* some text"
+        make_links(message).should == "<em>some text</em> some text <em>some text</em> some text"
+      end
+
+      it "should be recognized (2/2)" do
+        message = "_some text_ some text _some text_ some text"
+        make_links(message).should == "<em>some text</em> some text <em>some text</em> some text"
+      end
+    end
+
+    describe "strong emphasis" do
+      it "should be recognized (1/2)" do
+        message = "**some text** some text **some text** some text"
+        make_links(message).should == "<strong>some text</strong> some text <strong>some text</strong> some text"
+      end
+
+      it "should be recognized (2/2)" do
+        message = "__some text__ some text __some text__ some text"
+        make_links(message).should == "<strong>some text</strong> some text <strong>some text</strong> some text"
+      end
+    end
+
+    describe "imbricated weak and strong emphasis" do
+      it "should be rendered correctly" do
+        message = "__this is _some_ text__"
+        make_links(message).should == "<strong>this is <em>some</em> text</strong>"
+        message = "*this is **some** text*"
+        make_links(message).should == "<em>this is <strong>some</strong> text</em>"
+      end
+    end
+
+    it "should allow escaping" do
+      message = '*some text* \\*some text* \\**some text* _some text_ \\_some text_ \\__some text_'
+      make_links(message).should == "<em>some text</em> *some text<em> *</em>some text <em>some text</em> _some text<em> _</em>some text"
+    end
+  end
+
   
 end


### PR DESCRIPTION
'*some text*' or '_some text_' renders '_some text_' /// 
'**some text**' or '__some text__' renders '**some text**'

You can of course imbricate those tags.

'[some link](http://someurl.com\)' renders '[some link](http://someurl.com)' ///
'[some link](http://someurl.com "some title")' renders '[some link](http://someurl.com)'

I've made sure that the markdown links don't conflict with the auto-links that were already auto-generated (all tests for StatusMessagesHelper should pass including those I've added).
