### PR TITLE
492 vague signup wording

### DIFF
--- a/app/views/users/getting_started.html.haml
+++ b/app/views/users/getting_started.html.haml
@@ -30,7 +30,7 @@
   %h1{:style => "text-align:right;"}
     = "Welcome to Diaspora!"
     .description
-      Do the stuff below to further complete some things.
+      =t('.signup_steps')
 
   %h3{:style => "text-align:right;"}
     = link_to "Edit your profile", getting_started_path(:step => 1)

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -143,6 +143,7 @@ en:
           cancel: "Cancel"
       destroy: "Account successfully closed."
       getting_started:
+          signup_steps: "Complete your sign-up by doing these things:"
           'step_1':
               albums: "Albums"
               you_dont_have_any_photos: "You don't have any photos!  Go to the"


### PR DESCRIPTION
In file /app/views/users/getting_started.html.haml, changed wording "Do the stuff below to further complete some things." to "Complete your sign-up by doing these things:" That message is now in /config/locales/diaspora/en.yml
