### PR TITLE
496 eliminate self links getting started

### DIFF
--- a/app/views/users/getting_started.html.haml
+++ b/app/views/users/getting_started.html.haml
@@ -33,11 +33,23 @@
       Do the stuff below to further complete some things.
 
   %h3{:style => "text-align:right;"}
-    = link_to "Edit your profile", getting_started_path(:step => 1)
+    - if @step != 1
+      = link_to t('.edit_profile'), getting_started_path(:step => 1)
+    - else
+      %span{:style => "color: green;"}
+        = t('.edit_profile')
     %br
-    = link_to "Define your aspects", getting_started_path(:step => 2)
+    - if @step != 2
+      = link_to t('.define_aspects'), getting_started_path(:step => 2)
+    - else
+      %span{:style => "color:green;"}
+        = t('.define_aspects')
     %br
-    = link_to "Connect your services", getting_started_path(:step => 3)
+    - if @step != 3
+      = link_to t('.connect_services'), getting_started_path(:step => 3)
+    - else
+      %span{:style => "color:green;"}
+        = t('.connect_services')
     %br
 
 .span-15.last

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -148,6 +148,9 @@ en:
               you_dont_have_any_photos: "You don't have any photos!  Go to the"
               page_to_upload_some:  "page to upload some."
               or: "or"
+          edit_profile: "Edit your profile"
+          define_aspects: "Define your aspects"
+          connect_services: "Connect your services"
   comments:
       comment:
           ago: "ago"


### PR DESCRIPTION
As you go through the Getting Started process, the links at the left side of the page will be highlighted only if they go to a different page. Also pulled the strings for the link text into the locales folder.
