### PR TITLE
i18n fallbacks when there is a missing translation

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,7 +35,6 @@ class ApplicationController < ActionController::Base
   end
 
   def set_locale
-    I18n.default_locale = DEFAULT_LANGUAGE
     if current_user
       I18n.locale = current_user.language
     else

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -6,3 +6,6 @@
 I18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
 I18n.default_locale = DEFAULT_LANGUAGE
 I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
+AVAILABLE_LANGUAGE_CODES.each do |c|
+  I18n.fallbacks[c.to_sym] = [c.to_sym, DEFAULT_LANGUAGE.to_sym, :en]
+end

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -4,4 +4,4 @@
 
 # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
 I18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
-I18n.default_locale = :en
+I18n.default_locale = DEFAULT_LANGUAGE

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -5,3 +5,4 @@
 # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
 I18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
 I18n.default_locale = DEFAULT_LANGUAGE
+I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)


### PR DESCRIPTION
When there is a missing translation for the current language, I18n now fallbacks to the default language set in languages.yml. If it's also a missing translation for the default language, fallbacks to english.
