### PR TITLE
Bug #503: added 'lang' attribute in the html tag

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -3,7 +3,7 @@
 -#   the COPYRIGHT file.
 
 !!!
-%html
+%html{:lang => I18n.locale.to_s}
   %head
     %title
       = "#{current_user.real_name} | diaspora" if current_user


### PR DESCRIPTION
Render '<html lang="fr">' if the language is french for example, so the browser knows what's your language.
