### PR TITLE
511 nonstandard mongo port

### DIFF
--- a/config/initializers/_mongo.rb
+++ b/config/initializers/_mongo.rb
@@ -2,7 +2,7 @@
 #   licensed under the Affero General Public License version 3 or later.  See
 #   the COPYRIGHT file.
 
-ENV['MONGODB_URL'] = ENV['MONGOHQ_URL'] || URI::Generic.build(:scheme => 'mongodb', :host => APP_CONFIG['mongo_host'], :port => APP_CONFIG['mongo_port'], :path => "/diaspora-#{Rails.env}").to_s
+ENV['MONGODB_URL'] = ENV['MONGOHQ_URL'] || URI::Generic.build(:scheme => 'mongodb', :host => APP_CONFIG[:mongo_host], :port => APP_CONFIG[:mongo_port], :path => "/diaspora-#{Rails.env}").to_s
 
 MongoMapper.config = {::Rails.env => {'uri' => ENV['MONGODB_URL']}}
 MongoMapper.connect ::Rails.env


### PR DESCRIPTION
Sets mongo port and mongo host symbolically rather than as strings.  This allows use of a nonstandard (other than 27017) port for MongoDB
