### PR TITLE
Stopped _new_comment from generating duplicate form/field ids

### DIFF
--- a/app/views/comments/_new_comment.html.haml
+++ b/app/views/comments/_new_comment.html.haml
@@ -2,12 +2,12 @@
 -#   licensed under the Affero General Public License version 3 or later.  See
 -#   the COPYRIGHT file.
 
-= form_for Comment.new, :remote => true do |comment|
+= form_for Comment.new, :html => {:id => "new_comment_on_#{post.id}" }, :remote => true do |comment|
   %p
     = label_tag "comment_text_on_#{post.id}", t('.comment')
     = comment.text_area :text, :rows => 1, :id => "comment_text_on_#{post.id}", :class => "comment_box"
 
-  = comment.hidden_field :post_id, :value => post.id
+  = comment.hidden_field :post_id, :id => "post_id_on_#{post.id}", :value => post.id
 
   %p{:style => "text-align:right;"}
-    = comment.submit t('.comment'), :class => "comment_submit button"
+    = comment.submit t('.comment'), :id => "comment_submit_#{post.id}", :class => "comment_submit button"


### PR DESCRIPTION
This is _not_ tested in 1.8.7, runs fine on 1.9.2 though
