### PR TITLE
530 skip link

### DIFF
--- a/app/views/users/getting_started.html.haml
+++ b/app/views/users/getting_started.html.haml
@@ -61,5 +61,6 @@
     - if @step > 1
       = link_to t('back'), getting_started_path(:step => @step-1), :class => "button", :id => "previous_step"
 
-.bottom_notification
-  = link_to "#{t('.skip')} →", '#', :id => "getting_started_skip"
+- if @user.getting_started
+  .bottom_notification
+    = link_to "#{t('.skip')} →", '#', :id => "getting_started_skip"

--- a/features/signs_up.feature
+++ b/features/signs_up.feature
@@ -29,11 +29,17 @@ Feature: new user registration
 
     When I follow "Save and continue"
     Then I should see "You're all set up, O!"
+    And I should not see "skip getting started"
 
     When I follow "Continue on to your everyone page, an overview of all of your aspects."
     Then I should be on the home page
     And I should see "bring them to Diaspora!"
 
+  Scenario: new user skips the setup wizard and returns to the setup wizard
+    Given /^a user goes through the setup wizard$/
+    When I go to getting_started
+    Then I should not see "skip getting started"
+  
   Scenario: new user skips the setup wizard
     When I follow "skip getting started"
     And I wait for the home page to load


### PR DESCRIPTION
One-line fix, just a conditional to not display the "skip setup" link if the user is done with the "getting started" phase. Added a line to the use signup cucumber feature to check this.
