### PR TITLE
Google Ajax Libraries API Link

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -27,7 +27,7 @@
     = include_stylesheets :default, :media => 'all'
 
     
-    = javascript_include_tag "//ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"
+    = javascript_include_tag "//ajax.googleapis.com/ajax/libs/jquery/1.4.4/jquery.min.js"
     
     :javascript
       !window.jQuery && document.write(unescape('%3Cscript src="js/libs/jquery-1.4.4.js"%3E%3C/script%3E'))


### PR DESCRIPTION
The jQuery Google Ajax Libraries API URL to the specific 1.4.4 link instead of the generic /1/ release as this allows google to set a far future cache expire date for better caching and speed and prevents potential conflicts in case a jQuery update changes functionality
