### PR TITLE
#602 add i18n to make public in publisher

### DIFF
--- a/app/views/shared/_publisher.haml
+++ b/app/views/shared/_publisher.haml
@@ -63,7 +63,7 @@
           .public_toggle
             %p.checkbox_select
               = status.check_box( :public, {}, true, false )
-              = status.label :public, "make public"
+              = status.label :public, t('.make_public')
               = link_to (image_tag "social_media_logos/feed-16x16.png", :title => "RSS"), current_user.public_url 
               - if current_user.services
                 - for service in current_user.services      


### PR DESCRIPTION
This adds "make publish" message translation for desktop computer users.
It's already scoped in en.yml since mobile version uses the same key.
