### PR TITLE
HAML ugly mode makes view rendering 10% faster

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,3 +48,6 @@ Diaspora::Application.configure do
   config.i18n.fallbacks = true
   config.threadsafe!
 end
+
+# Sacrifice readability for a 10% performance boost
+Haml::Template::options[:ugly] = true


### PR DESCRIPTION
by not tabbing/whitespacing properly in production
