### PR TITLE
367 start script could expose sensitive information

### DIFF
--- a/script/server
+++ b/script/server
@@ -60,7 +60,7 @@ fi
 
 # Force AGPL
 if [ -w public -a ! -e  public/source.tar.gz ]; then
-    tar czf public/source.tar.gz  --exclude='source.tar.gz' -X .gitignore *
+    tar czf public/source.tar.gz  `git ls-tree -r master | awk '{print $4}'`
 fi
 if [ ! -e public/source.tar.gz ]; then
     echo "Error: Can't find, or even create, public/source.tar.gz. Exiting" >&2


### PR DESCRIPTION
This commit fix the issue #367, now includes files available in the git repository instead of excluding some using .gitignore (seems to be a safer way to do)
