### PR TITLE
Ruby192 load path

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -4,6 +4,10 @@
 
 # This file is used by Rack-based servers to start the application.
 
+if !$LOAD_PATH.include?('.')
+  $LOAD_PATH << '.'
+end
+
 require ::File.expand_path('../config/environment',  __FILE__)
 #use Rack::FiberPool
 require 'lib/chrome_frame'


### PR DESCRIPTION
I tried to load the app while running Ruby 1.9 and got some errors about not being able to load chrome frame. I realized that the file `lib/chrome_frame.rb` was not found since Ruby 1.9 does not include the current working directory (`'.'`) in the `$LOAD_PATH`

I googled around a bit on the subject and found this thread in which someone else was having the same problem:
http://groups.google.com/group/diaspora-dev/browse_thread/thread/9b743b8f5253488a/586107ea604840bb?lnk=raot

This small check in `config.ru` should solve the load path problem for Ruby 1.9.2 users.
