### PR TITLE
Flattr for site

### DIFF
--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -47,3 +47,7 @@
         #add_aspect_pane
           = render "aspects/new_aspect"
 
+-if APP_CONFIG[:flattr_this_site]
+  #flattr_this_site{:style => "margin-top:5px;margin-right:5px;"}
+    .right
+      = link_to "#{APP_CONFIG[:flattr_description]}", "#{APP_CONFIG[:pod_url]}", :title => "#{APP_CONFIG[:flattr_title]}", :class => "FlattrButton", :rev => "flattr;button:compact;uid:#{APP_CONFIG[:flattr_this_site]};category:text;tags:#{APP_CONFIG[:flattr_tags]};", :style => "display:none;"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -28,6 +28,16 @@
 
     
     = javascript_include_tag "//ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"
+
+    -if APP_CONFIG[:flattr_this_site]
+      :javascript
+        (function() {
+        var s = document.createElement('script'), t = document.getElementsByTagName('script')[0];
+        s.type = 'text/javascript';
+        s.async = true;
+        s.src = 'http://api.flattr.com/js/0.6/load.js?mode=auto';
+        t.parentNode.insertBefore(s, t);
+        })();
     
     :javascript
       !window.jQuery && document.write(unescape('%3Cscript src="/javascripts/vendor/jquery144.min.js"%3E%3C/script%3E'))

--- a/config/app_config.yml.example
+++ b/config/app_config.yml.example
@@ -73,7 +73,12 @@ default:
   piwik_id: 
   # the site url in raw format (e.g. pikwik.examplehost.com)
   piwik_url: 
-  
+     
+  #flattr support for this site (flattr_this_site = flattr uid)
+  flattr_this_site: false
+  flattr_title: "Title for this Flattr"
+  flattr_description: "Description for this flattr thing"
+  flattr_tags: "Tags,for,this,thing"
 
   #cloudfiles username and api-key, used for backups
   cloudfiles_username: 'example'


### PR DESCRIPTION
Its possible to define a flattr button for the site.

Its configurable via app_config.yml.

On the top right corner a flattr button shows up if a flattr uid is configured. The pod URL is used as url, title and description and tags can be configured in the config file.
