### PR TITLE
624 unset birthday

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -61,13 +61,6 @@ class PeopleController < ApplicationController
   end
 
   def update
-    # convert date selector into proper timestamp
-    
-    if birthday = params[:date]
-      unless [:month, :day, :year].any?{|x| birthday[x].blank?} 
-        params[:person][:profile][:birthday] ||= Date.parse("#{birthday[:year]}-#{birthday[:month]}-#{birthday[:day]}")
-      end
-    end
 
     # upload and set new profile photo
     params[:person][:profile] ||= {}

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -36,7 +36,8 @@ class Profile
 
   before_save :strip_names
 
-  attr_accessible :first_name, :last_name, :image_url, :image_url_medium, :image_url_small, :birthday, :gender, :bio, :searchable
+  attr_accessible :first_name, :last_name, :image_url, :image_url_medium,
+    :image_url_small, :birthday, :gender, :bio, :searchable, :date
 
 
   def person
@@ -83,6 +84,15 @@ class Profile
       super(url)
     else
       super(absolutify_local_url(url))
+    end
+  end
+
+  def date= params
+    if ['year', 'month', 'day'].all? { |key| params[key].present? }
+      date = Date.new(params['year'].to_i, params['month'].to_i, params['day'].to_i)
+      self.birthday = date
+    elsif ['year', 'month', 'day'].all? { |key| params[key] == '' }
+      self.birthday = nil
     end
   end
 

--- a/app/views/people/edit.html.haml
+++ b/app/views/people/edit.html.haml
@@ -34,7 +34,7 @@
       %h4
         = t('.your_birthday')
         %br
-        = select_date @person.profile.birthday, :prompt => true, 
+        = select_date @person.profile.birthday, :prompt => true, :prefix => 'person[profile][date]',
         :default => true, :order => t('date.order'), :start_year => 2000, :end_year => 1904
 
       %h4

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -73,4 +73,37 @@ describe Profile do
       xml.should_not include person.id.to_s
     end
   end
+
+  describe 'date=' do
+    let(:profile) { make_user.profile }
+
+    it 'accepts form data' do
+      profile.birthday.should == nil
+      profile.date = { 'year' => '2000', 'month' => '01', 'day' => '01' }
+      profile.birthday.year.should == 2000
+      profile.birthday.month.should == 1
+      profile.birthday.day.should == 1
+    end
+
+    it 'unsets the birthday' do
+      profile.birthday = Date.new(2000, 1, 1)
+      profile.date = { 'year' => '', 'month' => '', 'day' => ''}
+      profile.birthday.should == nil
+    end
+
+    it 'does not change with one or more blank values' do
+      profile.birthday = Date.new(2000, 1, 1)
+      profile.date = { 'year' => '2001', 'month' => '', 'day' => ''}
+      profile.birthday.year.should == 2000
+      profile.birthday.month.should == 1
+      profile.birthday.day.should == 1
+    end
+
+    it 'accepts blank initial vallues' do
+      profile.birthday.should == nil
+      profile.date = { 'year' => '2001', 'month' => '', 'day' => ''}
+      profile.birthday.should == nil
+    end
+  end
+
 end


### PR DESCRIPTION
Fixes bug #624
http://bugs.joindiaspora.com/projects/diaspora/issues/624

This change allows users to "unset" their birthday.

Previously the logic checked to see if all values for birthday were
present (year, month, day). If all values were present the update
would proceed.

Now, there is another condition. If all values are empty, then
also proceed with the update. Thus, allowing a user to "unset" their
birthday.
