### PR TITLE
Fix post delete confirmation with newest jquery

### DIFF
--- a/public/javascripts/rails.js
+++ b/public/javascripts/rails.js
@@ -80,10 +80,11 @@ jQuery(function ($) {
     /**
 * confirmation handler
 */
-    $('a[data-confirm],input[data-confirm]').live('click', function () {
+    $('a[data-confirm],input[data-confirm]').live('click', function(event) {
         var el = $(this);
         if (el.triggerAndReturn('confirm')) {
             if (!confirm(el.attr('data-confirm'))) {
+                event.stopImmediatePropagation();
                 return false;
             }
         }


### PR DESCRIPTION
This commit doesnt change the version of jquery, but the confirmation of deleting a post now works as intended with it.
