### PR TITLE
729 retain input on failure

### DIFF
--- a/public/javascripts/rails.js
+++ b/public/javascripts/rails.js
@@ -97,9 +97,13 @@ jQuery(function ($) {
     $('form[data-remote]').live('submit', function (e) {
         $(this).callRemote();
         e.preventDefault();
-	$(this).clearForm();
-	$(this).focusout();
     });
+
+    $('form[data-remote]').live('ajax:success', function (e) {
+        $(this).clearForm();
+        $(this).focusout();
+    });
+
 
     $('a[data-remote],input[data-remote]').live('click', function (e) {
         $(this).callRemote();

--- a/spec/javascripts/helpers/SpecHelper.js
+++ b/spec/javascripts/helpers/SpecHelper.js
@@ -11,12 +11,13 @@
 
 beforeEach(function() {
   $('#jasmine_content').empty();
-  spec.clearLiveEventBindings();
+  // NOTE Commented (as well as in afterEach) to keep the listeners from rails.js alive.
+  //spec.clearLiveEventBindings();
   jasmine.Clock.useMock();
 });
 
 afterEach(function() {
-  spec.clearLiveEventBindings();
+  //spec.clearLiveEventBindings();
   expect(spec.loadFixtureCount).toBeLessThan(2);
   spec.loadFixtureCount = 0;
 });

--- a/spec/javascripts/rails-spec.js
+++ b/spec/javascripts/rails-spec.js
@@ -1,0 +1,22 @@
+describe("rails", function() {
+  describe("remote forms", function() {
+    beforeEach(function() {
+      $("#jasmine_content").html(
+          '<form accept-charset="UTF-8" id="form" action="/status_messages" data-remote="true"  method="post">' +
+            '<textarea id="status_message_message" name="status_message[message]">Some status message</textarea>' +
+            '<input type="submit">' +
+          '</form>'
+      );
+    });
+    it("should retain form values if ajax fails", function() {
+      $('#form').trigger('ajax:failure');
+      expect($('#status_message_message').val()).not.toEqual("");
+    });
+    it("should clear form on ajax:success", function() {
+      $('#form').trigger('ajax:success');
+      
+      expect($('#status_message_message').val()).toEqual("");
+    
+    });
+  });
+});

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -25,6 +25,7 @@ src_files:
   - public/javascripts/view.js
   - public/javascripts/stream.js
   - public/javascripts/validation.js
+  - public/javascripts/rails.js
 # stylesheets
 #
 # Return an array of stylesheet filepaths relative to src_dir to include before jasmine specs.


### PR DESCRIPTION
Bugfix limiting the clearForm to 'ajax:success' instead of the 'submit' event.
