### PR TITLE
713 pointy cursor for add photos input

### DIFF
--- a/public/stylesheets/sass/application.sass
+++ b/public/stylesheets/sass/application.sass
@@ -752,6 +752,7 @@ label
   input
     :height 100%
     :width 100%
+    :cursor pointer
 
 #publisher
   :color #999


### PR DESCRIPTION
the box (i.e. border) around the file-field had the curser but the field itself not.

http://bugs.joindiaspora.com/issues/713
