### PR TITLE
Photo link in header

### DIFF
--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -38,6 +38,7 @@
       %li= link_to t('.view_profile'), current_user.person
       %li= link_to t('.edit_profile'), edit_person_path(current_user.person)
       %li= link_to t('.account_settings'), edit_user_path(current_user)
+      %li= link_to t('_photos'), person_photos_path(current_user.person)
       %li= link_to t('.logout'), destroy_user_session_path
 
     -unless @landing_page


### PR DESCRIPTION
Hi,

I just tested the git infrastructure and added a link to the 'photo section' into the header.
Nonetheless, I think it is good to have a direct link to photos.
Could you please pull this epsilon update?
I will afterwards work on real issues ;)

Thanks,
Frank
