### PR TITLE
Userscripttag

### DIFF
--- a/app/views/comments/_comment.haml
+++ b/app/views/comments/_comment.haml
@@ -7,7 +7,7 @@
   .content
     .from
       = person_link(hash[:person])
-    = markdownify(hash[:comment].text, :youtube_maps => hash[:comment][:youtube_titles])
+    %p.translatable= markdownify(hash[:comment].text, :youtube_maps => hash[:comment][:youtube_titles])
 
     .info
       %span.time

--- a/app/views/shared/_stream_element.haml
+++ b/app/views/shared/_stream_element.haml
@@ -28,7 +28,7 @@
         %span.aspect_badges
           = aspect_badges(aspects_with_post(all_aspects, post))
 
-    = render 'status_messages/status_message', :post => post, :photos => photos
+    %p.translatable= render 'status_messages/status_message', :post => post, :photos => photos
 
     .info
       %span.timeago= link_to(how_long_ago(post), status_message_path(post))


### PR DESCRIPTION
Not having the actual text wrapped has made it very tricky and slow to try and send the right data to Google API to translate with http://userscripts.org/scripts/show/91276 about 50% of the trafic to the API is from jd.com so this will allow all pods to work with the new version and not send extra data to the Google API, just the text that would need to be translated.
