### PR TITLE
Fix typo at default language

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -14,7 +14,7 @@ if File.exists?(File.expand_path("./config/languages.yml"))
   AVAILABLE_LANGUAGE_CODES = languages['available'].keys.map { |v| v.to_s }
 else
   AVAILABLE_LANGUAGES = { :en => 'English' }
-  DEFAULT_LANGUAGES = 'en'
+  DEFAULT_LANGUAGE = 'en'
   AVAILABLE_LANGUAGE_CODES = ['en']
 end
 


### PR DESCRIPTION
While testing detected that there is a typo for constant DEFAULT_LANGUAGE at environment.rb
