### PR TITLE
Fix signin button width

### DIFF
--- a/public/stylesheets/sass/application.sass
+++ b/public/stylesheets/sass/application.sass
@@ -2292,10 +2292,10 @@ ul.show_comments
           :color #888
 
       &.submit
-        :width 100px
+        :width auto
 
         input
-          :width 100px
+          :width auto
           :position relative
           :height 40px
           :top 0px


### PR DESCRIPTION
Fixed 'sign in' button width on the new login page. The '100px' width was causing the button caption to be wrapped for some languages(example: in French, 'Connexion' caption was wrapping).

Tested only with Firebug and Chrome dev console.
