### PR TITLE
Fix email invite link going to bank page

### DIFF
--- a/app/views/shared/_invitations.haml
+++ b/app/views/shared/_invitations.haml
@@ -13,7 +13,7 @@
         = link_to t('.by_email'), new_user_invitation_path, :title => t('.invite_someone'), :rel => 'facebox'
     - else
       %h4
-        = link_to t('.by_email'), new_user_invitation_path, :title => t('.invite_someone')
+        = link_to t('.by_email'), new_user_invitation_path, :title => t('.invite_someone'), :rel => 'facebox'
     %h5{:style => 'text-align:center;'}
       = t('.invitations_left', :count => invites) 
   - else


### PR DESCRIPTION
This got missed when this moved to a pop up, folks without facebook set up go not get the rel=facebox
