### PR TITLE
Jammitfix

### DIFF
--- a/config/assets.yml
+++ b/config/assets.yml
@@ -1,4 +1,7 @@
-package: on 
+package_assets: on
+embed_assets: on
+compress_assets: on
+gzip_assets: off
 javascripts:
   flash_socket:
     - public/javascripts/vendor/FABridge.js


### PR DESCRIPTION
gzip assets causes java errors and VM heap size failures on many machines (mostly VM's). Does not seem like gzip assets are needed right now.
