### PR TITLE
Pubphoto link name

### DIFF
--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -265,6 +265,7 @@ en:
           edit_delete_photo: "Edit photo description / delete photo"
           permalink: "permalink"
           collection_permalink: "collection permalink"
+          original_post: "Original Post"
       edit:
           editing: "Editing"
       photo:


### PR DESCRIPTION
has been missing forever, not sure how to trigger the translation process after this for all the other languages?
