### PR TITLE
Mobileshare link goes somewhere

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -129,7 +129,10 @@ class PeopleController < ApplicationController
       @aspects_with_person.include?(aspect)
     end
 
+    if !session[:mobile_view]
     render :layout => nil
+    end
+
   end
 
   private

--- a/app/views/aspects/_aspect_list_item.mobile.haml
+++ b/app/views/aspects/_aspect_list_item.mobile.haml
@@ -1,0 +1,8 @@
+-#   Copyright (c) 2010, Diaspora Inc.  This file is
+-#   licensed under the Affero General Public License version 3 or later.  See
+-#   the COPYRIGHT file.
+
+%li{:data=>{:guid=>aspect.id}}
+  %span.name
+    = aspect_membership_button(aspect, contact, person)
+    = aspect.name

--- a/app/views/aspects/add_to_aspect.mobile.haml
+++ b/app/views/aspects/add_to_aspect.mobile.haml
@@ -1,0 +1,7 @@
+-#   Copyright (c) 2010, Diaspora Inc.  This file is
+-#   licensed under the Affero General Public License version 3 or later.  See
+-#   the COPYRIGHT file.
+
+
+%p
+  Added to aspect

--- a/app/views/people/_share_with_pane.mobile.haml
+++ b/app/views/people/_share_with_pane.mobile.haml
@@ -1,0 +1,19 @@
+-#   Copyright (c) 2010, Diaspora Inc.  This file is
+-#   licensed under the Affero General Public License version 3 or later.  See
+-#   the COPYRIGHT file.
+
+- content_for :page_title do
+  %h1
+    DIASPORA*
+
+.aspect_list#aspects_list{:data=>{:person_id=>person.id}}
+  %ul
+    - for aspect in aspects_with_person
+      = render :partial => 'aspects/aspect_list_item', 
+               :locals => {:aspect => aspect, :person => person,
+                           :contact => contact}
+
+    - for aspect in aspects_without_person
+      = render :partial => 'aspects/aspect_list_item', 
+               :locals => {:aspect => aspect, :person => person,
+                           :contact => contact}

--- a/app/views/people/share_with.mobile.haml
+++ b/app/views/people/share_with.mobile.haml
@@ -1,0 +1,22 @@
+-#   Copyright (c) 2010, Diaspora Inc.  This file is
+-#   licensed under the Affero General Public License version 3 or later.  See
+-#   the COPYRIGHT file.
+
+- content_for :page_title do
+  %h1
+    DIASPORA*
+
+#share_with
+  #facebox_header
+    %p
+      = t('.share_with', :name => @person.name)
+
+      .description
+        = t('.accepts', :name => @person.first_name)
+  %br
+  = render :partial => 'share_with_pane',
+    :locals => {:person => @person,
+                :contact => @contact,
+                :aspects_with_person => @aspects_with_person,
+                :aspects_without_person => @aspects_without_person}
+


### PR DESCRIPTION
Start Sharing link on mobile UI just errors out with nowhere to go, added working path.
