### PR TITLE
559 posting empty messages

### DIFF
--- a/public/javascripts/publisher.js
+++ b/public/javascripts/publisher.js
@@ -12,6 +12,7 @@ var Publisher = {
   open: function(){
     Publisher.form().removeClass('closed');
     Publisher.form().find("textarea").css('min-height', '42px');
+    Publisher.determineSubmitAvailability();
   },
   cachedForm : false,
   form: function(){
@@ -27,6 +28,13 @@ var Publisher = {
     }
     return Publisher.cachedInput;
   },
+  cachedSubmit : false,
+  submit: function(){
+    if(!Publisher.cachedSubmit){
+      Publisher.cachedSubmit = Publisher.form().find('#status_message_submit');
+    }
+    return Publisher.cachedSubmit;
+  },
 
   cachedHiddenInput : false,
   hiddenInput: function(){
@@ -34,6 +42,14 @@ var Publisher = {
       Publisher.cachedHiddenInput = Publisher.form().find('#status_message_message');
     }
     return Publisher.cachedHiddenInput;
+  },
+
+  cachedSubmit : false,
+  submit: function(){
+    if(!Publisher.cachedSubmit){
+      Publisher.cachedSubmit = Publisher.form().find('#status_message_submit');
+    }
+    return Publisher.cachedSubmit;
   },
 
   autocompletion: {
@@ -184,6 +200,7 @@ var Publisher = {
 
     keyUpHandler : function(event){
       Publisher.autocompletion.repopulateHiddenInput();
+      Publisher.determineSubmitAvailability();
     },
 
     keyDownHandler : function(event){
@@ -252,6 +269,15 @@ var Publisher = {
       Publisher.oldInputContent = Publisher.input().val();
     }
   },
+  determineSubmitAvailability: function(){
+    var onlyWhitespaces = (Publisher.input().val().trim() == '');
+    var isSubmitDisabled = Publisher.submit().attr('disabled');
+    if (onlyWhitespaces && !isSubmitDisabled) {
+      Publisher.submit().attr('disabled', true);
+    } else if (!onlyWhitespaces && isSubmitDisabled) {
+      Publisher.submit().removeAttr('disabled');
+    }
+  },
   clear: function(){
     this.autocompletion.mentionList.clear();
     $("#photodropzone").find('li').remove();
@@ -261,6 +287,7 @@ var Publisher = {
     Publisher.cachedForm = false;
     Publisher.cachedInput = false;
     Publisher.cachedHiddenInput = false;
+    Publisher.cachedSubmit = false;
     $("div.public_toggle input").live("click", function(evt) {
       $("#publisher_service_icons").toggleClass("dim");
       if ($(this).attr('checked') == true) {

--- a/spec/javascripts/publisher-spec.js
+++ b/spec/javascripts/publisher-spec.js
@@ -30,6 +30,11 @@ describe("Publisher", function() {
         Publisher.open();
         expect(Publisher.form().hasClass('closed')).toBeFalsy();
         });
+      it("disables the share button", function() {
+        expect(Publisher.submit().attr('disabled')).toBeFalsy();
+        Publisher.open();
+        expect(Publisher.submit().attr('disabled')).toBeTruthy();
+        });
     });
     describe("close", function() {
       beforeEach(function() {
@@ -212,7 +217,41 @@ describe("Publisher", function() {
         });
       });
 
-
+      describe("keyUpHandler", function(){
+        var input;
+        var submit;
+        beforeEach(function(){
+          spec.loadFixture('aspects_index');
+          Publisher.initialize();
+          input = Publisher.input();
+          submit = Publisher.submit();
+          Publisher.open();
+        });
+        it("keep the share button disabled when adding only whitespaces", function(){
+          expect(submit.attr('disabled')).toBeTruthy();
+          input.val(' ');
+          input.keyup();
+          expect(submit.attr('disabled')).toBeTruthy();
+        });
+        it("enable the share button when adding non-whitespace characters", function(){
+          expect(submit.attr('disabled')).toBeTruthy();
+          input.val('some text');
+          input.keyup();
+          expect(submit.attr('disabled')).toBeFalsy();
+        });
+        it("should toggle share button disable/enable when playing with input", function(){
+          expect(submit.attr('disabled')).toBeTruthy();
+          input.val('         ');
+          input.keyup();
+          expect(submit.attr('disabled')).toBeTruthy();
+          input.val('text');
+          input.keyup();
+          expect(submit.attr('disabled')).toBeFalsy();
+          input.val('');
+          input.keyup();
+          expect(submit.attr('disabled')).toBeTruthy();
+        });
+      });
 
       describe("addMentionToInput", function(){
         var func;


### PR DESCRIPTION
The change disable the 'Share' button when the status message input textarea has only whitespaces characters.
