### PR TITLE
680 error on login goes away quickly

### DIFF
--- a/app/views/devise/sessions/new.haml
+++ b/app/views/devise/sessions/new.haml
@@ -17,6 +17,7 @@
             $("#spinner").fadeIn(300);
           });
         });
+        $(".login_error").remove();
       });
     });
 
@@ -25,6 +26,10 @@
     = image_tag('logo_caps.png', :id => 'logo', :width => 143, :height => 21)
     %br
     %br
+
+    - flash.each do |name, msg|
+      = content_tag :p, msg, :class => "login_error"
+
     = form_for(resource, :as => resource_name, :url => session_path(resource_name)) do |f|
       %p
         = f.label :username , t('username')

--- a/public/stylesheets/sass/application.sass
+++ b/public/stylesheets/sass/application.sass
@@ -90,6 +90,10 @@ form
   :text
     :shadow 0 1px #C66
 
+.login_error
+  :color rgb(208,49,43)
+  :text-shadow 1px 1px 7px rgb(208,49,43)
+
 .fieldWithErrors
   :display inline
 
@@ -677,7 +681,7 @@ a.paginate, #infscr-loading
 
 #main_stream .pagination
   :display none
-  
+
 .stream_element
   .right
     :position absolute


### PR DESCRIPTION
Flash error messages added above the login form. That way if someone miss the animated notification still knows the login failed.
