### PR TITLE
685 wrong language displayed on lang update

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -35,6 +35,7 @@ class UsersController < ApplicationController
       end
     elsif params[:user][:language]
       if @user.update_attributes(:language => params[:user][:language])
+        I18n.locale = @user.language
         flash[:notice] = I18n.t 'users.update.language_changed'
       else
         flash[:error] = I18n.t 'users.update.language_not_changed'


### PR DESCRIPTION
When updatting the user language the flash notification was displayed in the former language. This was because the flash hash was populated on the update action but the locale wasn't updated until the next run of the application controller.
