### PR TITLE
874 wrong time ago on notifications

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -19,7 +19,7 @@ class NotificationsController < ApplicationController
 
   def index
     @notifications = Notification.find(:all, :conditions => {:recipient_id => current_user.id},
-                                       :order => 'updated_at desc', :include => [:target, {:actors => :profile}]).paginate :page => params[:page], :per_page => 25
+                                       :order => 'created_at desc', :include => [:target, {:actors => :profile}]).paginate :page => params[:page], :per_page => 25
     @group_days = @notifications.group_by{|note| I18n.l(note.updated_at, :format => I18n.t('date.formats.fullmonth_day')) }
     respond_with @notifications
   end

--- a/app/views/notifications/index.html.haml
+++ b/app/views/notifications/index.html.haml
@@ -41,5 +41,5 @@
                 = notification_people_link(note)
                 = object_link(note)
 
-              %span.time= timeago(note.updated_at)
+              %span.time= timeago(note.created_at)
     = will_paginate @notifications


### PR DESCRIPTION
The calculation was being made with the updated_at attribute. So, for example, when changing the state of the notification from unreaded to readed, wrong time-ago was displayed.
