### PR TITLE
Form thumbnail spacing

### DIFF
--- a/app/views/photos/_new_photo.haml
+++ b/app/views/photos/_new_photo.haml
@@ -46,12 +46,13 @@
         $('#new_status_message').append("<input type='hidden' value='" + id + "' name='photos[]' />");
         $('#photodropzone').append(
           "<li class='publisher_photo' style='position:relative;'>" +
-            "<img  src='" + url +"' data-id='" + id + "' />" + 
+            "<img  src='" + url +"' data-id='" + id + "' />" +
             "<div class='x'> X </div>" +
             "<div class='circle'></div>" +
           "</li>"
           );
         $('#publisher').find("input[type='submit']").removeAttr('disabled');
+        $("#publisher textarea").css('paddingBottom', $("#photodropzone").height() + 10);
         $('.x').live('click', function(){
           var photo = $(this).closest('.publisher_photo');
           photo.addClass("dim");
@@ -60,8 +61,10 @@
                   success: function() {
                             photo.fadeOut(400, function(){
                               photo.remove();
+                              $("#publisher textarea").css('paddingBottom', $("#photodropzone").height() + 10);
                               if ( $('.publisher_photo').length  == 0){
                                 $("#publisher textarea").removeClass("with_attachments");
+                                $("#publisher textarea").css('paddingBottom', '');
                               }
                             });
                           }

--- a/public/javascripts/publisher.js
+++ b/public/javascripts/publisher.js
@@ -7,11 +7,11 @@
 var Publisher = {
   close: function(){
     Publisher.form().addClass('closed');
-    Publisher.form().find("textarea").css('min-height', '');
+    Publisher.form().find("textarea.ac_input").css('min-height', '');
   },
   open: function(){
     Publisher.form().removeClass('closed');
-    Publisher.form().find("textarea").css('min-height', '42px');
+    Publisher.form().find("textarea.ac_input").css('min-height', '42px');
     Publisher.determineSubmitAvailability();
   },
   cachedForm : false,
@@ -311,7 +311,7 @@ var Publisher = {
     Publisher.cachedInput = false;
     Publisher.cachedHiddenInput = false;
     Publisher.cachedSubmit = false;
-    
+
     Publisher.bindServiceIcons();
     Publisher.bindPublicIcon();
 

--- a/public/javascripts/publisher.js
+++ b/public/javascripts/publisher.js
@@ -281,7 +281,7 @@ var Publisher = {
   clear: function(){
     this.autocompletion.mentionList.clear();
     $("#photodropzone").find('li').remove();
-    $("#publisher textarea").removeClass("with_attachments");
+    $("#publisher textarea").removeClass("with_attachments").css('paddingBottom', '');
   },
   bindServiceIcons: function(){
     $(".service_icon").bind("click", function(evt){

--- a/public/javascripts/stream.js
+++ b/public/javascripts/stream.js
@@ -48,7 +48,7 @@ var Stream = {
 
     $(".new_status_message").live('ajax:loading', function(data, json, xhr) {
       $("#photodropzone").find('li').remove();
-      $("#publisher textarea").removeClass("with_attachments");
+      $("#publisher textarea").removeClass("with_attachments").css('paddingBottom', '');
     });
 
     $(".new_status_message").live('ajax:success', function(data, json, xhr) {

--- a/public/stylesheets/sass/application.sass
+++ b/public/stylesheets/sass/application.sass
@@ -869,7 +869,7 @@ label
 
     input
       :display inline
-    
+
     .right
       :top 2px
 
@@ -972,8 +972,13 @@ label
     :z-index 3
     :position absolute
     :bottom 0
+    :width 435px
     :left 5px
     li
+      :margin-right 4px
+      img
+        :height 50px
+        :width 50px
       .circle
         :display none
         :z-index 1


### PR DESCRIPTION
I noticed that when I uploaded photos along with my status update, if I uploaded too many the thumbnails had a tendency to flow outside the textarea.  This constrains them to the textarea and makes sure that they don't overlap the text.  To see the difference, try selecting 10 images to upload.

Also fixes a min-height css setting with breaks the jquery autoresize plugin on webkit.
