### PR TITLE
Long name omitted

### DIFF
--- a/app/views/people/_aspect_list.haml
+++ b/app/views/people/_aspect_list.haml
@@ -7,7 +7,7 @@
 .aspects
   - if !contact || !contact.persisted?
     %h4
-      = link_to truncate(t('people.show.not_connected', :name => person.name), :length => 49, :separator => ' ', :omission => ''),
+      = link_to truncate(t('people.show.not_connected', :name => person.name), :length => 49, :separator => ' ', :omission => t('people.show.long_name_omitted_lc')),
         {:controller => "contacts",
         :action => "new",
         :person_id => person.id},

--- a/app/views/people/_person.html.haml
+++ b/app/views/people/_person.html.haml
@@ -12,7 +12,7 @@
     - elsif (contact && contact.pending) || (request && request.recipient == person)
       = t('.pending_request')
     - elsif request && request.sender == person
-      = link_to t('people.show.incoming_request', :name => truncate(person.name, :length => 20, :separator => ' ', :omission => '')),
+      = link_to t('people.show.incoming_request', :name => truncate(person.name, :length => 20, :separator => ' ', :omission => t('people.show.long_name_omitted_uc'))),
         {:controller => "contacts",
         :action => "new",
         :person_id => person.id},

--- a/app/views/people/_person.mobile.haml
+++ b/app/views/people/_person.mobile.haml
@@ -12,7 +12,7 @@
     - elsif (contact && contact.pending) || (request && request.recipient == person)
       = t('.pending_request')
     - elsif request && request.sender == person
-      = link_to t('people.show.incoming_request', :name => truncate(person.name, :length => 20, :separator => ' ', :omission => '')),
+      = link_to t('people.show.incoming_request', :name => truncate(person.name, :length => 20, :separator => ' ', :omission => t('people.show.long_name_omitted_uc'))),
         {:controller => "contacts",
         :action => "new",
         :person_id => person.id},

--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -27,7 +27,7 @@
     - if user_signed_in? && !(@contact.persisted? || current_user.person == @person)
       .right
         - if @incoming_request
-          = link_to t('.incoming_request', :name => truncate(@person.name, :length => 20, :separator => ' ', :omission => '')),
+          = link_to t('.incoming_request', :name => truncate(@person.name, :length => 20, :separator => ' ', :omission => t('people.show.long_name_omitted_uc'))),
             {:controller => "contacts",
             :action => "new",
             :person_id => @person.id},

--- a/app/views/services/_remote_friend.html.haml
+++ b/app/views/services/_remote_friend.html.haml
@@ -5,7 +5,7 @@
     - elsif (friend[:contact] && friend[:contact].pending) || (friend[:request] && friend[:request].sender_id != friend[:person].id)
       = t('people.person.pending_request')
     - elsif (friend[:request] && friend[:request].sender_id == friend[:person].id)
-      = link_to t('people.show.incoming_request', :name => truncate(friend[:person].name, :length => 20, :separator => ' ', :omission => '')),
+      = link_to t('people.show.incoming_request', :name => truncate(friend[:person].name, :length => 20, :separator => ' ', :omission => t('people.show.long_name_omitted_uc'))),
         {:controller => "people",
         :action => "show",
         :id => friend[:person].id,

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -337,6 +337,8 @@ en:
       to_accept_or_ignore: "to accept or ignore it."
       does_not_exist: "Person does not exist!"
       not_connected: "You are not sharing with %{name}"
+      long_name_omitted_lc: " this person"
+      long_name_omitted_uc: "This person"
       recent_posts: "Recent Posts"
       recent_public_posts: "Recent Public Posts"
       similar_contacts: "similar contacts"


### PR DESCRIPTION
With buttons like "You are not sharing with %{name}" or "%{name} wants to share with you", there are problems if the name is too long. The current logic is to just drop the name, leaving buttons saying "You are not sharing with".

This change adds two global variables in en.yml so that instead of just dropping the name, it will insert "this person" or "This person". As in "You are not sharing with this person" or "This person wants to share with you"
