### PR TITLE
Problems with "You are not sharing with...." button rendering

### DIFF
--- a/app/views/people/_aspect_list.haml
+++ b/app/views/people/_aspect_list.haml
@@ -7,7 +7,7 @@
 .aspects
   - if !contact || !contact.persisted?
     %h4
-      = link_to truncate(t('people.show.not_connected', :name => person.name), :length => 49, :separator => ' ', :omission => ''),
+      = link_to t('people.show.not_connected'),
         {:controller => "contacts",
         :action => "new",
         :person_id => person.id},

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -338,7 +338,7 @@ en:
       return_to_aspects: "Return to your aspects page"
       to_accept_or_ignore: "to accept or ignore it."
       does_not_exist: "Person does not exist!"
-      not_connected: "You are not sharing with %{name}"
+      not_connected: "You are not sharing with this person"
       recent_posts: "Recent Posts"
       recent_public_posts: "Recent Public Posts"
       similar_contacts: "similar contacts"


### PR DESCRIPTION
The global variable 'people.show.not_connected' contained %{name}, so it outputs text at variable length. That variation could cause problems when rendered in the browser. The button "You are not sharing with..." could end up too long and do bad text wrapping. Or it might be truncated to just read "You are not sharing with."

This commit changes the variable to just read "You are not sharing with this person". This fixes the problems with variable lengths. And this is how some languages, like Spanish, already handle the text.
