### PR TITLE
Next and Previous arrows for mobile photos

### DIFF
--- a/app/views/photos/show.mobile.haml
+++ b/app/views/photos/show.mobile.haml
@@ -6,3 +6,12 @@
 #show_content.photo
   = image_tag @photo.url(:scaled_full)
 
+  -if @additional_photos && @additional_photos.length > 1
+    #photo_controls
+    %table
+      %tr
+        %td
+          =link_to "←", @prev_photo, :rel => 'prefetch', :class => 'arrow'
+        %td{:width => '100%'}
+        %td
+          =link_to "→", @next_photo, :rel => 'prefetch', :class => 'arrow'

--- a/public/stylesheets/sass/mobile.sass
+++ b/public/stylesheets/sass/mobile.sass
@@ -7,7 +7,7 @@
 
 $blue: #3F8FBA
 
-a:not([role='button'])
+a:not([role='button']):not(.arrow)
   :text
     :decoration none
   :font
@@ -169,6 +169,19 @@ a
   &.photo
     :background
       :color #000
+
+#photo_controls
+  :margin
+    :bottom -42px
+
+.arrow
+  :color white !important
+  :font
+    :size 26pt
+  :text
+    :shadow 0 1px 2px #333
+    :decoration none
+  :padding 0
 
 ul
   :margin 0
@@ -340,4 +353,3 @@ ul
   :background
     :color #333
   :color #ccc
-


### PR DESCRIPTION
When looking at a photo on a smartphone, this adds arrows in the bottom left and right of the photo, linking to the previous and the next photo in the collection. If the collection has just one photo, it adds nothing.

Looks nice on my Droid Eris, and in an iPhone simulator.
