### PR TITLE
Make dev-mode exception pages fast again

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -22,4 +22,18 @@ Diaspora::Application.configure do
   config.action_mailer.raise_delivery_errors = false
   config.active_support.deprecation = :log
   #config.threadsafe!
+
+  # Monkeypatch around the nasty "2.5MB exception page" issue, caused by very large environment vars
+  # This snippet via: http://stackoverflow.com/questions/3114993/exception-pages-in-development-mode-take-upwards-of-15-30-seconds-to-render-why
+  # Relevant Rails ticket: https://rails.lighthouseapp.com/projects/8994/tickets/5027-_request_and_responseerb-and-diagnosticserb-take-an-increasingly-long-time-to-render-in-development-with-multiple-show-tables-calls
+  config.after_initialize do
+    module SmallInspect
+      def inspect
+        "<#{self.class.name} - tooooo long>"
+      end
+    end
+    [ActionController::Base, ActionDispatch::RemoteIp::RemoteIpGetter, OmniAuth::Strategy, Warden::Proxy].each do |klazz|
+      klazz.send(:include, SmallInspect)
+    end
+  end
 end


### PR DESCRIPTION
Dev-mode error pages take forever to load because of humongous .inspect output. 

This monkeypatches certain large-ass objects (warden, omniauth.strategy, actioncontroller.base & a few others) until this fix can make it into Rails core:

https://rails.lighthouseapp.com/projects/8994/tickets/5027-_request_and_responseerb-and-diagnosticserb-take-an-increasingly-long-time-to-render-in-development-with-multiple-show-tables-calls

fwiw this made my error pages go from 3-5s to 100ms
