### PR TITLE
#1019 comment/post handles multiple youtube links properly

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -212,11 +212,10 @@ module ApplicationHelper
   end
 
   def process_youtube(message, youtube_maps)
-    regex = /( |^)(https?:\/\/)?www\.youtube\.com\/watch[^ ]*v=([A-Za-z0-9_\-]+)(&[^ ]*)?(#[^ ]+)?/
-    processed_message = message.gsub(regex) do |matched_string|
-      match_data = matched_string.match(regex)
-      video_id = match_data[3]
-      anchor = match_data[5]
+    processed_message = message.gsub(YoutubeTitles::YOUTUBE_ID_REGEX) do |matched_string|
+      match_data = matched_string.match(YoutubeTitles::YOUTUBE_ID_REGEX)
+      video_id = match_data[1]
+      anchor = match_data[2]
       anchor ||= ''
       if youtube_maps && youtube_maps[video_id]
         title = h(CGI::unescape(youtube_maps[video_id]))

--- a/lib/youtube_titles.rb
+++ b/lib/youtube_titles.rb
@@ -20,5 +20,5 @@ module YoutubeTitles
     end
   end
 
-  YOUTUBE_ID_REGEX = /(?:youtu\.be\/|(?:[a-z]{2,3}\.)?youtube\.com\/watch(?:\?|#!|.+&|.+&amp;)v=)([\w-]{11})/im unless defined? YOUTUBE_ID_REGEX
+  YOUTUBE_ID_REGEX = /(?:youtu\.be\/|(?:[a-z]{2,3}\.)?youtube\.com\/watch(?:\?|#!|.+&|.+&amp;)v=)([\w-]{11})(?:\S*(#[^ ]+))?/im unless defined? YOUTUBE_ID_REGEX
 end

--- a/lib/youtube_titles.rb
+++ b/lib/youtube_titles.rb
@@ -9,14 +9,16 @@ module YoutubeTitles
     end
     title || I18n.t('application.helper.video_title.unknown')
   end
+
   def get_youtube_title text
+    youtube_match = text.enum_for(:scan, YOUTUBE_ID_REGEX).map { Regexp.last_match }
+    return if youtube_match.empty?
+
     self.youtube_titles ||= {}
-    youtube_match = text.match(YOUTUBE_ID_REGEX)
-    return unless youtube_match
-    video_id = youtube_match[1]
-    unless self.youtube_titles[video_id]
-      self.youtube_titles[video_id] = CGI::escape(youtube_title_for(video_id))
+    youtube_match.each do |match_data|
+      self.youtube_titles[match_data[1]] = CGI::escape(youtube_title_for(match_data[1]))
     end
   end
-  YOUTUBE_ID_REGEX = /youtube\.com.*?v=([A-Za-z0-9_\\\-]+)/ unless defined? YOUTUBE_ID_REGEX
+
+  YOUTUBE_ID_REGEX = /(?:youtu\.be\/|(?:[a-z]{2,3}\.)?youtube\.com\/watch(?:\?|#!|.+&|.+&amp;)v=)([\w-]{11})/im unless defined? YOUTUBE_ID_REGEX
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -139,13 +139,13 @@ describe ApplicationHelper do
       end
 
       it "recognizes multiple links of different types" do
-        message = "http:// Hello World, this is for www.joindiaspora.com and not for http://www.google.com though their Youtube service is neat, take http://www.youtube.com/watch?v=foobar or www.youtube.com/watch?foo=bar&v=BARFOO&whatever=related It is a good idea we finally have youtube, so enjoy this video http://www.youtube.com/watch?v=rickrolld"
+        message = "http:// Hello World, this is for www.joindiaspora.com and not for http://www.google.com though their Youtube service is neat, take http://www.youtube.com/watch?v=foobar----- or www.youtube.com/watch?foo=bar&v=BARFOO-----&whatever=related It is a good idea we finally have youtube, so enjoy this video http://www.youtube.com/watch?v=rickrolld--"
         res = markdownify(message)
         res.should =~ /a target=\"_blank\" href=\"http:\/\/www.joindiaspora.com\"/
         res.should =~ /a target=\"_blank\" href=\"http:\/\/www.google.com\"/
-        res.should =~ /data-video-id="foobar"/
-        res.should =~ /data-video-id="BARFOO"/
-        res.should =~ /data-video-id="rickrolld"/
+        res.should =~ /data-video-id="foobar-----"/
+        res.should =~ /data-video-id="BARFOO-----"/
+        res.should =~ /data-video-id="rickrolld--"/
       end
 
       it "should recognize basic ftp links" do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -92,20 +92,22 @@ describe Comment do
     before do
       @message = alice.post :status_message, :text => "hi", :to => @alices_aspect.id
     end
+
     it 'should process youtube titles on the way in' do
-      video_id = "ABYnqp-bxvg"
-      url="http://www.youtube.com/watch?v=#{video_id}&a=GxdCwVVULXdvEBKmx_f5ywvZ0zZHHHDU&list=ML&playnext=1"
-      expected_title = "UP & down & UP & down &amp;"
+      first_video_id  = "ABYnqp-1111"
+      second_video_id = "ABYnqp-2222"
+      url             = "http://www.youtube.com/watch?v=#{first_video_id} http://www.youtube.com/watch?v=#{second_video_id}"
+      expected_title  = "UP & down & UP & down &amp;"
 
       mock_http = mock("http")
-      Net::HTTP.stub!(:new).with('gdata.youtube.com', 80).and_return(mock_http)
-      mock_http.should_receive(:get).with('/feeds/api/videos/'+video_id+'?v=2', nil).and_return(
+      Net::HTTP.stub!(:new).with('gdata.youtube.com', 80).twice.and_return(mock_http)
+      mock_http.should_receive(:get).with(/\/feeds\/api\/videos/, nil).twice.and_return(
         [nil, 'Foobar <title>'+expected_title+'</title> hallo welt <asd><dasdd><a>dsd</a>'])
 
       comment = alice.build_comment url, :on => @message
-
       comment.save!
-      Comment.find(comment.id).youtube_titles.should == {video_id => CGI::escape(expected_title)}
+
+      Comment.find(comment.id).youtube_titles.should == { first_video_id => CGI::escape(expected_title), second_video_id => CGI::escape(expected_title) }
     end
   end
 


### PR DESCRIPTION
Hey guys,

This should allow youtube_titles to store more than one youtube link. Current String#match will only return single last match. We just iterate #match to get all youtube ids and build the hash accordingly.

I also make sure all youtube regex use YoutubeTitles::YOUTUBE_ID_REGEX, it'll be more consistent site wide. 

Cheers!
Arzumy
