### PR TITLE
Fixing #348 - Change E-mail with confirmation

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -53,6 +53,13 @@ class UsersController < ApplicationController
         unless u[:a_ids] == ["home"]
           @user.aspects.where(:id => u[:a_ids]).update_all(:open => true)
         end
+      elsif u[:email]
+        @user.unconfirmed_email = u[:email]
+        if @user.save
+          flash[:notice] = I18n.t 'users.update.unconfirmed_email_changed'
+        else
+          flash[:error] = I18n.t 'users.update.unconfirmed_email_not_changed'
+        end
       end
     end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -150,4 +150,13 @@ class UsersController < ApplicationController
     tar_path = PhotoMover::move_photos(current_user)
     send_data( File.open(tar_path).read, :filename => "#{current_user.id}.tar" )
   end
+
+  def confirm_email
+    if current_user.confirm_email(params[:token])
+      flash[:notice] = I18n.t('users.confirm_email.email_confirmed', :email => current_user.email)
+    elsif current_user.unconfirmed_email.present?
+      flash[:error] = I18n.t('users.confirm_email.email_not_confirmed')
+    end
+    redirect_to edit_user_path
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -56,6 +56,7 @@ class UsersController < ApplicationController
       elsif u[:email]
         @user.unconfirmed_email = u[:email]
         if @user.save
+          @user.mail_confirm_email
           flash[:notice] = I18n.t 'users.update.unconfirmed_email_changed'
         else
           flash[:error] = I18n.t 'users.update.unconfirmed_email_not_changed'

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -115,6 +115,18 @@ class Notifier < ActionMailer::Base
     end
   end
 
+  def confirm_email(receiver_id)
+    @receiver = User.find_by_id(receiver_id)
+
+    attachments.inline['logo_caps.png'] = ATTACHMENT
+
+    I18n.with_locale(@receiver.language) do
+      mail(:to => "\"#{@receiver.name}\" <#{@receiver.unconfirmed_email}>",
+           :subject => I18n.t('notifier.confirm_email.subject', :unconfirmed_email => @receiver.unconfirmed_email), 
+           :host => AppConfig[:pod_uri].host)
+    end
+  end
+
   private
   def log_mail recipient_id, sender_id, type
     log_string = "event=mail mail_type=#{type} recipient_id=#{recipient_id} sender_id=#{sender_id}"

--- a/app/models/jobs/mail_confirm_email.rb
+++ b/app/models/jobs/mail_confirm_email.rb
@@ -1,0 +1,8 @@
+module Job
+  class MailConfirmEmail < Base
+    @queue = :mail
+    def self.perform_delegate(user_id)
+      Notifier.confirm_email(user_id).deliver
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,7 @@ class User < ActiveRecord::Base
   validates_format_of :username, :with => /\A[A-Za-z0-9_]+\z/
   validates_length_of :username, :maximum => 32
   validates_inclusion_of :language, :in => AVAILABLE_LANGUAGE_CODES
+  validates_format_of :unconfirmed_email, :with  => Devise.email_regexp, :allow_blank => true
 
   validates_presence_of :person, :unless => proc {|user| user.invitation_token.present?}
   validates_associated :person
@@ -43,6 +44,7 @@ class User < ActiveRecord::Base
   before_save do
     person.save if person && person.changed?
   end
+  before_save :guard_unconfirmed_email
 
   attr_accessible :getting_started, :password, :password_confirmation, :language, :disable_mail
 
@@ -347,6 +349,14 @@ class User < ActiveRecord::Base
   def remove_mentions
     Mention.where( :person_id => self.person.id).each do |mentioned_person|
       mentioned_person.delete
+    end
+  end
+
+  def guard_unconfirmed_email
+    self.unconfirmed_email = nil if unconfirmed_email.blank? || unconfirmed_email == email
+    
+    if unconfirmed_email_changed?
+      self.confirm_email_token = unconfirmed_email ? ActiveSupport::SecureRandom.hex(15) : nil
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -206,6 +206,12 @@ class User < ActiveRecord::Base
     end
   end
 
+  def mail_confirm_email
+    return false if unconfirmed_email.blank?
+    Resque.enqueue(Job::MailConfirmEmail, id)
+    true 
+  end
+
   ######### Posts and Such ###############
   def retract(post)
     if post.respond_to?(:relayable?) && post.relayable?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -93,6 +93,12 @@ class User < ActiveRecord::Base
     true
   end
 
+  def confirm_email(token)
+    return false if token.blank? || token != confirm_email_token
+    self.email = unconfirmed_email
+    save
+  end
+
   ######### Aspects ######################
   def move_contact(person, to_aspect, from_aspect)
     return true if to_aspect == from_aspect

--- a/app/views/notifier/confirm_email.html.haml
+++ b/app/views/notifier/confirm_email.html.haml
@@ -1,0 +1,12 @@
+%p
+  = t('notifier.hello', :name => @receiver.profile.first_name)
+%p
+  != t('notifier.confirm_email.click_link', :unconfirmed_email => @receiver.unconfirmed_email)
+  %br
+  = link_to root_url, root_url
+  
+  %br
+  %br
+  = t('notifier.love') 
+  %br
+  = t('notifier.diaspora')

--- a/app/views/notifier/confirm_email.html.haml
+++ b/app/views/notifier/confirm_email.html.haml
@@ -3,7 +3,7 @@
 %p
   != t('notifier.confirm_email.click_link', :unconfirmed_email => @receiver.unconfirmed_email)
   %br
-  = link_to root_url, root_url
+  = link_to confirm_email_url(:token => @receiver.confirm_email_token), confirm_email_url(:token => @receiver.confirm_email_token)
   
   %br
   %br

--- a/app/views/notifier/confirm_email.text.haml
+++ b/app/views/notifier/confirm_email.text.haml
@@ -1,7 +1,7 @@
 != t('notifier.hello', :name => @receiver.profile.first_name)
 
 != t('notifier.confirm_email.click_link', :unconfirmed_email => @receiver.unconfirmed_email)
-!= root_url
+!= confirm_email_url(:token => @receiver.confirm_email_token)
 
 != "#{t('notifier.love')} \n"
 != t('notifier.diaspora')

--- a/app/views/notifier/confirm_email.text.haml
+++ b/app/views/notifier/confirm_email.text.haml
@@ -1,0 +1,7 @@
+!= t('notifier.hello', :name => @receiver.profile.first_name)
+
+!= t('notifier.confirm_email.click_link', :unconfirmed_email => @receiver.unconfirmed_email)
+!= root_url
+
+!= "#{t('notifier.love')} \n"
+!= t('notifier.diaspora')

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -22,8 +22,15 @@
   .span-5.last
     %h3
       = t('.your_email')
-    %p
-      = current_user.email
+    = form_for 'user', :url => user_path, :html => { :method => :put } do |f|
+      = f.error_messages
+      %p
+        = f.text_field :email, :value => @user.unconfirmed_email || @user.email
+        = f.submit t('.change_email')
+    %br
+    - if @user.unconfirmed_email.present?
+      %p= t('.email_awaiting_confirmation', :email => @user.email, :unconfirmed_email => @user.unconfirmed_email)
+    %br
 
   %br
   %br

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -735,6 +735,9 @@ en:
       unconfirmed_email_not_changed: "E-Mail Change Failed"
     public:
       does_not_exist: "User %{username} does not exist!"
+    confirm_email:
+      email_confirmed: "E-Mail %{email} activated"
+      email_not_confirmed: "E-Mail could not be activated. Wrong link?"
 
   webfinger:
     fetch_failed: "failed to fetch webfinger profile for %{profile_url}"

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -401,6 +401,9 @@ en:
         subject: "%{name} has just liked your post"
         liked: "%{name} has just liked your post: "
         sign_in: "Sign in to view it"
+    confirm_email:
+        subject: "Please activate your new e-mail address %{unconfirmed_email}"
+        click_link: "To activate your new e-mail address %{unconfirmed_email}, please click this link:"
 
   people:
     zero: "no people"

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -688,6 +688,7 @@ en:
       close_account: "Close Account"
       change_language: "Change Language"
       change_password: "Change Password"
+      change_email: "Change E-Mail"
       new_password: "New Password"
       current_password: "Current password"
       download_xml: "download my xml"
@@ -703,6 +704,7 @@ en:
       private_message: "...you receive a private message?"
       liked: "...someone likes your post?"
       change: "Change"
+      email_awaiting_confirmation: "We have sent you an activation link to %{unconfirmed_email}. Till you follow this link and activate the new address, we will continue to use your original address %{email}."
     destroy: "Account successfully closed."
     getting_started:
       welcome: "Welcome to Diaspora!"
@@ -726,6 +728,8 @@ en:
       language_changed: "Language Changed"
       language_not_changed: "Language Change Failed"
       email_notifications_changed: "Email notifications changed"
+      unconfirmed_email_changed: "E-Mail Changed. Needs activation."
+      unconfirmed_email_not_changed: "E-Mail Change Failed"
     public:
       does_not_exist: "User %{username} does not exist!"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Diaspora::Application.routes.draw do
     get 'public/:username'          => :public,          :as => 'users_public'
     match 'getting_started'         => :getting_started, :as => 'getting_started'
     get 'getting_started_completed' => :getting_started_completed
+    get 'confirm_email/:token'      => :confirm_email,   :as => 'confirm_email'
   end
 
   # This is a hack to overide a route created by devise.

--- a/db/migrate/20110601083310_add_unconfirmed_email_to_users.rb
+++ b/db/migrate/20110601083310_add_unconfirmed_email_to_users.rb
@@ -1,0 +1,9 @@
+class AddUnconfirmedEmailToUsers < ActiveRecord::Migration
+  def self.up
+    add_column :users, :unconfirmed_email, :string, :default => nil, :null => true
+  end
+
+  def self.down
+    remove_column :users, :unconfirmed_email
+  end
+end

--- a/db/migrate/20110601091059_add_confirm_email_token_to_users.rb
+++ b/db/migrate/20110601091059_add_confirm_email_token_to_users.rb
@@ -1,0 +1,9 @@
+class AddConfirmEmailTokenToUsers < ActiveRecord::Migration
+  def self.up
+    add_column :users, :confirm_email_token, :string, :limit => 30
+  end
+
+  def self.down
+    remove_column :users, :confirm_email_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20110527135552) do
+ActiveRecord::Schema.define(:version => 20110601091059) do
 
   create_table "aspect_memberships", :force => true do |t|
     t.integer  "aspect_id",  :null => false
@@ -369,6 +369,8 @@ ActiveRecord::Schema.define(:version => 20110527135552) do
     t.integer  "invited_by_id"
     t.string   "invited_by_type"
     t.string   "authentication_token",   :limit => 30
+    t.string   "unconfirmed_email"
+    t.string   "confirm_email_token",    :limit => 30
   end
 
   add_index "users", ["authentication_token"], :name => "index_users_on_authentication_token", :unique => true

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -180,4 +180,31 @@ describe UsersController do
       response.should redirect_to new_user_session_path
     end
   end
+
+  describe '#confirm_email' do
+    before do
+      @user.update_attribute(:unconfirmed_email, 'my@newemail.com')
+    end
+
+    it 'redirects to to the user edit page' do
+      get 'confirm_email', :token => @user.confirm_email_token
+      response.should redirect_to edit_user_path
+    end
+
+    it 'confirms email' do
+      get 'confirm_email', :token => @user.confirm_email_token
+      @user.reload
+      @user.email.should eql('my@newemail.com')
+      request.flash[:notice].should eql(I18n.t('users.confirm_email.email_confirmed', :email => 'my@newemail.com'))
+      request.flash[:error].should be_blank
+    end
+    
+    it 'does NOT confirm email with wrong token' do
+      get 'confirm_email', :token => @user.confirm_email_token.reverse
+      @user.reload
+      @user.email.should_not eql('my@newemail.com')
+      request.flash[:error].should eql(I18n.t('users.confirm_email.email_not_confirmed'))
+      request.flash[:notice].should be_blank
+    end
+  end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -108,6 +108,32 @@ describe UsersController do
       end
     end
 
+    describe 'email' do
+      it 'allow the user to change his (unconfirmed) email' do
+        put(:update, :id => @user.id, :user => { :email => "my@newemail.com"})
+        @user.reload
+        @user.unconfirmed_email.should eql("my@newemail.com")
+      end
+      
+      it 'informs the user about success' do
+        put(:update, :id => @user.id, :user => { :email => "my@newemail.com"})
+        request.flash[:notice].should eql(I18n.t('users.update.unconfirmed_email_changed'))
+        request.flash[:error].should be_blank
+      end
+      
+      it 'informs the user about failure' do
+        put(:update, :id => @user.id, :user => { :email => "my@newemailcom"})
+        request.flash[:error].should eql(I18n.t('users.update.unconfirmed_email_not_changed'))
+        request.flash[:notice].should be_blank
+      end
+
+      it 'allow the user to change his (unconfirmed) email to blank (= abort confirmation)' do
+        put(:update, :id => @user.id, :user => { :email => ""})
+        @user.reload
+        @user.unconfirmed_email.should eql(nil)
+      end
+    end
+
     describe 'email settings' do
       it 'lets the user turn off mail' do
         par = {:id => @user.id, :user => {:email_preferences => {'mentioned' => 'true'}}}

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -231,7 +231,7 @@ describe Notifier do
       end
 
       it 'has the activation link in the body' do
-        pending
+        confirm_email.body.encoded.should include(confirm_email_url(:token => user.confirm_email_token))
       end
 
     end

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -207,5 +207,33 @@ describe Notifier do
 
     end
 
+    describe ".confirm_email" do
+      before do
+        user.update_attribute(:unconfirmed_email, "my@newemail.com")
+      end
+
+      let!(:confirm_email) { Notifier.confirm_email(user.id) }
+      
+      it 'goes to the right person' do
+        confirm_email.to.should == [user.unconfirmed_email]
+      end
+
+      it 'has the unconfirmed emil in the subject' do
+        confirm_email.subject.should include(user.unconfirmed_email)
+      end
+
+      it 'has the unconfirmed emil in the body' do
+        confirm_email.body.encoded.should include(user.unconfirmed_email)
+      end
+
+      it 'has the receivers name in the body' do
+        confirm_email.body.encoded.should include(user.person.profile.first_name)
+      end
+
+      it 'has the activation link in the body' do
+        pending
+      end
+
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -686,7 +686,7 @@ describe User do
         alice.mail_confirm_email.should eql(false)
       end
     end
-    
+
     describe '#confirm_email' do
       context 'on user with unconfirmed email' do
         before do
@@ -729,14 +729,14 @@ describe User do
           user.unconfirmed_email.should eql(nil)
           user.confirm_email_token.should eql(nil)
         end
-        
+
         it 'returns false and does not change anything on blank token' do
           user.confirm_email("").should eql(false)
           user.email.should_not eql("alice@newmail.com")
           user.unconfirmed_email.should eql(nil)
           user.confirm_email_token.should eql(nil)
         end
-        
+
         it 'returns false and does not change anything on blank token' do
           user.confirm_email(nil).should eql(false)
           user.email.should_not eql("alice@newmail.com")

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -113,6 +113,11 @@ describe User do
         alice.email = eve.email
         alice.should_not be_valid
       end
+      
+      it "requires a vaild email address" do
+        alice.email = "somebody@anywhere"
+        alice.should_not be_valid
+      end
     end
 
     describe "of language" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -686,5 +686,64 @@ describe User do
         alice.mail_confirm_email.should eql(false)
       end
     end
+    
+    describe '#confirm_email' do
+      context 'on user with unconfirmed email' do
+        before do
+          user.update_attribute(:unconfirmed_email, "alice@newmail.com")
+        end
+
+        it 'confirms email and set the unconfirmed_email to email on valid token' do
+          user.confirm_email(user.confirm_email_token).should eql(true)
+          user.email.should eql("alice@newmail.com")
+          user.unconfirmed_email.should eql(nil)
+          user.confirm_email_token.should eql(nil)
+        end
+
+        it 'returns false and does not change anything on wrong token' do
+          user.confirm_email(user.confirm_email_token.reverse).should eql(false)
+          user.email.should_not eql("alice@newmail.com")
+          user.unconfirmed_email.should_not eql(nil)
+          user.confirm_email_token.should_not eql(nil)
+        end
+        
+        it 'returns false and does not change anything on blank token' do
+          user.confirm_email("").should eql(false)
+          user.email.should_not eql("alice@newmail.com")
+          user.unconfirmed_email.should_not eql(nil)
+          user.confirm_email_token.should_not eql(nil)
+        end
+        
+        it 'returns false and does not change anything on blank token' do
+          user.confirm_email(nil).should eql(false)
+          user.email.should_not eql("alice@newmail.com")
+          user.unconfirmed_email.should_not eql(nil)
+          user.confirm_email_token.should_not eql(nil)
+        end
+      end
+
+      context 'on user without unconfirmed email' do
+        it 'returns false and does not change anything on any token' do
+          user.confirm_email("12345"*6).should eql(false)
+          user.email.should_not eql("alice@newmail.com")
+          user.unconfirmed_email.should eql(nil)
+          user.confirm_email_token.should eql(nil)
+        end
+        
+        it 'returns false and does not change anything on blank token' do
+          user.confirm_email("").should eql(false)
+          user.email.should_not eql("alice@newmail.com")
+          user.unconfirmed_email.should eql(nil)
+          user.confirm_email_token.should eql(nil)
+        end
+        
+        it 'returns false and does not change anything on blank token' do
+          user.confirm_email(nil).should eql(false)
+          user.email.should_not eql("alice@newmail.com")
+          user.unconfirmed_email.should eql(nil)
+          user.confirm_email_token.should eql(nil)
+        end
+      end
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -673,5 +673,18 @@ describe User do
         user.confirm_email_token.size.should eql(30)
       end
     end
+    
+    describe '#mail_confirm_email' do
+      it 'enqueues a mail job on user with unconfirmed email' do
+        user.update_attribute(:unconfirmed_email, "alice@newmail.com")
+        Resque.should_receive(:enqueue).with(Job::MailConfirmEmail, alice.id).once
+        alice.mail_confirm_email.should eql(true)
+      end
+
+      it 'enqueues NO mail job on user without unconfirmed email' do
+        Resque.should_not_receive(:enqueue).with(Job::MailConfirmEmail, alice.id)
+        alice.mail_confirm_email.should eql(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
I implemented a basic version with confirmation over e-mail and some specs. 

Since this is my first non-trivial commit to diaspora it would be nice to have some opinions on the code. 
- Are there any (coding) rules/principles I ignored?
- In Notifier.confirm_email I skipped to call log_mail, because there is no obvious sender/sender_id. Is this required?
- I would like to move the new code in user.rb to a encapsulating UserModule (Diaspora::UserModules::ConfirmEmail). D'accord?
- After your go, I would also like to add german translations for the new strings in en.yml

Thanks in advance for any advice/hint.
