### PR TITLE
Issue #1050: Changed cancel-link of a new message to back

### DIFF
--- a/app/views/conversations/new.haml
+++ b/app/views/conversations/new.haml
@@ -51,4 +51,4 @@
 
       .text-right
         = conversation.submit t('.send'), :disable_with => t('shared.publisher.posting'), :class => 'button'
-        = link_to t('cancel'), conversations_path
+        = link_to t('cancel'), :back


### PR DESCRIPTION
Hi,
this is my first pull request. I'm new to diaspora, ruby, rails, git and github. ;-) I hope my (little) bugfix isn't that wrong.
Cheers
ndee
