### PR TITLE
Adds ability to parse plain-text tags

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -20,6 +20,7 @@ class ProfilesController < ApplicationController
   def update
     # upload and set new profile photo
     params[:profile] ||= {}
+    params[:tags] << params[:profile][:tag_string] unless params[:profile][:tag_string].nil?
     params[:profile][:tag_string] = (params[:tags]) ? params[:tags].gsub(',',' ') : ""
     params[:profile][:searchable] ||= false
     params[:profile][:photo] = Photo.where(:author_id => current_user.person.id,

--- a/spec/controllers/profiles_controller_spec.rb
+++ b/spec/controllers/profiles_controller_spec.rb
@@ -49,6 +49,15 @@ describe ProfilesController do
       put :update, params
       @user.person(true).profile.tag_list.to_set.should == ['apples', 'oranges'].to_set
     end
+    
+    it 'sets plaintext tags' do
+      params = { :id => @user.person.id,
+                 :tags => ',#apples,#oranges,',
+                 :profile => {:tag_string => '#pears'} }
+      
+      put :update, params
+      @user.person(true).profile.tag_list.to_set.should == ['apples', 'oranges', 'pears'].to_set
+    end
 
     context 'with a profile photo set' do
       before do


### PR DESCRIPTION
Tags that haven't been autocompleted and clicked on will be
added as tags as well. There should only be one tag like this
at a time, since adding a space between tags turns it into
a list item.
