### PR TITLE
correct reference to ./config/app.yml

### DIFF
--- a/public/default.html
+++ b/public/default.html
@@ -112,7 +112,7 @@
             <li>
               <h2>Configure your <abbr class="helpful" title="A Diaspora installation">pod</abbr></h2>
               <img src='images/icons/cog.png'/>
-              <p>Look at <code class="helpful" title='General pod configuration (location to upload photos, SSL certs, etc.)'>config/app.yml.example</code> and <code class="helpful" title="mySQL username/password">config/database.yml.example</code> for help.</p>
+              <p>Look at <code class="helpful" title='General pod configuration (location to upload photos, SSL certs, etc.)'>config/application.yml.example</code> and <code class="helpful" title="mySQL username/password">config/database.yml.example</code> for help.</p>
             </li>
 
             <li>


### PR DESCRIPTION
The page that is initially shown after starting diaspora for the first
time tells the administrator to customize `./config/app.yml.example`,
which doesn't exist. The file is actually called
`./config/application.yml.example`.
