### PR TITLE
Corrected german translation (from noun to verb for 'mention')

### DIFF
--- a/config/locales/diaspora/de.yml
+++ b/config/locales/diaspora/de.yml
@@ -439,7 +439,7 @@ de:
       does_not_exist: "Person existiert nicht!"
       edit: "Bearbeiten"
       incoming_request: "Du hast eine eingehende Anfrage von dieser Person."
-      mention: "Erwähnung"
+      mention: "Erwähnen"
       message: "Nachricht"
       no_posts: "Keine Beiträge zum Anzeigen!"
       not_connected: "Du teilst nicht mit dieser Person"


### PR DESCRIPTION
Just a minor correction in the German translation:
the button to mention a user should be labelled 'Erwähnen' (verb) instead of 'Erwähnung' (noun).
