### PR TITLE
sort new private messages on top to not have to scroll

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -11,7 +11,7 @@ class Conversation < ActiveRecord::Base
 
   has_many :conversation_visibilities, :dependent => :destroy
   has_many :participants, :class_name => 'Person', :through => :conversation_visibilities, :source => :person
-  has_many :messages, :order => 'created_at ASC'
+  has_many :messages, :order => 'created_at DESC'
 
   belongs_to :author, :class_name => 'Person'
 


### PR DESCRIPTION
Had several people complain about that, especially when the conversation has more than 10 messages. I for one have two conversations with 50+ messages, it‘s a pain.

Hopefully this suffices to change it, first dip in Ruby code.
