### PR TITLE
sort new private messages on top, descending

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -11,7 +11,7 @@ class Conversation < ActiveRecord::Base
 
   has_many :conversation_visibilities, :dependent => :destroy
   has_many :participants, :class_name => 'Person', :through => :conversation_visibilities, :source => :person
-  has_many :messages, :order => 'created_at ASC'
+  has_many :messages, :order => 'created_at DESC'
 
   belongs_to :author, :class_name => 'Person'
 

--- a/app/views/conversations/_show.haml
+++ b/app/views/conversations/_show.haml
@@ -20,8 +20,6 @@
 %br
 .span-15.last
   .stream
-    = render :partial => 'messages/message', :collection => conversation.messages
-
     .stream_element.new_message
       = owner_image_tag(:thumb_small)
 
@@ -31,3 +29,5 @@
           .right
             = message.submit t('cancel'), :name => "reset", :id => "reset_button", :type => "reset", :class => "button", :tabindex => 3
             = message.submit t('.reply').capitalize, :class => 'button creation', :tabindex => 2
+
+    = render :partial => 'messages/message', :collection => conversation.messages


### PR DESCRIPTION
Had several people complain about that, especially when the conversation has more than 10 messages. I for one have two conversations with 50+ messages, it‘s a pain.

Hopefully this suffices to change both sorting order and display of new message box on top. First dip in Ruby code & can‘t test it at the moment.
