### PR TITLE
Fix issue #1410, remove cancel button in messages conversation

### DIFF
--- a/app/views/conversations/_show.haml
+++ b/app/views/conversations/_show.haml
@@ -29,5 +29,4 @@
         = form_for [conversation, Message.new] do |message|
           = message.text_area :text, :rows => 5, :tabindex => 1
           .right
-            = message.submit t('cancel'), :name => "reset", :id => "reset_button", :type => "reset", :class => "button", :tabindex => 3
             = message.submit t('.reply').capitalize, :class => 'button creation', :tabindex => 2

--- a/app/views/conversations/new.haml
+++ b/app/views/conversations/new.haml
@@ -50,5 +50,4 @@
       .clearfix
 
       .bottom_submit_section
-        = submit_tag t('cancel'), :class => 'button', :type => :reset, :rel => "close", :confirm => t('.abandon_changes')
         = conversation.submit t('.send'), :disable_with => t('shared.publisher.posting'), :class => 'button creation'


### PR DESCRIPTION
Cancel button removed for private messages. Reasoning at http://github.com/diaspora/diaspora/issues/1410#issuecomment-1613473
