### PR TITLE
Issue #1126 - When the last photo is deleted from the publisher, we now c

### DIFF
--- a/app/views/photos/_new_photo.haml
+++ b/app/views/photos/_new_photo.haml
@@ -72,6 +72,10 @@
                               if ( $('.publisher_photo').length  == 0){
                                 textarea.removeClass("with_attachments");
                                 textarea.css('paddingBottom', '');
+
+                                if( $('#status_message_text').attr("value") == ""){
+                                  Publisher.close()
+                                }
                               }
                             });
                           }

--- a/features/posts.feature
+++ b/features/posts.feature
@@ -37,6 +37,38 @@ Feature: posting
       And I go to "bob@bob.bob"'s page
       Then I should see a "img" within ".stream_element:first div.photo_attachments"
 
+    Scenario: back out of posting a photo-only post
+      Given I expand the publisher
+      And I have turned off jQuery effects
+      When I attach the file "spec/fixtures/button.png" to hidden element "file" within "#file-upload"
+      And I wait for the ajax to finish
+      And I click to delete the first uploaded photo
+      And I wait for the ajax to finish
+      Then I should not see an uploaded image within the photo drop zone
+      And the publisher should be collapsed
+
+    Scenario: back out of uploading a picture to a post with text
+      Given I expand the publisher
+      And I have turned off jQuery effects
+      When I fill in "status_message_fake_text" with "I am eating a yogurt"
+      And I attach the file "spec/fixtures/button.png" to hidden element "file" within "#file-upload"
+      And I wait for the ajax to finish
+      And I click to delete the first uploaded photo
+      And I wait for the ajax to finish
+      Then I should not see an uploaded image within the photo drop zone
+      And the publisher should be expanded
+
+    Scenario: back out of uploading a picture when another has been attached
+      Given I expand the publisher
+      And I have turned off jQuery effects
+      When I fill in "status_message_fake_text" with "I am eating a yogurt"
+      And I attach the file "spec/fixtures/button.png" to hidden element "file" within "#file-upload"
+      And I attach the file "spec/fixtures/button.png" to hidden element "file" within "#file-upload"
+      And I wait for the ajax to finish
+      And I click to delete the first uploaded photo
+      And I wait for the ajax to finish
+      Then I should see an uploaded image within the photo drop zone
+      And the publisher should be expanded
 
     Scenario: post a photo with text
       Given I expand the publisher

--- a/features/step_definitions/custom_web_steps.rb
+++ b/features/step_definitions/custom_web_steps.rb
@@ -11,6 +11,14 @@ And /^I expand the publisher$/ do
     ')
 end
 
+Then /^the publisher should be collapsed$/ do
+	find("#publisher")["class"].should include("closed")
+end
+
+Then /^the publisher should be expanded$/ do
+	find("#publisher")["class"].should_not include("closed")
+end
+
 When /^I append "([^"]*)" to the publisher$/ do |stuff|
   # Wait for the publisher to appear and all the elements to lay out
   wait_until { evaluate_script("$('#status_message_fake_text').focus().length == 1") }
@@ -46,6 +54,10 @@ end
 
 When /^I click to delete the first comment$/ do
   page.execute_script('$(".comment.posted").first().find(".comment_delete").click()')
+end
+
+When /^I click to delete the first uploaded photo$/ do
+  page.execute_script('$("#photodropzone").find(".x").first().click()')
 end
 
 And /^I click "([^"]*)" button$/ do |arg1|

--- a/features/step_definitions/posts_steps.rb
+++ b/features/step_definitions/posts_steps.rb
@@ -8,3 +8,7 @@ end
 Then /^I should see an uploaded image within the photo drop zone$/ do
   find("#photodropzone img")["src"].should include("uploads/images")
 end
+
+Then /^I should not see an uploaded image within the photo drop zone$/ do
+  find("#photodropzone img").should be_nil
+end


### PR DESCRIPTION
Issue #1126 - When the last photo is deleted from the publisher, we now collapse the publisher if no status text had been entered.
