### PR TITLE
Fix #1486 profile update was crashing with invalid birthday date

### DIFF
--- a/spec/controllers/profiles_controller_spec.rb
+++ b/spec/controllers/profiles_controller_spec.rb
@@ -68,6 +68,32 @@ describe ProfilesController do
       @user.person(true).profile.tag_list.to_set.should == ['apples', 'oranges', 'bananas'].to_set
     end
 
+    it 'sets valid birthday' do
+      params = { :id => @user.person.id,
+                 :profile => {
+                   :date => {
+                     :year => '2001',
+                     :month => '02',
+                     :day => '28' } } }
+
+      put :update, params
+      @user.person(true).profile.birthday.year.should == 2001
+      @user.person(true).profile.birthday.month.should == 2
+      @user.person(true).profile.birthday.day.should == 28
+    end
+
+    it 'displays error for invalid birthday' do
+      params = { :id => @user.person.id,
+                 :profile => {
+                   :date => {
+                     :year => '2001',
+                     :month => '02',
+                     :day => '31' } } }
+
+      put :update, params
+      flash[:error].should_not be_blank
+    end
+
     context 'with a profile photo set' do
       before do
         @params = { :id => @user.person.id,

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -183,6 +183,20 @@ describe Profile do
       profile.date = { 'year' => '2001', 'month' => '', 'day' => ''}
       profile.birthday.should == nil
     end
+
+    it 'does not accept invalid dates' do
+      profile.birthday = nil
+      profile.date = { 'year' => '2001', 'month' => '02', 'day' => '31' }
+      profile.birthday.should == nil
+    end
+
+    it 'does not change with invalid dates' do
+      profile.birthday = Date.new(2000, 1, 1)
+      profile.date = { 'year' => '2001', 'month' => '02', 'day' => '31' }
+      profile.birthday.year.should == 2000
+      profile.birthday.month.should == 1
+      profile.birthday.day.should == 1
+    end
   end
 
   describe 'tags' do


### PR DESCRIPTION
Closes #1486 issue, crashing when updating profile with an invalid bithday date, say Febraury 31st.
An exception was getting raised on the date setter (date=()) when trying to create a Date object with the invalid date values.
