### PR TITLE
[PaperCut] add underlining for hovered tags

### DIFF
--- a/public/stylesheets/sass/application.sass
+++ b/public/stylesheets/sass/application.sass
@@ -2609,7 +2609,7 @@ ul.show_comments,
   :display inline-block
   &:hover
     :text
-      :decoration none
+      :decoration underline
     :background
       :color lighten($blue, 47%)
 


### PR DESCRIPTION
Sorry, I was thinking about the hash tags again and I think that changing the background slightly is not enough.
Maybe we should also underline them when hovered.
