### PR TITLE
Issue #1431: Suggest when the first letter typed, not the third

### DIFF
--- a/app/views/conversations/new.haml
+++ b/app/views/conversations/new.haml
@@ -12,7 +12,7 @@
       searchObjProps: "name",
       asHtmlID: "contact_ids",
       retrieveLimit: 10,
-      minChars: 3,
+      minChars: 1,
       keyDelay: 0,
       startText: '',
       emptyText: '#{t('no_results')}',


### PR DESCRIPTION
Closes issue #1431.
The contact suggest now fires when the first letter is typed, not the third.
This is a problem when you have contacts with less than 3 letters name.
