### PR TITLE
Refactor conversations creation

### DIFF
--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -28,6 +28,8 @@ class ConversationsController < ApplicationController
 
     params[:conversation][:participant_ids] = person_ids | [current_user.person.id]
     params[:conversation][:author] = current_user.person
+    message_text = params[:conversation].delete(:text)
+    params[:conversation][:messages_attributes] = [ {:author => current_user.person, :text => message_text }]
 
     if @conversation = Conversation.create(params[:conversation])
       Postzord::Dispatch.new(current_user, @conversation).post

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -15,15 +15,7 @@ class Conversation < ActiveRecord::Base
 
   belongs_to :author, :class_name => 'Person'
 
-  def self.create(opts={})
-    opts = opts.dup
-    msg_opts = {:author => opts[:author], :text => opts.delete(:text)}
-
-    cnv = super(opts)
-    message = Message.new(msg_opts.merge({:conversation_id => cnv.id}))
-    message.save
-    cnv
-  end
+  accepts_nested_attributes_for :messages
 
   def recipients
     self.participants - [self.author]

--- a/spec/controllers/conversation_visibilities_controller_spec.rb
+++ b/spec/controllers/conversation_visibilities_controller_spec.rb
@@ -9,8 +9,12 @@ describe ConversationVisibilitiesController do
     @user1 = alice
     sign_in :user, @user1
 
-    hash = { :author => @user1.person, :participant_ids => [@user1.contacts.first.person.id, @user1.person.id],
-             :subject => 'not spam', :text => 'cool stuff'}
+    hash = {
+      :author => @user1.person,
+      :participant_ids => [@user1.contacts.first.person.id, @user1.person.id],
+      :subject => 'not spam',
+      :messages_attributes => [ {:author => @user1.person, :text => 'cool stuff'} ]
+    }
     @conversation = Conversation.create(hash)
   end
 

--- a/spec/controllers/conversations_controller_spec.rb
+++ b/spec/controllers/conversations_controller_spec.rb
@@ -40,8 +40,12 @@ describe ConversationsController do
     end
 
     it 'retrieves all conversations for a user' do
-      hash = {:author => alice.person, :participant_ids => [alice.contacts.first.person.id, alice.person.id],
-              :subject => 'not spam', :text => 'cool stuff'}
+      hash = {
+        :author => alice.person,
+        :participant_ids => [alice.contacts.first.person.id, alice.person.id],
+        :subject => 'not spam',
+        :messages_attributes => [ {:author => alice.person, :text => 'cool stuff'} ]
+      }
       3.times { Conversation.create(hash) }
 
       get :index
@@ -80,8 +84,13 @@ describe ConversationsController do
 
     it 'dispatches the conversation' do
       cnv = Conversation.create(
-        @hash[:conversation].merge({:author => alice.person, :participant_ids => [alice.contacts.first.person.id]}))
-
+        {
+          :author => alice.person,
+          :participant_ids => [alice.contacts.first.person.id, alice.person.id],
+          :subject => 'not spam',
+          :messages_attributes => [ {:author => alice.person, :text => 'cool stuff'} ]
+        }
+      )
       p = Postzord::Dispatch.new(alice, cnv)
       Postzord::Dispatch.stub!(:new).and_return(p)
       p.should_receive(:post)
@@ -91,8 +100,12 @@ describe ConversationsController do
 
   describe '#show' do
     before do
-      hash = {:author => alice.person, :participant_ids => [alice.contacts.first.person.id, alice.person.id],
-              :subject => 'not spam', :text => 'cool stuff'}
+      hash = {
+        :author => alice.person,
+        :participant_ids => [alice.contacts.first.person.id, alice.person.id],
+        :subject => 'not spam',
+        :messages_attributes => [ {:author => alice.person, :text => 'cool stuff'} ]
+      }
       @conversation = Conversation.create(hash)
     end
 

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -17,8 +17,12 @@ describe MessagesController do
 
   describe '#create' do
     before do
-      @create_hash = { :author => @user1.person, :participant_ids => [@user1.contacts.first.person.id, @user1.person.id],
-                       :subject => "cool stuff", :text => "stuff"}
+      @create_hash = {
+        :author => @user1.person,
+        :participant_ids => [@user1.contacts.first.person.id, @user1.person.id],
+        :subject => 'cool stuff',
+        :messages_attributes => [ {:author => @user1.person, :text => 'stuff'} ]
+      }
     end
 
     context "on my own post" do

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -134,8 +134,12 @@ describe Notifier do
       @user2 = bob
       @participant_ids = @user2.contacts.map{|c| c.person.id} + [ @user2.person.id]
 
-      @create_hash = { :author => @user2.person, :participant_ids => @participant_ids ,
-                       :subject => "cool stuff", :text => 'hey'}
+      @create_hash = {
+        :author => @user2.person,
+        :participant_ids => @participant_ids,
+        :subject => "cool stuff",
+        :messages_attributes => [ {:author => @user2.person, :text => 'hey'} ]
+      }
 
       @cnv = Conversation.create(@create_hash)
 

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -10,8 +10,12 @@ describe Conversation do
     @user2 = bob
     @participant_ids = [@user1.contacts.first.person.id, @user1.person.id]
 
-    @create_hash = { :author => @user1.person, :participant_ids => @participant_ids ,
-                     :subject => "cool stuff", :text => 'hey'}
+    @create_hash = {
+      :author => @user1.person,
+      :participant_ids => @participant_ids,
+      :subject => "cool stuff",
+      :messages_attributes => [ {:author => @user1.person, :text => 'hey'} ]
+    }
   end
 
   it 'creates a message on create' do
@@ -60,8 +64,8 @@ describe Conversation do
 
     describe '#receive' do
       before do
-        Conversation.destroy_all
         Message.destroy_all
+        Conversation.destroy_all
       end
 
       it 'creates a message' do

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -10,8 +10,12 @@ describe Message do
     @user1 = alice
     @user2 = bob
 
-    @create_hash = { :author => @user1.person, :participant_ids => [@user1.contacts.first.person.id, @user1.person.id],
-                     :subject => "cool stuff", :text => "stuff"}
+    @create_hash = {
+      :author => @user1.person,
+      :participant_ids => [@user1.contacts.first.person.id, @user1.person.id],
+      :subject => "cool stuff",
+      :messages_attributes => [ {:author => @user1.person, :text => 'stuff'} ]
+    }
 
     @cnv = Conversation.create(@create_hash)
     @message = @cnv.messages.first
@@ -64,8 +68,12 @@ describe Message do
     before do
       @local_luke, @local_leia, @remote_raphael = set_up_friends
 
-      cnv_hash = {:author => @remote_raphael, :participant_ids => [@local_luke.person, @local_leia.person, @remote_raphael].map(&:id),
-                  :subject => 'cool story, bro', :text => 'hey'}
+      cnv_hash = {
+        :author => @remote_raphael,
+        :participant_ids => [@local_luke.person, @local_leia.person, @remote_raphael].map(&:id),
+        :subject => 'cool story, bro',
+        :messages_attributes => [ {:author => @remote_raphael, :text => 'hey'} ]
+      }
 
       @remote_parent = Conversation.create(cnv_hash.dup)
 

--- a/spec/models/notifications/private_message_spec.rb
+++ b/spec/models/notifications/private_message_spec.rb
@@ -9,8 +9,12 @@ describe Notifications::PrivateMessage do
       @user1 = alice
       @user2 = bob
 
-      @create_hash = { :author => @user1.person, :participant_ids => [@user1.contacts.first.person.id, @user1.person.id],
-                       :subject => "cool stuff", :text => "stuff"}
+      @create_hash = {
+        :author => @user1.person,
+        :participant_ids => [@user1.contacts.first.person.id, @user1.person.id],
+        :subject => 'cool stuff',
+        :messages_attributes => [ {:author => @user1.person, :text => 'stuff'} ]
+      }
 
       @cnv = Conversation.create(@create_hash)
       @msg = @cnv.messages.first


### PR DESCRIPTION
All began when i was trying to tackle issue #1329 which consisted of validating that conversations had recipients and not blank text on it's creation.
The manual way the conversation was being created made this task a little nasty. For example, deleting the created message when the conversation was invalid.
Then i questioned why we weren't using `accept_nested_attributes_for :messages`, which is basically the refactor itself.
With this change, making validations work, either for converstations or messages, it just a matter of adding the standard model ones.

Opinions? 
