### PR TITLE
Show 4 comments if there are less than 5 comments, otherwise the last 3 comments only

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -118,8 +118,14 @@ class Post < ActiveRecord::Base
   end
 
   # @return [Array<Comment>]
-  def last_three_comments
-    self.comments.order('created_at DESC').limit(3).includes(:author => :profile).reverse
+  def last_three_or_four_comments
+    last_comments = self.comments.order('created_at DESC').limit(5).includes(:author => :profile).reverse
+    
+    if last_comments.length>4
+      last_comments.last(3)
+    else
+      last_comments.last(4)
+    end
   end
 end
 

--- a/app/views/comments/_comments.haml
+++ b/app/views/comments/_comments.haml
@@ -8,7 +8,7 @@
 
 %ul.comments{:class => ('loaded' if post.comments.size <= 3)}
   -if post.comments.size > 3 && !comments_expanded
-    = render :partial => 'comments/comment', :collection => post.last_three_comments, :locals => {:post => post}
+    = render :partial => 'comments/comment', :collection => post.last_three_or_four_comments, :locals => {:post => post}
   -else
     = render :partial => 'comments/comment', :collection => post.comments, :locals => {:post => post}
 

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -62,11 +62,23 @@ describe Post do
     it 'returns the last three comments of a post' do
       post = bob.post :status_message, :text => "hello", :to => 'all'
       created_at = Time.now - 100
+      comments = [alice, eve, bob, alice, eve].map do |u|
+        created_at = created_at + 10
+        u.comment("hey", :post => post, :created_at => created_at)
+      end
+      post.last_three_or_four_comments.map{|c| c.id}.should == comments.last(3).map{|c| c.id}
+    end
+  end
+
+  describe '#last_four_comments' do
+    it 'returns the last four comments of a post (if there are only four comments)' do
+      post = bob.post :status_message, :text => "hello", :to => 'all'
+      created_at = Time.now - 100
       comments = [alice, eve, bob, alice].map do |u|
         created_at = created_at + 10
         u.comment("hey", :post => post, :created_at => created_at)
       end
-      post.last_three_comments.map{|c| c.id}.should == comments[1,3].map{|c| c.id}
+      post.last_three_or_four_comments.map{|c| c.id}.should == comments.last(4).map{|c| c.id}
     end
   end
 


### PR DESCRIPTION
A link labeled 'Show 1 more comment' is kind of stupid. Show in this one comment right away takes the same space on the page and makes more sense.

So if there are 4 comments all 4 comments are shown. If there are more than 4 comments only the last 3 comments are shown.
