### PR TITLE
Add Commentable Mixin

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -59,7 +59,7 @@ class LikesController < ApplicationController
       current_user.find_visible_post_by_id(params[:post_id])
     else
       comment = Comment.find(params[:comment_id])
-      comment = nil unless current_user.find_visible_post_by_id(comment.post_id)
+      comment = nil unless current_user.find_visible_post_by_guid(comment.post_guid)
       comment
     end
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -23,7 +23,7 @@ class Comment < ActiveRecord::Base
   xml_attr :text
   xml_attr :diaspora_handle
 
-  belongs_to :post, :touch => true
+  belongs_to :post, :touch => true, :foreign_key => :post_guid, :primary_key => :guid
   belongs_to :author, :class_name => 'Person'
 
   validates_presence_of :text, :post

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -10,12 +10,11 @@ class Post < ActiveRecord::Base
   include Diaspora::Guid
 
   include Diaspora::Likeable
+  include Diaspora::Commentable
 
   xml_attr :diaspora_handle
   xml_attr :public
   xml_attr :created_at
-
-  has_many :comments, :dependent => :destroy
 
   has_many :aspect_visibilities
   has_many :aspects, :through => :aspect_visibilities
@@ -115,11 +114,6 @@ class Post < ActiveRecord::Base
 
   def activity_streams?
     false
-  end
-
-  # @return [Array<Comment>]
-  def last_three_comments
-    self.comments.order('created_at DESC').limit(3).includes(:author => :profile).reverse
   end
 end
 

--- a/app/views/comments/_comment.html.haml
+++ b/app/views/comments/_comment.html.haml
@@ -5,7 +5,7 @@
 %li.comment.posted{:id => comment.guid, :class => ("hidden" if(defined? hidden))}
   - if current_user && (current_user.owns?(comment) || current_user.owns?(post))
     .right.controls
-      = link_to image_tag('deletelabel.png'), post_comment_path(comment.post_id, comment), :confirm => t('are_you_sure'), :method => :delete, :remote => true, :class => "delete comment_delete", :title => t('delete')
+      = link_to image_tag('deletelabel.png'), post_comment_path(comment.post_guid, comment), :confirm => t('are_you_sure'), :method => :delete, :remote => true, :class => "delete comment_delete", :title => t('delete')
   = person_image_link(comment.author, :size => :thumb_small)
   .content
     %span.from

--- a/db/migrate/20110814175007_link_comments_to_post_by_guid.rb
+++ b/db/migrate/20110814175007_link_comments_to_post_by_guid.rb
@@ -1,0 +1,27 @@
+class LinkCommentsToPostByGuid < ActiveRecord::Migration
+  def self.up
+    add_column :comments, :post_guid, :string, :null => false
+    add_index "comments", ["post_guid"], :name => "index_comments_on_post_guid"
+ 
+    execute <<-SQL
+      UPDATE comments SET comments.post_guid = 
+        (SELECT posts.guid FROM posts WHERE posts.id = comments.post_id)
+    SQL
+
+    remove_foreign_key :comments, :post
+    remove_column :comments, :post_id
+  end
+
+  def self.down
+    add_column :comments, :post_id, :integer, :null => false
+    add_foreign_key :comments, :posts
+    add_index "comments", ["post_id"], :name => "index_comments_on_post_id"
+
+    execute <<-SQL
+      UPDATE comments SET comments.post_id = 
+        (SELECT posts.id FROM posts WHERE posts.guid = comments.post_guid)
+    SQL
+    
+    remove_column :comments, :post_guid
+  end
+end

--- a/lib/diaspora/commentable.rb
+++ b/lib/diaspora/commentable.rb
@@ -1,0 +1,18 @@
+#   Copyright (c) 2010, Diaspora Inc.  This file is
+#   licensed under the Affero General Public License version 3 or later.  See
+#   the COPYRIGHT file.
+
+module Diaspora
+  module Commentable
+    def self.included(model)
+      model.instance_eval do
+        has_many :comments, :foreign_key => :post_guid, :primary_key => :guid, :dependent => :destroy
+      end
+    end
+
+    # @return [Array<Comment>]
+    def last_three_comments
+      self.comments.order('created_at DESC').limit(3).includes(:author => :profile).reverse
+    end
+  end
+end

--- a/lib/diaspora/user/querying.rb
+++ b/lib/diaspora/user/querying.rb
@@ -13,6 +13,10 @@ module Diaspora
         post ||= Post.where(key => id, :public => true).where(opts).first
       end
 
+      def find_visible_post_by_guid( guid, opts={} )
+        find_visible_post_by_id( guid, opts={:key => :guid} )
+      end
+
       def visible_posts(opts = {})
         defaults = {
           :type => ['StatusMessage', 'Photo'],


### PR DESCRIPTION
The current problem with the Comments is that they can only be associated with a Post.
This patch allows an association beween any model that has a GUID and a comment.

Background:
If we want Photos not inherit from Posts, we need the foreign key to be the Post's GUID, not the Post's ID.
