### PR TITLE
[PaperCut] Change cursor for lightbox thumbs

### DIFF
--- a/public/stylesheets/sass/lightbox.scss
+++ b/public/stylesheets/sass/lightbox.scss
@@ -105,6 +105,7 @@
     height: 70px;
     width: 70px;
     margin-right: 5px;
+    cursor: pointer;
 
     &:last-child{
       margin-right: 0;


### PR DESCRIPTION
When you hover the thumbnails in the lightbox the cursor stays the same.
This patch will change it to the 'hovered-link cursor'
