### PR TITLE
Refactor aspect listings partial. Splited in two, one for aspects and other for contacts

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -60,22 +60,6 @@ module ApplicationHelper
     @rtl ||= RTL_LANGUAGES.include? I18n.locale
   end
 
-  def controller_index_path
-    kontroller = request.filtered_parameters["controller"]
-    if kontroller.downcase != "contacts"
-      kontroller = "aspects"
-    end
-    self.send((kontroller + "_path").to_sym)
-  end
-
-  def left_nav_root
-    if request.filtered_parameters["controller"] == "contacts"
-      t('contacts.index.my_contacts')
-    else
-      t('aspects.index.your_aspects')
-    end
-  end
-
   def contacts_link
     if current_user.contacts.size > 0
       contacts_path

--- a/app/helpers/aspect_global_helper.rb
+++ b/app/helpers/aspect_global_helper.rb
@@ -49,14 +49,6 @@ module AspectGlobalHelper
     link_to aspect.name, aspects_path( opts[:params] ), opts
   end
 
-  def aspect_listing_link_opts aspect
-    if controller.instance_of?(ContactsController)
-      {:href => contacts_path(:a_id => aspect.id)}
-    else
-      {:href => aspects_path("a_ids[]" => aspect.id), :class => "aspect_selector name hard_aspect_link", 'data-guid' => aspect.id}
-    end
-  end
-
   def aspect_or_all_path(aspect)
     if @aspect.is_a? Aspect
       aspect_path @aspect

--- a/app/views/aspects/_aspect_listings.haml
+++ b/app/views/aspects/_aspect_listings.haml
@@ -4,10 +4,8 @@
 
 %ul#aspect_nav.left_nav
   %li.all_aspects{:class => ("active" if params["set"] != "all" && params["set"] != "only_sharing" && !@featured && !@finder)}
-    %a.home_selector{:href => controller_index_path, :class => ("sub_selected" if params["a_id"])}
-      .contact_count
-        = my_contacts_count
-      = left_nav_root
+    %a.home_selector{:href => aspects_path, :class => ("sub_selected" if params["a_id"])}
+      = t('aspects.index.your_aspects')
 
     %ul.sub_nav
       - for aspect in all_aspects
@@ -15,24 +13,8 @@
           .edit
             = link_to image_tag("icons/pencil.svg", :height => 12, :title => t('contacts.index.edit_aspect', :name => aspect.name)), edit_aspect_path(aspect), :rel => "facebox"
 
-          %a.aspect_selector{aspect_listing_link_opts(aspect)}
-            .contact_count
-              = aspect.contacts.size
+          %a.aspect_selector{:href => aspects_path("a_ids[]" => aspect.id), :class => "aspect_selector name hard_aspect_link", 'data-guid' => aspect.id}
             = aspect
 
       %li
         = link_to t('.add_an_aspect'), new_aspect_path, :class => "new_aspect", :rel => "facebox"
-
-  %li.all_contacts{:class => ("active" if params["set"] == "all" || params["set"] == "only_sharing")}
-    %a.aspect_selector{:href => contacts_path(:set => "all"), :class => ("sub_selected" if params["set"] == "only_sharing")}
-      .contact_count
-        = all_contacts_count
-      = t('contacts.index.all_contacts')
-
-    %ul.sub_nav
-      %li{:class => ("active" if params["set"] == "only_sharing")}
-        %a.aspect_selector{:href => contacts_path(:set => "only_sharing")}
-          .contact_count
-            = only_sharing_count
-          = t('contacts.index.only_sharing_with_me')
-

--- a/app/views/contacts/_aspect_listings.haml
+++ b/app/views/contacts/_aspect_listings.haml
@@ -1,0 +1,35 @@
+-#   Copyright (c) 2010, Diaspora Inc.  This file is
+-#   licensed under the Affero General Public License version 3 or later.  See
+-#   the COPYRIGHT file.
+
+%ul#aspect_nav.left_nav
+  %li.all_aspects{:class => ("active" if params["set"] != "all" && params["set"] != "only_sharing" && !@featured && !@finder)}
+    %a.home_selector{:href => contacts_path, :class => ("sub_selected" if params["a_id"])}
+      .contact_count
+        = my_contacts_count
+      = t('contacts.index.my_contacts')
+
+    %ul.sub_nav
+      - for aspect in all_aspects
+        %li{:data => {:aspect_id => aspect.id}, :class => ("active" if params["a_id"].to_i == aspect.id)}
+          %a.aspect_selector{:href => contacts_path(:a_id => aspect.id)}
+            .contact_count
+              = aspect.contacts.size
+            = aspect
+
+      %li
+        = link_to t('aspects.aspect_listings.add_an_aspect'), new_aspect_path, :class => "new_aspect", :rel => "facebox"
+
+  %li.all_contacts{:class => ("active" if params["set"] == "all" || params["set"] == "only_sharing")}
+    %a.aspect_selector{:href => contacts_path(:set => "all"), :class => ("sub_selected" if params["set"] == "only_sharing")}
+      .contact_count
+        = all_contacts_count
+      = t('contacts.index.all_contacts')
+
+    %ul.sub_nav
+      %li{:class => ("active" if params["set"] == "only_sharing")}
+        %a.aspect_selector{:href => contacts_path(:set => "only_sharing")}
+          .contact_count
+            = only_sharing_count
+          = t('contacts.index.only_sharing_with_me')
+

--- a/app/views/shared/_contact_sidebar.html.haml
+++ b/app/views/shared/_contact_sidebar.html.haml
@@ -3,7 +3,7 @@
 -#   the COPYRIGHT file.
 
 .span-5.append-1
-  = render 'aspects/aspect_listings'
+  = render 'contacts/aspect_listings'
 
   %hr
 

--- a/public/stylesheets/sass/application.sass
+++ b/public/stylesheets/sass/application.sass
@@ -2927,12 +2927,6 @@ ul.left_nav
       :width 182px
 
 .section
-  .contact_count
-    :display none !important
-
-  .all_contacts
-    :display none !important
-
   .left_nav
     a.aspect_selector,
     a.home_selector


### PR DESCRIPTION
Hey guys, just opened this pull request in order to get some feedback..

IMHO this `aspect_listings` partial used in both aspects and contacts page was getting a bit nasty:
- Having a lot of 'only-contacts' code hidden for the home page
- Also for the contacts page side the edit pencils weren't used
- Using helpers with conditional code

I think this could cause:
- difficult to extend the partial if something is needed only on one end
- vulnerable to introduce a bug for one of the pages without noticing
- maybe confusion for new contributors

Thoughts? :D
