### PR TITLE
fixed html markup which broke applied direction

### DIFF
--- a/app/views/comments/_comment.mobile.haml
+++ b/app/views/comments/_comment.mobile.haml
@@ -14,6 +14,6 @@
   .content
     .from
       = person_link(comment.author)
-    %p{ :class => direction_for(comment.text) }
+    %div{ :class => direction_for(comment.text) }
       = markdownify(comment, :youtube_maps => comment[:youtube_titles])
 

--- a/app/views/messages/_message.haml
+++ b/app/views/messages/_message.haml
@@ -11,6 +11,6 @@
       %time.timeago{:datetime => message.created_at}
         = how_long_ago(message)
 
-    %p{ :class => direction_for(message.text) }
+    %div{ :class => direction_for(message.text) }
       = markdownify(message)
 

--- a/app/views/status_messages/_status_message.haml
+++ b/app/views/status_messages/_status_message.haml
@@ -15,5 +15,5 @@
         - for photo in photos[1..photos.size]
           = link_to (image_tag photo.url(:thumb_small), :class => 'stream-photo thumb_small', 'data-small-photo' => photo.url(:thumb_medium), 'data-full-photo' => photo.url), photo_path(photo), :class => 'stream-photo-link'
 
-%p{:class => direction_for(post.text)}
+%div{:class => direction_for(post.text)}
   != markdownify(post, :youtube_maps => post[:youtube_titles])

--- a/public/stylesheets/sass/rtl.sass
+++ b/public/stylesheets/sass/rtl.sass
@@ -256,3 +256,5 @@ ul.left_nav .contact_count, ul.left_nav .edit
   :float left
   :margin-right 10px
 
+div.content span.rtl
+  :display block


### PR DESCRIPTION
checkout commit messages but here's the summary:
- changed display of span tags to block so direction:rtl/ltr could be applied on text
- changed &lt;p class="rtl"&gt;&lt;p&gt;...&lt;/p&gt;&lt;/p&gt; to &lt;div class=&quot;rtl&quot;&gt;&lt;p&gt;...&lt;/p&gt;&lt;/div&gt;
