### PR TITLE
default profile photo is no longer marked as set

### DIFF
--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -29,6 +29,10 @@ module ProfilesHelper
   # @param [Profile, Symbol] Profile and field in question
   # @return [Boolean] The field in question is set?
   def field_filled_out?(profile, field)
-    profile.send("#{field}".to_sym).present?
+    if field != :image_url
+      profile.send("#{field}".to_sym).present?
+    else
+      profile.send("#{field}".to_sym) != "/images/user/default.png" 
+    end
   end
 end

--- a/spec/helpers/profiles_helper.rb
+++ b/spec/helpers/profiles_helper.rb
@@ -17,6 +17,15 @@ describe ProfilesHelper do
       @profile.bio = "abc"
       field_filled_out?(@profile, :bio).should be_true
     end
+
+    it 'returns false if default profile photo is used' do
+      field_filled_out?(@profile, :image_url).should be_false
+    end
+
+    it 'returns true if custom profile photo is set' do
+      @profile.image_url = "abc.jpg"
+      field_filled_out?(@profile, :image_url).should be_true
+    end
   end
 
   describe '#profile_field_tag' do


### PR DESCRIPTION
Fixes a bug on getting_started page. User profile photo should not be marked as set when user has not set his photo. But it is becouse User.profile.send(:image_url) returns path to default picture (string) and helper method field_filled_out? want to see nil value to tell that it is unset.
