### PR TITLE
Make string in authorizations translateable

### DIFF
--- a/app/views/authorizations/index.html.haml
+++ b/app/views/authorizations/index.html.haml
@@ -24,4 +24,4 @@
             = app.description
 
     - else
-      You haven't registered any applications yet.
+      = t('.no_applications')

--- a/app/views/authorizations/index.mobile.haml
+++ b/app/views/authorizations/index.mobile.haml
@@ -20,5 +20,5 @@
           = app.description
 
   - else
-    You haven't registered any applications yet.
+    = t('.no_applications')
 %br

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -800,6 +800,8 @@ en:
   authorizations:
     index:
       revoke_access: "Revoke Access"
+      no_applications: "You haven't registered any applications yet."
+      
 
   users:
     edit:


### PR DESCRIPTION
this make the string 'You haven't registered any applications yet.' in authorizations translateable
