### PR TITLE
removes underline in tag search form on getting started page

### DIFF
--- a/app/views/users/getting_started.haml
+++ b/app/views/users/getting_started.haml
@@ -128,7 +128,7 @@
             = t('.hashtag_explanation')
 
           .span-5.append-1
-            = form_tag(tags_path, :method => 'get', :class => "tag search_form") do
+            = form_tag(tags_path, :method => 'get', :class => "tag_input search_form") do
               = text_field_tag 'q', nil, :placeholder => t(".search_for_hashtags"), :type => 'search', :results => 5
           .span-5.last
             %h4{:style => "margin-top:7px;"}

--- a/public/javascripts/pages/users-getting-started.js
+++ b/public/javascripts/pages/users-getting-started.js
@@ -3,6 +3,6 @@ Diaspora.Pages.UsersGettingStarted = function() {
 
   this.subscribe("page/ready", function(evt, body) {
     self.peopleSearch = self.instantiate("Search", body.find("form.people.search_form"));
-    self.tagSearch = self.instantiate("Search", body.find("form.tag.search_form"));
+    self.tagSearch = self.instantiate("Search", body.find("form.tag_input.search_form"));
   });
 };


### PR DESCRIPTION
search hashtag input field has the same class (tag) as regular hashtags in comments and text in that field is underlined (only firefox issue)
