### PR TITLE
Fix #1960: User menu inaccessible for people with low resolutions

### DIFF
--- a/public/javascripts/view.js
+++ b/public/javascripts/view.js
@@ -4,6 +4,13 @@
 */
 var View = {
   initialize: function() {
+    /* Header */
+    jQuery(window).bind('scroll resize', function() {
+      var scrollLeft = jQuery(window).scrollLeft();
+      jQuery('header').css('left', '-' + scrollLeft + 'px')
+      jQuery('header').css('width', jQuery(window).width() + scrollLeft + 'px');
+    });
+
     /* Buttons */
     $("input:submit").addClass("button");
 

--- a/public/javascripts/view.js
+++ b/public/javascripts/view.js
@@ -5,10 +5,12 @@
 var View = {
   initialize: function() {
     /* Header */
+    jQuery('header').css('width', jQuery(document).width() + 'px');
+
     jQuery(window).bind('scroll resize', function() {
-      var scrollLeft = jQuery(window).scrollLeft();
-      jQuery('header').css('left', '-' + scrollLeft + 'px')
-      jQuery('header').css('width', (jQuery(window).width() + scrollLeft) + 'px');
+      jQuery('header')
+        .css('left', '-' + jQuery(window).scrollLeft() + 'px')
+        .css('width', jQuery(document).width() + 'px');
     });
 
     /* Buttons */

--- a/public/javascripts/view.js
+++ b/public/javascripts/view.js
@@ -8,7 +8,7 @@ var View = {
     jQuery(window).bind('scroll resize', function() {
       var scrollLeft = jQuery(window).scrollLeft();
       jQuery('header').css('left', '-' + scrollLeft + 'px')
-      jQuery('header').css('width', jQuery(window).width() + scrollLeft + 'px');
+      jQuery('header').css('width', (jQuery(window).width() + scrollLeft) + 'px');
     });
 
     /* Buttons */


### PR DESCRIPTION
Fixes Issue #1960.

Header element is now shifted and resized any time the window is scrolled or resized. This has the added benefit of letting a user resize the window below 950px wide and still have full access to the entire header.
