### PR TITLE
fixes new user's language setting

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -360,6 +360,8 @@ class User < ActiveRecord::Base
   def setup(opts)
     self.username = opts[:username]
     self.email = opts[:email]
+    self.language = opts[:language]
+    self.language ||= I18n.locale.to_s
     self.valid?
     errors = self.errors
     errors.delete :person

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -360,7 +360,6 @@ class User < ActiveRecord::Base
   def setup(opts)
     self.username = opts[:username]
     self.email = opts[:email]
-    self.language ||= 'en'
     self.valid?
     errors = self.errors
     errors.delete :person

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -202,7 +202,8 @@ describe User do
 
       it "should save with current language if blank" do
         I18n.locale = :fr
-        user = Factory(:user, :language => nil)
+        user = User.build(:username => 'max', :email => 'foo@bar.com', :password => 'password', :password_confirmation => 'password')
+        user.save!
         user.language.should == 'fr'
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -203,8 +203,13 @@ describe User do
       it "should save with current language if blank" do
         I18n.locale = :fr
         user = User.build(:username => 'max', :email => 'foo@bar.com', :password => 'password', :password_confirmation => 'password')
-        user.save!
         user.language.should == 'fr'
+      end
+
+      it "should save with language what is set" do
+        I18n.locale = :fr
+        user = User.build(:username => 'max', :email => 'foo@bar.com', :password => 'password', :password_confirmation => 'password', :language => 'de')
+        user.language.should == 'de'
       end
     end
   end


### PR DESCRIPTION
All new users are created with English language because that line causes that method set_current_language is never called.
