### PR TITLE
changes aspect.contacts_visible default to false

### DIFF
--- a/app/views/aspects/new.haml
+++ b/app/views/aspects/new.haml
@@ -17,7 +17,7 @@
 
     %p.checkbox_select
       = aspect.label :contacts_visible, t('aspects.edit.make_aspect_list_visible')
-      = aspect.check_box :contacts_visible, :default => true
+      = aspect.check_box :contacts_visible, :default => false
 
     %br
 

--- a/db/migrate/20110913190531_aspects_contacts_visible_default_false.rb
+++ b/db/migrate/20110913190531_aspects_contacts_visible_default_false.rb
@@ -1,0 +1,13 @@
+class AspectsContactsVisibleDefaultFalse < ActiveRecord::Migration
+  def self.up
+    change_table :aspects do |t|
+      t.change :contacts_visible, :boolean, {:default => false, :null => false}
+    end
+  end
+
+  def self.down
+    change_table :aspects do |t|
+      t.change :contacts_visible, :boolean, {:default => true, :null => false}
+    end
+  end
+end


### PR DESCRIPTION
All default aspects for new users are created with contacts_visible set to true.
And it is true by default even in new aspect form.
I think it is wrong.
