### PR TITLE
Ability to mount resque jobs monitoring directly into Diaspora* routes

### DIFF
--- a/app/models/app_config.rb
+++ b/app/models/app_config.rb
@@ -117,7 +117,7 @@ HELP
 
   def self.[] (key)
     return self.pod_uri if key == :pod_uri
-    return ENV[key.to_s] if ENV[key.to_s].present? && ENV["HEROKU"]
+    return ENV[key.to_s] if ENV[key.to_s] && ENV["HEROKU"]
     super
   end
 

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -165,6 +165,8 @@ defaults: &defaults
   # Use paypal for recurring donations
   paypal_hosted_button_id: ""
 
+  # Mount resque-web into routes
+  mount_resque_web: true
 
 #
 # Use this section to override default settings in specific environments
@@ -176,6 +178,7 @@ development:
 
 production:
   <<: *defaults
+  mount_resque_web: false
 
 
 #

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -27,3 +27,27 @@ if AppConfig.single_process_mode?
     end
   end
 end
+
+if AppConfig.mount_resque_web
+  require 'resque/server'
+
+  class AdminRack
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      user = env['warden'].authenticate(:scope => :user)
+      if user && user.admin?
+        @app.call(env)
+      else
+        [307, {"Location" => '/'}, self]
+      end
+    end
+
+    def each(&block)
+    end
+  end
+
+  Resque::Server.use AdminRack
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,6 +157,11 @@ Diaspora::Application.routes.draw do
 
   get 'mobile/toggle', :to => 'home#toggle_mobile', :as => 'toggle_mobile'
 
+  # Resque web
+  if AppConfig.mount_resque_web
+    mount Resque::Server.new, :at => '/resque-jobs'
+  end
+
   # Startpage
 
   root :to => 'home#show'


### PR DESCRIPTION
As resque-web is considered as a debug tool, route is disabled for
production by default, and can be enabled via the `mount_resque_web` key
in application.yml.
