### PR TITLE
Opera header gradient

### DIFF
--- a/public/stylesheets/sass/_mixins.scss
+++ b/public/stylesheets/sass/_mixins.scss
@@ -71,6 +71,7 @@ $easing: linear;
   
   background-image: -webkit-gradient(linear, 0% $start, 0% $end, from($from), to($to));
   background-image: -moz-linear-gradient(top, $from $start, $to $end);
+  background-image: -o-linear-gradient(top, $from $start, $to $end);
 }
 
 @mixin opacity($val){


### PR DESCRIPTION
I was trying out Diaspora in Opera and I noticed that the header background doesn't appear.  I just added the -o-linear-gradient to the _mixins.scss file and it started working in Opera.
