### PR TITLE
Added oEmbed support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ gem 'rails-i18n'
 gem 'nokogiri'
 gem 'redcarpet', "2.0.0b5"
 gem 'roxml', :git => 'git://github.com/Empact/roxml.git', :ref => '7ea9a9ffd2338aaef5b0'
+gem 'ruby-oembed'
 
 # queue
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -406,6 +406,7 @@ GEM
       linecache19 (>= 0.5.11)
       ruby-debug-base19 (>= 0.11.19)
     ruby-hmac (0.4.0)
+    ruby-oembed (0.8.3)
     ruby-openid (2.1.8)
     ruby-openid-apps-discovery (1.2.0)
       ruby-openid (>= 2.1.7)
@@ -531,6 +532,7 @@ DEPENDENCIES
   rspec-rails (>= 2.0.0)
   ruby-debug
   ruby-debug19
+  ruby-oembed
   sass (= 3.1.4)
   selenium-webdriver (~> 2.7.0)
   settingslogic (= 2.0.6)

--- a/app/helpers/markdownify_helper.rb
+++ b/app/helpers/markdownify_helper.rb
@@ -17,7 +17,7 @@ module MarkdownifyHelper
     }
 
     render_options[:filter_html] = true
-
+    render_options[:oembed] ||= false
 
     # This ugly little hack basically means 
     #   "Give me the rawest contents of target available"
@@ -32,7 +32,11 @@ module MarkdownifyHelper
     return '' if message.blank?
 
     #renderer = Redcarpet::Render::HTML.new(render_options)
-    renderer = Diaspora::Markdownify::HTML.new(render_options)
+    if render_options[:oembed]
+      renderer = Diaspora::Markdownify::HTMLwithOEmbed.new(render_options)
+    else
+      renderer = Diaspora::Markdownify::HTML.new(render_options)
+    end
     markdown = Redcarpet::Markdown.new(renderer, markdown_options)
 
     message = markdown.render(message).html_safe

--- a/app/models/jobs/gather_o_embed_data.rb
+++ b/app/models/jobs/gather_o_embed_data.rb
@@ -1,0 +1,38 @@
+#   Copyright (c) 2010-2011, Diaspora Inc.  This file is
+#   licensed under the Affero General Public License version 3 or later.  See
+#   the COPYRIGHT file.
+#
+
+module Jobs
+  class GatherOEmbedData < Base
+    @queue = :http_service
+
+    class GatherOEmbedRenderer < Redcarpet::Render::HTML
+      include ActionView::Helpers::TextHelper
+      include ActionView::Helpers::TagHelper
+
+      def autolink(link, type)
+        return link if OEmbedCache.exists?(:url => link)
+        
+        begin
+          res = ::OEmbed::Providers.get(link, {:maxwidth => 420, :maxheight => 420, :frame => 1, :iframe => 1})
+        rescue Exception => e
+          # noop
+        else
+          data = res.fields
+          data['trusted_endpoint_url'] = res.provider.endpoint
+          cache = OEmbedCache.new(:url => link, :data => data)
+          cache.save
+        end
+        
+        return link
+      end
+    end
+
+    def self.perform(text)
+      renderer = GatherOEmbedRenderer.new({})
+      markdown = Redcarpet::Markdown.new(renderer, {:autolink => true})
+      message = markdown.render(text)
+    end
+  end
+end

--- a/app/models/o_embed_cache.rb
+++ b/app/models/o_embed_cache.rb
@@ -1,0 +1,3 @@
+class OEmbedCache < ActiveRecord::Base
+  serialize :data
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -50,6 +50,11 @@ class Post < ActiveRecord::Base
     @reshare_count ||= Post.where(:root_guid => self.guid).count
   end
 
+  def text= nd
+    Resque.enqueue(Jobs::GatherOEmbedData, nd)
+    write_attribute(:text, nd)
+  end
+
   def diaspora_handle= nd
     self.author = Person.where(:diaspora_handle => nd).first
     write_attribute(:diaspora_handle, nd)

--- a/app/views/comments/_comment.html.haml
+++ b/app/views/comments/_comment.html.haml
@@ -14,7 +14,7 @@
       –
 
     %span{:class => direction_for(comment.text)}
-      = markdownify(comment, :youtube_maps => comment.youtube_titles)
+      = markdownify(comment, :oembed => true, :youtube_maps => comment.youtube_titles)
 
     .comment_info
       %time.timeago{:datetime => comment.created_at}

--- a/app/views/messages/_message.haml
+++ b/app/views/messages/_message.haml
@@ -12,5 +12,5 @@
         = how_long_ago(message)
 
     %div{ :class => direction_for(message.text) }
-      = markdownify(message)
+      = markdownify(message, :oembed => true)
 

--- a/app/views/people/_profile_sidebar.html.haml
+++ b/app/views/people/_profile_sidebar.html.haml
@@ -22,13 +22,13 @@
             %h4
               =t('.bio')
             %div{ :class => direction_for(person.profile.bio) }
-              = markdownify(person.profile.bio, :newlines => true)
+              = markdownify(person.profile.bio, :oembed => true, :newlines => true)
         - unless person.profile.location.blank?
           %li
             %h4
               =t('.location')
             %div{ :class => direction_for(person.profile.location) }
-              = markdownify(person.profile.location, :newlines => true)
+              = markdownify(person.profile.location, :oembed => true, :newlines => true)
 
         %li
           - unless person.profile.gender.blank?

--- a/app/views/photos/show.html.haml
+++ b/app/views/photos/show.html.haml
@@ -40,7 +40,7 @@
 
     .span-8.last
       %p
-        = markdownify(photo.status_message)
+        = markdownify(photo.status_message, :oembed => true)
       %span{:style=>'font-size:smaller'}
         =link_to t('.collection_permalink'), post_path(photo.status_message)
       %br

--- a/app/views/status_messages/_status_message.haml
+++ b/app/views/status_messages/_status_message.haml
@@ -16,4 +16,4 @@
           = link_to (image_tag photo.url(:thumb_small), :class => 'stream-photo thumb_small', 'data-small-photo' => photo.url(:thumb_medium), 'data-full-photo' => photo.url), photo_path(photo), :class => 'stream-photo-link'
 
 %div{:class => direction_for(post.text)}
-  != markdownify(post, :youtube_maps => post[:youtube_titles])
+  != markdownify(post, :oembed => true, :youtube_maps => post[:youtube_titles])

--- a/config/initializers/oembed.rb
+++ b/config/initializers/oembed.rb
@@ -1,0 +1,4 @@
+require 'oembed'
+OEmbed::Providers.register_all
+OEmbed::Providers.register_fallback(OEmbed::ProviderDiscovery)
+

--- a/db/migrate/20110924112840_create_o_embed_caches.rb
+++ b/db/migrate/20110924112840_create_o_embed_caches.rb
@@ -1,0 +1,14 @@
+class CreateOEmbedCaches < ActiveRecord::Migration
+  def self.up
+    create_table :o_embed_caches do |t|
+      t.string :url, :limit => 1024, :null => false, :unique => true
+      t.text :data, :null => false
+    end
+    add_index :o_embed_caches, :url
+  end
+
+  def self.down
+    remove_index :o_embed_caches, :column => :url
+    drop_table :o_embed_caches
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20111002013921) do
+ActiveRecord::Schema.define(:version => 20110911213207) do
 
   create_table "aspect_memberships", :force => true do |t|
     t.integer  "aspect_id",  :null => false
@@ -278,7 +278,7 @@ ActiveRecord::Schema.define(:version => 20111002013921) do
     t.integer  "image_width"
     t.string   "provider_display_name"
     t.string   "actor_url"
-    t.string   "objectId"
+    t.integer  "objectId"
     t.string   "root_guid",             :limit => 30
     t.string   "status_message_guid"
     t.integer  "likes_count",                         :default => 0
@@ -287,7 +287,6 @@ ActiveRecord::Schema.define(:version => 20111002013921) do
 
   add_index "posts", ["author_id"], :name => "index_posts_on_person_id"
   add_index "posts", ["guid"], :name => "index_posts_on_guid", :unique => true
-  add_index "posts", ["root_guid"], :name => "index_posts_on_root_guid"
   add_index "posts", ["status_message_guid", "pending"], :name => "index_posts_on_status_message_guid_and_pending"
   add_index "posts", ["status_message_guid"], :name => "index_posts_on_status_message_guid"
   add_index "posts", ["type", "pending", "id"], :name => "index_posts_on_type_and_pending_and_id"
@@ -332,9 +331,9 @@ ActiveRecord::Schema.define(:version => 20111002013921) do
   add_index "service_users", ["uid", "service_id"], :name => "index_service_users_on_uid_and_service_id", :unique => true
 
   create_table "services", :force => true do |t|
-    t.string   "type",          :limit => 127, :null => false
-    t.integer  "user_id",                      :null => false
-    t.string   "uid",           :limit => 127
+    t.string   "type",          :null => false
+    t.integer  "user_id",       :null => false
+    t.string   "uid"
     t.string   "access_token"
     t.string   "access_secret"
     t.string   "nickname"

--- a/features/oembed.feature
+++ b/features/oembed.feature
@@ -1,0 +1,55 @@
+@javascript
+Feature: oembed
+  In order to make videos easy accessible
+  As a user
+  I want the links in my posts be replaced by their oEmbed representation
+
+  Background:
+    Given a user named "Alice Smith" with email "alice@alice.alice"
+    And I have several oEmbed data in cache
+    When I sign in as "alice@alice.alice"
+    And I am on the home page
+
+  Scenario: Post a secure video link
+    Given I expand the publisher
+    When I fill in "status_message_fake_text" with "http://youtube.com/watch?v=M3r2XDceM6A&format=json"
+    And I press "Share"
+
+    And I follow "Your Aspects"
+    Then I should see a video player
+
+  Scenario: Post an unsecure video link
+    Given I expand the publisher
+    When I fill in "status_message_fake_text" with "http://mytube.com/watch?v=M3r2XDceM6A&format=json"
+    And I press "Share"
+
+    And I follow "Your Aspects"
+    Then I should not see a video player
+    And I should see "http://mytube.com/watch?v=M3r2XDceM6A&format=json"
+
+  Scenario: Post an unsecure rich-typed link
+    Given I expand the publisher
+    When I fill in "status_message_fake_text" with "http://myrichtube.com/watch?v=M3r2XDceM6A&format=json"
+    And I press "Share"
+
+    And I follow "Your Aspects"
+    Then I should not see a video player
+    And I should see "http://myrichtube.com/watch?v=M3r2XDceM6A&format=json"
+
+  Scenario: Post a photo link
+    Given I expand the publisher
+    When I fill in "status_message_fake_text" with "http://farm4.static.flickr.com/3123/2341623661_7c99f48bbf_m.jpg"
+    And I press "Share"
+
+    And I follow "Your Aspects"
+    Then I should see a "img" within ".stream_element"
+
+  Scenario: Post an unsupported text link
+    Given I expand the publisher
+    When I fill in "status_message_fake_text" with "http://www.we-do-not-support-oembed.com/index.html"
+    And I press "Share"
+
+    And I follow "Your Aspects"
+    Then I should see "http://www.we-do-not-support-oembed.com/index.html" within ".stream_element"
+
+

--- a/features/step_definitions/oembed.rb
+++ b/features/step_definitions/oembed.rb
@@ -1,0 +1,118 @@
+Given /^I have several oEmbed data in cache$/ do
+  scenarios = {
+    "photo" => {
+      "oembed_data" => {
+        "trusted_endpoint_url" => "__!SPOOFED!__",
+        "version" => "1.0",
+        "type" => "photo",
+        "title" => "ZB8T0193",
+        "width" => "240",
+        "height" => "160",
+        "url" => "http://farm4.static.flickr.com/3123/2341623661_7c99f48bbf_m.jpg"
+      },
+      "link_url" => 'http://www.flickr.com/photos/bees/2341623661',
+      "oembed_get_request" => "http://www.flickr.com/services/oembed/?format=json&frame=1&iframe=1&maxheight=420&maxwidth=420&url=http://www.flickr.com/photos/bees/2341623661",
+    },
+
+    "unsupported" => {
+      "oembed_data" => {},
+      "oembed_get_request" => 'http://www.we-do-not-support-oembed.com/index.html',
+      "link_url" => 'http://www.we-do-not-support-oembed.com/index.html',
+      "discovery_data" => 'no LINK tag!',
+    },
+
+    "secure_video" => {
+      "oembed_data" => {
+        "version" => "1.0",
+        "type" => "video",
+        "width" => 425,
+        "height" => 344,
+        "title" => "Amazing Nintendo Facts",
+        "html" => "<object width=\"425\" height=\"344\">
+            <param name=\"movie\" value=\"http://www.youtube.com/v/M3r2XDceM6A&fs=1\"></param>
+            <param name=\"allowFullScreen\" value=\"true\"></param>
+            <param name=\"allowscriptaccess\" value=\"always\"></param>
+            <embed src=\"http://www.youtube.com/v/M3r2XDceM6A&fs=1\"
+	            type=\"application/x-shockwave-flash\" width=\"425\" height=\"344\"
+	            allowscriptaccess=\"always\" allowfullscreen=\"true\"></embed>
+          </object>",
+      },
+      "link_url" => "http://youtube.com/watch?v=M3r2XDceM6A&format=json",
+      "oembed_get_request" => "http://www.youtube.com/oembed?format=json&frame=1&iframe=1&maxheight=420&maxwidth=420&url=http://youtube.com/watch?v=M3r2XDceM6A",
+    },
+
+    "unsecure_video" => {
+      "oembed_data" => {
+        "version" => "1.0",
+        "type" => "video",
+        "title" => "This is a video from an unsecure source",
+        "html" => "<object width=\"425\" height=\"344\">
+            <param name=\"movie\" value=\"http://www.youtube.com/v/M3r2XDceM6A&fs=1\"></param>
+            <param name=\"allowFullScreen\" value=\"true\"></param>
+            <param name=\"allowscriptaccess\" value=\"always\"></param>
+            <embed src=\"http://www.youtube.com/v/M3r2XDceM6A&fs=1\"
+	            type=\"application/x-shockwave-flash\" width=\"425\" height=\"344\"
+	            allowscriptaccess=\"always\" allowfullscreen=\"true\"></embed>
+          </object>",
+      },
+      "link_url" => "http://myrichtube.com/watch?v=M3r2XDceM6A&format=json",
+      "discovery_data" => '<link rel="alternate" type="application/json+oembed" href="http://www.mytube.com/oembed?format=json&frame=1&iframe=1&maxheight=420&maxwidth=420&url=http://mytube.com/watch?v=M3r2XDceM6A" />',
+      "oembed_get_request" => "http://www.mytube.com/oembed?format=json&frame=1&iframe=1&maxheight=420&maxwidth=420&url=http://mytube.com/watch?v=M3r2XDceM6A",
+    },
+
+    "secure_rich" => {
+      "oembed_data" => {
+        "version" => "1.0",
+        "type" => "rich",
+        "width" => 425,
+        "height" => 344,
+        "title" => "Amazing Nintendo Facts",
+        "html" => "<object width=\"425\" height=\"344\">
+            <param name=\"movie\" value=\"http://www.youtube.com/v/M3r2XDceM6A&fs=1\"></param>
+            <param name=\"allowFullScreen\" value=\"true\"></param>
+            <param name=\"allowscriptaccess\" value=\"always\"></param>
+            <embed src=\"http://www.youtube.com/v/M3r2XDceM6A&fs=1\"
+	            type=\"application/x-shockwave-flash\" width=\"425\" height=\"344\"
+	            allowscriptaccess=\"always\" allowfullscreen=\"true\"></embed>
+          </object>",
+      },
+      "link_url" => "http://yourichtube.com/watch?v=M3r2XDceM6A&format=json",
+      "oembed_get_request" => "http://www.youtube.com/oembed?format=json&frame=1&iframe=1&maxheight=420&maxwidth=420&url=http://youtube.com/watch?v=M3r2XDceM6A",
+    },
+
+    "unsecure_rich" => {
+      "oembed_data" => {
+        "version" => "1.0",
+        "type" => "rich",
+        "title" => "This is a video from an unsecure source",
+        "html" => "<object width=\"425\" height=\"344\">
+            <param name=\"movie\" value=\"http://www.youtube.com/v/M3r2XDceM6A&fs=1\"></param>
+            <param name=\"allowFullScreen\" value=\"true\"></param>
+            <param name=\"allowscriptaccess\" value=\"always\"></param>
+            <embed src=\"http://www.youtube.com/v/M3r2XDceM6A&fs=1\"
+	            type=\"application/x-shockwave-flash\" width=\"425\" height=\"344\"
+	            allowscriptaccess=\"always\" allowfullscreen=\"true\"></embed>
+          </object>",
+      },
+      "link_url" => "http://mytube.com/watch?v=M3r2XDceM6A&format=json",
+      "discovery_data" => '<link rel="alternate" type="application/json+oembed" href="http://www.mytube.com/oembed?format=json&frame=1&iframe=1&maxheight=420&maxwidth=420&url=http://mytube.com/watch?v=M3r2XDceM6A" />',
+      "oembed_get_request" => "http://www.mytube.com/oembed?format=json&frame=1&iframe=1&maxheight=420&maxwidth=420&url=http://mytube.com/watch?v=M3r2XDceM6A",
+    },
+  }
+  scenarios.each do |type, data|
+    unless type=='unsupported'
+      url = data['oembed_get_request'].split('?')[0]
+      store_data = data['oembed_data'].merge('trusted_endpoint_url' => url)
+      OEmbedCache.new(:url => data['link_url'], :data => store_data.to_json);
+    end
+  end
+end
+
+Then /^I should see a video player$/ do
+  page.has_css?('object')
+end
+
+Then /^I should not see a video player$/ do
+  page.has_no_css?('object')
+end
+

--- a/lib/diaspora/markdownify.rb
+++ b/lib/diaspora/markdownify.rb
@@ -1,14 +1,73 @@
 require 'erb'
+require 'cgi'
 
 module Diaspora
   module Markdownify
     class HTML < Redcarpet::Render::HTML
-
       include ActionView::Helpers::TextHelper
       include ActionView::Helpers::TagHelper
 
       def autolink(link, type)
-        auto_link(link, :link => :urls )
+        auto_link(link, :link => :urls)
+      end
+    end
+
+    class HTMLwithOEmbed < Redcarpet::Render::HTML
+      include ActionView::Helpers::UrlHelper
+      include ActionView::Helpers::TextHelper
+      include ActionView::Helpers::TagHelper
+      include ActionView::Helpers::AssetTagHelper
+      include ActionView::Helpers::RawOutputHelper
+
+      def autolink(link, type)
+        # SECURITY NOTICE! CROSS-SITE SCRIPTING!
+        # these endpoints may inject html code into our page
+        secure_endpoints = [::OEmbed::Providers::Youtube.endpoint,
+                            ::OEmbed::Providers::Viddler.endpoint,
+                            ::OEmbed::Providers::Qik.endpoint,
+                            ::OEmbed::Providers::Revision3.endpoint,
+                            ::OEmbed::Providers::Hulu.endpoint,
+                            ::OEmbed::Providers::Vimeo.endpoint,
+                            'http://soundcloud.com/oembed',
+                           ]
+
+        # note that 'trusted_endpoint_url' is the only information
+        # in OEmbed that we can trust. anything else may be spoofed!
+        link = CGI.unescapeHTML(link)
+        cache = OEmbedCache.find_by_url(link)
+        if not cache.nil? and cache.data.has_key?('type')
+          case cache.data['type']
+            when 'video', 'rich'
+              if secure_endpoints.include?(cache.data['trusted_endpoint_url']) and cache.data.has_key?('html')
+                rep = raw(cache.data['html'])
+              elsif cache.data.has_key?('thumbnail_url')
+                img_options = {}
+                img_options.merge!({:height => cache.data['thumbnail_height'],
+                                    :width  => cache.data['thumbnail_width']}) if cache.data.has_key?('thumbnail_width') and cache.data.has_key?('thumbnail_height')
+                img_options[:alt] = cache.data['title'] if cache.data.has_key?('title')
+                rep = link_to(image_tag(cache.data['thumbnail_url'], img_options),
+                              link, :target => '_blank')
+              end
+
+            when 'photo'
+              if cache.data.has_key?('url')
+                img_options = {}
+                img_options.merge!({:height => cache.data['height'],
+                                    :width  => cache.data['width']}) if cache.data.has_key?('width') and cache.data.has_key?('height')
+                img_options[:alt] = cache.data['title'] if cache.data.has_key?('title')
+                rep = link_to(image_tag(cache.data['url'], img_options),
+                              link, :target => '_blank')
+            end
+          end
+
+          title = cache.data['title'] \
+                                     if cache.data.has_key?('title') and \
+                                     not cache.data['title'].blank?
+        end
+
+        title ||= link
+        rep ||= link_to(title, link, :target => '_blank') if rep.blank?
+        return rep
       end
     end
   end

--- a/spec/helpers/markdownify_helper_spec.rb
+++ b/spec/helpers/markdownify_helper_spec.rb
@@ -52,6 +52,134 @@ describe MarkdownifyHelper do
         formatted = markdownify(message)
         formatted.should =~ /hovercard/
       end
+
+      context 'when posting a link with oEmbed support' do
+        scenarios = {
+          "photo" => {
+            "oembed_data" => {
+              "trusted_endpoint_url" => "__!SPOOFED!__",
+              "version" => "1.0",
+              "type" => "photo",
+              "title" => "ZB8T0193",
+              "width" => "240",
+              "height" => "160",
+              "url" => "http://farm4.static.flickr.com/3123/2341623661_7c99f48bbf_m.jpg"
+            },
+            "link_url" => 'http://www.flickr.com/photos/bees/2341623661',
+            "oembed_get_request" => "http://www.flickr.com/services/oembed/?format=json&frame=1&iframe=1&maxheight=420&maxwidth=420&url=http://www.flickr.com/photos/bees/2341623661",
+          },
+
+          "unsupported" => {
+            "oembed_data" => "",
+            "oembed_get_request" => 'http://www.we-do-not-support-oembed.com/index.html',
+            "link_url" => 'http://www.we-do-not-support-oembed.com/index.html'
+          },
+
+          "secure_video" => {
+            "oembed_data" => {
+	            "version" => "1.0",
+	            "type" => "video",
+	            "width" => 425,
+	            "height" => 344,
+	            "title" => "Amazing Nintendo Facts",
+	            "html" => "<object width=\"425\" height=\"344\">
+			            <param name=\"movie\" value=\"http://www.youtube.com/v/M3r2XDceM6A&fs=1\"></param>
+			            <param name=\"allowFullScreen\" value=\"true\"></param>
+			            <param name=\"allowscriptaccess\" value=\"always\"></param>
+			            <embed src=\"http://www.youtube.com/v/M3r2XDceM6A&fs=1\"
+				            type=\"application/x-shockwave-flash\" width=\"425\" height=\"344\"
+				            allowscriptaccess=\"always\" allowfullscreen=\"true\"></embed>
+		            </object>",
+            },
+            "link_url" => "http://youtube.com/watch?v=M3r2XDceM6A&format=json",
+            "oembed_get_request" => "http://www.youtube.com/oembed?format=json&frame=1&iframe=1&maxheight=420&maxwidth=420&url=http://youtube.com/watch?v=M3r2XDceM6A",
+          },
+
+          "unsecure_video" => {
+            "oembed_data" => {
+	            "version" => "1.0",
+	            "type" => "video",
+	            "title" => "This is a video from an unsecure source",
+	            "html" => "<object width=\"425\" height=\"344\">
+			            <param name=\"movie\" value=\"http://www.youtube.com/v/M3r2XDceM6A&fs=1\"></param>
+			            <param name=\"allowFullScreen\" value=\"true\"></param>
+			            <param name=\"allowscriptaccess\" value=\"always\"></param>
+			            <embed src=\"http://www.youtube.com/v/M3r2XDceM6A&fs=1\"
+				            type=\"application/x-shockwave-flash\" width=\"425\" height=\"344\"
+				            allowscriptaccess=\"always\" allowfullscreen=\"true\"></embed>
+		            </object>",
+            },
+            "link_url" => "http://mytube.com/watch?v=M3r2XDceM6A&format=json",
+            "discovery_data" => '<link rel="alternate" type="application/json+oembed" href="http://www.mytube.com/oembed?format=json&frame=1&iframe=1&maxheight=420&maxwidth=420&url=http://mytube.com/watch?v=M3r2XDceM6A" />',
+            "oembed_get_request" => "http://www.mytube.com/oembed?format=json&frame=1&iframe=1&maxheight=420&maxwidth=420&url=http://mytube.com/watch?v=M3r2XDceM6A",
+          },
+
+          "secure_rich" => {
+            "oembed_data" => {
+	            "version" => "1.0",
+	            "type" => "rich",
+	            "width" => 425,
+	            "height" => 344,
+	            "title" => "Amazing Nintendo Facts",
+	            "html" => "<object width=\"425\" height=\"344\">
+			            <param name=\"movie\" value=\"http://www.youtube.com/v/M3r2XDceM6A&fs=1\"></param>
+			            <param name=\"allowFullScreen\" value=\"true\"></param>
+			            <param name=\"allowscriptaccess\" value=\"always\"></param>
+			            <embed src=\"http://www.youtube.com/v/M3r2XDceM6A&fs=1\"
+				            type=\"application/x-shockwave-flash\" width=\"425\" height=\"344\"
+				            allowscriptaccess=\"always\" allowfullscreen=\"true\"></embed>
+		            </object>",
+            },
+            "link_url" => "http://youtube.com/watch?v=M3r2XDceM6A&format=json",
+            "oembed_get_request" => "http://www.youtube.com/oembed?format=json&frame=1&iframe=1&maxheight=420&maxwidth=420&url=http://youtube.com/watch?v=M3r2XDceM6A",
+          },
+
+          "unsecure_rich" => {
+            "oembed_data" => {
+	            "version" => "1.0",
+	            "type" => "rich",
+	            "title" => "This is a video from an unsecure source",
+	            "html" => "<object width=\"425\" height=\"344\">
+			            <param name=\"movie\" value=\"http://www.youtube.com/v/M3r2XDceM6A&fs=1\"></param>
+			            <param name=\"allowFullScreen\" value=\"true\"></param>
+			            <param name=\"allowscriptaccess\" value=\"always\"></param>
+			            <embed src=\"http://www.youtube.com/v/M3r2XDceM6A&fs=1\"
+				            type=\"application/x-shockwave-flash\" width=\"425\" height=\"344\"
+				            allowscriptaccess=\"always\" allowfullscreen=\"true\"></embed>
+		            </object>",
+            },
+            "link_url" => "http://mytube.com/watch?v=M3r2XDceM6A&format=json",
+            "discovery_data" => '<link rel="alternate" type="application/json+oembed" href="http://www.mytube.com/oembed?format=json&frame=1&iframe=1&maxheight=420&maxwidth=420&url=http://mytube.com/watch?v=M3r2XDceM6A" />',
+            "oembed_get_request" => "http://www.mytube.com/oembed?format=json&frame=1&iframe=1&maxheight=420&maxwidth=420&url=http://mytube.com/watch?v=M3r2XDceM6A",
+          },
+        }
+
+        scenarios.each do |type, data|
+          specify 'for type "'+type+'"' do
+            stub_request(:get, data['oembed_get_request']).to_return(:status => 200, :body => data['oembed_data'].to_json.to_s)
+            stub_request(:get, data['link_url']).to_return(:status => 200, :body => data['discovery_data']) if data.has_key?('discovery_data')
+
+            message = "Look at this! "+data['link_url']
+            Jobs::GatherOEmbedData.perform(message)
+            OEmbedCache.find_by_url(data['link_url']).should_not be_nil unless type == 'unsupported'
+
+            formatted = markdownify(message, :oembed => true)
+            case type
+              when 'photo'
+                formatted.should =~ /#{data['oembed_data']['url']}/
+              when 'unsupported'
+                formatted.should =~ /#{data['link_url']}/
+              when 'secure_video', 'secure_rich'
+                formatted.should =~ /#{data['oembed_data']['html']}/
+              when 'unsecure_video', 'unsecure_rich'
+                formatted.should_not =~ /#{data['oembed_data']['html']}/
+                formatted.should =~ /#{data['oembed_data']['title']}/
+                formatted.should =~ /#{data['oembed_data']['url']}/
+            end
+          end
+        end
+
+      end
     end
   end
 end

--- a/spec/helpers/markdownify_helper_spec.rb
+++ b/spec/helpers/markdownify_helper_spec.rb
@@ -156,8 +156,9 @@ describe MarkdownifyHelper do
 
         scenarios.each do |type, data|
           specify 'for type "'+type+'"' do
-            stub_request(:get, data['oembed_get_request']).to_return(:status => 200, :body => data['oembed_data'].to_json.to_s)
+            url = 
             stub_request(:get, data['link_url']).to_return(:status => 200, :body => data['discovery_data']) if data.has_key?('discovery_data')
+            stub_request(:get, data['oembed_get_request']).to_return(:status => 200, :body => data['oembed_data'].to_json.to_s)
 
             message = "Look at this! "+data['link_url']
             Jobs::GatherOEmbedData.perform(message)

--- a/spec/models/jobs/gather_o_embed_data.rb
+++ b/spec/models/jobs/gather_o_embed_data.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+describe Jobs::GatherOEmbedData do
+  before do
+    @flickr_oembed_data = {
+      "trusted_endpoint_url" => "__!SPOOFED!__",
+      "version" => "1.0",
+      "type" => "photo",
+      "author_url" => "http://www.flickr.com/photos/bees/",
+      "cache_age" => 3600,
+      "provider_name" => "Flickr",
+      "provider_url" => "http://www.flickr.com/",
+      "title" => "ZB8T0193",
+      "author_name" => "Bees",
+      "width" => "240",
+      "height" => "160",
+      "url" => "https://farm4.static.flickr.com/3123/2341623661_7c99f48bbf_m.jpg"
+    }
+
+    @flickr_oembed_url = 'http://www.flickr.com/services/oembed/'
+    @flickr_photo_url = 'http://www.flickr.com/photos/bees/2341623661'
+    @flickr_oembed_get_request = @flickr_oembed_url+"?format=json&frame=1&iframe=1&maxheight=420&maxwidth=420&url="+@flickr_photo_url
+
+    @no_oembed_url = 'http://www.we-do-not-support-oembed.com/index.html'
+
+    stub_request(:get, @flickr_oembed_get_request).to_return(:status => 200, :body => @flickr_oembed_data.to_json)
+    stub_request(:get, @no_oembed_url).to_return(:status => 200, :body => '<html><body>hello there</body></html>')
+  end
+
+  describe '.perform' do
+    it 'requests not data from the internet' do
+      Jobs::GatherOEmbedData.perform("Look at this! "+@flickr_photo_url)
+
+      a_request(:get, @flickr_oembed_get_request).should have_been_made
+    end
+
+    it 'requests not data from the internet only once' do
+      Jobs::GatherOEmbedData.perform("Look at this! "+@flickr_photo_url)
+      Jobs::GatherOEmbedData.perform("Look at this! "+@flickr_photo_url)
+
+      a_request(:get, @flickr_oembed_get_request).should have_been_made.times(1)
+    end
+
+    it 'creates one cache entry' do
+      Jobs::GatherOEmbedData.perform("Look at this! "+@flickr_photo_url)
+
+      expected_data = @flickr_oembed_data
+      expected_data['trusted_endpoint_url'] = @flickr_oembed_url
+      OEmbedCache.find_by_url(@flickr_photo_url).data.should == expected_data
+
+      Jobs::GatherOEmbedData.perform("Look at this! "+@flickr_photo_url)
+      OEmbedCache.count(:conditions => {:url => @flickr_photo_url}).should == 1
+    end
+
+    it 'creates no cache entry for unsupported pages' do
+      Jobs::GatherOEmbedData.perform("This page is lame! It does not support oEmbed: "+@no_oembed_url)
+      OEmbedCache.find_by_url(@no_oembed_url).should be_nil
+    end
+  end
+end

--- a/spec/models/o_embed_cache_spec.rb
+++ b/spec/models/o_embed_cache_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe OEmbedCache do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -27,6 +27,17 @@ describe Post do
     end
   end
 
+  describe 'oEmbed' do
+    it 'should gather oEmbed data' do
+      stub_request(:get, "http://gdata.youtube.com/feeds/api/videos/M3r2XDceM6A?v=2").to_return(:status => 200, :body => "")
+
+      text = 'http://youtube.com/watch?v=M3r2XDceM6A&format=json'
+      Resque.should_receive(:enqueue).with(Jobs::GatherOEmbedData, text)
+      post = Factory.create(:status_message, :author => @user.person, :text => text)
+      post.save!
+    end
+  end
+
   describe 'serialization' do
     it 'should serialize the handle and not the sender' do
       post = @user.post :status_message, :text => "hello", :to => @aspect.id


### PR DESCRIPTION
This adds support for oEmbed.
Note that cucumber test are missing. I will implement these tomorrow. But I'd like to get feedback about this implementation.

oEmbed link titles and photos are supported for any servers. Only videos and 'rich content' is restricted to [some providers](https://github.com/manuels/diaspora/commit/6bf8467a9615c7a7c8b8834b4e8172aefeb0c068#L14R25) due to security reasons (XSS injections are possible).
