### PR TITLE
db: Fixed the migration of the database.

### DIFF
--- a/db/migrate/0000_create_schema.rb
+++ b/db/migrate/0000_create_schema.rb
@@ -133,10 +133,10 @@ class CreateSchema < ActiveRecord::Migration
     add_index :requests, [:sender_id, :recipient_id], :unique => true
 
     create_table :services do |t|
-      t.string :type
+      t.string :type, :limit => 127
       t.integer :user_id
       t.string :provider
-      t.string :uid
+      t.string :uid, :limit => 127
       t.string :access_token
       t.string :access_secret
       t.string :nickname

--- a/db/migrate/20110926120220_fix_indexes_to_serivces.rb
+++ b/db/migrate/20110926120220_fix_indexes_to_serivces.rb
@@ -1,5 +1,8 @@
-class AddIndexesToSerivces < ActiveRecord::Migration
+class FixIndexesToSerivces < ActiveRecord::Migration
+  # This alters the tables to avoid a mysql bug
+  # See http://bugs.joindiaspora.com/issues/835
   def self.up
+    remove_index :services, :column => [:type, :uid]
     change_column(:services, :type, :string, :limit => 127)
     change_column(:services, :uid, :string, :limit => 127)
     add_index :services, [:type, :uid]


### PR DESCRIPTION
The limit down to 127 is needed cause of a long time bug in mysql. The
error message looks like this when creating an index.

Mysql2::Error: Specified key was too long; max key length is 1000 bytes

So with utf8 (3 bytes for one char) you exceed this with two
varchar(255).

See http://bugs.mysql.com/bug.php?id=4541 guru meditation

Signed-off-by: Andreas Schneider asn@cryptomilk.org
