### PR TITLE
Minor Cosmetic Usability Change

### DIFF
--- a/public/stylesheets/sass/application.sass
+++ b/public/stylesheets/sass/application.sass
@@ -3380,6 +3380,7 @@ ul#getting_started
   :display block
   :color white
   :position fixed
+  :z-index 49
   :right 20px
   :bottom 20px
   :opacity 0


### PR DESCRIPTION
Ensured that the back-to-top button remains on top and won't be covered by images on small screens, by setting its z-index to 49 (the top bar has a z-index of 50).
