### PR TITLE
Call save instead of save! in save_object, preventing a lot of errors in resque

### DIFF
--- a/lib/postzord/receiver/public.rb
+++ b/lib/postzord/receiver/public.rb
@@ -45,7 +45,7 @@ module Postzord
       def save_object
         @object = Diaspora::Parser::from_xml(@salmon.parsed_data)
         raise "Object is not public" if object_can_be_public_and_it_is_not?
-        @object.save!
+        @object.save
       end
 
       # @return [Array<Integer>] User ids


### PR DESCRIPTION
`Postzord::Receiver::Public.perform!` has a `return unless save_object` but since `save!` was called, it wasn’t working as intended.
