### PR TITLE
fix mobile stylesheet load. fix gradient background

### DIFF
--- a/config/assets.yml
+++ b/config/assets.yml
@@ -92,6 +92,6 @@ stylesheets:
 
   mobile:
     #- public/stylesheets/vendor/jquery.mobile-1.0b2.min.css
-    - public/stylesheets/vendor/html5-boilerplate-mobile.css
     - public/stylesheets/mobile.css
+    - public/stylesheets/vendor/html5-boilerplate-mobile.css
 

--- a/public/stylesheets/sass/_mixins.scss
+++ b/public/stylesheets/sass/_mixins.scss
@@ -64,7 +64,7 @@ $easing: linear;
 }
 
 @mixin linear-gradient($from, $to, $start:0%, $end:100%){
-  background-image: mix($from,$to);
+  background-color: mix($from,$to);
 
   filter: progid:DXImageTransform.Microsoft.gradient(GradientType=0, startColorstr=$from, endColorstr=$to);
   -ms-filter: "progid:DXImageTransform.Microsoft.gradient (GradientType=0, startColorstr=#{$from}, endColorstr=#{$to})";


### PR DESCRIPTION
This should fix problems with boilerplate stylesheet.

As described on [their site](http://html5boilerplate.com/docs/Get-Started!/), all personal styles should be included in their .scss right after the comment line that begins with 'Primary Styles'. This because media queries are not widely supported.

Btw making jammit loading mobile.scss before boilerplate seems to work.
