### PR TITLE
add username blacklist

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,7 @@ class User < ActiveRecord::Base
   validates :username, :presence => true, :uniqueness => true
   validates_format_of :username, :with => /\A[A-Za-z0-9_]+\z/
   validates_length_of :username, :maximum => 32
+  validates_exclusion_of :username, :in => USERNAME_BLACKLIST
   validates_inclusion_of :language, :in => AVAILABLE_LANGUAGE_CODES
   validates_format_of :unconfirmed_email, :with  => Devise.email_regexp, :allow_blank => true
 

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -27,6 +27,10 @@ else
   RTL_LANGUAGES = []
 end
 
+# Blacklist of usernames
+USERNAME_BLACKLIST = ['admin', 'administrator', 'hostmaster', 'info', 'postmaster', 'root', 'ssladmin', 
+  'ssladministrator', 'sslwebmaster', 'sysadmin', 'webmaster', 'support', 'contact']
+
 # Initialize the rails application
 Diaspora::Application.initialize!
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -151,6 +151,13 @@ describe User do
         alice.username =  "hexagooooooooooooooooooooooooooon"
         alice.should_not be_valid
       end
+      
+      it "cannot be one of the blacklist names" do
+        ['hostmaster', 'postmaster', 'root', 'webmaster'].each do |username|
+          alice.username =  username
+          alice.should_not be_valid
+        end
+      end
     end
 
     describe "of email" do


### PR DESCRIPTION
In order to provide an e-mail service to our users, they shouldn't be able to register names like hostmaster, postmaster, root, webmaster, ... To ensure this, we added a blacklist support fo usernames. This feature is tested and working.

Greetings,
Christophe Sokol and Paul Spieker
