### PR TITLE
Fix hovercard font size when injected in headings

### DIFF
--- a/public/stylesheets/sass/hovercard.scss
+++ b/public/stylesheets/sass/hovercard.scss
@@ -73,6 +73,7 @@
   position: absolute;
   display: none;
   z-index: 10;
+  font-size: small;
 
   min-width: 250px;
   max-width: 300px;


### PR DESCRIPTION
When a hovercard was injected in a heading (e.g. <h2>), the font would
be too large, as it inherited the font-size of the parent tag. This sets
the font-size of the `#hovercard_container` to `small`, so as to overwrite
inherited sizes.
The hovercard looks now identical, irrespective of its injection point.
