### PR TITLE
Profil and photolink in profiles

### DIFF
--- a/app/views/people/_sub_header.html.haml
+++ b/app/views/people/_sub_header.html.haml
@@ -1,4 +1,7 @@
 #author_info
+  .navigation
+    = link_to t('people.show.profile'), person
+    = link_to t('people.show.photos'), person_photos_path(person)
   .right
     - if user_signed_in? && current_user.person != person
       = aspect_membership_dropdown(contact, person, 'right')

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -532,6 +532,8 @@ en:
       start_sharing: "start sharing"
       message: "Message"
       mention: "Mention"
+      profile: "Profile"
+      photos: "Photos"
     sub_header:
       you_have_no_tags: "you have no tags!"
       add_some: "add some"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -107,6 +107,7 @@ ActiveRecord::Schema.define(:version => 20111002013921) do
     t.string   "service"
     t.string   "identifier"
     t.boolean  "admin",        :default => false
+    t.string   "language",     :default => "en"
   end
 
   add_index "invitations", ["aspect_id"], :name => "index_invitations_on_aspect_id"

--- a/public/stylesheets/sass/application.sass
+++ b/public/stylesheets/sass/application.sass
@@ -389,6 +389,12 @@ ul.as-selections
   .description
     :margin
       :bottom 10px
+      
+  .navigation
+    a
+      :color #505050
+      :margin
+        :right 15px
 
 #conversation_inbox a
   &:hover


### PR DESCRIPTION
this adds two links to the profile: "profile" and "photos"
i think the link in the profile_photo is not clear and not intuitiv.

http://cloud.despora.de/apps/files_sharing/get.php?token=c191a82e2fe5e03c816690f4622af22fdeb13199
