### PR TITLE
Reshare link for already reshared

### DIFF
--- a/app/helpers/reshares_helper.rb
+++ b/app/helpers/reshares_helper.rb
@@ -16,7 +16,7 @@ module ResharesHelper
         :remote => true,
         :confirm => t('reshares.reshare.reshare_confirmation', :author => post.root.author.name)
     else
-      link_to t("reshares.reshare.reshare_original"),
+      link_to t('shared.reshare.reshare'),
                 reshares_path(:root_guid => post.guid),
                 :method => :post,
                 :remote => true,

--- a/app/helpers/reshares_helper.rb
+++ b/app/helpers/reshares_helper.rb
@@ -16,8 +16,7 @@ module ResharesHelper
         :remote => true,
         :confirm => t('reshares.reshare.reshare_confirmation', :author => post.root.author.name)
     else
-      link_to t("reshares.reshare.reshare",
-                :count => post.reshares.size),
+      link_to t("reshares.reshare.reshare_original"),
                 reshares_path(:root_guid => post.guid),
                 :method => :post,
                 :remote => true,

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -29,7 +29,7 @@ class Post < ActiveRecord::Base
   has_many :resharers, :class_name => 'Person', :through => :reshares, :source => :author
 
   belongs_to :author, :class_name => 'Person'
-  
+
   validates :guid, :uniqueness => true
 
   scope :all_public, where(:public => true, :pending => false)
@@ -47,7 +47,7 @@ class Post < ActiveRecord::Base
   end
 
   def reshare_count
-    @reshare_count ||= Post.where(:root_guid => self.guid).count
+    @reshare_count ||= Post.find_all_by_root_guid(self.guid).count
   end
 
   def diaspora_handle= nd

--- a/app/models/reshare.rb
+++ b/app/models/reshare.rb
@@ -32,7 +32,7 @@ class Reshare < Post
   def notification_type(user, person)
     Notifications::Reshared if root.author == user.person
   end
-  
+
   private
 
   def after_parse
@@ -62,7 +62,7 @@ class Reshare < Post
 
   def root_must_be_public
     if self.root && !self.root.public
-      errors[:base] << "you must reshare public posts"
+      errors[:base] << "Only posts which are public may be reshared."
       return false
     end
   end

--- a/app/views/shared/_stream_element.html.haml
+++ b/app/views/shared/_stream_element.html.haml
@@ -31,7 +31,7 @@
           –
           %span.timeago
             = link_to(how_long_ago(post), post_path(post))
-          - if post.reshares.any?
+          - if post.reshare_count > 0
             –
             %span.num_reshares
               = t("reshares.reshare.reshare", :count => post.reshares.size)

--- a/app/views/shared/_stream_element.html.haml
+++ b/app/views/shared/_stream_element.html.haml
@@ -31,6 +31,10 @@
           –
           %span.timeago
             = link_to(how_long_ago(post), post_path(post))
+          - if post.reshares.any?
+            –
+            %span.num_reshares
+              = t("reshares.reshare.reshare", :count => post.reshares.size)
 
       - if post.activity_streams?
         = link_to image_tag(post.image_url, 'data-small-photo' => post.image_url, 'data-full-photo' => post.image_url, :class => 'stream-photo'), post.object_url, :class => "stream-photo-link"

--- a/spec/helpers/reshares_helper_spec.rb
+++ b/spec/helpers/reshares_helper_spec.rb
@@ -1,15 +1,5 @@
 require 'spec_helper'
 
-# Specs in this file have access to a helper object that includes
-# the ResharesHelper. For example:
-#
-# describe ResharesHelper do
-#   describe "string concat" do
-#     it "concats two strings with spaces" do
-#       helper.concat_strings("this","that").should == "this that"
-#     end
-#   end
-# end
 describe ResharesHelper do
   include StreamHelper
 
@@ -19,6 +9,41 @@ describe ResharesHelper do
       lambda {
         reshare_link(reshare)
       }.should_not raise_error
+    end
+
+    describe 'for a typical post' do
+      before :each do
+        aspect = alice.aspects.first
+        @post = alice.build_post :status_message, :text => "ohai", :to => aspect.id, :public => true
+        @post.save!
+        alice.add_to_streams(@post, [aspect])
+        alice.dispatch_post @post, :to => aspect.id
+      end
+
+      describe 'which has not been reshared' do
+        before :each do
+          @post.reshare_count.should == 0
+        end
+
+        it 'has "Reshare original" as the English text' do
+          reshare_link(@post).should =~ %r{>Reshare original</a>}
+        end
+      end
+
+      describe 'which has been reshared' do
+        before :each do
+          @reshare = Factory.create(:reshare, :root => @post)
+          @post.reshare_count.should == 1
+        end
+
+        it 'has "Reshare original" as the English text' do
+          reshare_link(@post).should =~ %r{>Reshare original</a>}
+        end
+
+        it 'its reshare has "Reshare original" as the English text' do
+          reshare_link(@reshare).should =~ %r{>Reshare original</a>}
+        end
+      end
     end
   end
 end

--- a/spec/helpers/reshares_helper_spec.rb
+++ b/spec/helpers/reshares_helper_spec.rb
@@ -25,8 +25,8 @@ describe ResharesHelper do
           @post.reshare_count.should == 0
         end
 
-        it 'has "Reshare original" as the English text' do
-          reshare_link(@post).should =~ %r{>Reshare original</a>}
+        it 'has "Reshare" as the English text' do
+          reshare_link(@post).should =~ %r{>Reshare</a>}
         end
       end
 
@@ -37,7 +37,7 @@ describe ResharesHelper do
         end
 
         it 'has "Reshare original" as the English text' do
-          reshare_link(@post).should =~ %r{>Reshare original</a>}
+          reshare_link(@post).should =~ %r{>Reshare</a>}
         end
 
         it 'its reshare has "Reshare original" as the English text' do

--- a/spec/helpers/reshares_helper_spec.rb
+++ b/spec/helpers/reshares_helper_spec.rb
@@ -36,7 +36,7 @@ describe ResharesHelper do
           @post.reshare_count.should == 1
         end
 
-        it 'has "Reshare original" as the English text' do
+        it 'has "Reshare" as the English text' do
           reshare_link(@post).should =~ %r{>Reshare</a>}
         end
 

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -90,4 +90,45 @@ describe Post do
       @post.reload.updated_at.to_i.should == old_time.to_i
     end
   end
+
+  describe '#reshare_count' do
+    before :each do
+      @post = @user.post :status_message, :text => "hello", :to => @aspect.id, :public => true
+      @post.reshares.size.should == 0
+    end
+
+    describe 'when post has not been reshared' do
+      it 'returns zero' do
+        @post.reshare_count.should == 0
+      end
+    end
+
+    describe 'when post has been reshared exactly 1 time' do
+      before :each do
+        @post.reshares.size.should == 0
+        @reshare = Factory.create(:reshare, :root => @post)
+        @post.reload
+        @post.reshares.size.should == 1
+      end
+
+      it 'returns 1' do
+        @post.reshare_count.should == 1
+      end
+    end
+
+    describe 'when post has been reshared more than once' do
+      before :each do
+        @post.reshares.size.should == 0
+        Factory.create(:reshare, :root => @post)
+        Factory.create(:reshare, :root => @post)
+        Factory.create(:reshare, :root => @post)
+        @post.reload
+        @post.reshares.size.should == 3
+      end
+
+      it 'returns the number of reshares' do
+        @post.reshare_count.should == 3
+      end
+    end
+  end
 end

--- a/spec/models/reshare_spec.rb
+++ b/spec/models/reshare_spec.rb
@@ -18,7 +18,9 @@ describe Reshare do
   end
 
   it 'require public root' do
-    Factory.build(:reshare, :root => Factory.build(:status_message, :public => false)).should_not be_valid
+    reshare = Factory.build(:reshare, :root => Factory.build(:status_message, :public => false))
+    reshare.should_not be_valid
+    reshare.errors[:base].should include('Only posts which are public may be reshared.')
   end
 
   it 'forces public' do


### PR DESCRIPTION
This patch makes all reshare links have appropriate text which describes the action that will take place when the user clicks.  Previously, the link text would have been "n reshares" if the post had any reshares.  A user wanting to reshare would likely not realize they need to click "n reshares" to do a reshare themselves.  This patch rectifies this UX problem.

I believe I've covered all the bases, but not only am I a bit sleepy at this time, but I couldn't get the cucumber stories to run locally, so I could only add rspec specs.  If any adjustments are needed before this patch can be accepted, please let me know, and I'll see what I can do.
