### PR TITLE
Fix #2091 - Aspects selection on mobile

### DIFF
--- a/app/views/layouts/application.mobile.haml
+++ b/app/views/layouts/application.mobile.haml
@@ -46,6 +46,9 @@
     = yield(:head)
 
   %body
+    #main{:role => "main"}
+      = yield
+
     %header
       = link_to(image_tag('white@2x.png', :height => 20, :width => 127, :id => 'header_title'), aspects_path)
       - if user_signed_in?
@@ -53,9 +56,6 @@
           = yield(:header_action)
         - else
           = link_to(image_tag('icons/compose_mobile2.png', :height => 28, :width => 28), new_status_message_path, :class => 'compose_icon')
-
-    #main{:role => "main"}
-      = yield
 
     - if user_signed_in?
       = render :partial =>'shared/footer'


### PR DESCRIPTION
Because of a jQuery mobile bug, if the main div isn't directly under body, select tag won't work [1](https://github.com/jquery/jquery-mobile/issues/1051#issuecomment-1453177).
They are still working on it [2](https://github.com/jquery/jquery-mobile/issues/2066).
This is a temporary workaround.
