### PR TITLE
Reopen Publisher after changing Aspect selection if there is unsent text 

### DIFF
--- a/public/javascripts/widgets/aspect-navigation.js
+++ b/public/javascripts/widgets/aspect-navigation.js
@@ -134,6 +134,9 @@
         });
 
         self.globalPublish("stream/reloaded");
+        if( post !== "" ) {
+          Publisher.open();
+        }
         self.fadeIn();
       });
     };


### PR DESCRIPTION
Reopen Publisher after changing Aspect selection if there is unsent text in the Publisher.  This fixes [issue 2102](https://github.com/diaspora/diaspora/issues/2102).
