### PR TITLE
Explicitly specify order of comments, since we cannot assume MySQL orderi

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -16,7 +16,7 @@ class Post < ActiveRecord::Base
   xml_attr :public
   xml_attr :created_at
 
-  has_many :comments, :dependent => :destroy
+  has_many :comments, :order => 'created_at', :dependent => :destroy
 
   has_many :aspect_visibilities
   has_many :aspects, :through => :aspect_visibilities
@@ -107,11 +107,6 @@ class Post < ActiveRecord::Base
 
   def comment_email_subject
     I18n.t('notifier.a_post_you_shared')
-  end
-
-  # @return [Array<Comment>]
-  def last_three_comments
-    self.comments.order('created_at DESC').limit(3).includes(:author => :profile).reverse
   end
 
   # @return [Integer]

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -29,7 +29,7 @@ class Post < ActiveRecord::Base
   has_many :resharers, :class_name => 'Person', :through => :reshares, :source => :author
 
   belongs_to :author, :class_name => 'Person'
-  
+
   validates :guid, :uniqueness => true
 
   after_create :cache_for_author

--- a/app/views/comments/_comments.html.haml
+++ b/app/views/comments/_comments.html.haml
@@ -9,9 +9,9 @@
 
   %ul.comments{:class => ('loaded' if post.comments.size <= 3)}
     -if post.comments.size > 3 && !comments_expanded
-      = render :partial => 'comments/comment', :collection => post.last_three_comments, :locals => {:post => post}
+      = render :partial => 'comments/comment', :collection => post.comments.last(3), :locals => {:post => post}
     -else
-      = render :partial => 'comments/comment', :collection => post.comments.order('created_at'), :locals => {:post => post}
+      = render :partial => 'comments/comment', :collection => post.comments, :locals => {:post => post}
 
   - unless commenting_disabled?(post)
     .new_comment_form_wrapper{:class => comment_form_wrapper_class(post)}

--- a/app/views/comments/_comments.html.haml
+++ b/app/views/comments/_comments.html.haml
@@ -11,7 +11,7 @@
     -if post.comments.size > 3 && !comments_expanded
       = render :partial => 'comments/comment', :collection => post.last_three_comments, :locals => {:post => post}
     -else
-      = render :partial => 'comments/comment', :collection => post.comments, :locals => {:post => post}
+      = render :partial => 'comments/comment', :collection => post.comments.order('created_at'), :locals => {:post => post}
 
   - unless commenting_disabled?(post)
     .new_comment_form_wrapper{:class => comment_form_wrapper_class(post)}

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -44,7 +44,7 @@ describe Post do
     end
 
     describe 'includes for a stream' do
-      it 'inclues author profile and mentions' 
+      it 'inclues author profile and mentions'
       it 'should include photos and root of reshares(but does not)'
     end
 
@@ -199,7 +199,7 @@ describe Post do
       @post.should_cache_for_author?.should be_false
     end
   end
-  
+
   describe "#receive" do
     it 'returns false if the post does not verify' do
       @post = Factory(:status_message, :author => bob.person)
@@ -225,7 +225,7 @@ describe Post do
         @known_post.should_receive(:update_attributes)
         @post.send(:receive_persisted, bob, eve.person, @known_post).should == true
       end
-      
+
       it 'returns false if trying to update a non-mutable object' do
         @known_post.stub(:mutable?).and_return(false)
         @known_post.should_not_receive(:update_attributes)
@@ -242,7 +242,7 @@ describe Post do
       it "receives the post from the contact of the author" do
         @post.send(:receive_persisted, bob, eve.person, @known_post).should == true
       end
-      
+
       it 'notifies the user if they are mentioned' do
         bob.stub(:contact_for).with(eve.person).and_return(stub(:receive_post => true))
         bob.should_receive(:notify_if_mentioned).and_return(true)
@@ -264,7 +264,7 @@ describe Post do
         bob.should_receive(:contact_for).with(eve.person).and_return(stub(:receive_post => true))
         @post.send(:receive_non_persisted, bob, eve.person).should == true
       end
-      
+
       it 'notifies the user if they are mentioned' do
         bob.stub(:contact_for).with(eve.person).and_return(stub(:receive_post => true))
         bob.should_receive(:notify_if_mentioned).and_return(true)

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -106,15 +106,33 @@ describe Post do
     end
   end
 
-  describe '#last_three_comments' do
-    it 'returns the last three comments of a post' do
+  describe '#comments' do
+    it 'returns the comments of a post in created_at order' do
       post = bob.post :status_message, :text => "hello", :to => 'all'
       created_at = Time.now - 100
-      comments = [alice, eve, bob, alice].map do |u|
-        created_at = created_at + 10
-        u.comment("hey", :post => post, :created_at => created_at)
-      end
-      post.last_three_comments.map{|c| c.id}.should == comments[1,3].map{|c| c.id}
+
+      # Posts are created out of time order.
+      # i.e. id order is not created_at order
+      alice.comment 'comment a', :post => post, :created_at => created_at + 10
+      eve.comment   'comment d', :post => post, :created_at => created_at + 50
+      bob.comment   'comment b', :post => post, :created_at => created_at + 30
+      alice.comment 'comment e', :post => post, :created_at => created_at + 90
+      eve.comment   'comment c', :post => post, :created_at => created_at + 40
+
+      post.comments.map(&:text).should == [
+        'comment a',
+        'comment b',
+        'comment c',
+        'comment d',
+        'comment e',
+      ]
+      post.comments.map(&:author).should == [
+        alice.person,
+        bob.person,
+        eve.person,
+        eve.person,
+        alice.person,
+      ]
     end
   end
 


### PR DESCRIPTION
Explicitly specify order of comments, since we cannot assume MySQL ordering (which is by id).  This issue manifested itself only when a post has 2 or 3 comments.  With more than 3, the code was already ordering correctly.

This fixes [issue 2007](https://github.com/diaspora/diaspora/issues/2007).
