### PR TITLE
[PaperCut] Allow new lines (<br>)

### DIFF
--- a/app/helpers/markdownify_helper.rb
+++ b/app/helpers/markdownify_helper.rb
@@ -17,6 +17,7 @@ module MarkdownifyHelper
     }
 
     render_options[:filter_html] = true
+    render_options[:hard_wrap] ||= true
 
 
     # This ugly little hack basically means 


### PR DESCRIPTION
A lot of users complain, that single line breaks are eaten by markdown. Double line breaks result correctly in a new paragraph.

this fixes the issue with the single line beaks (which are translated into `<br>`s now)
