### PR TITLE
Fixed "string vs. integer" spec breakage in spec/models/user/querying_spec.rb

### DIFF
--- a/lib/diaspora/user/querying.rb
+++ b/lib/diaspora/user/querying.rb
@@ -41,7 +41,7 @@ module Diaspora
       # @return [Array<Integer>]
       def visible_ids_from_sql(opts={})
         opts = prep_opts(opts)
-        Post.connection.select_values(visible_posts_sql(opts))
+        Post.connection.select_values(visible_posts_sql(opts)).map { |id| id.to_i }
       end
 
       def visible_posts_sql(opts={})


### PR DESCRIPTION
Fixed "string vs. integer" spec breakage in spec/models/user/querying_spec.rb .
