### PR TITLE
Issue #2173: embedded objects overlap top bar

### DIFF
--- a/app/models/o_embed_cache.rb
+++ b/app/models/o_embed_cache.rb
@@ -45,8 +45,8 @@ class OEmbedCache < ActiveRecord::Base
     if ['video', 'rich'].include? self.data['type'] and self.is_trusted_and_has_html?
       subs = [
         # youtube
-        { :from => /("http:\/\/www\.youtube\.com\/embed\/.{11})(")/,
-          :to   => '\1?wmode=transparent\2' },
+        { :from => /("http:\/\/www\.youtube\.com\/embed\/.{11}\?)/,
+          :to   => '\1wmode=transparent&' },
         # soundcloud
         { :from => /(<object height=".+" width=".+">\s*)(<param name="movie" value="http:\/\/player\.soundcloud\.com\/player\.swf)/,
           :to   => '\1<param name="wmode" value="transparent"></param>\2' },

--- a/app/models/o_embed_cache.rb
+++ b/app/models/o_embed_cache.rb
@@ -19,6 +19,7 @@ class OEmbedCache < ActiveRecord::Base
     else
       self.data = response.fields
       self.data['trusted_endpoint_url'] = response.provider.endpoint
+      self.fix_embed_code
       self.save
     end
   end
@@ -38,5 +39,20 @@ class OEmbedCache < ActiveRecord::Base
       :width => self.data.fetch(prefix + 'width', ''),
       :alt => self.data.fetch('title', ''),
     }
+  end
+
+  def fix_embed_code
+    if ['video', 'rich'].include? self.data['type'] and self.is_trusted_and_has_html?
+      subs = [
+        # youtube
+        { :from => /("http:\/\/www\.youtube\.com\/embed\/.{11})(")/,
+          :to   => '\1?wmode=transparent\2' },
+        # soundcloud
+        { :from => /(<object height=".+" width=".+">\s*)(<param name="movie" value="http:\/\/player\.soundcloud\.com\/player\.swf)/,
+          :to   => '\1<param name="wmode" value="transparent"></param>\2' },
+      ]
+
+      subs.each {|s| self.data['html'].gsub!(s[:from], s[:to])}
+    end
   end
 end


### PR DESCRIPTION
This modifies the embedding code returned by the oembed providers such that the Flash object doesn't overlap the top bar anymore.
