### PR TITLE
remove ghost doubles of links on Android browsers

### DIFF
--- a/public/stylesheets/sass/mobile.scss
+++ b/public/stylesheets/sass/mobile.scss
@@ -470,8 +470,9 @@ header {
   z-index: 10;
   top: 0;
 
-  /* force hardware acceleration on webkit browsers */
-  -webkit-transform: translateZ(0);
+  /* force hardware acceleration on webkit browsers 
+     10/17/2011 - removed for now, causes ghost doubles of links on some Android browsers */
+  /*-webkit-transform: translateZ(0);*/
 
   border: {
     bottom: 1px solid #222;
@@ -481,8 +482,9 @@ header {
     float: right; } }
 
 .stream_element {
-  /* force hardware acceleration on webkit browsers */
-  -webkit-transform: translateZ(0);
+  /* force hardware acceleration on webkit browsers 
+     10/17/2011 - removed for now, causes ghost doubles of links on some Android browsers */
+  /*-webkit-transform: translateZ(0);*/
 }
 
 footer {


### PR DESCRIPTION
The WebKit acceleration call -webkit-transform: translateZ(0) appears to causes "ghost doubles" of links in some Android browsers, which causes links to exists both in their proper locations as well as in a second location offset down from the proper one. This is annoying. If these two calls are removed from mobile.scss, everything works properly.
