### PR TITLE
Fix issue #2173 (oembed overlapping top bar)

### DIFF
--- a/app/models/o_embed_cache.rb
+++ b/app/models/o_embed_cache.rb
@@ -45,8 +45,8 @@ class OEmbedCache < ActiveRecord::Base
     if ['video', 'rich'].include? self.data['type'] and self.is_trusted_and_has_html?
       subs = [
         # youtube
-        { :from => /("http:\/\/www\.youtube\.com\/embed\/.{11})(")/,
-          :to   => '\1?wmode=transparent\2' },
+        { :from => /("http:\/\/www\.youtube\.com\/embed\/.{11}\?)/,
+          :to   => '\1wmode=transparent&' },
         # soundcloud
         { :from => /(<object height=".+" width=".+">\s*)(<param name="movie" value="http:\/\/player\.soundcloud\.com\/player\.swf)/,
           :to   => '\1<param name="wmode" value="transparent"></param>\2' },

--- a/app/models/o_embed_cache.rb
+++ b/app/models/o_embed_cache.rb
@@ -19,6 +19,7 @@ class OEmbedCache < ActiveRecord::Base
     else
       self.data = response.fields
       self.data['trusted_endpoint_url'] = response.provider.endpoint
+      self.fix_embed_code
       self.save
     end
   end
@@ -38,5 +39,20 @@ class OEmbedCache < ActiveRecord::Base
       :width => self.data.fetch(prefix + 'width', ''),
       :alt => self.data.fetch('title', ''),
     }
+  end
+
+  def fix_embed_code
+    if ['video', 'rich'].include? self.data['type'] and self.is_trusted_and_has_html?
+      subs = [
+        # youtube
+        { :from => /("http:\/\/www\.youtube\.com\/embed\/.{11})(")/,
+          :to   => '\1?wmode=transparent\2' },
+        # soundcloud
+        { :from => /(<object height=".+" width=".+">\s*)(<param name="movie" value="http:\/\/player\.soundcloud\.com\/player\.swf)/,
+          :to   => '\1<param name="wmode" value="transparent"></param>\2' },
+      ]
+
+      subs.each {|s| self.data['html'].gsub!(s[:from], s[:to])}
+    end
   end
 end

--- a/lib/tasks/fix-oembed-cache.rake
+++ b/lib/tasks/fix-oembed-cache.rake
@@ -1,0 +1,24 @@
+namespace :db do
+
+  desc "Fix cached oembed objects to stop them from overlapping on the top bar"
+  task :oembed_fix => :environment do
+    print "Fetching cached oembed responses that need fixing..."
+    caches = OEmbedCache.where('url LIKE :youtube OR url LIKE :soundcloud',
+                                { :youtube => "%youtube.com%",
+                                  :soundcloud => "%soundcloud.com%" })
+    puts "DONE. #{caches.length} records fetched."
+
+    # only leave those that haven't had the wmode fix applied
+    caches.delete_if {|c| c.data['html'].include? 'wmode'}
+    if caches.empty?
+      puts "Nothing to do."
+      next
+    end
+
+    # run fix
+    print "Fixing #{caches.length} cached oembed responses..."
+    caches.each {|c| c.fix_embed_code; c.save}
+    puts "DONE!"
+  end
+
+end

--- a/lib/tasks/fix-oembed-cache.rake
+++ b/lib/tasks/fix-oembed-cache.rake
@@ -1,7 +1,7 @@
-namespace :db do
+namespace :oembed do
 
   desc "Fix cached oembed objects to stop them from overlapping on the top bar"
-  task :oembed_fix => :environment do
+  task :update => :environment do
     print "Fetching cached oembed responses that need fixing..."
     caches = OEmbedCache.where('url LIKE :youtube OR url LIKE :soundcloud',
                                 { :youtube => "%youtube.com%",

--- a/spec/models/o_embed_cache_spec.rb
+++ b/spec/models/o_embed_cache_spec.rb
@@ -1,5 +1,43 @@
 require 'spec_helper'
 
 describe OEmbedCache do
-  pending "add some examples to (or delete) #{__FILE__}"
+
+  describe '#fix_embed_code' do
+
+    it "appends a wmode pair to the query string of youtube urls" do
+      oembed_yt = OEmbedCache.new
+      oembed_yt.url = "http://www.youtube.com/watch?v=NVIkck02qao&feature="
+      oembed_yt.data = {
+                "html"=>"<iframe width=\"420\" height=\"315\" src=\"http://www.youtube.com/embed/uJi2rkHiNqg?fs=1&feature=oembed\" frameborder=\"0\" allowfullscreen></iframe>",
+                "trusted_endpoint_url"=>"http://www.youtube.com/oembed",
+                "type"=>"video" }
+      oembed_yt.fix_embed_code
+      oembed_yt.data['html'].should include("wmode=transparent")
+    end
+
+    it "injects a wmode param tag to soundcloud object html" do
+      oembed_sc = OEmbedCache.new
+      oembed_sc.url = "http://soundcloud.com/rekado/on-the-inside-its-just-as-bad"
+      oembed_sc.data = {
+        "html"=>"<object height=\"81\" width=\"420\">\n<param name=\"movie\" value=\"http://player.soundcloud.com/player.swf?url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F23603731\"></param>\n<param name=\"allowscriptaccess\" value=\"always\"></param>\n<embed allowscriptaccess=\"always\" height=\"81\" src=\"http://player.soundcloud.com/player.swf?url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F23603731\" type=\"application/x-shockwave-flash\" width=\"420\"></embed>\n</object>\n\n<span><a href=\"http://soundcloud.com/rekado/on-the-inside-its-just-as-bad\">On the inside it's just as bad</a> by <a href=\"http://soundcloud.com/rekado\">rekado</a></span>\n",
+        "trusted_endpoint_url"=>"http://soundcloud.com/oembed",
+        "type"=>"rich" }
+
+      oembed_sc.fix_embed_code
+      oembed_sc.data['html'].should include("param name=\"wmode\" value=\"transparent\"")
+    end
+
+    it "only processes objects that are of type 'video' or 'rich'" do
+      oembed = OEmbedCache.new
+      oembed.url = "http://some-provier.com/some-resource"
+      oembed.data = {
+        "html"=>"<p>test</p>",
+        "trusted_endpoint_url"=>"http://soundcloud.com/oembed",
+        "type"=>"not-rich" }
+      oembed.fix_embed_code
+      oembed.data['html'].should_not include("wmode")
+    end
+
+  end
+
 end


### PR DESCRIPTION
Adds a new method to OEmbedCache to fix the embedding code (fix_embed_code), such that the embedded objects don't overlap the top bar.

Limitations:
- because of memoization this only works for new links that are not yet in the cache; pod owners would have to run `OEmbedCache.all.map{|i| i.fix_embed_code; i.save}` to fix existing caches
- in Firefox the SoundCloud player ignores the fix; it works in WebKit browsers, though
