### PR TITLE
Set photos_id_seq properly for PostgreSQL

### DIFF
--- a/db/migrate/20111019013244_postgresql_photos_id_seq_init.rb
+++ b/db/migrate/20111019013244_postgresql_photos_id_seq_init.rb
@@ -1,0 +1,11 @@
+class PostgresqlPhotosIdSeqInit < ActiveRecord::Migration
+  def self.up
+    if postgres?
+      execute "SELECT setval('photos_id_seq', COALESCE( ( SELECT MAX(id)+1 FROM photos ), 1 ) )"
+    end
+  end
+
+  def self.down
+    # No reason or need to migrate this down.
+  end
+end


### PR DESCRIPTION
Set photos_id_seq properly for PostgreSQL (re: recent "MovePhotosToTheirOwnTable" migration, which neglected to do this).
