### PR TITLE
fix-mobile-notifications-bug-and-add-footer

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -5,9 +5,6 @@
 class NotificationsController < VannaController
   include NotificationsHelper
 
-  include ActionController::MobileFu
-  has_mobile_fu
-
   def update(opts=params)
     note = Notification.where(:recipient_id => current_user.id, :id => opts[:id]).first
     if note

--- a/app/controllers/vanna_controller.rb
+++ b/app/controllers/vanna_controller.rb
@@ -16,8 +16,13 @@ class VannaController < Vanna::Base
   layout "application"
   include ActionController::Flash
   default_url_options[:host] = "localhost"
+
+  # heinous hack: since loading the full MobileFu method breaks the mobile Notifications view, I just copied the contents of has_mobile_fu here
   include ActionController::MobileFu::InstanceMethods
   helper_method :is_mobile_device?
+  helper_method :in_mobile_view?
+  helper_method :is_device?
+  helper_method :mobile_device
 
   protect_from_forgery :except => :receive
 

--- a/app/views/shared/_footer.mobile.haml
+++ b/app/views/shared/_footer.mobile.haml
@@ -3,3 +3,10 @@
     = link_to current_user.name, current_user.person
   = link_to t('layouts.application.toggle'), toggle_mobile_path
   = link_to t('layouts.header.logout'), destroy_user_session_path
+  %br
+  %br
+  = link_to t('notifications.index.notifications'), notifications_path
+  = "(#{@notification_count})"
+  = link_to t('conversations.index.message_inbox'), conversations_path
+  = "(#{@unread_message_count})"
+


### PR DESCRIPTION
Fix the bug that caused an error when accessing the notifications page from mobile.

Add links to access notifications and private messages to mobile footer.
