### PR TITLE
re-enable photo viewing on mobile

### DIFF
--- a/app/views/shared/_photo_area.mobile.haml
+++ b/app/views/shared/_photo_area.mobile.haml
@@ -9,7 +9,7 @@
         - if post.photos.size > 1
           .additional_photo_count
             = "+ #{post.photos.size-1}"
-        = image_tag post.photos.first.url(:thumb_large), :class => "stream-photo big-stream-photo"
+        = link_to (image_tag post.photos.first.url(:thumb_large), :class => "stream-photo big-stream-photo"), photo_path(post.photos.first), :class => "stream-photo-link"
   - elsif post.activity_streams?
     = image_tag post.image_url
 

--- a/public/stylesheets/sass/mobile.scss
+++ b/public/stylesheets/sass/mobile.scss
@@ -425,6 +425,49 @@ body {
   margin: {
     top: -2px; }; }
 
+#show_content {
+  padding: 12px;
+  padding-bottom: 24px;
+  border: {
+    bottom: 1px solid #bbb; };
+  background: {
+    color: #fff; };
+
+  font: {
+    size: larger; };
+
+  img {
+    max-width: 100%; }
+
+  .photo {
+    text-align: center; }
+
+  .controls {
+    font: {
+      size: smaller; };
+  }
+
+  &.photo {
+    background: {
+      color: #000; };
+  }
+}
+
+#photo_controls {
+  margin: {
+    bottom: -42px; };
+}
+
+.arrow {
+  color: white !important;
+  font: {
+    size: 26pt; };
+  text: {
+    shadow: 0 1px 2px #333;
+    decoration: none; };
+  padding: 0;
+}
+
 #author_info.profile {
   box-shadow: inset 0 -1px 3px #111;
   margin-top: -10px;


### PR DESCRIPTION
Posts with more than one photo only show the first photo in the mobile view. This commit allows the user to click on the front photo and browse the other attached photos.
