### PR TITLE
allow user to prevent his/her own text from showing up in email notifications

### DIFF
--- a/app/mailers/notification_mailers/also_commented.rb
+++ b/app/mailers/notification_mailers/also_commented.rb
@@ -2,14 +2,17 @@ module NotificationMailers
   class AlsoCommented < NotificationMailers::Base
     include ActionView::Helpers::TextHelper
 
-    attr_accessor :comment
+    attr_accessor :comment, :text_owner
 
     def set_headers(comment_id)
       @comment = Comment.find_by_id(comment_id)
+      @text_owner = @comment.author.owner
+      @post_owner = @comment.parent.author.owner
+      @post_author_name = @comment.post.author.name
 
       if mail?
         @headers[:from] = "\"#{@comment.author.name} (Diaspora*)\" <#{AppConfig[:smtp_sender_address]}>"
-        @headers[:subject] = truncate(@comment.parent.comment_email_subject, :length => TRUNCATION_LEN)
+        @headers[:subject] = @post_owner.user_preferences.exists?(:email_type => 'silent') ? "#{I18n.t('notifier.comment_on_post.silenced_subject', :name => "#{@post_author_name}")}" : truncate(@comment.parent.comment_email_subject, :length => TRUNCATION_LEN)
         @headers[:subject] = "Re: #{@headers[:subject]}"
       end
     end

--- a/app/mailers/notification_mailers/comment_on_post.rb
+++ b/app/mailers/notification_mailers/comment_on_post.rb
@@ -2,13 +2,16 @@ module NotificationMailers
   class CommentOnPost < NotificationMailers::Base
     include ActionView::Helpers::TextHelper
 
-    attr_accessor :comment
+    attr_accessor :comment, :text_owner
 
     def set_headers(comment_id)
       @comment = Comment.find(comment_id)
+      @text_owner = @comment.author.owner
+      @post_owner = @comment.parent.author.owner
+      @post_author_name = @comment.post.author.name
 
       @headers[:from] = "\"#{@comment.author.name} (Diaspora*)\" <#{AppConfig[:smtp_sender_address]}>"
-      @headers[:subject] = truncate(@comment.parent.comment_email_subject, :length => TRUNCATION_LEN)
+      @headers[:subject] = @post_owner.user_preferences.exists?(:email_type => 'silent') ? "#{I18n.t('notifier.comment_on_post.silenced_subject', :name => "#{@post_author_name}")}" : truncate(@comment.parent.comment_email_subject, :length => TRUNCATION_LEN)
       @headers[:subject] = "Re: #{@headers[:subject]}"
     end
   end

--- a/app/mailers/notification_mailers/liked.rb
+++ b/app/mailers/notification_mailers/liked.rb
@@ -1,9 +1,10 @@
 module NotificationMailers
   class Liked < NotificationMailers::Base
-    attr_accessor :like
+    attr_accessor :like, :text_owner
 
     def set_headers(like_id)
       @like = Like.find(like_id)
+      @text_owner = @like.target.author.owner
 
       @headers[:subject] = I18n.t('notifier.liked.liked', :name => @sender.name)
     end

--- a/app/mailers/notification_mailers/mentioned.rb
+++ b/app/mailers/notification_mailers/mentioned.rb
@@ -1,9 +1,10 @@
 module NotificationMailers
   class Mentioned < NotificationMailers::Base
-    attr_accessor :post
+    attr_accessor :post, :text_owner
 
     def set_headers(target_id)
       @post = Mention.find_by_id(target_id).post
+      @text_owner = @post.author.owner
 
       @headers[:subject] = I18n.t('notifier.mentioned.subject', :name => @sender.name)
     end

--- a/app/mailers/notification_mailers/private_message.rb
+++ b/app/mailers/notification_mailers/private_message.rb
@@ -1,14 +1,15 @@
 module NotificationMailers
   class PrivateMessage < NotificationMailers::Base
-    attr_accessor :message, :conversation, :participants
+    attr_accessor :message, :conversation, :participants, :text_owner
 
     def set_headers(message_id)
-      @message  = Message.find_by_id(message_id)
+      @message = Message.find_by_id(message_id)
       @conversation = @message.conversation
       @participants = @conversation.participants
+      @text_owner = @message.author.owner
 
       @headers[:from] = "\"#{@message.author.name} (Diaspora*)\" <#{AppConfig[:smtp_sender_address]}>"
-      @headers[:subject] = @conversation.subject.strip
+      @headers[:subject] = @text_owner.user_preferences.exists?(:email_type => 'silent') ? "#{I18n.t('notifier.private_message.silenced_subject', :name => "#{@sender.name}")}" : @conversation.subject.strip
       @headers[:subject] = "Re: #{@headers[:subject]}" if @conversation.messages.size > 1
     end
   end

--- a/app/mailers/notification_mailers/reshared.rb
+++ b/app/mailers/notification_mailers/reshared.rb
@@ -1,9 +1,10 @@
 module NotificationMailers
   class Reshared < NotificationMailers::Base
-    attr_accessor :reshare
+    attr_accessor :reshare, :text_owner
 
     def set_headers(reshare_id)
       @reshare = Reshare.find(reshare_id)
+      @text_owner = @reshare.root.author.owner
 
       @headers[:subject] = I18n.t('notifier.reshared.reshared', :name => @sender.name)
     end

--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -10,7 +10,8 @@ class UserPreference < ActiveRecord::Base
    "started_sharing",
    "also_commented",
    "liked",
-   "reshared"]
+   "reshared",
+   "silent"]
 
   def must_be_valid_email_type
     unless VALID_EMAIL_TYPES.include?(self.email_type)
@@ -18,3 +19,5 @@ class UserPreference < ActiveRecord::Base
     end
   end
 end
+
+

--- a/app/views/notifier/also_commented.html.haml
+++ b/app/views/notifier/also_commented.html.haml
@@ -1,4 +1,6 @@
 %p
-  = comment_message(@notification.comment, :process_newlines => true)
+  = @notification.text_owner.user_preferences.exists?(:email_type => 'silent') ? "#{t('notifier.comment_on_post.silenced', :name => "#{@notification.sender.name}")}" : comment_message(@notification.comment, :process_newlines => true)
 %p
   = link_to t('notifier.comment_on_post.reply', :name => @notification.comment.post.author.first_name), post_url(@notification.comment.post)
+
+

--- a/app/views/notifier/also_commented.text.haml
+++ b/app/views/notifier/also_commented.text.haml
@@ -1,1 +1,3 @@
-!= comment_message(@notification.comment)
+!= @notification.text_owner.user_preferences.exists?(:email_type => 'silent') ? "#{t('notifier.comment_on_post.silenced', :name => "#{@notification.sender.name}")}" : comment_message(@notification.comment)
+
+

--- a/app/views/notifier/comment_on_post.html.haml
+++ b/app/views/notifier/comment_on_post.html.haml
@@ -1,4 +1,6 @@
 %p
-  = comment_message(@notification.comment, :process_newlines => true)
+  = @notification.text_owner.user_preferences.exists?(:email_type => 'silent') ? "#{t('notifier.comment_on_post.silenced', :name => "#{@notification.sender.name}")}" : comment_message(@notification.comment, :process_newlines => true)
 %p
   = link_to t('notifier.comment_on_post.reply', :name => @notification.comment.post.author.name), post_url(@notification.comment.post)
+
+

--- a/app/views/notifier/comment_on_post.text.haml
+++ b/app/views/notifier/comment_on_post.text.haml
@@ -1,1 +1,3 @@
-!= comment_message(@notification.comment)
+!= @notification.text_owner.user_preferences.exists?(:email_type => 'silent') ? "#{t('notifier.comment_on_post.silenced', :name => "#{@notification.sender.name}")}" : comment_message(@notification.comment)
+
+

--- a/app/views/notifier/liked.html.haml
+++ b/app/views/notifier/liked.html.haml
@@ -2,7 +2,9 @@
   = "#{t('.liked', :name => "#{@notification.sender.name}")}:"
 
 %p{:style => "font-style:italic;color:#666"}
-  = post_message(@notification.like.target, :process_newlines => true)
+  = @notification.text_owner.user_preferences.exists?(:email_type => 'silent') ? "#{t('notifier.liked.silenced')}" : post_message(@notification.like.target, :process_newlines => true)
 
 %p
   = link_to t('.view_post'), post_url(@notification.like.target)
+
+

--- a/app/views/notifier/liked.text.haml
+++ b/app/views/notifier/liked.text.haml
@@ -1,3 +1,4 @@
 != "#{t('notifier.liked.liked', :name => "#{@notification.sender.name}")}:"
-!=post_message(@notification.like.target)
+!= @notification.text_owner.user_preferences.exists?(:email_type => 'silent') ? "#{t('notifier.liked.silenced_text')}" : post_message(@notification.like.target)
+
 

--- a/app/views/notifier/mentioned.html.haml
+++ b/app/views/notifier/mentioned.html.haml
@@ -1,4 +1,6 @@
 %p
-  = post_message(@notification.post, :process_newlines => true, :length => 600)
+  = @notification.text_owner.user_preferences.exists?(:email_type => 'silent') ? "#{t('notifier.mentioned.silenced', :name => "#{@notification.sender.name}")}" : post_message(@notification.post, :process_newlines => true, :length => 600)
 %p
   = link_to t('notifier.comment_on_post.reply', :name => @notification.post.author.name), post_url(@notification.post)
+
+

--- a/app/views/notifier/mentioned.text.haml
+++ b/app/views/notifier/mentioned.text.haml
@@ -1,1 +1,3 @@
-!= post_message(@notification.post, :process_newlines => true, :length => 600)
+!= @notification.text_owner.user_preferences.exists?(:email_type => 'silent') ? "#{t('notifier.mentioned.silenced', :name => "#{@notification.sender.name}")}" : post_message(@notification.post, :process_newlines => true, :length => 600)
+
+

--- a/app/views/notifier/private_message.html.haml
+++ b/app/views/notifier/private_message.html.haml
@@ -1,4 +1,6 @@
 %p
-  = post_message(@notification.message, :process_newlines => true, :length => 2000)
+  = @notification.text_owner.user_preferences.exists?(:email_type => 'silent') ? "#{t('notifier.private_message.silenced', :name => "#{@notification.sender.name}")}" : post_message(@notification.message, :process_newlines => true, :length => 2000)
 %p
   = link_to t('.reply_to_or_view'), conversations_url(:conversation_id => @notification.conversation)
+
+

--- a/app/views/notifier/private_message.text.haml
+++ b/app/views/notifier/private_message.text.haml
@@ -1,1 +1,3 @@
-!= @notification.message.text
+!= @notification.text_owner.user_preferences.exists?(:email_type => 'silent') ? "#{t('notifier.private_message.silenced', :name => "#{@notification.sender.name}")}" : @notification.message.text
+
+

--- a/app/views/notifier/reshared.html.haml
+++ b/app/views/notifier/reshared.html.haml
@@ -2,7 +2,9 @@
   = "#{t('.reshared', :name => "#{@notification.sender.name}")}:"
 
 %p{:style => "font-style:italic;color:#666"}
-  = post_message(@notification.reshare.root, :process_newlines => true)
+  = @notification.text_owner.user_preferences.exists?(:email_type => 'silent') ? "#{t('notifier.reshared.silenced')}" : post_message(@notification.reshare.root, :process_newlines => true)
 
 %p
   = link_to t('.view_post'), post_url(@notification.reshare)
+
+

--- a/app/views/notifier/reshared.text.haml
+++ b/app/views/notifier/reshared.text.haml
@@ -1,3 +1,4 @@
 != "#{t('notifier.reshared.reshared', :name => "#{@notification.sender.name}")}:"
-!=post_message(@notification.reshare.root)
+!= @notification.text_owner.user_preferences.exists?(:email_type => 'silent') ? "#{t('notifier.reshared.silenced_text')}" : post_message(@notification.reshare.root)
+
 

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -147,6 +147,14 @@
         %p.checkbox_select
           = type.label :reshared, t('.reshared')
           = type.check_box :reshared, {:checked =>  @email_prefs['reshared']}, false, true
+
+
+        %br
+        %br
+        %br
+        %p.checkbox_select
+          = type.label t('.silenced')
+          = type.check_box :silent, {:checked => @email_prefs['silent']}, false, true
     %br
     = f.submit t('.change'), :class => "button"
 

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -491,17 +491,26 @@ en:
         sharing: "has started sharing with you!"
         view_profile: "View %{name}'s profile"
     comment_on_post:
+        silenced_subject: "%{name}'s post"
+        silenced: "%{name} has a new comment"
         reply: "Reply or view %{name}'s post >"
     mentioned:
         subject: "%{name} has mentioned you on Diaspora*"
         mentioned: "mentioned you in a post:"
+        silenced: "%{name} has mentioned you in a post."
     private_message:
+        silenced_subject: "%{name}'s private message"
+        silenced: "%{name} has sent you a private message."
         reply_to_or_view: "Reply to or view this conversation >"
     liked:
         liked: "%{name} liked your post"
+        silenced: "Click link below to see the post"
+        silenced_text: "Visit the Diaspora page to see the post"
         view_post: "View post >"
     reshared:
         reshared: "%{name} reshared your post"
+        silenced: "Click link below to see the post"
+        silenced_text: "Login to your account to see the post"
         view_post: "View post >"
     confirm_email:
         subject: "Please activate your new email address %{unconfirmed_email}"
@@ -907,6 +916,7 @@ en:
       private_message: "...you receive a private message?"
       liked: "...someone likes your post?"
       reshared: "...someone reshares your post?"
+      silenced: "Allow the text of your posts (or comments, messages, etc.) to be in email notifications?"
       change: "Change"
       email_awaiting_confirmation: "We have sent you an activation link to %{unconfirmed_email}. Until you follow this link and activate the new address, we will continue to use your original address %{email}."
       stream_preferences: "Stream Preferences"


### PR DESCRIPTION
This commit implements a choice for the user to have his/her text hidden in email notifications. It doesn't change whether or not those notifications are sent out, it just keeps the text of the private message (or post, comment, etc.) from displaying in the email.

I don't believe it changes anything that should interfere with federation.

There aren't any tests for it yet. I'm not familiar with rspec or cucumber. I wanted to get this pull going so people could at least look at it.

This fixes #2026.
