### PR TITLE
backup task handles postgresql dumps

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -159,10 +159,13 @@ defaults: &defaults
   piwik_url:
 
   # Backups
+  backup_retention_days: 3
 
   # cloudfiles username and api-key - used for backups
   cloudfiles_username: 'example'
   cloudfiles_api_key:  'abc123'
+  cloudfiles_db_container: 'Database Backup'
+  cloudfiles_images_container: 'Image Backup'
 
   # Donations
 

--- a/lib/tasks/backup.rake
+++ b/lib/tasks/backup.rake
@@ -102,9 +102,10 @@ namespace :backup do
       cf = CloudFiles::Connection.new(:username => AppConfig[:cloudfiles_username], :api_key => AppConfig[:cloudfiles_api_key])
       container = cf.container(AppConfig[:cloudfiles_images_container])
 
+      images_dir = File.join(File.dirname(__FILE__), '..', '..', 'public/uploads/images/')
       FileUtils.mkdir_p(tmp_backup_dir)
       tar_name = "photos_#{Time.now.to_i}.tar"
-      `tar cfPz /dev/stdout /usr/local/app/diaspora/public/uploads/images/ | split -d -b 4831838208 - #{tmp_backup_dir}/#{tar_name}`
+      `tar cfPz /dev/stdout #{images_dir} | split -d -b 4831838208 - #{tmp_backup_dir}/#{tar_name}`
 
       (0..99).each do |n|
         padded_str = n.to_s.rjust(2,'0')

--- a/lib/tasks/backup.rake
+++ b/lib/tasks/backup.rake
@@ -54,6 +54,7 @@ namespace :backup do
 
       puts "Dumping PostgreSQL at #{Time.now.to_s}"
       `PGPASSFILE=#{tmp_backup_dir}/#{tmp_pass_file} nice pg_dump -h #{host} -p #{port} -U #{user} #{database} > #{tmp_backup_dir}/#{tmp_db_dir}/#{tmp_sql_file} `
+      File.delete(tmp_backup_dir + "/" + tmp_pass_file)
 
       puts "Gzipping dump at #{Time.now.to_s}"
       tar_name = "postgresql_#{Time.now.to_i}.tar"
@@ -74,7 +75,6 @@ namespace :backup do
       puts("event=backup status=success type=database")
 
       File.delete(tmp_backup_dir + "/" + tar_name)
-      File.delete(tmp_backup_dir + "/" + tmp_pass_file)
       File.delete(tmp_backup_dir + "/" + tmp_db_dir + "/" + tmp_sql_file)
       Dir.delete(tmp_backup_dir + "/" + tmp_db_dir)
       Dir.delete(tmp_backup_dir)

--- a/lib/tasks/backup.rake
+++ b/lib/tasks/backup.rake
@@ -64,7 +64,7 @@ namespace :backup do
 
       puts "Gzipping dump at #{Time.now.to_s}"
       tar_name = "mysql_#{Time.now.to_i}.tar"
-      `nice tar cfPz /tmp/backup/#{tar_name} #{tmp_backup_dir}/#{tmp_db_dir}`
+      `nice tar cfPz #{tmp_backup_dir}/#{tar_name} #{tmp_backup_dir}/#{tmp_db_dir}`
     end
 
     file = container.create_object(tar_name)


### PR DESCRIPTION
Modified backup task to handle postgresql data. backup:mysql is now backup:database and keys off of the "adapter" field in database.yml to determine whether to backup mysql or postgresql.
