### PR TITLE
Multi oembed

### DIFF
--- a/app/models/embedding.rb
+++ b/app/models/embedding.rb
@@ -1,0 +1,8 @@
+#   Copyright (c) 2010-2011, Diaspora Inc.  This file is
+#   licensed under the Affero General Public License version 3 or later.  See
+#   the COPYRIGHT file.
+
+class Embedding < ActiveRecord::Base
+  belongs_to :post
+  belongs_to :o_embed_cache
+end

--- a/app/models/jobs/gather_o_embed_data.rb
+++ b/app/models/jobs/gather_o_embed_data.rb
@@ -9,7 +9,7 @@ module Jobs
 
     def self.perform(post_id, url)
       post = Post.find(post_id)
-      post.o_embed_cache = OEmbedCache.find_or_create_by_url(url)
+      post.o_embed_caches << OEmbedCache.find_or_create_by_url(url)
       post.save
     end
   end

--- a/app/models/o_embed_cache.rb
+++ b/app/models/o_embed_cache.rb
@@ -2,7 +2,8 @@ class OEmbedCache < ActiveRecord::Base
   serialize :data
   attr_accessible :url
 
-  has_many :posts
+  has_many :embeddings
+  has_many :posts, :through => :embeddings
 
   def self.find_or_create_by_url(url)
    cache = OEmbedCache.find_or_initialize_by_url(url)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -16,12 +16,13 @@ class Post < ActiveRecord::Base
   has_many :reshares, :class_name => "Reshare", :foreign_key => :root_guid, :primary_key => :guid
   has_many :resharers, :class_name => 'Person', :through => :reshares, :source => :author
 
-  belongs_to :o_embed_cache
+  has_many :embeddings
+  has_many :o_embed_caches, :through => :embeddings, :source => :o_embed_cache
 
   after_create :cache_for_author
 
   #scopes
-  scope :includes_for_a_stream, includes(:o_embed_cache, {:author => :profile}, :mentions => {:person => :profile}) #note should include root and photos, but i think those are both on status_message
+  scope :includes_for_a_stream, includes({:author => :profile}, :mentions => {:person => :profile}) #note should include root and photos, but i think those are both on status_message
 
   def self.excluding_blocks(user)
     people = user.blocks.includes(:person).map{|b| b.person}

--- a/app/models/status_message.rb
+++ b/app/models/status_message.rb
@@ -26,7 +26,7 @@ class StatusMessage < Post
   attr_accessor :oembed_url
 
   after_create :create_mentions
-  after_create :queue_gather_oembed_data, :if => :contains_oembed_url_in_text?
+  after_create :queue_gather_oembed_data
 
   #scopes
   scope :where_person_is_mentioned, lambda { |person|
@@ -175,13 +175,12 @@ class StatusMessage < Post
   end
 
   def queue_gather_oembed_data
-    Resque.enqueue(Jobs::GatherOEmbedData, self.id, self.oembed_url)
-  end
-
-  def contains_oembed_url_in_text?
     require 'uri'
     urls = URI.extract(self.raw_message, ['http', 'https'])
-    self.oembed_url = urls.find{|url| ENDPOINT_HOSTS_STRING.match(URI.parse(url).host)}
+    oembed_urls = urls.keep_if{|url| ENDPOINT_HOSTS_STRING.match(URI.parse(url).host)}
+    oembed_urls.each do |url|
+      Resque.enqueue(Jobs::GatherOEmbedData, self.id, url)
+    end
   end
 
   def update_photos_counter

--- a/app/views/status_messages/_status_message.html.haml
+++ b/app/views/status_messages/_status_message.html.haml
@@ -16,5 +16,5 @@
 
 %div{:class => [direction_for(post.text), 'collapsible']}
   != markdownify(post)
-  - if post.o_embed_cache_id.present?
-    = o_embed_html(post.o_embed_cache)
+  - post.o_embed_caches.each do |cache|
+    = o_embed_html(cache)

--- a/db/migrate/20111030144614_many_posts_to_many_o_embed_caches.rb
+++ b/db/migrate/20111030144614_many_posts_to_many_o_embed_caches.rb
@@ -1,0 +1,29 @@
+class ManyPostsToManyOEmbedCaches < ActiveRecord::Migration
+  def self.up
+    create_table :embeddings do |t|
+      t.integer :post_id
+      t.integer :o_embed_cache_id
+    end
+
+    posts_with_embed = Post.where(Post.arel_table[:o_embed_cache_id].not_eq(nil))
+    posts_with_embed.each do |p|
+      p.o_embed_caches << p.o_embed_cache
+      p.save
+    end
+
+    remove_column(:posts, :o_embed_cache_id)
+  end
+
+  def self.down
+    add_column(:posts, :o_embed_cache_id, :integer)
+    Post.reset_column_information
+
+    OEmbedCache.all.each do |o|
+      p = o.posts.first
+      p.o_embed_cache_id = o.id
+      p.save
+    end
+
+    drop_table :embeddings
+  end
+end

--- a/spec/models/status_message_spec.rb
+++ b/spec/models/status_message_spec.rb
@@ -307,18 +307,12 @@ STR
     end
   end
 
-  describe '#contains_url_in_text?' do
-    it 'returns an array of all urls found in the raw message' do
-      sm = Factory(:status_message, :text => 'http://youtube.com is so cool.  so is https://joindiaspora.com')
-      sm.contains_oembed_url_in_text?.should_not be_nil
-      sm.oembed_url.should == 'http://youtube.com'
-    end
-  end
-
   describe 'oembed' do
-    it 'should queue a GatherOembedData if it includes a link' do
-      sm = Factory.build(:status_message, :text => 'http://youtube.com is so cool.  so is https://joindiaspora.com')
-      Resque.should_receive(:enqueue).with(Jobs::GatherOEmbedData, instance_of(Fixnum), instance_of(String))
+    it 'should queue as many GatherOembedData jobs as there are oembed links' do
+      sm = Factory.build(:status_message, :text => 'video: http://youtube.com
+                                                    music: http://soundcloud.com
+                                                    info: https://joindiaspora.com')
+      Resque.should_receive(:enqueue).with(Jobs::GatherOEmbedData, instance_of(Fixnum), instance_of(String)).twice()
       sm.save
     end
   end


### PR DESCRIPTION
This allows embedding of more than one resource (e.g. a song on SoundCloud and a video on YouTube) in a post by changing the association of posts to o_embed_caches to a many-to-many relationship through an embeddings table.

The migration "rewires" existing caches (this may take a while on a large database).
