### PR TITLE
Fixed post links of remote pods

### DIFF
--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -129,7 +129,7 @@ class PhotosController < ApplicationController
         format.html do
           flash[:notice] = I18n.t 'photos.destroy.notice'
           if StatusMessage.find_by_guid(photo.status_message_guid)
-              respond_with photo, :location => post_path(photo.status_message)
+              respond_with photo, :location => post_path(photo.status_message.guid)
           else
             respond_with photo, :location => person_photos_path(current_user.person)
           end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -8,7 +8,7 @@ module CommentsHelper
     if post.comments.size <= 3
       link_to "#{t('stream_helper.hide_comments')}", post_comments_path(post.id), :class => "toggle_post_comments"
     elsif ! user_signed_in?
-      link_to "#{t('stream_helper.show_comments', :count => post.comments.size - 3)}", post_path(post.id, :all_comments => '1'), :class => "toggle_post_comments"
+      link_to "#{t('stream_helper.show_comments', :count => post.comments.size - 3)}", post_path(post.guid, :all_comments => '1'), :class => "toggle_post_comments"
     else
       link_to "#{t('stream_helper.show_comments', :count => post.comments.size - 3)}", post_comments_path(post.id), :class => "toggle_post_comments"
     end

--- a/app/helpers/markdownify_helper.rb
+++ b/app/helpers/markdownify_helper.rb
@@ -8,17 +8,20 @@ module MarkdownifyHelper
   def markdownify(target, render_options={})
 
     markdown_options = {
-      :autolink            => true,
-      :fenced_code_blocks  => true,
-      :space_after_headers => true,
-      :strikethrough       => true,
-      :superscript         => true,
-      :tables              => true,
-      :no_intra_emphasis   => true,
+      :autolink               => true,
+      :fenced_code_blocks     => true,
+      :space_after_headers    => true,
+      :strikethrough          => true,
+      :superscript            => true,
+      :tables                 => true,
+      :no_intra_emphasis      => true,
+      :localize_diaspora_urls => true,
     }
 
     render_options[:filter_html] = true
     render_options[:hard_wrap] ||= true
+    render_options[:localize_diaspora_urls] ||= true
+    render_options[:remote_pod_url] = target.author.pod_url if target.respond_to?(:author) and render_options[:localize_diaspora_urls]
 
     # This ugly little hack basically means
     #   "Give me the rawest contents of target available"

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -12,13 +12,13 @@ module NotificationsHelper
 
     if note.instance_of?(Notifications::Mentioned)
       if post = note.linked_object
-        translation(target_type, :actors => actors, :count => actors_count, :post_link => link_to(t('notifications.post'), post_path(post)).html_safe)
+        translation(target_type, :actors => actors, :count => actors_count, :post_link => link_to(t('notifications.post'), post_path(post.guid)).html_safe)
       else
         t(note.deleted_translation_key, :actors => actors, :count => actors_count).html_safe
       end
     elsif note.instance_of?(Notifications::CommentOnPost) || note.instance_of?(Notifications::AlsoCommented) || note.instance_of?(Notifications::Reshared) || note.instance_of?(Notifications::Liked)
       if post = note.linked_object
-        translation(target_type, :actors => actors, :count => actors_count, :post_author => h(post.author.name), :post_link => link_to(t('notifications.post'), post_path(post), 'data-ref' => post.id, :class => 'hard_object_link').html_safe)
+        translation(target_type, :actors => actors, :count => actors_count, :post_author => h(post.author.name), :post_link => link_to(t('notifications.post'), post_path(post.guid), 'data-ref' => post.id, :class => 'hard_object_link').html_safe)
       else
         t(note.deleted_translation_key, :actors => actors, :count => actors_count).html_safe
       end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -276,7 +276,9 @@ class Person < ActiveRecord::Base
     end 
   end
 
-  
+  def pod_url
+    diaspora_handle.split('@')[1]
+  end
   
   # @param person [Person]
   # @param url [String]

--- a/app/views/apps/show.html.haml
+++ b/app/views/apps/show.html.haml
@@ -22,7 +22,7 @@
     - for post in @posts
       .image-element.stream_element
         .hold-me
-          = link_to(image_tag(post.image_url), post_path(post))
+          = link_to(image_tag(post.image_url), post_path(post.guid))
           .via
             = post.author.name
           .time{:integer => post.created_at.to_i}

--- a/app/views/photos/show.html.haml
+++ b/app/views/photos/show.html.haml
@@ -42,7 +42,7 @@
       %p
         = markdownify(photo.status_message, :oembed => true)
       %span{:style=>'font-size:smaller'}
-        =link_to t('.collection_permalink'), post_path(photo.status_message)
+        =link_to t('.collection_permalink'), post_path(photo.status_message.guid)
       %br
       %br
 

--- a/app/views/posts/_photo.html.haml
+++ b/app/views/posts/_photo.html.haml
@@ -18,4 +18,4 @@
     = post.text
 
 %br
-= link_to t('photos.show.show_original_post'), post_path(post.status_message)
+= link_to t('photos.show.show_original_post'), post_path(post.status_message.guid)

--- a/app/views/reshares/_reshare.haml
+++ b/app/views/reshares/_reshare.haml
@@ -14,7 +14,7 @@
           %span.details
             –
             %span.timeago
-              = link_to(how_long_ago(post), post_path(post))
+              = link_to(how_long_ago(post), post_path(post.guid))
             –
             = t("reshares.reshare.reshare", :count => post.reshare_count)
 

--- a/app/views/shared/_stream_element.html.haml
+++ b/app/views/shared/_stream_element.html.haml
@@ -31,7 +31,7 @@
         %span.details
           –
           %span.timeago
-            = link_to(how_long_ago(post), post_path(post))
+            = link_to(how_long_ago(post), post_path(post.guid))
 
       - if post.activity_streams?
         = link_to image_tag(post.image_url, 'data-small-photo' => post.image_url, 'data-full-photo' => post.image_url, :class => 'stream-photo'), post.object_url, :class => "stream-photo-link"

--- a/lib/diaspora/markdownify.rb
+++ b/lib/diaspora/markdownify.rb
@@ -6,8 +6,33 @@ module Diaspora
       include ActionView::Helpers::TextHelper
       include ActionView::Helpers::TagHelper
 
+      def initialize(options={})
+        @options = options
+        super(options)
+      end
+
       def autolink(link, type)
         auto_link(link, :link => :urls, :html => { :target => "_blank" })
+      end
+
+      def postprocess(full_document)
+        if @options[:localize_diaspora_urls] && @options[:remote_pod_url]
+          localize_diaspora_url(full_document)
+        else
+          full_document
+        end
+      end
+
+      def localize_diaspora_url(full_document)
+        base_url = "https://#{@options[:remote_pod_url]}/posts/"
+        full_document.gsub(/#{base_url}([0-9a-z]*)/) { |url|
+          guid = $1
+          if guid.length>8 and Post.exists?(:guid => guid)
+            "https://#{AppConfig[:pod_url]}/posts/"+guid
+          else
+            url
+          end
+        }
       end
 
     end

--- a/spec/helpers/notifications_helper_spec.rb
+++ b/spec/helpers/notifications_helper_spec.rb
@@ -68,14 +68,14 @@ describe NotificationsHelper do
     describe 'for a like' do
       it 'should include a link to the post' do
         output = object_link(@notification, notification_people_link(@notification))
-        output.should include post_path(@post)
+        output.should include post_path(@post.guid)
       end
 
       it 'includes the boilerplate translation' do
         output = object_link(@notification, notification_people_link(@notification))
         output.should include t("#{@notification.popup_translation_key}.two",
                                 :actors => notification_people_link(@notification),
-                                :post_link => "<a href=\"#{post_path(@post)}\" class=\"hard_object_link\" data-ref=\"#{@post.id}\">#{t('notifications.post')}</a>")
+                                :post_link => "<a href=\"#{post_path(@post.guid)}\" class=\"hard_object_link\" data-ref=\"#{@post.id}\">#{t('notifications.post')}</a>")
       end
 
       context 'when post is deleted' do

--- a/spec/lib/diaspora/markdownify_spec.rb
+++ b/spec/lib/diaspora/markdownify_spec.rb
@@ -3,7 +3,13 @@ require 'spec_helper'
 describe Diaspora::Markdownify::HTML do
   describe '#autolink' do
     before do
-      @html = Diaspora::Markdownify::HTML.new
+      renderer_options = {
+        :remote_pod_url => 'anotherpod.com',
+        :localize_diaspora_urls => true,
+      }
+      @html = Diaspora::Markdownify::HTML.new(renderer_options)
+
+      post = Factory(:status_message, :guid => "925951e0695300ff")
     end
 
     it 'should make all of the links open in a new tab' do
@@ -13,6 +19,18 @@ describe Diaspora::Markdownify::HTML do
       link = doc.css("a")
 
       link.attr("target").value.should == "_blank"
+    end
+
+    it 'should transform urls of foreign pods to the local pod for post guids in postprocessing' do
+      markdownified = @html.postprocess("hello, look at this: <a href='https://anotherpod.com/posts/925951e0695300ff'>https://anotherpod.com/posts/925951e0695300ff</a>. It's great!")
+      url = "https://#{AppConfig[:pod_url]}/posts/925951e0695300ff"
+      markdownified.should =~ /#{url}/
+    end
+
+    it 'should not transform urls of foreign pods to the local pod for post ids in postprocessing' do
+      markdownified = @html.postprocess("hello, look at this: <a href='https://anotherpod.com/posts/123'>https://anotherpod.com/posts/123</a>. It's great!")
+      url = "https://#{AppConfig[:pod_url]}/posts/123"
+      markdownified.should_not =~ /#{url}/
     end
   end
 end


### PR DESCRIPTION
When alice on joindiaspora.com posts a link to 'https://joindiaspora.com/posts/:guid' and bob on geraspora views this this status message the link in this post is modified from 'https://joindiaspora.com/posts/:guid' to 'https://pod.geraspora.de/posts/:guid'
