### PR TITLE
Don't collapse post contents when viewing only a single post

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -32,6 +32,8 @@ class PostsController < ApplicationController
         notification.save
       end
 
+      @expand_post = true
+
       respond_to do |format|
         format.xml{ render :xml => @post.to_diaspora_xml }
         format.mobile{render 'posts/show.mobile.haml'}

--- a/app/views/status_messages/_status_message.html.haml
+++ b/app/views/status_messages/_status_message.html.haml
@@ -14,7 +14,7 @@
         - for photo in photos[1..photos.size]
           = link_to (image_tag photo.url(:thumb_small), :class => 'stream-photo thumb_small', 'data-small-photo' => photo.url(:thumb_medium), 'data-full-photo' => photo.url), photo_path(photo), :class => 'stream-photo-link'
 
-%div{:class => [direction_for(post.text), 'collapsible']}
+%div{:class => [direction_for(post.text), @expand_post ? "" : "collapsible"]}
   != markdownify(post)
   - if post.o_embed_cache_id.present?
     = o_embed_html(post.o_embed_cache)

--- a/spec/controllers/aspects_controller_spec.rb
+++ b/spec/controllers/aspects_controller_spec.rb
@@ -131,6 +131,12 @@ describe AspectsController do
       response.should render_template('shared/_stream')
     end
 
+    it 'displays long posts collapsed' do
+      alice.post(:status_message, :text => "ohai "*800, :to => @alices_aspect_2.id)
+      get :index, :only_posts => true
+      doc.css('.collapsible').should_not be_nil
+    end
+
     it 'assigns an Stream::Aspect' do
       get :index
       assigns(:stream).class.should == Stream::Aspect

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -7,7 +7,7 @@ require 'spec_helper'
 describe PostsController do
   before do
     aspect = alice.aspects.first
-    @message = alice.build_post :status_message, :text => "ohai", :to => aspect.id
+    @message = alice.build_post :status_message, :text => "ohai "*800, :to => aspect.id
     @message.save!
 
     alice.add_to_streams(@message, [aspect])
@@ -25,6 +25,12 @@ describe PostsController do
         response.should be_success
         doc.has_link?('Like').should be_true
         doc.has_link?('Comment').should be_true
+      end
+
+      it 'does not collapse the post' do
+        get :show, "id" => @message.id
+        response.should be_success
+        doc.css('collapsible').should be_empty
       end
 
       it 'succeeds on mobile' do


### PR DESCRIPTION
One should not have to click on "show more..." if one is viewing a single post on its dedicated view. This introduces a "collapsible" helper which takes a controller object. As the _stream_element partial is used by many views, passing a variable along the chain to force full display of the post contents seemed inelegant. The helper will only attach the 'collapsible' class if the post is not viewed through the posts/show view.
