### PR TITLE
Fix issue #2173 (oembed overlapping top bar) // CSS approach

### DIFF
--- a/public/stylesheets/sass/application.sass
+++ b/public/stylesheets/sass/application.sass
@@ -149,7 +149,7 @@ form
 
 header
   @include box-shadow(0,1px,2px,rgba(0,0,0,0.5))
-  @include linear-gradient(rgba(35,30,30,0.95),rgba(35,30,30,1))
+  @include linear-gradient(rgb(40,35,35),rgb(35,30,30))
 
   :z-index 1001
   :padding 6px 0


### PR DESCRIPTION
The alternative CSS solution described here:
https://github.com/diaspora/diaspora/pull/2206#issuecomment-2639192

This kills the transparency gradient on the header to keep Flash objects from overlapping.
