### PR TITLE
fixed 500 error on people's photos view

### DIFF
--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -27,7 +27,7 @@
     = render 'people/sub_header', :person => @person, :contact => @contact
 
     / hackity hack until we get a photo stream
-    - if (@posts && @posts.length > 0) || @stream.stream_posts.length > 0
+    - if (@posts && @posts.length > 0) || (@stream && @stream.stream_posts.length > 0)
       -if @post_type == :photos
         = render 'photos/index', :photos => @posts
       - else


### PR DESCRIPTION
fixed 500 error if one is opening people's photos view and there are no images in the user's stream
