### PR TITLE
display number of reshares on own posts

### DIFF
--- a/app/views/shared/_stream_element.html.haml
+++ b/app/views/shared/_stream_element.html.haml
@@ -87,5 +87,9 @@
       .likes.on_post
         .likes_container
           = render "likes/likes_container", :target_id => post.id, :likes_count => post.likes_count, :current_user => current_user, :target_type => "Post"
+      - if user_signed_in? && post.author.owner_id == current_user.id && post.reshare_count > 0
+        .reshares.on_post
+          = image_tag('icons/reshare.svg')
+          = t("reshares.reshare.reshare", :count => post.reshare_count)
 
       = render "comments/comments", :post => post, :current_user => current_user, :commenting_disabled => commenting_disabled?(post)

--- a/public/images/icons/reshare.svg
+++ b/public/images/icons/reshare.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 14.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 43363)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   width="100px"
+   height="93.615px"
+   viewBox="0 0 100 93.615"
+   enable-background="new 0 0 100 93.615"
+   xml:space="preserve"
+   inkscape:version="0.48.2 r9819"
+   sodipodi:docname="reshare.svg"><metadata
+   id="metadata3130"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+   id="defs3128" /><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1914"
+   inkscape:window-height="1053"
+   id="namedview3126"
+   showgrid="false"
+   inkscape:zoom="4.5131657"
+   inkscape:cx="151.81351"
+   inkscape:cy="25.206592"
+   inkscape:window-x="3"
+   inkscape:window-y="24"
+   inkscape:window-maximized="0"
+   inkscape:current-layer="Layer_1" />
+
+<path
+   style="fill:#000000"
+   d="m 4.5423688,72.958417 34.9764942,-22.212566 0,10.006255 38,0 0,-12.699787 18.859328,-12.299726 0.13693,18.66618 c -0.004,21.705841 -0.6739,23.922684 -8.26692,27.369513 -3.76724,1.710126 -6.709315,1.922296 -26.927078,1.941858 l -22.697741,0.02196 0.0602,10.02166 z m -0.01977,-33.85811 C 4.5268988,17.602023 5.1300238,15.52161 12.439794,11.792443 16.122979,9.9134222 18.260796,9.7521062 39.479023,9.7521062 l 23.039838,0 c 0.02733,-3.2966814 -0.02093,-6.5925323 -0.06666,-9.88872649 l 33.941,19.20901229 -34.87434,23.719204 0,-10.03949 -38,0 -0.06334,12.5 -18.9366602,12.696403 0.0037,-18.848202 z"
+   id="path3272"
+   inkscape:connector-curvature="0"
+   sodipodi:nodetypes="cccccccssccccsscccccccccc" /></svg>

--- a/public/stylesheets/sass/application.sass
+++ b/public/stylesheets/sass/application.sass
@@ -588,6 +588,7 @@ ul.as-selections
 ul.comments,
 ul.show_comments,
 .likes_container,
+.reshares,
 .stream_element .reshare
 
   .avatar
@@ -2259,11 +2260,12 @@ ul.show_comments,
   a
     :color #999
 
-.likes_container
-  :padding 4px
+.reshares
+  :color #999
 
 ul.show_comments,
-.likes_container
+.likes_container,
+.reshares
   img
     :position relative
     :top 2px


### PR DESCRIPTION
Display how often your own post has been reshared in a very similar manner as likes are displayed. It's not very pretty, though. The way the two are grouped in the mobile interface is nicer and probably also works for this.
