### PR TITLE
IE: Go directly to notifications page

### DIFF
--- a/public/javascripts/widgets/notifications-badge.js
+++ b/public/javascripts/widgets/notifications-badge.js
@@ -12,7 +12,9 @@
         ajaxLoader: dropdown.find(".ajax_loader")
       });
 
-      self.badgeLink.toggle(self.showDropdown, self.hideDropdown);
+      if( ! $.browser.msie ) {
+        self.badgeLink.toggle(self.showDropdown, self.hideDropdown);
+      }
 
       self.dropdown.click(function(evt) {
         evt.stopPropagation();


### PR DESCRIPTION
Don't use a dropdown for notifications in IE (because it doesn't render properly).  Just go to notifications URL on click.

This fixes issue #2357.
