### PR TITLE
Remove a comment from the publisher Haml code, so publisher isn't mangled

### DIFF
--- a/app/views/shared/_publisher.html.haml
+++ b/app/views/shared/_publisher.html.haml
@@ -17,7 +17,7 @@
 
 -if publisher_explain
   :javascript
-    $(document).ready(function() 
+    $(document).ready(function()
       {
         Publisher.triggerGettingStarted();
       });
@@ -54,7 +54,6 @@
                 = image_tag "social_media_logos/#{service.provider}-16x16.png", :title => service.provider.titleize, :class => "service_icon dim", :id =>"#{service.provider}", :maxchar => "#{service.class::MAX_CHARACTERS}"
             = link_to (image_tag "icons/monotone_wrench_settings.png"), "#question_mark_pane", :class => 'question_mark', :rel => 'facebox', :title => t('shared.public_explain.manage')
 
-          // NOTE(dropdown special casing to DRY up -- taken from the aspect_dropdown partial)
           .dropdown{:class => "hang_right", :title => popover_with_close_html("2. #{t('shared.public_explain.control_your_audience')}"), 'data-content'=> t('shared.public_explain.visibility_dropdown')}
             .button.toggle.publisher
               - if publisher_public


### PR DESCRIPTION
Remove a comment from the publisher Haml code, so publisher isn't mangled in Firefox 3.  "//" is not really proper Haml comment syntax anyway.
