### PR TITLE
Mobile bookmarklet

### DIFF
--- a/app/controllers/status_messages_controller.rb
+++ b/app/controllers/status_messages_controller.rb
@@ -34,7 +34,11 @@ class StatusMessagesController < ApplicationController
     @aspects = current_user.aspects
     @selected_contacts = @aspects.map { |aspect| aspect.contacts }.flatten.uniq
     @aspect_ids = @aspects.map{|x| x.id}
-    render :layout => nil
+    if is_mobile_device?
+      #render :layout
+    else
+      render :layout => nil
+    end
   end
 
   def create

--- a/app/controllers/status_messages_controller.rb
+++ b/app/controllers/status_messages_controller.rb
@@ -34,9 +34,7 @@ class StatusMessagesController < ApplicationController
     @aspects = current_user.aspects
     @selected_contacts = @aspects.map { |aspect| aspect.contacts }.flatten.uniq
     @aspect_ids = @aspects.map{|x| x.id}
-    if is_mobile_device?
-      #render :layout
-    else
+    if ! is_mobile_device?
       render :layout => nil
     end
   end

--- a/app/views/status_messages/bookmarklet.mobile.haml
+++ b/app/views/status_messages/bookmarklet.mobile.haml
@@ -1,0 +1,20 @@
+-#   Copyright (c) 2010-2011, Diaspora Inc.  This file is
+-#   licensed under the Affero General Public License version 3 or later.  See
+-#   the COPYRIGHT file.
+
+= include_javascripts :mobile
+
+:javascript
+  $(document).ready(function() 
+    {
+    var contents = "#{params[:title]} - #{params[:url]}";
+    if ("#{params[:notes]}".length > 0){
+      contents = contents + " - #{params[:notes]}";
+    }
+    if (contents.length > 0) {
+      $("#status_message_text").val(contents);
+    }
+  });
+
+= render :partial => 'shared/publisher', :locals => { :aspect => :profile, :selected_aspects => @aspects,  :aspect_ids => @aspect_ids }
+


### PR DESCRIPTION
A small change adding a missing mobile bookmarklet view to fix the internal server error 500 appearing when a user with a mobile browsers clicks a link that leads to the bookmarklet.

The actual posting is done via the normal status messages mobile posting and none of the bookmarklet bugs have been fixed :)
