### PR TITLE
Only show post deletion spinner when the AJAX call actually gets underway

### DIFF
--- a/public/javascripts/widgets/stream-element.js
+++ b/public/javascripts/widgets/stream-element.js
@@ -44,10 +44,10 @@
       self.deletePostLink.click(function(evt) {
         evt.preventDefault();
 
-        $([
-          self.deletePostLink,
-          self.hidePostLoader
-        ]).toggleClass("hidden");
+        self.hidePostLoader.ajaxStart( function() {
+          self.deletePostLink.addClass("hidden");
+          $(this).removeClass('hidden');
+        } );
       });
 
       self.focusCommentLink.click(function(evt) {


### PR DESCRIPTION
Only show post deletion spinner when the AJAX call actually gets underway (i.e. not when the user cancels the deletion).

This fixes issue #1924.
