### PR TITLE
Do not install ruby-debug on travis-ci.org, it only wastes time 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -141,9 +141,11 @@ group :development do
   gem 'capistrano-ext', '1.2.1', :require => false
   gem 'linecache', '0.43', :platforms => :mri_18
   gem 'parallel_tests'
-  gem 'ruby-debug-base19', '0.11.23' if RUBY_VERSION.include? '1.9.1'
-  gem 'ruby-debug19', :platforms => :ruby_19
-  gem 'ruby-debug', :platforms => :mri_18
+  unless ENV["CI"]
+    gem 'ruby-debug-base19', '0.11.23' if RUBY_VERSION.include? '1.9.1'
+    gem 'ruby-debug19', :platforms => :ruby_19
+    gem 'ruby-debug', :platforms => :mri_18
+  end
   gem 'sod', :git => 'git://github.com/MikeSofaer/sod.git', :require => false
   gem 'yard'
 end


### PR DESCRIPTION
We are trying to make Ruby project maintainers aware of how long it takes to compile linecache
every time. See https://twitter.com/#!/travisci/status/134609246036836352.
