### PR TITLE
update system timer gem version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
       Platform (>= 0.4.0)
       open4
     Platform (0.4.0)
-    SystemTimer (1.2.1)
+    SystemTimer (1.2.3)
     abstract (1.0.0)
     actionmailer (3.0.10)
       actionpack (= 3.0.10)


### PR DESCRIPTION
I was unable to db:migrate or start workers. looks like bug was: https://github.com/ph7/system-timer/pull/13
my error was: undefined method `exclusive' for Thread:Class

This is a old bug, but I did update packages yesterday.

using the new version solved my issues.
