### PR TITLE
guid default of "" never gets set to a secure random hex (in mysql at least)

### DIFF
--- a/lib/diaspora/guid.rb
+++ b/lib/diaspora/guid.rb
@@ -9,7 +9,6 @@ module Diaspora::Guid
 
   # @return [String] The model's guid.
   def set_guid
-    self.guid ||= ActiveSupport::SecureRandom.hex(8)
     self.guid = ActiveSupport::SecureRandom.hex(8) if self.guid.blank?
   end
 end

--- a/lib/diaspora/guid.rb
+++ b/lib/diaspora/guid.rb
@@ -10,5 +10,6 @@ module Diaspora::Guid
   # @return [String] The model's guid.
   def set_guid
     self.guid ||= ActiveSupport::SecureRandom.hex(8)
+    self.guid = ActiveSupport::SecureRandom.hex(8) if self.guid.blank?
   end
 end


### PR DESCRIPTION
Won't be assigned with `||=` as`""` is not `nil`.

Without this I can't post status messages:
````Started POST "/status_messages" --> Completed 422 Unprocessable Entity
JSON response: {"errors":["Guid has already been taken"]}

```

This might be better dealt with somewhere else such as the have the schema/ migrations such that the default value for this column is `NULL` rather than `""`.
```
