### PR TITLE
Let notification dropdown action links float so they don't overlap with the heading.

### DIFF
--- a/public/stylesheets/sass/application.sass
+++ b/public/stylesheets/sass/application.sass
@@ -3091,8 +3091,10 @@ a.toggle_selector
 
   .right
     :font-size smaller
-    :right 10px
-    :top 13px
+    :display inline
+    :position relative
+    :float right
+    :top 4px
     :font
       :weight bold
 


### PR DESCRIPTION
This is a simple fix for #2370

I am not able to test this cross-browser, as I don't have a D\* setup for testing. Actually, this is my first contact with Sass plus my first ever pull request. So bear with me if this is not perfect.
