### PR TITLE
deleted tokens:show:login_with_diaspora_is_comming

### DIFF
--- a/app/views/tokens/show.html.haml
+++ b/app/views/tokens/show.html.haml
@@ -40,6 +40,3 @@
     %h3
       != t('.connecting_is_simple', :diaspora_id => current_user.diaspora_handle, :href_link => 'http://cubbi.es/users/edit')
 
-    %p.subtle
-      = t('.log_in_with_diaspora_is_comming')
-

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -865,7 +865,6 @@ en:
       daniels_account: "Daniel's Diaspora account"
       making_the_connection: "Making the Connection"
       connecting_is_simple: "Connecting your Diaspora account is simple!  Just enter your Diaspora ID (<b>%{diaspora_id}</b>) from your cubbies <a href='%{href_link}'>settings page</a> and hit connect."
-      log_in_with_diaspora_is_comming: "Pretty soon, you'll be able to connect to a new application without creating an account separate from your one on Diaspora."
       via: "(via %{link})"
 
   authorizations:


### PR DESCRIPTION
deleted tokens:show:login_with_diaspora_is_comming, because it got outdated by now
