### PR TITLE
Vimperator aspects dropdown

### DIFF
--- a/app/helpers/aspect_global_helper.rb
+++ b/app/helpers/aspect_global_helper.rb
@@ -70,7 +70,7 @@ module AspectGlobalHelper
 
     str = <<LISTITEM
 <li data-aspect_id=#{aspect.id} class='#{klass} aspect_selector'>
-  #{aspect.name}
+  <a href='#'>#{aspect.name}</a>
 </li>
 LISTITEM
     str.html_safe

--- a/app/views/shared/_publisher.html.haml
+++ b/app/views/shared/_publisher.html.haml
@@ -59,7 +59,7 @@
             = link_to (image_tag "icons/monotone_wrench_settings.png"), "#question_mark_pane", :class => 'question_mark', :rel => 'facebox', :title => t('shared.public_explain.manage')
 
           .dropdown{ ! current_user.getting_started? ? {:class => "hang_right"} : { :class => "hang_right", :title => popover_with_close_html("2. #{t('shared.public_explain.control_your_audience')}"), 'data-content'=> t('shared.public_explain.visibility_dropdown')} }
-            .button.toggle.publisher
+            %button.button.toggle.publisher{:type => 'button'}
               - if publisher_public
                 = t('public')
               - elsif all_aspects_selected?(selected_aspects)

--- a/app/views/shared/_publisher.html.haml
+++ b/app/views/shared/_publisher.html.haml
@@ -73,10 +73,10 @@
             .wrapper
               %ul.dropdown_list{:unSelectable => 'on', 'data-person_id' => (person.id if defined?(person) && person), 'data-service_uid' => (service_uid if defined?(service_uid))}
                 %li.public.radio{"data-aspect_id" => "public", :class => ("selected" if publisher_public)}
-                  = t('public')
+                  = link_to t('public'), '#'
 
                 %li.divider.all_aspects.radio{:style => "border-bottom: 1px solid #ddd;", "data-aspect_id" => "all_aspects", :class => ("selected" if (!publisher_public && all_aspects_selected?(selected_aspects)))}
-                  = t('all_aspects')
+                  = link_to t('all_aspects'), '#'
 
                 - for aspect in all_aspects
                   = aspect_dropdown_list_item(aspect, !all_aspects_selected?(selected_aspects) && selected_aspects.include?(aspect) )

--- a/public/stylesheets/sass/application.sass
+++ b/public/stylesheets/sass/application.sass
@@ -962,7 +962,9 @@ label:not(.bootstrapped)
         :align right
       .dropdown
         button
-          width: 75px
+          width: 100%
+        a
+          :color #222
         :text
           :align left
 

--- a/public/stylesheets/sass/application.sass
+++ b/public/stylesheets/sass/application.sass
@@ -964,7 +964,9 @@ label:not(.bootstrapped)
         button
           width: 100%
         a
-          :color #222
+          :color inherit
+          &:hover
+            :text-decoration none
         :text
           :align left
 

--- a/public/stylesheets/sass/application.sass
+++ b/public/stylesheets/sass/application.sass
@@ -961,6 +961,8 @@ label:not(.bootstrapped)
       :text
         :align right
       .dropdown
+        button
+          width: 75px
         :text
           :align left
 


### PR DESCRIPTION
The aspects dropdown is not a real widget, but consists of divs and list items. To interact with the dropdown with a browser that implements a keyboard interface (like vimperator, pentadactyl, uzbl or luakit) generic widgets must be used.
This patch replaces the dropdown button with a real button and wraps the aspect selectors in hash links.

Tested with vimperator, pentadactyl and luakit.
