### PR TITLE
remove resque, remove 404 images from bothering thin

### DIFF
--- a/chef/cookbooks/diaspora/templates/default/nginx.conf.erb
+++ b/chef/cookbooks/diaspora/templates/default/nginx.conf.erb
@@ -36,10 +36,6 @@ http {
   <% end %>
   }
 
-  upstream resque_web {
-    server localhost:5678;
-  }
-
   server {
    listen       843;
 
@@ -53,23 +49,6 @@ http {
     root html;
    }
 
-  }
-
-  server {
-   listen  7894;
-   server_name  <%= @url %>  www.<%= @url %>;
-
-   auth_basic "Restricted";
-   auth_basic_user_file  htpasswd;
-
-   ssl on;
-   ssl_certificate      /usr/local/nginx/conf/diaspora.crt;
-   ssl_certificate_key  /usr/local/nginx/conf/diaspora.key;
-
-   location / {
-      proxy_set_header Host $http_host;
-      proxy_pass http://resque_web;
-   }
   }
 
   server {
@@ -91,6 +70,11 @@ http {
    location /assets {
     expires 1d;
     add_header Cache-Control public;
+   }
+    
+   location /uploads/images {
+   expires 5d;
+   add_header Cache-Control public;
    }
 
    location / {


### PR DESCRIPTION
   location /uploads/images {
    expires 5d;
    add_header Cache-Control public;
   }

saves a lot of thin work for images that are missing, jd.com may also benefit from these even thought a lot are on s3 and old links still hit nginx then 404 back to thin to 404 the request out, thin does not need to be bothered the image is not there
