### PR TITLE
Issue #2265: change upload photo alt text

### DIFF
--- a/app/views/shared/_publisher.html.haml
+++ b/app/views/shared/_publisher.html.haml
@@ -40,7 +40,7 @@
             = status.hidden_field :text, :value => h(publisher_hidden_text), :class => 'clear_on_submit'
 
             #file-upload{:title => t('.upload_photos')}
-              = image_tag 'icons/camera.png'
+              = image_tag 'icons/camera.png', :alt => t('.upload_photos').titleize
 
       - if publisher_public
         = hidden_field_tag 'aspect_ids[]', "public"


### PR DESCRIPTION
Change upload photo alt text from 'camera' to 'Upload Photos'

For more details:
https://github.com/diaspora/diaspora/issues/2265
