### PR TITLE
Add dependency status from Gemnasium to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Diaspora
 [![Build Status](https://secure.travis-ci.org/diaspora/diaspora.png)](http://travis-ci.org/diaspora/diaspora)
 
+[![Dependency Status](https://gemnasium.com/diaspora/diaspora.png?travis)](https://gemnasium.com/diaspora/diaspora)
+
 The privacy aware, personally controlled, do-it-all, open source social
 network.
 


### PR DESCRIPTION
This is a good way to help make sure your gem dependencies are up-to-date with the latest versions.
