### PR TITLE
Fix from-scratch migration on PostgreSQL with a non-root DB user

### DIFF
--- a/db/migrate/20110105051803_create_import_tables.rb
+++ b/db/migrate/20110105051803_create_import_tables.rb
@@ -178,17 +178,17 @@ class CreateImportTables < ActiveRecord::Migration
   end
 
   def self.down
-    drop_table :mongo_users
-    drop_table :mongo_services
-    drop_table :mongo_requests
-    drop_table :mongo_post_visibilities
-    drop_table :mongo_invitations
-    drop_table :mongo_contacts
-    drop_table :mongo_comments
-    drop_table :mongo_profiles
-    drop_table :mongo_people
-    drop_table :mongo_posts
-    drop_table :mongo_aspect_memberships
-    drop_table :mongo_aspects
+    execute 'DROP TABLE mongo_users'
+    execute 'DROP TABLE mongo_services'
+    execute 'DROP TABLE mongo_requests'
+    execute 'DROP TABLE mongo_post_visibilities'
+    execute 'DROP TABLE mongo_invitations'
+    execute 'DROP TABLE mongo_contacts'
+    execute 'DROP TABLE mongo_comments'
+    execute 'DROP TABLE mongo_profiles'
+    execute 'DROP TABLE mongo_people'
+    execute 'DROP TABLE mongo_posts'
+    execute 'DROP TABLE mongo_aspect_memberships'
+    execute 'DROP TABLE mongo_aspects'
   end
 end

--- a/db/migrate/20110301202619_drop_statistics.rb
+++ b/db/migrate/20110301202619_drop_statistics.rb
@@ -1,7 +1,7 @@
 class DropStatistics < ActiveRecord::Migration
   def self.up
-    drop_table :statistics
-    drop_table :data_points
+    execute 'DROP TABLE statistics'
+    execute 'DROP TABLE data_points'
   end
 
   def self.down

--- a/db/migrate/20110406202932_drop_requests_table.rb
+++ b/db/migrate/20110406202932_drop_requests_table.rb
@@ -10,7 +10,7 @@ class DropRequestsTable < ActiveRecord::Migration
     remove_index :requests, [:sender_id, :recipient_id]
     remove_index :requests, :sender_id
 
-    drop_table :requests
+    execute 'DROP TABLE requests'
 
     execute( <<SQL
       DELETE contacts.* FROM contacts

--- a/db/migrate/20110604012703_drop_mongo_remains.rb
+++ b/db/migrate/20110604012703_drop_mongo_remains.rb
@@ -10,7 +10,7 @@ class DropMongoRemains < ActiveRecord::Migration
     remove_index :services, :mongo_id
     remove_index :users, :mongo_id
 
-    drop_table :mongo_notifications
+    execute 'DROP TABLE mongo_notifications'
   end
 
   def self.down

--- a/db/migrate/20110830170929_remove_pod_stats_table.rb
+++ b/db/migrate/20110830170929_remove_pod_stats_table.rb
@@ -1,6 +1,6 @@
 class RemovePodStatsTable < ActiveRecord::Migration
   def self.up
-    drop_table :pod_stats
+    execute 'DROP TABLE pod_stats'
   end
 
   def self.down


### PR DESCRIPTION
You get problems like:

```
ERROR: permission denied: "RI_ConstraintTrigger_506060" is a system trigger
```

This change is necessary or else nobody will be able to install Diaspora with PostgreSQL.
