### PR TITLE
Clicking on read notification makes it unread.

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -11,7 +11,7 @@ class NotificationsController < VannaController
   def update(opts=params)
     note = Notification.where(:recipient_id => current_user.id, :id => opts[:id]).first
     if note
-      note.update_attributes(:unread => false)
+      note.update_attributes(:unread => !note.unread)
       {}
     else
       Response.new :status => 404

--- a/public/javascripts/widgets/notifications.js
+++ b/public/javascripts/widgets/notifications.js
@@ -15,14 +15,22 @@
         notificationArea: notificationArea
       });
 
-      $(".stream_element.unread").live("mousedown", function() {
-        self.decrementCount();
+        $(".stream_element.unread").live("mousedown", function() {
+          self.decrementCount();
 
-        $.ajax({
-          url: "notifications/" + $(this).removeClass("unread").data("guid"),
-          type: "PUT"
+          $.ajax({
+            url: "notifications/" + $(this).removeClass("unread").data("guid"),
+            type: "PUT"
+          });
         });
-      });
+        $(".stream_element").live("mousedown", function() {
+          self.incrementCount();
+
+          $.ajax({
+            url: "notifications/" + $(this).addClass("unread").data("guid"),
+            type: "PUT"
+          });
+        });
 
       $("a.more").live("click", function(evt) {
         evt.preventDefault();

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -14,10 +14,17 @@ describe NotificationsController do
   end
 
   describe '#update' do
-    it 'marks a notification as read' do
+    it 'marks a notification as read if it was unread' do
       note = Factory(:notification, :recipient => @user)
       @controller.update :id => note.id
       Notification.first.unread.should == false
+    end
+    it 'marks a notification as unread if it was read' do
+      note = Factory(:notification, :recipient => @user)
+      @controller.update :id => note.id
+      Notification.first.unread.should == false
+      @controller.update :id => note.id
+      Notification.first.unread.should == true
     end
 
     it 'only lets you read your own notifications' do


### PR DESCRIPTION
This changes the behavior of the notifications page in that clicking on a read message will now set it as unread. We discussed this issue on IRC, but I can't find any tickets that seem to match.

Please forgive any errors, git/github/diaspora noob working here! First Pull Request! But I did include a test.

I think I was wrong that this is in the Master branch, right? I switched my development now to a branch. Sorry!
