### PR TITLE
Would diaspora like a pure-Ruby Flash policy server?

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,9 @@ gem 'messagebus_ruby_api', '1.0.1'
 gem 'em-synchrony', :platforms => :ruby_19
 gem 'em-websocket'
 
+# web sockets flash fallback
+gem 'flash_policy_server'
+
 group :production do # we don't install these on travis to speed up test runs
   # chef
   gem 'chef', '~> 0.10.4', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,6 +183,7 @@ GEM
     fixture_builder (0.3.1)
       activerecord (>= 2)
       activesupport (>= 2)
+    flash_policy_server (0.0.3)
     fog (1.1.1)
       builder
       excon (~> 0.7.4)
@@ -466,6 +467,7 @@ DEPENDENCIES
   faraday-stack
   fastercsv (= 1.5.4)
   fixture_builder (= 0.3.1)
+  flash_policy_server
   fog
   foreigner (~> 1.1.0)
   foreman


### PR DESCRIPTION
Hi, 

I was installing a pod the other day and wanted to get websockets (and the Flash-sockets fallback) running. I was using Nginx rather than Apache. For me, the idea of using the Apache module for the Flash policy server, as detailed at https://github.com/diaspora/diaspora/wiki/Websockets wouldn't work. 

To get everything working, I've whipped up a simple flash_policy_server gem.  It provides a policy server which runs on a socket on port 843, and is basically a gem command where you run:

 sudo flash_policy_server

...and it serves the policy file, prompting you to save a crossdomain.xml if it doesn't exist yet. 

This pull request pulls the policy server into diaspora's Gemfile, if it's accepted I can write up some detailed diaspora-related policy server instructions to go with it on the websockets wiki page. 
