### PR TITLE
added support for uploading images with .tiff extensions

### DIFF
--- a/app/uploaders/processed_image.rb
+++ b/app/uploaders/processed_image.rb
@@ -10,7 +10,7 @@ class ProcessedImage < CarrierWave::Uploader::Base
   end
 
   def extension_white_list
-    %w(jpg jpeg png gif)
+    %w(jpg jpeg png gif tiff)
   end
 
   def filename


### PR DESCRIPTION
add support for uploading tiff images, also the Preview native extension
and to have a broader support for images so users dont have to go thru
the trouble of saving a new image with a different extension without corrupting the file
or image(s) itself.
