### PR TITLE
Thumbnail resize bug

### DIFF
--- a/app/models/jobs/process_photo.rb
+++ b/app/models/jobs/process_photo.rb
@@ -6,15 +6,29 @@
 module Jobs
   class ProcessPhoto < Base
     @queue = :photos
-    def self.perform(id)
+    def self.perform(id, after_process = nil)
       photo = Photo.find(id)
       unprocessed_image = photo.unprocessed_image
 
       return false if photo.processed? || unprocessed_image.path.try(:include?, ".gif")
 
       photo.processed_image.store!(unprocessed_image)
+      photo.update_remote_path
 
-      photo.save!
+      result = photo.save!
+
+      after_process.call( photo ) unless( after_process.nil? )
+      
+      result
     end
+    
+    def self.update_profile( a_photo )
+      profile_params = { :image_url => a_photo.url(:thumb_large),
+                         :image_url_medium => a_photo.url(:thumb_medium),
+                         :image_url_small => a_photo.url(:thumb_small)}
+                         
+      a_photo.author.owner.update_profile(profile_params)
+    end
+    
   end
 end

--- a/app/uploaders/processed_image.rb
+++ b/app/uploaders/processed_image.rb
@@ -6,7 +6,7 @@ class ProcessedImage < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
 
   def store_dir
-    "uploads/images"
+    "uploads/user_images"
   end
 
   def extension_white_list

--- a/app/uploaders/unprocessed_image.rb
+++ b/app/uploaders/unprocessed_image.rb
@@ -6,7 +6,7 @@ class UnprocessedImage < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
 
   def store_dir
-    "uploads/images"
+    "uploads/tmp_images"
   end
 
   def extension_white_list
@@ -17,8 +17,16 @@ class UnprocessedImage < CarrierWave::Uploader::Base
     model.random_string + File.extname(@filename) if @filename
   end
 
-  version :thumb_small
-  version :thumb_medium
-  version :thumb_large
-  version :scaled_full
+  version :thumb_small do
+    process :resize_to_limit => [100,100]
+    process :strip
+  end
+
+  def strip
+    manipulate! do |img|
+      img.strip
+      img = yield(img) if block_given?
+      img
+    end
+  end
 end

--- a/app/views/photos/_new_photo.haml
+++ b/app/views/photos/_new_photo.haml
@@ -40,7 +40,7 @@
        onComplete: function(id, fileName, responseJSON) {
         $('#fileInfo').text(fileName + ' completed');
         var id = responseJSON.data.photo.id,
-            url = responseJSON.data.photo.unprocessed_image.url,
+            url = responseJSON.data.photo.unprocessed_image.thumb_small.url,
             currentPlaceholder = $('li.loading').first();
 
         $("#publisher textarea").addClass("with_attachments");

--- a/features/step_definitions/posts_steps.rb
+++ b/features/step_definitions/posts_steps.rb
@@ -6,7 +6,7 @@ JSON
 end
 
 Then /^I should see an uploaded image within the photo drop zone$/ do
-  find("#photodropzone img")["src"].should include("uploads/images")
+  find("#photodropzone img")["src"].should include("uploads/tmp_images/thumb_small_")
 end
 
 Then /^I should not see an uploaded image within the photo drop zone$/ do

--- a/spec/models/jobs/process_photo_spec.rb
+++ b/spec/models/jobs/process_photo_spec.rb
@@ -21,7 +21,23 @@ describe Jobs::ProcessPhoto do
     @saved_photo.processed_image.path.should_not be_nil
     result.should be true
   end
+  
+  context 'when trying to update the profile pic' do
+    it 'saves the profile image when set' do
+      @saved_photo.processed_image.path.should be_nil
+      result = Jobs::ProcessPhoto.perform(@saved_photo.id, Proc.new { |a_photo| Jobs::ProcessPhoto.update_profile( a_photo ) } )
+      
+      @saved_photo.reload
+      @user.person.profile.image_url.should == @saved_photo.url(:thumb_large)
+    end
 
+    it 'doesnt save the profile image when not' do
+      @saved_photo.processed_image.path.should == nil
+      result = Jobs::ProcessPhoto.perform(@saved_photo.id, nil)
+      @user.person.profile.image_url.should == "/images/user/default.png"
+    end
+  end
+  
   context 'when trying to process a photo that has already been processed' do
     before do
       Jobs::ProcessPhoto.perform(@saved_photo.id)

--- a/spec/models/photo_spec.rb
+++ b/spec/models/photo_spec.rb
@@ -208,7 +208,14 @@ describe Photo do
 
   describe '#queue_processing_job' do
     it 'should queue a resque job to process the images' do
-      Resque.should_receive(:enqueue).with(Jobs::ProcessPhoto, @photo.id)
+      Resque.should_receive(:enqueue).with(Jobs::ProcessPhoto, @photo.id, nil)
+      @photo.post_proc_proc = nil
+      @photo.queue_processing_job
+    end
+    it 'should queue a resque job to process the images and run the supplied proc' do
+      a_proc = Proc.new { |a_ph| }
+      @photo.post_proc_proc = a_proc
+      Resque.should_receive(:enqueue).with(Jobs::ProcessPhoto, @photo.id, a_proc)
       @photo.queue_processing_job
     end
   end


### PR DESCRIPTION
Under some installations uploaded images weren't being processed correctly.

This separates uploaded photos into 2 different, a tmp_photos directory that can be cleaned out periodically and a user_images folder where fina version go after they are processed.
It also makes sure that the profile thumbnail uses the correctly sized photo.
