### PR TITLE
Issue 2570: avatar alt text breaks layout

### DIFF
--- a/public/stylesheets/sass/application.sass
+++ b/public/stylesheets/sass/application.sass
@@ -70,6 +70,8 @@ form
   :width 50px
   :height 50px
 
+  :overflow hidden
+
 #content
   :background
     :color #fff


### PR DESCRIPTION
Issue: https://github.com/diaspora/diaspora/issues/2570 , "When a contact's profile photo fails to load, the alt text breaks the layout", which contains the text "This can easily be fixed by adding overflow: hidden to the CSS class .avatar."

So I added `:overflow hidden` to .`avatar`.

Also I am not sure how to associate a pull request to an issue.
