### PR TITLE
fixed issue 1991 - giving long pre & code a scrollbar

### DIFF
--- a/public/stylesheets/blueprint/screen.css
+++ b/public/stylesheets/blueprint/screen.css
@@ -47,7 +47,7 @@ abbr, acronym {border-bottom:1px dotted #666;}
 address {margin:0 0 1.5em;font-style:italic;}
 del {color:#666;}
 pre {margin:1.5em 0;white-space:pre;}
-pre, code, tt {font:1em 'andale mono', 'lucida console', monospace;line-height:1.5;}
+pre, code, tt {font:1em 'andale mono', 'lucida console', monospace;line-height:1.5;overflow:auto;}
 li ul, li ol {margin:0;}
 ul, ol {margin:0 1.5em 1.5em 0;padding-left:3.333em;}
 ul {list-style-type:disc;}


### PR DESCRIPTION
https://github.com/diaspora/diaspora/issues/1991 - sporkbox says "The fix is simple. If a width for the element is already set in CSS, just add "overflow: auto" to its CSS attributes and it should bring up a scrollbar when it's too wide." 

So I added `overflow:auto;` to the `pre, code, tt` element. 

Not sure where the width for the element is set but I tested it in firebug, and adding `overflow:auto` there does add a scroll bar to the long `code` snippet in https://joindiaspora.com/posts/469005 .
