### PR TITLE
Add the project name to the title of the Devise login page.

### DIFF
--- a/app/views/sessions/new.haml
+++ b/app/views/sessions/new.haml
@@ -4,6 +4,7 @@
 
 = content_for :page_title do
   = t('devise.sessions.new.sign_in')
+  | DIASPORA* ALPHA
 
 = content_for :head do
   = include_javascripts :login


### PR DESCRIPTION
My first pull request to the project :)
This fixes a minor annoyance - some programs like KeePassX rely on a unique name in the title of the window for knowing which auth info to autofill with. Rather than just "Sign in" this commit appends the project name ("DIASPORA\* ALPHA") so that people who use KeePassX, like myself, can autofill the login form with a keypress.
