### PR TITLE
heroku:install_requirements task fails on default heroku apps

### DIFF
--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -24,6 +24,7 @@ namespace :heroku do
   end
 
   task :install_requirements do
+    system 'heroku addons:remove logging:basic'
     system 'heroku addons:add logging:expanded'
     system 'heroku addons:add redistogo:nano'
   end


### PR DESCRIPTION
logging:expanded cannot be installed until logging:basic (included by default) is removed.
