### PR TITLE
Fix #2598 (back button issue) by having jQuery force the browser to not cache JSON responses...

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -55,7 +55,7 @@ module ApplicationHelper
   def jquery_include_tag
     javascript_include_tag('//ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js') +
     content_tag(:script) do
-      "!window.jQuery && document.write(unescape(\"#{escape_javascript(include_javascripts(:jquery))}\"))".html_safe
+      "!window.jQuery && document.write(unescape(\"#{escape_javascript(include_javascripts(:jquery))}\")); jQuery.ajaxSetup({'cache': false});".html_safe
     end
   end
 end


### PR DESCRIPTION
This is what upstream https://github.com/documentcloud/backbone/issues/630 suggests, and it fixes the back button issue.
