### PR TITLE
rake task to recreate correct thumbnail sizes

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -62,6 +62,21 @@ namespace :db do
     puts "everything should be peachy"
   end
 
+  desc 'Create correctly sized thumbnails for all photos in the database'
+  task :fix_broken_thumbnails do
+    puts "correcting the thumnail size for all photos in database"
+    require File.join(File.dirname(__FILE__), '..', '..', 'config', 'environment')
+    pub_folder = File.join(File.dirname(__FILE__), '..', '..', 'public' )
+    Photo.all.each do |photo|
+      if photo.processed_image && photo.processed_image.url
+        if FileTest.exists?( File.join( pub_folder, photo.processed_image.url ) )
+          photo.processed_image.recreate_versions!
+        end
+      end
+    end
+    puts "thumbnail sizes fixed"
+  end
+
   task :move_private_key do
     require File.join(File.dirname(__FILE__), '..', '..', 'config', 'environment')
     User.all.each do |user|


### PR DESCRIPTION
On my pod I had an issue where resque couldn't create thumbnails in the correct sizes for a brief time. Profiles uploaded during that time would have the full size image as their small thumbnail and be attached to all posts. Quite annoying.

Anyway this is a rake task that runs through the database and recreates thumbnails in the correct sizes for all of the photos. Which will clear the problem up if anyone had it at some time in the past. Worked for me...
