### PR TITLE
2671 markdown image links

### DIFF
--- a/public/javascripts/vendor/markdown.js
+++ b/public/javascripts/vendor/markdown.js
@@ -786,6 +786,26 @@ Markdown.dialects.Gruber.inline = {
         // Not an esacpe
         return [ 1, "\\" ];
     },
+    "[![": function image_link( text ) {
+      
+      var m = text.match( /^\[(.*)\][ \t]*\([ \t]*(\S+)(?:[ \t]+(["'])(.*?)\3)?[ \t]*\)/ );
+      if(m) {
+        var link_img = this.processInline( m[1] )[0];
+        if ( m[2] && m[2][0] == '<' && m[2][m[2].length-1] == '>' )
+        m[2] = m[2].substring( 1, m[2].length - 1 );
+        
+        // Process escapes only
+        m[2] = this.dialect.inline.__call__.call( this, m[2], /\\/ )[0];
+        
+        var attrs = { href: m[2] || "" };
+        if ( m[4] !== undefined)
+        attrs.title = m[4];
+        
+        var link = [ "link", attrs, link_img ];
+        return [ m[0].length, link ];
+        
+      }
+    },
 
     "![": function image( text ) {
       // ![Alt text](/path/to/img.jpg "Optional title")

--- a/spec/javascripts/app/views/post_view_spec.js
+++ b/spec/javascripts/app/views/post_view_spec.js
@@ -47,6 +47,13 @@ describe("app.views.Post", function(){
       expect(window.markdown.toHTML).toHaveBeenCalledWith("I have three Belly Buttons")
     })
 
+    it("should correctly interpret markdown link syntax", function(){
+      this.statusMessage.set({text: "[![alt text](http://example.com/eg.png 'image title')](http://example.com 'link title')"})
+      spyOn(window.markdown, "toHTML")
+      new app.views.Post({model: this.statusMessage.render();
+      expect(window.markdown.toHTML).toMatch("<p><a href=\"http://example.com\" title=\"link title\"><img alt=\"alt text\" title=\"image title\" src=\"http://example.com/eg.png\"></img></a></p>");
+    })
+
     context("changes hashtags to links", function(){
       it("links to a hashtag to the tag page", function(){
         this.statusMessage.set({text: "I love #parties"})


### PR DESCRIPTION
https://github.com/diaspora/diaspora/issues/2671

Have tested this several times on my test server, and it is generating valid html for the image link syntax. Have written a test for the change (which I think should work). However, was unable to run this with rspec due to multiple errors showing for spec/javascripts/app/views/post_view_spec.js starting with the following on line 5:

/home/diaspora/.rvm/gems/ree-1.8.7-2011.12@diaspora/gems/rspec-core-2.8.0/lib/rspec/core/configuration.rb:698:in `load': /var/www/diaspora/spec/javascripts/app/views/post_view_spec.js:5: odd number list for Hash (SyntaxError)
      loginAs({name: "alice", avatar : {small : "h...

I'm viewing that as a separate problem.
