### PR TITLE
Provides a link on unread notifications that marks them as unread.

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -11,8 +11,8 @@ class NotificationsController < VannaController
   def update(opts=params)
     note = Notification.where(:recipient_id => current_user.id, :id => opts[:id]).first
     if note
-      note.update_attributes(:unread => false)
-      {}
+      note.set_read_state(opts[:set_unread] != "true" )
+      { :guid => note.id, :unread => note.unread }
     else
       Response.new :status => 404
     end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -36,6 +36,9 @@ class Notification < ActiveRecord::Base
     self.recipient.mail(self.mail_job, self.recipient_id, actor.id, target.id)
   end
 
+  def set_read_state( read_state )
+    self.update_attributes( :unread => !read_state )
+  end
 
   def mail_job
     raise NotImplementedError.new('Subclass this.')

--- a/app/views/notifications/index.html.haml
+++ b/app/views/notifications/index.html.haml
@@ -2,33 +2,40 @@
 -self.extend AspectsHelper
 -self.extend ApplicationHelper
 -self.extend ErrorMessagesHelper
-.span-13
-  %h2
-    %span.notification_count{:class => ('unread' if @notification_count > 0)}
-      = @notification_count
-    = t('.notifications')
-.span-8.last
-  = link_to t('.mark_all_as_read'), read_all_notifications_path, :class => 'button'
+#notifications_content
+  .span-13
+    %h2
+      %span.notification_count{:class => ('unread' if @notification_count > 0)}
+        = @notification_count
+      = t('.notifications')
+  .span-8.last
+    = link_to t('.mark_all_as_read'), read_all_notifications_path, :class => 'button'
+  .span-24.last
+    .stream.notifications
+      - group_days.each do |day, notes|
+        .day_group.span-24.last
+          .span-3
+            .date
+              .day= the_day(day.split(' '))
+              .month= the_month(day.split(' '))
 
-.span-24.last
-  .stream.notifications
-    - group_days.each do |day, notes|
-      .day_group.span-24.last
-        .span-3
-          .date
-            .day= the_day(day.split(' '))
-            .month= the_month(day.split(' '))
+          .span-8.notifications_for_day
+            - notes.each do |note|
+              .stream_element{:data=>{:guid => note.id}, :class => "#{note.unread ? 'unread' : 'read'}"}
+                - if note.type == "Notifications::StartedSharing" && contact = current_user.contact_for(note[:target])
+                  .right
+                    = aspect_membership_dropdown(contact, note[:target], 'left')
 
-        .span-8.notifications_for_day
-          - notes.each do |note|
-            .stream_element{:data=>{:guid => note.id}, :class => "#{note.unread ? 'unread' : ''}"}
-              - if note.type == "Notifications::StartedSharing" && contact = current_user.contact_for(note[:target])
-                .right
-                  = aspect_membership_dropdown(contact, note[:target], 'left')
+                %span.from
+                  = notification_message_for(note)
+                %br
+                %time= timeago(note.created_at)
+                %a{:class => 'unread-setter'}
+                  mark unread
+          .span-13.last
+      = will_paginate notifications
 
-              %span.from
-                = notification_message_for(note)
-              %br
-              %time= timeago(note.created_at)
-        .span-13.last
-    = will_paginate notifications
+:javascript
+  $(document).ready(function(){
+    Diaspora.page.header.notifications.setUpNotificationPage( $("#notifications_content" ) );
+  });

--- a/public/javascripts/widgets/header.js
+++ b/public/javascripts/widgets/header.js
@@ -4,8 +4,8 @@
 
     this.subscribe("widget/ready", function(evt, header) {
       self.notifications = self.instantiate("Notifications",
-        header.find("#notifications"),
-        header.find("#notification_badge .badge_count")
+        header.find("#notification_badge .badge_count"),
+        header.find(".notifications")
       );
 
       self.notificationsDropdown = self.instantiate("NotificationsDropdown",

--- a/public/javascripts/widgets/notifications-badge.js
+++ b/public/javascripts/widgets/notifications-badge.js
@@ -63,6 +63,7 @@
         $.each(notifications, function(index, notification) {
           var notificationElement = $("<div/>")
             .addClass("notification_element")
+            .data( "guid", notification.id )
             .html(notification.translation)
             .prepend($("<img/>", { src: notification.actors[0].avatar }))
             .append("<br />")
@@ -70,19 +71,15 @@
               "class": "timeago",
               "title": notification.created_at
             }))
+            .append('<a class="unread-setter">mark unread</a>')
             .appendTo(self.dropdownNotifications);
 
           notificationElement.find("abbr.timeago").timeago();
 
           if(notification.unread) {
-            notificationElement.addClass("unread");
-            $.ajax({
-              url: "/notifications/" + notification.id,
-              type: "PUT",
-              success: function() {
-                Diaspora.page.header.notifications.decrementCount();
-              }
-            });
+            Diaspora.page.header.notifications.setUpUnread( notificationElement );
+          }else{
+            Diaspora.page.header.notifications.setUpRead( notificationElement );
           }
         });
       });

--- a/public/javascripts/widgets/notifications.js
+++ b/public/javascripts/widgets/notifications.js
@@ -8,32 +8,99 @@
   var Notifications = function() {
     var self = this;
     
-    this.subscribe("widget/ready", function(evt, notificationArea, badge) {
+    this.subscribe("widget/ready", function(evt, badge, notificationMenu) {
       $.extend(self, {
         badge: badge,
         count: parseInt(badge.html()) || 0,
-        notificationArea: notificationArea
+        notificationArea: null,
+        notificationMenu: notificationMenu
       });
 
-      $(".stream_element.unread").live("mousedown", function() {
-        self.decrementCount();
-
-        $.ajax({
-          url: "notifications/" + $(this).removeClass("unread").data("guid"),
-          type: "PUT"
-        });
-      });
-
-      $("a.more").live("click", function(evt) {
+      $("a.more").click( function(evt) {
         evt.preventDefault();
         $(this).hide()
           .next(".hidden")
           .removeClass("hidden");
       });
     });
-    
+    this.setUpNotificationPage = function( contentArea ) {
+      self.notificationArea = contentArea;
+      contentArea.find(".unread,.read").each(function(index) {
+        if ( $(this).hasClass("unread") ) {
+          self.setUpUnread( $(this) );
+        } else {
+          self.setUpRead( $(this) );
+        }
+      });
+    }
+    this.unreadClick = function() {
+      $.ajax({
+        url: "/notifications/" + $(this).parent().data("guid"),
+        data: { set_unread: true },
+        type: "PUT",
+        success: self.clickSuccess
+      });
+    };
+    this.readClick = function() {
+      $.ajax({
+        url: "/notifications/" + $(this).data("guid"),
+        data: { set_unread: false },
+        type: "PUT",
+        success: self.clickSuccess
+      });
+    };
+    this.setUpUnread = function( an_obj ) {
+      an_obj.removeClass("read").addClass( "unread" );
+      an_obj.find('.unread-setter').hide();
+      an_obj.find('.unread-setter').unbind("click");
+      an_obj.unbind( "mouseenter mouseleave" );
+      an_obj.click(self.readClick);
+    }
+    this.setUpRead = function( an_obj ) {
+      an_obj.removeClass("unread").addClass( "read" );
+      an_obj.unbind( "click" );
+      an_obj.find(".unread-setter").click(Diaspora.page.header.notifications.unreadClick);
+      an_obj.hover(
+        function () {
+          $(this).find(".unread-setter").show();
+        },
+        function () {
+          $(this).find(".unread-setter").hide();
+        }
+      );
+    }
+    this.clickSuccess = function( data ) {
+      var jsList = jQuery.parseJSON(data);
+      var itemID = jsList["guid"]
+      var isUnread = jsList["unread"]
+      if ( isUnread ) {
+        self.incrementCount();
+      }else{
+        self.decrementCount();
+      }
+      self.notificationMenu.find('.read,.unread').each(function(index) {
+        if ( $(this).data("guid") == itemID ) {
+          if ( isUnread ) {
+            self.setUpUnread( $(this) )
+          } else {
+            self.setUpRead( $(this) )
+          }
+        }
+      });
+      if ( self.notificationArea ) {
+        self.notificationArea.find('.read,.unread').each(function(index) {
+          if ( $(this).data("guid") == itemID ) {
+            if ( isUnread ) {
+              self.setUpUnread( $(this) )
+            } else {
+              self.setUpRead( $(this) )
+            }
+          }
+        });
+      }
+    };
     this.showNotification = function(notification) {
-      $(notification.html).prependTo(this.notificationArea)
+      $(notification.html).prependTo(this.notificationMenu)
 				.fadeIn(200)
 				.delay(8000)
 				.fadeOut(200, function() {
@@ -50,13 +117,20 @@
 
       if(self.badge.text() !== "") {
 				self.badge.text(self.count);
+        if ( self.notificationArea ) {
+          self.notificationArea.find( ".notification_count" ).text(self.count);
 
-				if(self.count === 0) {
-	  			self.badge.addClass("hidden");
-				}
-				else if(self.count === 1) {
-	  			self.badge.removeClass("hidden");
-				}
+          if(self.count === 0) {
+            self.badge.addClass("hidden");
+            if ( self.notificationArea )
+              self.notificationArea.find( ".notification_count" ).removeClass("unread");
+          }
+          else if(self.count === 1) {
+            self.badge.removeClass("hidden");
+            if ( self.notificationArea )
+              self.notificationArea.find( ".notification_count" ).addClass("unread");
+          }
+        }
       }
     };
 

--- a/public/stylesheets/sass/application.sass
+++ b/public/stylesheets/sass/application.sass
@@ -2987,6 +2987,12 @@ ul.left_nav
   .user_card
     :margin-left 8px
 
+.unread-setter
+  :float right
+  :display none
+  :cursor pointer
+  :margin-top 8px
+
 .stream_container
   :min-height 500px
 
@@ -3139,7 +3145,8 @@ a.toggle_selector
   .notification_element
     :padding 10px
     :min-height 30px
-
+    &:hover
+      :background-color #FAFAFA
     > img
       :height 30px
       :width 30px

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -14,10 +14,24 @@ describe NotificationsController do
   end
 
   describe '#update' do
-    it 'marks a notification as read' do
-      note = Factory(:notification, :recipient => @user)
+    it 'marks a notification as read if it gets no other information' do
+      note = mock_model( Notification )
+      Notification.should_receive( :where ).and_return( [note] )
+      note.should_receive( :set_read_state ).with( true )
       @controller.update :id => note.id
-      Notification.first.unread.should == false
+    end
+    it 'marks a notification as read if it is told to' do
+      note = mock_model( Notification )
+      Notification.should_receive( :where ).and_return( [note] )
+      note.should_receive( :set_read_state ).with( true )
+      @controller.update :id => note.id, :set_unread => "false"
+    end
+
+    it 'marks a notification as unread if it is told to' do
+      note = mock_model( Notification )
+      Notification.should_receive( :where ).and_return( [note] )
+      note.should_receive( :set_read_state ).with( false )
+      @controller.update :id => note.id, :set_unread => "true"
     end
 
     it 'only lets you read your own notifications' do

--- a/spec/javascripts/widgets/notifications-spec.js
+++ b/spec/javascripts/widgets/notifications-spec.js
@@ -3,13 +3,46 @@
  *   the COPYRIGHT file.
  */
 describe("Diaspora.Widgets.Notifications", function() {
-  var changeNotificationCountSpy, notifications;
+  var changeNotificationCountSpy, notifications, incrementCountSpy, decrementCountSpy;
 
   beforeEach(function() {
     spec.loadFixture("aspects_index");
-    notifications = Diaspora.BaseWidget.instantiate("Notifications", $("#notifications"), $("#notification_badge .badge_count"));
+    this.view = new app.views.Header().render();
+
+    notifications = Diaspora.BaseWidget.instantiate("Notifications", this.view.$("#notification_badge .badge_count"), this.view.$(".notifications"));
 
     changeNotificationCountSpy = spyOn(notifications, "changeNotificationCount").andCallThrough();
+    incrementCountSpy = spyOn(notifications, "incrementCount").andCallThrough();
+    decrementCountSpy = spyOn(notifications, "decrementCount").andCallThrough();
+  });
+
+  describe("clickSuccess", function(){
+    it("changes the css to a read cell", function() {
+      this.view.$(".notifications").html(
+        '<div id="1" class="stream_element read" data-guid=1></div>' +
+        '<div id="2" class="stream_element unread" data-guid=2></div>'
+      );
+      notifications.clickSuccess(JSON.stringify({guid:2,unread:false}));
+      expect( this.view.$('.stream_element#2')).toHaveClass("read");
+    });
+    it("changes the css to an unread cell", function() {
+      this.view.$(".notifications").html(
+        '<div id="1" class="stream_element read" data-guid=1></div>' +
+        '<div id="2" class="stream_element unread" data-guid=2></div>'
+      );
+      notifications.clickSuccess(JSON.stringify({guid:1,unread:true}));
+      expect( this.view.$('.stream_element#1')).toHaveClass("unread");
+    });
+
+
+    it("calls Notifications.decrementCount on a read cell", function() {
+      notifications.clickSuccess(JSON.stringify({guid:1,unread:false}));
+      expect(notifications.decrementCount).toHaveBeenCalled();
+    });
+    it("calls Notifications.incrementCount on a unread cell", function() {
+      notifications.clickSuccess(JSON.stringify({guid:1,unread:true}));
+      expect(notifications.incrementCount).toHaveBeenCalled();
+    });
   });
 
   describe("decrementCount", function() {
@@ -40,13 +73,13 @@ describe("Diaspora.Widgets.Notifications", function() {
 
   describe("showNotification", function() {
     it("prepends a div to div#notifications", function() {
-      expect($("#notifications div").length).toEqual(0);
+      expect(this.view.$(".notifications div").length).toEqual(1);
 
       notifications.showNotification({
-        html: '<div class="notification"></div>'
+        html: '<div class="notification_element"></div>'
       });
 
-      expect($("#notifications div").length).toEqual(1);
+      expect(this.view.$(".notifications div").length).toEqual(2);
     });
 
     it("only increments the notification count if specified to do so", function() {

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -40,6 +40,21 @@ describe Notification do
     end
   end
 
+  describe 'set_read_state method' do
+    it "should set an unread notification to read" do
+      @note.unread = true
+      @note.set_read_state( true )
+      @note.unread.should == false
+    end
+    it "should set an read notification to unread" do
+      @note.unread = false
+      @note.set_read_state( false )
+      @note.unread.should == true
+    end
+
+  end
+
+
   describe '.concatenate_or_create' do
     it 'creates a new notificiation if the notification does not exist, or if it is unread' do
       @note.unread = false


### PR DESCRIPTION
This is a repost of the pull request https://github.com/diaspora/diaspora/pull/2547
Adapted to work in the new layout with some suggested improvements made, a little cleaner too. This duplicates the functionality currently running on Pistos' builds.
I know this code may not survive the upcoming UX refresh, but in case it does I figured I'd finish it up...
