### PR TITLE
fix syntax for psql backend

### DIFF
--- a/db/migrate/20120202190701_remove_public_share_visibilities.rb
+++ b/db/migrate/20120202190701_remove_public_share_visibilities.rb
@@ -24,13 +24,13 @@ class RemovePublicShareVisibilities < ActiveRecord::Migration
 
       while index < shareable_size + 100 do
         sql = <<-SQL
-          DELETE sv
+          DELETE
             FROM share_visibilities AS sv
-              INNER JOIN #{table_name}
-              ON sv.shareable_id = #{table_name}.id
-              WHERE sv.shareable_type = "#{type}"
-                AND #{table_name}.public IS TRUE
-                AND #{table_name}.id < #{index};
+              USING #{table_name} as p
+              WHERE sv.shareable_id = p.id
+                AND sv.shareable_type = '#{type}'
+                AND p.public IS TRUE
+                AND p.id < #{index};
         SQL
 
         puts "deleted public share vis up to #{index} of #{type}"


### PR DESCRIPTION
- PostgreSQL doesn't allow double quotes for values. Double quotes are
  used for surrounding table names that contain spaces. Single quotes
  should be used for values.
- DELETE in a JOIN is not permitted in SQL-99 (see
  http://drupal.org/node/555562) so we use USING with WHERE instead
