### PR TITLE
add previously missing translation in the invitation-lightbox

### DIFF
--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -339,6 +339,7 @@ en:
       aspect: "Aspect"
       already_invited: "The following people have not accepted your invitation:"
       resend: "Resend"
+      check_out_diaspora: "Check out Diaspora!"
     check_token:
       not_found: "Invitation token not found"
     edit:


### PR DESCRIPTION
The "Personal Message" field should contain "Check out Diaspora," but it currently is

``` html
<span class="translation_missing" title="translation missing: en.invitations.new.check_out_diaspora">Check Out Diaspora</span>
```
