### PR TITLE
fixed and improved capistrano recipe

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -20,6 +20,7 @@ set :use_sudo, false
 set :scm_verbose, true
 set :repository_cache, "remote_cache"
 set :deploy_via, :checkout
+set :bundle_without,  [:development, :test, :heroku]
 
 # Figure out the name of the current local branch
 def current_git_branch

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -47,7 +47,10 @@ namespace :deploy do
 
   task :restart do
     thins = capture_svstat "/service/thin*"
-    matches = thins.match(/(thin_\d+):/).captures
+    matches = thins.split("\n").inject([]) do |list, line|
+      m = line.match(/(thin_\d+):/)
+      list << m.captures[0] unless m.nil?
+    end
 
     matches.each_with_index do |thin, index|
       unless index == 0

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -41,7 +41,7 @@ namespace :deploy do
   end
 
   task :bundle_static_assets do
-    run "cd #{current_path} && sass --update public/stylesheets/sass:public/stylesheets"
+    run "cd #{current_path} && bundle exec sass --update public/stylesheets/sass:public/stylesheets"
     run "cd #{current_path} && bundle exec jammit"
   end
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -46,7 +46,7 @@ namespace :deploy do
   end
 
   task :restart do
-    thins = capture "svstat /service/thin*"
+    thins = capture_svstat "/service/thin*"
     matches = thins.match(/(thin_\d+):/).captures
 
     matches.each_with_index do |thin, index|
@@ -54,25 +54,25 @@ namespace :deploy do
         puts "sleeping for 20 seconds"
         sleep(20)
       end
-      run "svc -t /service/#{thin}"
+      svc "-t /service/#{thin}"
     end
 
-    run "svc -t /service/resque_worker*"
+    svc "-t /service/resque_worker*"
   end
 
   task :kill do
-    run "svc -k /service/thin*"
-    run "svc -k /service/resque_worker*"
+    svc "-k /service/thin*"
+    svc "-k /service/resque_worker*"
   end
 
   task :start do
-    run "svc -u /service/thin*"
-    run "svc -u /service/resque_worker*"
+    svc "-u /service/thin*"
+    svc "-u /service/resque_worker*"
   end
 
   task :stop do
-    run "svc -d /service/thin*"
-    run "svc -d /service/resque_worker*"
+    svc "-d /service/thin*"
+    svc "-d /service/resque_worker*"
   end
 
   desc 'Copy resque-web assets to public folder'
@@ -91,5 +91,18 @@ after 'deploy:symlink' do
   deploy.symlink_cookie_secret
   deploy.bundle_static_assets
   deploy.copy_resque_assets
+end
+
+
+def maybe_sudo(cmd)
+  "#{svc_sudo ? sudo : ''} #{cmd}"
+end
+
+def svc(opts)
+  run(maybe_sudo("svc #{opts}"))
+end
+
+def capture_svstat(opts)
+  capture(maybe_sudo("svstat #{opts}"))
 end
 

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -12,3 +12,6 @@ if config['branch']
 end
 set :repository, config['repo']
 server config['server'], :app, :web, :db, :primary => true
+set :svc_sudo, (config['svc_sudo'] || false)
+default_run_options[:pty] = true if svc_sudo
+

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -12,3 +12,6 @@ if config['branch']
 end
 set :repository, config['repo']
 server config['server'], :app, :web, :db, :primary => true
+set :svc_sudo, (config['svc_sudo'] || false)
+default_run_options[:pty] = true if svc_sudo
+

--- a/config/deploy_config.yml.example
+++ b/config/deploy_config.yml.example
@@ -10,6 +10,8 @@ production:
   password: 'password'
   rails_env: 'production'
   repo: 'git://github.com/diaspora/diaspora.git'
+  #set svc_sudo to true if you want to run scv and svstat with sudo. default: false
+  svc_sudo: false
 staging:
   server: 'staging.example.com'
   deploy_to: '/var/www/diaspora'
@@ -18,3 +20,4 @@ staging:
   password: 'password'
   rails_env: 'staging'
   repo: 'git://github.com/diaspora/diaspora.git'
+  svc_sudo: false


### PR DESCRIPTION
Hi, 

I had some "problems" upgrading my POD with capistrano so I improved and fixed a couple of things.

This pull request includes the following improvements:
- do not install heroku gemset group
- execute sass with bundle exec
- run svc and svstat with sudo (configurable)
- fixed thin instances detection

Heroku:
heroku gemset includes pg gem without checking ENV['DB'], who deploy with capistrano isn't an heroku user (or it'll deploy with heroku gem)

sudo:
I'm running my pod under root user, so I'm not allowed to run svc and svstat.
With this patch you can specify svc_sudo in deploy_config.yml 
If true it will use sudo (only for svc and svstat) otherwise not.
If the option is missing it will fallback to false value and behave exactly as before.

thin detection:

``` ruby
s = <<-EOS
/service/thin_0: up (pid 5758) 68 seconds
/service/thin_1: up (pid 17639) 16397 seconds
/service/thin_2: up (pid 17640) 16397 seconds
EOS

puts "svstat output:"
puts s

puts "single match invocation output:"
puts s.match(/(thin_\d+):/).captures.inspect #=> ["thin_0"]


res = s.split("\n").inject([]) do |list, line| 
  m = line.match(/(thin_\d+):/) 
  list += m.captures unless m.nil?
end

puts "multi-line match invocation output:"
puts res.inspect #=> ["thin_0", "thin_1", "thin_2"]
```
