### PR TITLE
Fix #1308: publisher submits w/o pasted text

### DIFF
--- a/config/assets.yml
+++ b/config/assets.yml
@@ -80,6 +80,7 @@ javascripts:
     - public/javascripts/friend-finder.js
   home:
     - public/javascripts/publisher.js
+    - public/javascripts/jquery.textchange.min.js
     - public/javascripts/aspect-edit-pane.js
     - public/javascripts/fileuploader-custom.js
   people:

--- a/public/javascripts/jquery.textchange.min.js
+++ b/public/javascripts/jquery.textchange.min.js
@@ -1,0 +1,10 @@
+/*!
+ * jQuery TextChange Plugin
+ * http://www.zurb.com/playground/jquery-text-change-custom-event
+ *
+ * Copyright 2010, ZURB
+ * Released under the MIT License
+ */
+ (function(a){a.event.special.textchange={setup:function(){a(this).data("lastValue",this.contentEditable==="true"?a(this).html():a(this).val());a(this).bind("keyup.textchange",a.event.special.textchange.handler);a(this).bind("cut.textchange paste.textchange input.textchange",a.event.special.textchange.delayedHandler)},teardown:function(){a(this).unbind(".textchange")},handler:function(){a.event.special.textchange.triggerIfChanged(a(this))},delayedHandler:function(){var c=a(this);setTimeout(function(){a.event.special.textchange.triggerIfChanged(c)},
+ 25)},triggerIfChanged:function(a){var b=a[0].contentEditable==="true"?a.html():a.val();b!==a.data("lastValue")&&(a.trigger("textchange",[a.data("lastValue")]),a.data("lastValue",b))}};a.event.special.hastext={setup:function(){a(this).bind("textchange",a.event.special.hastext.handler)},teardown:function(){a(this).unbind("textchange",a.event.special.hastext.handler)},handler:function(c,b){b===""&&b!==a(this).val()&&a(this).trigger("hastext")}};a.event.special.notext={setup:function(){a(this).bind("textchange",
+ a.event.special.notext.handler)},teardown:function(){a(this).unbind("textchange",a.event.special.notext.handler)},handler:function(c,b){a(this).val()===""&&a(this).val()!==b&&a(this).trigger("notext")}}})(jQuery);

--- a/public/javascripts/publisher.js
+++ b/public/javascripts/publisher.js
@@ -151,8 +151,8 @@ var Publisher = {
     });
   },
 
-  keyUp : function(){
-    Publisher.determineSubmitAvailability()
+  textChange : function(){
+    Publisher.determineSubmitAvailability();
     Publisher.input().mentionsInput("val", function(value) {
       Publisher.hiddenInput().val(value);
     });
@@ -215,7 +215,7 @@ var Publisher = {
     }
 
     Publisher.input().autoResize({'extraSpace' : 10});
-    Publisher.input().keyup(Publisher.keyUp)
+    Publisher.input().bind('textchange', Publisher.textChange);
   }
 };
 


### PR DESCRIPTION
Text can be input not only with the keyboard but also with a right-click
paste or a middle mouse button paste in X. The publisher now listens to
the 'textchange' event instead of ignoring anything but a 'keyup'.
