### PR TITLE
intentionally failing specs - dirty input breaks bookmarklet (+fix)

### DIFF
--- a/app/views/status_messages/bookmarklet.html.haml
+++ b/app/views/status_messages/bookmarklet.html.haml
@@ -21,8 +21,9 @@
       });
 
       var contents = "#{params[:title]} - #{params[:url]}";
-      if ("#{params[:notes]}".length > 0){
-        contents = contents + " - #{params[:notes]}";
+      var notes    = "#{escape_javascript params[:notes]}";
+      if (notes.length > 0){
+        contents = contents + " - " + notes;
       }
 
       $("#publisher #status_message_fake_text").val(contents);

--- a/spec/controllers/status_messages_controller_spec.rb
+++ b/spec/controllers/status_messages_controller_spec.rb
@@ -16,9 +16,35 @@ describe StatusMessagesController do
   end
 
   describe '#bookmarklet' do
+    def pass_test_args(text='cute kitty')
+      get :bookmarklet, {:url => 'https://www.youtube.com/watch?v=0Bmhjf0rKe8',
+                         :title => 'Surprised Kitty',
+                         :notes => text}
+    end
+    
     it 'succeeds' do
       get :bookmarklet
       response.should be_success
+      
+      #TODO replace response.body with html_for('body') as soon as there is a <body>
+      save_fixture(response.body, 'empty_bookmarklet') 
+    end
+
+    it 'accepts get params' do
+      pass_test_args
+      response.should be_success
+      
+      #TODO replace response.body with html_for('body') as soon as there is a <body>
+      save_fixture(response.body, 'prefilled_bookmarklet')
+    end
+    
+    it 'correctly deals with dirty input' do
+      test_text = "**love** This is such a\n\n great \"cute kitty\" '''blabla'''"
+      pass_test_args(test_text)
+      response.should be_success
+      
+      #TODO replace response.body with html_for('body') as soon as there is a <body>
+      save_fixture(response.body, 'prefilled_bookmarklet_dirty')
     end
   end
 

--- a/spec/javascripts/bookmarklet-spec.js
+++ b/spec/javascripts/bookmarklet-spec.js
@@ -1,0 +1,39 @@
+/*   Copyright (c) 2010-2012, Diaspora Inc.  This file is
+*   licensed under the Affero General Public License version 3 or later.  See
+*   the COPYRIGHT file.
+*/ 
+
+describe("bookmarklet", function() {
+
+  describe("base functionality", function(){
+    beforeEach( function(){
+      spec.loadFixture('empty_bookmarklet');
+    });
+
+    it('verifies the publisher is loaded', function(){
+      expect(typeof Publisher === "object").toBeTruthy();
+    });
+
+    it('verifies we are using the bookmarklet', function(){
+      expect(Publisher.bookmarklet).toBeTruthy();
+    });
+  });
+
+  describe("prefilled bookmarklet", function(){
+    it('fills in some text into the publisher', function(){
+      spec.loadFixture('prefilled_bookmarklet');
+      expect($("#publisher #status_message_fake_text").val() == "").toBeFalsy();
+      expect($("#publisher #status_message_text").val() == "").toBeFalsy();
+    });
+
+    it('handles dirty input well', function(){
+      spec.loadFixture('prefilled_bookmarklet_dirty');
+      expect($("#publisher #status_message_fake_text").val() == "").toBeFalsy();
+      expect($("#publisher #status_message_text").val() == "").toBeFalsy();      
+    });
+  });
+
+  
+
+  
+});


### PR DESCRIPTION
see also #2741 #2751 #2800

(the last jasmine spec should fail)
(I hope jasmine is the correct choice here and not cucumber ...)
