### PR TITLE
fix shifted image button in firefox

### DIFF
--- a/public/stylesheets/sass/application.sass
+++ b/public/stylesheets/sass/application.sass
@@ -1021,17 +1021,17 @@ label
 
     :display inline-block
 
-    :padding 0.3em
+    :padding .3em .3em 3px
     :cursor pointer
 
     img
       @include opacity(0.4)
-
+      :vertical-align bottom
       :display inline-block
       :margin 0
       :padding 0
       :margin
-        :bottom -3px
+        :bottom 1px
 
     &:hover
       :background


### PR DESCRIPTION
this normalizes the css, since webkit and gecko seem to have different views on vertical alignment...
see before/after screenshot for details

![example](http://img543.imageshack.us/img543/2528/publisherbeforeafter.png)
http://img543.imageshack.us/img543/2528/publisherbeforeafter.png
