### PR TITLE
fix contact page css

### DIFF
--- a/public/stylesheets/sass/application.sass
+++ b/public/stylesheets/sass/application.sass
@@ -2362,7 +2362,12 @@ a.toggle_selector
 #people_stream.contacts
   .stream_element
     :padding 10px
+    :position relative
     :min-height 30px
+
+    & > a
+      :float left
+
     .right
       :top 16px
 


### PR DESCRIPTION
before - after comparison should say it all

![contacts](http://img844.imageshack.us/img844/84/contactsbeforeafter.png)
(that second contact was added after the first screenshot was made...)
