### PR TITLE
Fix wrong plural in German translation.

### DIFF
--- a/config/locales/javascript/javascript.de.yml
+++ b/config/locales/javascript/javascript.de.yml
@@ -74,7 +74,7 @@ de:
       more_comments:
         few: "Zeige <%= count %> weitere Kommentare"
         many: "Zeige <%= count %> weitere Kommentare"
-        one: "Zeige einen weiteren Kommentare"
+        one: "Zeige einen weiteren Kommentar"
         other: "Zeige <%= count %> weitere Kommentare"
         two: "Zeige <%= count %> weitere Kommentare"
         zero: "Keine weiteren Kommentare"


### PR DESCRIPTION
German translation was wrong for the "one" case here. One = singular.
