### PR TITLE
bookmarklet fixes

### DIFF
--- a/app/views/status_messages/bookmarklet.html.haml
+++ b/app/views/status_messages/bookmarklet.html.haml
@@ -1,22 +1,50 @@
--#   Copyright (c) 2010-2011, Diaspora Inc.  This file is
+-#   Copyright (c) 2010-2012, Diaspora Inc.  This file is
 -#   licensed under the Affero General Public License version 3 or later.  See
 -#   the COPYRIGHT file.
 
-= include_javascripts :jquery
-= include_javascripts :main
-= include_stylesheets :default, :media => 'all'
-= stylesheet_link_tag "blueprint/screen", :media => 'screen'
-= javascript_include_tag "publisher.js"
+!!!
+%html{:lang => I18n.locale.to_s, :dir => (rtl?) ? 'rtl' : 'ltr'}
+  %head
+    %meta{:charset => 'utf-8'}
 
-:javascript
-  Diaspora.I18n.loadLocale(#{get_javascript_strings_for(current_user.language).to_json}, "#{current_user.language}");
-  $(document).ready(function() 
-    {
+    %title
+      = page_title yield(:page_title)
+
+    %meta{'http-equiv' => 'X-UA-Compatible', :content => 'IE=edge,chrome=1'}
+    %meta{"http-equiv"=>"Content-Type", :content=>"text/html; charset=utf-8"}/
+
+    %link{:rel => 'shortcut icon', :href => '/favicon.png'}
+    %link{:rel => 'apple-touch-icon', :href => '/apple-touch-icon.png'}
+
+    = csrf_meta_tag
+
+    = jquery_include_tag
+    = include_javascripts :main, :templates
+    = javascript_include_tag "publisher.js"
+    :javascript
+      Diaspora.I18n.loadLocale(#{get_javascript_strings_for(I18n.locale).to_json}, "#{I18n.locale}");
+    
+    = stylesheet_link_tag "blueprint/screen", :media => 'screen'
+    = include_stylesheets :default, :media => 'all'
+    :css
+      body { margin: 0; padding: 0; }
+      #new_status_message_pane { margin: 1em 0 0; }
+      #new_status_message_pane h4 { margin: 0 0 0 1em; }
+
+  %body
+    #new_status_message_pane
+      .span-15.last
+        %h4
+          =t('bookmarklet.post_something')
+        = render :partial => 'shared/publisher', :locals => { :aspect => :profile, :selected_aspects => @aspects,  :aspect_ids => @aspect_ids }
+
+    :javascript
       Publisher.bookmarklet = true;
+      app.publisher = new app.views.Publisher();
+      
       $("#publisher").bind('ajax:success', function(){
         $('h4').text("#{t('bookmarklet.post_success')}");
-        Publisher.close();
-
+        app.publisher.close();
         window.setTimeout(window.close, 2000, true);
       });
 
@@ -29,11 +57,4 @@
       $("#publisher #status_message_fake_text").val(contents);
       $("#publisher #status_message_text").val(contents);
       $('input.button')[0].removeAttribute('disabled');
-  });
-
-#new_status_message_pane
-  .span-15.last
-    %h4
-      =t('bookmarklet.post_something')
-    = render :partial => 'shared/publisher', :locals => { :aspect => :profile, :selected_aspects => @aspects,  :aspect_ids => @aspect_ids }
 

--- a/public/javascripts/app/views/publisher_view.js
+++ b/public/javascripts/app/views/publisher_view.js
@@ -34,7 +34,12 @@ app.views.Publisher = Backbone.View.extend({
     }, {
       url : "/status_messages",
       success : function() {
-        app.stream.posts.add(statusMessage.toJSON());
+        if(app.publisher) {
+          $(app.publisher.el).trigger('ajax:success');
+        }
+        if(app.stream) {
+          app.stream.posts.add(statusMessage.toJSON());
+        }
       }
     });
 

--- a/spec/controllers/status_messages_controller_spec.rb
+++ b/spec/controllers/status_messages_controller_spec.rb
@@ -21,30 +21,35 @@ describe StatusMessagesController do
                          :title => 'Surprised Kitty',
                          :notes => text}
     end
-    
+
     it 'succeeds' do
       get :bookmarklet
       response.should be_success
-      
-      #TODO replace response.body with html_for('body') as soon as there is a <body>
-      save_fixture(response.body, 'empty_bookmarklet') 
+    end
+
+    it 'contains a complete html document' do
+      get :bookmarklet
+
+      doc = Nokogiri(response.body)
+      doc.xpath('//head').count.should equal 1
+      doc.xpath('//body').count.should equal 1
+
+      save_fixture(html_for('body'), 'empty_bookmarklet') 
     end
 
     it 'accepts get params' do
       pass_test_args
       response.should be_success
-      
-      #TODO replace response.body with html_for('body') as soon as there is a <body>
-      save_fixture(response.body, 'prefilled_bookmarklet')
+
+      save_fixture(html_for('body'), 'prefilled_bookmarklet')
     end
-    
+
     it 'correctly deals with dirty input' do
       test_text = "**love** This is such a\n\n great \"cute kitty\" '''blabla'''"
       pass_test_args(test_text)
       response.should be_success
-      
-      #TODO replace response.body with html_for('body') as soon as there is a <body>
-      save_fixture(response.body, 'prefilled_bookmarklet_dirty')
+
+      save_fixture(html_for('body'), 'prefilled_bookmarklet_dirty')
     end
   end
 


### PR DESCRIPTION
- bookmarklet now is a complete (valid?) html document (+test)
- fix error "JST is not defined" (prevented prefilling bookmarklet) by including the new js templates
- it auto-expands to the size of the text that was selected
- it self-closes after posting again
