### PR TITLE
Fix atom feed bug (bug mash 7)

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -99,13 +99,10 @@ class UsersController < ApplicationController
   end
 
   def public
-    if user = User.find_by_username(params[:username])
+    if @user = User.find_by_username(params[:username])
       respond_to do |format|
         format.atom do
-          posts = StatusMessage.where(:author_id => user.person.id, :public => true).order('created_at DESC').limit(25)
-          director = Diaspora::Director.new
-          ostatus_builder = Diaspora::OstatusBuilder.new(user, posts)
-          render :xml => director.build(ostatus_builder), :content_type => 'application/atom+xml'
+          @posts = StatusMessage.where(:author_id => @user.person.id, :public => true).order('created_at DESC').limit(25)
         end
 
         format.any { redirect_to person_path(user.person) }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -105,7 +105,7 @@ class UsersController < ApplicationController
           @posts = StatusMessage.where(:author_id => @user.person.id, :public => true).order('created_at DESC').limit(25)
         end
 
-        format.any { redirect_to person_path(user.person) }
+        format.any { redirect_to person_path(@user.person) }
       end
     else
       redirect_to stream_path, :error => I18n.t('users.public.does_not_exist', :username => params[:username])

--- a/app/models/status_message.rb
+++ b/app/models/status_message.rb
@@ -125,22 +125,6 @@ class StatusMessage < Post
     identifiers.empty? ? [] : Person.where(:diaspora_handle => identifiers)
   end
 
-  def to_activity(opts={})
-    author = opts[:author] || self.author #Use an already loaded author if passed in.
-    <<-XML
-  <entry>
-    <title>#{x(self.formatted_message(:plain_text => true))}</title>
-    <content>#{x(self.formatted_message(:plain_text => true))}</content>
-    <link rel="alternate" type="text/html" href="#{author.url}p/#{self.id}"/>
-    <id>#{author.url}p/#{self.id}</id>
-    <published>#{self.created_at.xmlschema}</published>
-    <updated>#{self.updated_at.xmlschema}</updated>
-    <activity:verb>http://activitystrea.ms/schema/1.0/post</activity:verb>
-    <activity:object-type>http://activitystrea.ms/schema/1.0/note</activity:object-type>
-  </entry>
-    XML
-  end
-
   def after_dispatch(sender)
     self.update_and_dispatch_attached_photos(sender)
   end

--- a/app/views/users/public.atom.builder
+++ b/app/views/users/public.atom.builder
@@ -1,0 +1,40 @@
+atom_feed({'xmlns:thr' => 'http://purl.org/syndication/thread/1.0',
+ 'xmlns:georss' => 'http://www.georss.org/georss', 
+ 'xmlns:activity' => 'http://activitystrea.ms/spec/1.0/', 
+ 'xmlns:media' => 'http://purl.org/syndication/atommedia',
+ 'xmlns:poco' => 'http://portablecontacts.net/spec/1.0', 
+ 'xmlns:ostatus' => 'http://ostatus.org/schema/1.0', 
+ 'xmlns:statusnet' => 'http://status.net/schema/api/1/',
+ :id => "#{@user.public_url}.atom",
+ :root_url => "#{@user.public_url}"}) do |feed|
+
+  feed.tag! :generator, 'Diaspora', :uri => "#{AppConfig[:pod_url]}"
+  feed.title "#{@user.name}'s Public Feed"
+  feed.subtitle "Updates from #{@user.name} on Diaspora"
+  feed.logo "#{@user.person.profile.image_url(:thumb_small)}"
+  feed.updated @posts[0].created_at if @posts.length > 0
+  feed.tag! :link, :rel => 'avatar', :type => 'image/jpeg', 'media:width' => '100',
+   	    'media:height' => '100', :href => "#{@user.profile.image_url}"
+  feed.tag! :link, :href => "#{AppConfig[:pubsub_server]}", :rel => 'hub'
+
+  feed.author do |author|
+    author.name @user.name
+    author.uri local_or_remote_person_path(@user.person, :absolute => true)
+    
+    author.tag! 'activity:object-type', 'http://activitystrea.ms/schema/1.0/person'
+    author.tag! 'poco:preferredUsername', @user.username
+    author.tag! 'poco:displayName', @user.person.name
+  end
+
+
+  @posts.each do |post|
+    feed.entry post, :url => "#{@user.person.url}p/#{post.id}",
+      :id => "#{@user.person.url}p/#{post.id}" do |entry|
+
+      entry.title truncate(post.formatted_message(:plain_text => true), :length => 50)
+      entry.content post.formatted_message(:plain_text => true), :type => 'html'
+      entry.tag! 'activity:verb', 'http://activitystrea.ms/schema/1.0/post'
+      entry.tag! 'activity:object-type', 'http://activitystrea.ms/schema/1.0/note'
+    end
+  end  
+end

--- a/spec/models/status_message_spec.rb
+++ b/spec/models/status_message_spec.rb
@@ -287,13 +287,6 @@ STR
         @marshalled.diaspora_handle.should == @message.diaspora_handle
       end
     end
-
-
-    describe '#to_activity' do
-      it 'should render a string' do
-        @message.to_activity.should_not be_blank
-      end
-    end
   end
 
   describe '#after_dispatch' do


### PR DESCRIPTION
Description:
- Created a new file app/views/users/public.atom.builder to hold the view code of Atom feed render, using Builder render template and Rails Atom Feed helper.
- Modified  app/controllers/users_controller.rb, removing "render :xml =>...", allowing the controller to render the Atom feed using the corresponding view (app/views/users/public.atom.builder).

I'm not sure if we need to do any modifications on StatusMessage class (remove the to_activity() method), Diaspora::Director or Diaspora::OStatusBuilder. I've set a 50 character truncation length for the entries title, is this a good value or it can be changed?.  Please give some advice and help about this.

Thanks.
