### PR TITLE
fix for #2770

### DIFF
--- a/app/views/photos/_new_photo.haml
+++ b/app/views/photos/_new_photo.haml
@@ -29,7 +29,7 @@
         $('#file-upload').addClass("loading");
         $('#publisher').find("input[type='submit']").attr('disabled','disabled');
 
-        $("#publisher textarea").addClass("with_attachments");
+        Publisher.wrapper().addClass("with_attachments");
         $('#photodropzone').append(
           "<li class='publisher_photo loading' style='position:relative;'>" +
             "<img src='/images/ajax-loader2.gif' />" +
@@ -43,7 +43,7 @@
             url = responseJSON.data.photo.unprocessed_image.url,
             currentPlaceholder = $('li.loading').first();
 
-        $("#publisher textarea").addClass("with_attachments");
+        Publisher.wrapper().addClass("with_attachments");
         $('#new_status_message').append("<input type='hidden' value='" + id + "' name='photos[]' />");
 
         // replace image placeholders
@@ -68,10 +68,8 @@
                   success: function() {
                             photo.fadeOut(400, function(){
                               photo.remove();
-                              textarea.css('paddingBottom', $("#photodropzone").height() + 10);
                               if ( $('.publisher_photo').length  == 0){
-                                textarea.removeClass("with_attachments");
-                                textarea.css('paddingBottom', '');
+                                Publisher.wrapper().removeClass("with_attachments");
                               }
                             });
                           }

--- a/public/javascripts/app/views/publisher_view.js
+++ b/public/javascripts/app/views/publisher_view.js
@@ -8,7 +8,7 @@ app.views.Publisher = Backbone.View.extend({
 
   events : {
     "focus textarea" : "open",
-    "click #hide_publisher" : "close",
+    "click #hide_publisher" : "clear",
     "submit form" : "createStatusMessage"
   },
 
@@ -48,10 +48,8 @@ app.views.Publisher = Backbone.View.extend({
   },
 
   clear : function() {
-    this.$('textarea')
-      .removeClass("with_attachments")
-      .css("paddingBottom", "")
-      .val("");
+    this.$('textarea').val("");
+    this.$('#publisher_textarea_wrapper').removeClass("with_attachments");
 
     // remove photos
     this.$("#photodropzone").find('li').remove();

--- a/public/javascripts/publisher.js
+++ b/public/javascripts/publisher.js
@@ -15,6 +15,10 @@ var Publisher = {
     return Publisher.cachedInput = Publisher.cachedInput || Publisher.form().find('#status_message_fake_text');
   },
 
+  wrapper: function(){
+    return Publisher.cachedWrapper = Publisher.cachedWrapper || Publisher.form().find('#publisher_textarea_wrapper');
+  },
+
   hiddenInput: function(){
     return Publisher.cachedHiddenInput= Publisher.cachedHiddenInput || Publisher.form().find('#status_message_text');
   },
@@ -37,10 +41,8 @@ var Publisher = {
 
   clear: function(){
     $("#photodropzone").find('li').remove();
-    Publisher.input()
-      .removeClass("with_attachments")
-      .css('paddingBottom', '')
-      .mentionsInput("reset");
+    Publisher.input().mentionsInput("reset");
+    Publisher.wrapper().removeClass("with_attachments");
   },
 
   bindServiceIcons: function(){
@@ -195,14 +197,6 @@ var Publisher = {
 
     Publisher.bindServiceIcons();
     Publisher.bindAspectToggles();
-
-    /* close text area */
-    Publisher.form().delegate("#hide_publisher", "click", function(){
-      $.each(Publisher.form().find("textarea"), function(idx, element){
-        $(element).val("");
-      });
-      Publisher.close();
-    });
 
     Mentions.initialize(Publisher.input());
 

--- a/public/stylesheets/sass/application.sass
+++ b/public/stylesheets/sass/application.sass
@@ -835,9 +835,8 @@ form p.checkbox_select
       :outline 0
       :background transparent
 
-    &.with_attachments
-      :padding
-        :bottom 70px
+  &.with_attachments
+    :padding-bottom 38px
 
   #photodropzone
     :z-index 3
@@ -852,6 +851,7 @@ form p.checkbox_select
       :margin-right 4px
       img
         :width 50px
+        :max-height 55px
       .circle
         @include border-radius(20px)
 


### PR DESCRIPTION
- apply the padding to the wrapper element, not to the textarea  
  apparently padding a textarea makes it shrink in firefox... ?
- don't use manual padding, instead specify max-height for images  
  extra-huge images are jolted, but they don't explode the layout
- closing handled by view,  
  gets rid of "Publisher.close is not a function" error msg
#2770
