### PR TITLE
Added truncation of titles of status messages in activity feeds (atom). Fixes #2192

### DIFF
--- a/app/models/status_message.rb
+++ b/app/models/status_message.rb
@@ -127,10 +127,12 @@ class StatusMessage < Post
 
   def to_activity(opts={})
     author = opts[:author] || self.author #Use an already loaded author if passed in.
+
+    post_text = x(self.formatted_message(:plain_text => true))
     <<-XML
   <entry>
-    <title>#{x(self.formatted_message(:plain_text => true))}</title>
-    <content>#{x(self.formatted_message(:plain_text => true))}</content>
+    <title>#{post_text.truncate(100)}</title>
+    <content>#{post_text}</content>
     <link rel="alternate" type="text/html" href="#{author.url}p/#{self.id}"/>
     <id>#{author.url}p/#{self.id}</id>
     <published>#{self.created_at.xmlschema}</published>

--- a/spec/models/status_message_spec.rb
+++ b/spec/models/status_message_spec.rb
@@ -290,8 +290,20 @@ STR
 
 
     describe '#to_activity' do
+      before do
+        @trunc_text = "I hate WALRUSES! I hate pandas and especially hate bushbabies. But the animal I hate most of all,..."
+        @long_text = "I hate WALRUSES! I hate pandas and especially hate bushbabies. But the animal I hate most of all, is the lesser spotted llama"
+
+        @message = Factory(:status_message, :text => @long_text, :author => @user.person)
+        @xml = @message.to_xml.to_s
+      end
+
       it 'should render a string' do
         @message.to_activity.should_not be_blank
+      end
+
+      it 'truncates the title attribute' do
+        @message.to_activity.should include(@trunc_text)
       end
     end
   end


### PR DESCRIPTION
Titles are now cut off at 100 chars, relevant test case included.
