### PR TITLE
Fix for Timestamps in Message Pane

### DIFF
--- a/public/stylesheets/sass/application.sass
+++ b/public/stylesheets/sass/application.sass
@@ -683,8 +683,6 @@ form p.checkbox_select
   input
     :height 100%
     :width 100%
-    :cursor pointer
-  a:hover
     :cursor pointer  
 
 #publisher

--- a/public/stylesheets/sass/application.sass
+++ b/public/stylesheets/sass/application.sass
@@ -684,6 +684,8 @@ form p.checkbox_select
     :height 100%
     :width 100%
     :cursor pointer
+  a:hover
+    :cursor pointer  
 
 #publisher
   :z-index 1
@@ -1737,9 +1739,6 @@ ul#press_logos
     :top 14px
     :padding
       :bottom 5px
-    :text-overflow ellipsis
-    :overflow hidden
-    :white-space nowrap
 
     a
       :color inherit
@@ -1908,8 +1907,8 @@ ul#press_logos
       :weight normal
 
   .timestamp
-    :position absolute
-    :right 10px
+    :position relative
+    :float right
     :font
       :weight normal
     :color $blue
@@ -2728,9 +2727,6 @@ a.toggle_selector
     :bottom 10px
   h1,h3
     :color #fff
-    :text-overflow ellipsis
-    :overflow hidden
-    :white-space nowrap
   :background orange
   &:hover
     #gs-skip-x
@@ -2826,5 +2822,4 @@ a.toggle_selector
   :font-size smaller
   :color #999
   a
-    :color #666
     :color #666


### PR DESCRIPTION
This may end up just being a temporary workaround, but the timestamps in the Messages list have this odd error where they just hang there as you scroll. Changing the positioning style and making it float:right fixes it.

Also, this is my first commit. :)
