### PR TITLE
adapt host-meta document to RFC 6415

### DIFF
--- a/app/views/publics/host_meta.erb
+++ b/app/views/publics/host_meta.erb
@@ -1,9 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<XRD xmlns='http://docs.oasis-open.org/ns/xri/xrd-1.0'
-     xmlns:hm='http://host-meta.net/xrd/1.0'>
-     <hm:Host><%= AppConfig[:pod_bare_domain] %></hm:Host>
+<XRD xmlns='http://docs.oasis-open.org/ns/xri/xrd-1.0'>
+
+  <!-- Resource-specific Information -->
+
   <Link rel='lrdd'
-        template='<%= AppConfig[:pod_url] %>webfinger?q={uri}'>
-    <Title>Resource Descriptor</Title>
-  </Link>
+        type='application/xrd+xml'
+        template='<%= AppConfig[:pod_url] %>webfinger?q={uri}' />
+
 </XRD>


### PR DESCRIPTION
https://tools.ietf.org/html/rfc6415 ("Web Host Metadata")

removed `<hm:Host>` element, since it was removed from the standard (and D\* doesn't do anything with it anyway),
also adding type attribute to `<link rel="lrdd" />` for consistency with the example in the RFC (D\* only cares about the `template` attribute[<sup>[1]</sup>](https://github.com/diaspora/diaspora/blob/master/lib/webfinger.rb#L88), so this is merely syntactic sugar).

Takes care of #2824
