### PR TITLE
Fix positioning in message pane timestamps.

### DIFF
--- a/public/stylesheets/sass/application.sass
+++ b/public/stylesheets/sass/application.sass
@@ -1917,8 +1917,8 @@ ul#press_logos
       :weight normal
 
   .timestamp
-    :position absolute
-    :right 10px
+    :position relative
+    :float right
     :font
       :weight normal
     :color $blue


### PR DESCRIPTION
As it currently stands, the message timestamps are all messed up when you try and scroll; I think having them in absolute positioning does this. So, this fix takes care of it!

This is also my first commit, well, the first one that counts. <333333
