### PR TITLE
disable superscripts on server-side markdownify, since they are disabled...

### DIFF
--- a/app/helpers/markdownify_helper.rb
+++ b/app/helpers/markdownify_helper.rb
@@ -12,7 +12,6 @@ module MarkdownifyHelper
       :fenced_code_blocks  => true,
       :space_after_headers => true,
       :strikethrough       => true,
-      :superscript         => true,
       :tables              => true,
       :no_intra_emphasis   => true,
     }


### PR DESCRIPTION
... client-side too

Client-side there is currently no support for `<sup>`ed text.  Would not it be better to have a consistent behavior?

Fix for #2938
