### PR TITLE
Improve visual style of comment box on ShowPages, fix #2974

### DIFF
--- a/public/stylesheets/sass/new-templates.scss
+++ b/public/stylesheets/sass/new-templates.scss
@@ -582,7 +582,16 @@ body.idle {
   left: 0;
   width: 100%;
   height: 100%;
+  border-bottom: 1px solid #474746;
+  box-shadow: 1px 4px 9px #222;
 }
+
+.comment-content h1, .comment-content h2, .comment-content h3, .comment-content h4, .comment-content h5, .comment-content h6 {
+color: white;
+text-shadow: 1px 1px black;
+text-rendering: optimizelegibility;
+}
+
 
 #post-feedback:hover {
   #post-info-sneaky:not(.passive) {


### PR DESCRIPTION
This improves the situation of comment boxes on ShowPages. Headers in comments now are no longer black-on-black, but instead a simple white with a black text shadow. Additionally, I've added a nifty little visual part of the top of the invoker to give more of a visual separation between the top of it, and the comment content inside it.
