### PR TITLE
Fix to allow white spaces in Rails.root path for the integration rake task

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -23,11 +23,11 @@ namespace :db do
       puts envs.inspect
       envs.each do |env|
         puts "dropping #{env}..."
-        `cd #{Rails.root} && RAILS_ENV=#{env} bundle exec rake db:drop`
+        `cd "#{Rails.root}" && RAILS_ENV=#{env} bundle exec rake db:drop`
         puts "creating #{env}..."
-        `cd #{Rails.root} && RAILS_ENV=#{env} bundle exec rake db:create`
+        `cd "#{Rails.root}" && RAILS_ENV=#{env} bundle exec rake db:create`
         puts "migrating #{env}..."
-        `cd #{Rails.root} && RAILS_ENV=#{env} bundle exec rake db:migrate`
+        `cd "#{Rails.root}" && RAILS_ENV=#{env} bundle exec rake db:migrate`
       end
     end
   end


### PR DESCRIPTION
If there are white spaces in the path to the rails root then the integration rake task fails. Just added quotation marks to fix it and thought that it might be worth a pull request to help others with this. Not sure if this fix is too small, so please let me know what you think! Trying to get into the diaspora source right now.
Thanks Stephan
