### PR TITLE
Cross-Origin Resource Sharing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,10 @@ gem 'whenever'
 
 gem 'thin', '~> 1.3.1',    :require => false
 
+# cross-origin resource sharing
+
+gem 'rack-cors', '~> 0.2.4', :require => 'rack/cors'
+
 # authentication
 
 gem 'devise', '~> 1.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -300,6 +300,8 @@ GEM
     polyglot (0.3.3)
     proxies (0.2.1)
     rack (1.2.5)
+    rack-cors (0.2.4)
+      rack
     rack-fiber_pool (0.9.2)
     rack-google-analytics (0.10.0)
     rack-mobile-detect (0.3.0)
@@ -496,6 +498,7 @@ DEPENDENCIES
   omniauth-twitter
   parallel_tests
   pg
+  rack-cors (~> 0.2.4)
   rack-google-analytics
   rack-piwik
   rack-rewrite (~> 1.2.1)

--- a/app/controllers/publics_controller.rb
+++ b/app/controllers/publics_controller.rb
@@ -12,12 +12,11 @@ class PublicsController < ApplicationController
   # We use newrelic_ignore to prevent artifical RPM bloat; however,
   # I am commenting this line out for the time being to debug some apparent
   # issues on Heroku.
-  # 
+  #
   # newrelic_ignore if EnviromentConfiguration.using_new_relic?
 
   skip_before_filter :set_header_data
   skip_before_filter :set_grammatical_gender
-  before_filter :allow_cross_origin, :only => [:hcard, :host_meta, :webfinger]
   before_filter :check_for_xml, :only => [:receive, :receive_public]
   before_filter :authenticate_user!, :only => [:index]
 
@@ -80,12 +79,6 @@ class PublicsController < ApplicationController
 
     render :nothing => true, :status => 202
   end
-
-
-  def allow_cross_origin
-    headers["Access-Control-Allow-Origin"] = "*"
-  end
-
 
 
   private

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,7 @@
+Rails.application.config.middleware.insert 0, Rack::Cors do
+  allow do
+    origins '*'
+    resource '/.well-known/host-meta'
+    resource '/webfinger'
+  end
+end


### PR DESCRIPTION
Remove partial support for CORS on webfinger routes and replace it with the
Rack::Cors middleware. This provides more complete CORS support and works
around a caching issue with nginx on Heroku and potentially other reverse
proxies.

CORS headers are only added if the incoming request includes an "Origin"
header, which seems to be correct according to the CORS spec.

references #2216 (I wasn't able to attach a pull request to the issue)
