### PR TITLE
small fixes for oembed in posts

### DIFF
--- a/public/javascripts/app/views/content_view.js
+++ b/public/javascripts/app/views/content_view.js
@@ -3,7 +3,7 @@ app.views.Content = app.views.StreamObject.extend({
   events: {
     "click .oembed .thumb": "showOembedContent"
   },
-  
+
   presenter : function(){
     return _.extend(this.defaultPresenter(), {
       text : app.helpers.textFormatter(this.model),
@@ -37,10 +37,10 @@ app.views.Content = app.views.StreamObject.extend({
 
   showOembedContent: function() {
     var oembed = $(this.el).find(".oembed");
-    var embedHTML = $( this.embedHTML() );
-    var paramSeparator = ( /\\?/.test(embedHTML.attr("href")) ) ? "&" : "?";
-    embedHTML.attr("src", embedHTML.attr("src") + paramSeparator + "autoplay=1");
-    oembed.html( embedHTML );
+    var insertHTML = jQuery( this.embedHTML() );
+    var paramSeparator = ( /\?/.test(insertHTML.attr("src")) ) ? "&" : "?";
+    insertHTML.attr("src", insertHTML.attr("src") + paramSeparator + "autoplay=1");
+    oembed.html( insertHTML );
   }
 });
 

--- a/public/javascripts/app/views/content_view.js
+++ b/public/javascripts/app/views/content_view.js
@@ -37,7 +37,7 @@ app.views.Content = app.views.StreamObject.extend({
 
   showOembedContent: function() {
     var oembed = $(this.el).find(".oembed");
-    var insertHTML = jQuery( this.embedHTML() );
+    var insertHTML = $( this.embedHTML() );
     var paramSeparator = ( /\?/.test(insertHTML.attr("src")) ) ? "&" : "?";
     insertHTML.attr("src", insertHTML.attr("src") + paramSeparator + "autoplay=1");
     oembed.html( insertHTML );

--- a/public/stylesheets/sass/application.sass
+++ b/public/stylesheets/sass/application.sass
@@ -1830,6 +1830,7 @@ ul#press_logos
   .collapsible
     .oembed
       :background url('/images/ajax-loader2.gif') no-repeat center center
+      :display inline-block
 
       .thumb
         :position relative


### PR DESCRIPTION
- make container inline-block to fit content (for overlay image + loading spinner to always be centered)
- fix javascript ("src" instead of "href" for iframes, also too many "\" in regex)  
  and disambiguate variable/function name
