### PR TITLE
Oembed providers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,7 @@ gem 'rails-i18n'
 gem 'nokogiri', '1.5.0'
 gem 'redcarpet', "2.0.1"
 gem 'roxml', :git => 'git://github.com/Empact/roxml.git', :ref => '7ea9a9ffd2338aaef5b0'
-gem 'ruby-oembed'
+gem 'ruby-oembed', '~> 0.8.7'
 
 # queue
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -384,7 +384,7 @@ GEM
       linecache19 (>= 0.5.11)
       ruby-debug-base19 (>= 0.11.19)
     ruby-hmac (0.4.0)
-    ruby-oembed (0.8.5)
+    ruby-oembed (0.8.7)
     ruby-progressbar (0.0.10)
     ruby_core_source (0.1.5)
       archive-tar-minitar (>= 0.5.2)
@@ -523,7 +523,7 @@ DEPENDENCIES
   rspec-rails (>= 2.0.0)
   ruby-debug
   ruby-debug19
-  ruby-oembed
+  ruby-oembed (~> 0.8.7)
   sass
   selenium-webdriver (~> 2.16.0)
   settingslogic!

--- a/app/models/status_message.rb
+++ b/app/models/status_message.rb
@@ -157,7 +157,7 @@ class StatusMessage < Post
   def contains_oembed_url_in_text?
     require 'uri'
     urls = URI.extract(self.raw_message, ['http', 'https'])
-    self.oembed_url = urls.find{|url| ENDPOINT_HOSTS_STRING.match(URI.parse(url).host)}
+    self.oembed_url = urls.find{ |url| !TRUSTED_OEMBED_PROVIDERS.find(url).nil? }
   end
 
   protected

--- a/config/initializers/oembed.rb
+++ b/config/initializers/oembed.rb
@@ -1,16 +1,20 @@
 require 'oembed'
 require 'uri'
 
-OEmbed::Providers.register_all
+OEmbedCubbies = OEmbed::Provider.new("http://cubbi.es/oembed")
+
+OEmbed::Providers.register(
+  OEmbed::Providers::Youtube,
+  OEmbed::Providers::Vimeo,
+  OEmbed::Providers::Flickr,
+  OEmbed::Providers::SoundCloud,
+  OEmbedCubbies
+)
 OEmbed::Providers.register_fallback(OEmbed::ProviderDiscovery)
+
 #
 # SECURITY NOTICE! CROSS-SITE SCRIPTING!
 # these endpoints may inject html code into our page
 # note that 'trusted_endpoint_url' is the only information
 # in OEmbed that we can trust. anything else may be spoofed!
-SECURE_ENDPOINTS = [::OEmbed::Providers::Youtube.endpoint,
-                    ::OEmbed::Providers::Flickr.endpoint,
-                    'http://soundcloud.com/oembed',
-                    'http://cubbi.es/oembed'
-                   ]
-ENDPOINT_HOSTS_STRING = SECURE_ENDPOINTS.map{|e| URI.parse(e.split('{')[0]).host}.to_s
+TRUSTED_OEMBED_PROVIDERS = OEmbed::Providers

--- a/config/initializers/oembed.rb
+++ b/config/initializers/oembed.rb
@@ -1,20 +1,27 @@
 require 'oembed'
 require 'uri'
 
-OEmbedCubbies = OEmbed::Provider.new("http://cubbi.es/oembed")
-
-OEmbed::Providers.register(
-  OEmbed::Providers::Youtube,
-  OEmbed::Providers::Vimeo,
-  OEmbed::Providers::Flickr,
-  OEmbed::Providers::SoundCloud,
-  OEmbedCubbies
-)
-OEmbed::Providers.register_fallback(OEmbed::ProviderDiscovery)
-
 #
 # SECURITY NOTICE! CROSS-SITE SCRIPTING!
 # these endpoints may inject html code into our page
 # note that 'trusted_endpoint_url' is the only information
 # in OEmbed that we can trust. anything else may be spoofed!
+
+OEmbedCubbies = OEmbed::Provider.new("http://cubbi.es/oembed")
+
+oembed_provider_list = [
+  OEmbed::Providers::Youtube,
+  OEmbed::Providers::Vimeo,
+  OEmbed::Providers::Flickr,
+  OEmbed::Providers::SoundCloud,
+  OEmbedCubbies
+]
+
+SECURE_ENDPOINTS = oembed_provider_list.map do |provider|
+  OEmbed::Providers.register(provider)
+  provider.endpoint
+end
+
+OEmbed::Providers.register_fallback(OEmbed::ProviderDiscovery)
+
 TRUSTED_OEMBED_PROVIDERS = OEmbed::Providers

--- a/spec/models/status_message_spec.rb
+++ b/spec/models/status_message_spec.rb
@@ -320,19 +320,24 @@ STR
     end
   end
 
-  describe '#contains_url_in_text?' do
-    it 'returns an array of all urls found in the raw message' do
-      sm = Factory(:status_message, :text => 'http://youtube.com is so cool.  so is https://joindiaspora.com')
-      sm.contains_oembed_url_in_text?.should_not be_nil
-      sm.oembed_url.should == 'http://youtube.com'
-    end
-  end
-
   describe 'oembed' do
+    before do
+      @youtube_url = "https://www.youtube.com/watch?v=3PtFwlKfvHI"
+      @message_text = "#{@youtube_url} is so cool. so is this link -> https://joindiaspora.com"
+    end
+
     it 'should queue a GatherOembedData if it includes a link' do
-      sm = Factory.build(:status_message, :text => 'http://youtube.com is so cool.  so is https://joindiaspora.com')
+      sm = Factory.build(:status_message, :text => @message_text)
       Resque.should_receive(:enqueue).with(Jobs::GatherOEmbedData, instance_of(Fixnum), instance_of(String))
       sm.save
+    end
+
+    describe '#contains_oembed_url_in_text?' do
+      it 'returns the oembed urls found in the raw message' do
+        sm = Factory(:status_message, :text => @message_text)
+        sm.contains_oembed_url_in_text?.should_not be_nil
+        sm.oembed_url.should == @youtube_url
+      end
     end
   end
 end


### PR DESCRIPTION
Updated ruby-oembed gem to 0.8.7,
restructured the way oEmbed Providers are specified,
also added Vimeo to the list,
adapted tests to what has changed

(this makes things like "youtu.be" possible)
