### PR TITLE
Issue #3016 - Bugfix to prevent SPAM of private messages

### DIFF
--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -70,7 +70,7 @@ class ConversationsController < ApplicationController
 
   def new
     all_contacts_and_ids = Contact.connection.select_rows(
-      current_user.contacts.joins(:person => :profile).
+      current_user.contacts.where(:sharing => true).joins(:person => :profile).
         select("contacts.id, profiles.first_name, profiles.last_name, people.diaspora_handle").to_sql
     ).map{|r| {:value => r[0], :name => Person.name_from_attrs(r[1], r[2], r[3]).gsub(/(")/, "'")} }
 

--- a/app/models/user/querying.rb
+++ b/app/models/user/querying.rb
@@ -100,6 +100,11 @@ module User::Querying
     contact_for_person_id(person.id)
   end
 
+  def receiving_from(person)
+    return nil unless person
+    receiving_from_person_id(person.id)
+  end
+
   def aspects_with_shareable(base_class_name_or_class, shareable_id)
     base_class_name = base_class_name_or_class
     base_class_name = base_class_name_or_class.base_class.to_s if base_class_name_or_class.is_a?(Class)
@@ -108,6 +113,10 @@ module User::Querying
 
   def contact_for_person_id(person_id)
     Contact.where(:user_id => self.id, :person_id => person_id).includes(:person => :profile).first
+  end
+
+  def receiving_from_person_id(person_id)
+    Contact.where(:user_id => self.id, :person_id => person_id, :receiving => true).includes(:person => :profile).first
   end
 
   # @param [Person] person

--- a/lib/postzord/receiver/private.rb
+++ b/lib/postzord/receiver/private.rb
@@ -76,6 +76,7 @@ class Postzord::Receiver::Private < Postzord::Receiver
   def validate_object
     raise "Contact required unless request" if contact_required_unless_request
     raise "Relayable object, but no parent object found" if relayable_without_parent?
+    raise "Message from person the recipient is not receiving from" if message_from_person_not_receiving_from?
 
     assign_sender_handle_if_request
 
@@ -111,6 +112,15 @@ class Postzord::Receiver::Private < Postzord::Receiver
     unless @object.is_a?(Request) || @user.contact_for(@sender)
       FEDERATION_LOGGER.info("event=receive status=abort reason='sender not connected to recipient' recipient=#{@user_person.diaspora_handle} sender=#{@sender.diaspora_handle}")
       return true 
+    end
+  end
+
+  def message_from_person_not_receiving_from?
+    if @object.is_a?(Message) || @object.is_a?(Conversation)
+      unless @user.receiving_from(@sender)
+        FEDERATION_LOGGER.info("event=receive status=abort reason='message from person the recipient is not receiving from' recipient=#{@user_person.diaspora_handle} sender=#{@sender.diaspora_handle}")
+        return true
+      end
     end
   end
 


### PR DESCRIPTION
Prevent SPAM of private messages by blocking messages and conversations from contacts, the user did not agree to receive from yet. This makes it necessary to confirm a friendship relationship between two persons by choosing to generally receive posts from the other person, prior to be able to receive private messages.
At the moment, messages get not only accepted but are also directly shown to the user as opposed to what happens with status messages which are received but not being displayed prior to establishing a bidirectional relationship.

Hope this gets accepted as a bugfix. Please let me know if there is something I should change to meet the code conventions or other requirements. I tried to name functions alike others that have similar tasks.  Also I did not include tests for these changes so far, as already mentioned on IRC.

I will try to get deeper into the testing process over the next days.
Please tell me what you think!
Thanks in advance, Stephan
