### PR TITLE
don't let oembed content grow beyond stream width

### DIFF
--- a/public/stylesheets/sass/application.sass
+++ b/public/stylesheets/sass/application.sass
@@ -1851,6 +1851,7 @@ ul#press_logos
     .oembed
       :background url('/images/ajax-loader2.gif') no-repeat center center
       :display inline-block
+      :max-width 100%
 
       .thumb
         :position relative


### PR DESCRIPTION
It seems not all youtube thumbs are the same size...
