### PR TITLE
Limit allowed contacts for sending messages to

### DIFF
--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -70,7 +70,7 @@ class ConversationsController < ApplicationController
 
   def new
     all_contacts_and_ids = Contact.connection.select_rows(
-      current_user.contacts.joins(:person => :profile).
+      current_user.contacts.where(:sharing => true).joins(:person => :profile).
         select("contacts.id, profiles.first_name, profiles.last_name, people.diaspora_handle").to_sql
     ).map{|r| {:value => r[0], :name => Person.name_from_attrs(r[1], r[2], r[3]).gsub(/(")/, "'")} }
 

--- a/spec/controllers/conversations_controller_spec.rb
+++ b/spec/controllers/conversations_controller_spec.rb
@@ -18,8 +18,10 @@ describe ConversationsController do
       response.should be_success
     end
 
-    it "assigns a json list of contacts" do
-      assigns(:contacts_json).should include(alice.contacts.first.person.name)
+    it "assigns a json list of contacts that are sharing with the person" do
+      assigns(:contacts_json).should include(alice.contacts.where(:sharing => true).first.person.name)
+      alice.contacts << Contact.new(:person_id => eve.person.id, :user_id => alice.id, :sharing => false, :receiving => true)
+      assigns(:contacts_json).should_not include(alice.contacts.where(:sharing => false).first.person.name)
     end
 
     it "assigns a contact if passed a contact id" do


### PR DESCRIPTION
This fix limits the allowed contacts the user can send messages to, to the ones that are sharing with him.
