### PR TITLE
Add Resque.before_fork to correct critical problem for PostgreSQL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,6 @@ gem 'ruby-oembed', '~> 0.8.7'
 # queue
 
 gem 'resque', '1.20.0'
-gem 'resque-ensure-connected', :git => 'git://github.com/socialcast/resque-ensure-connected.git'
 gem 'resque-timeout', '1.0.0'
 gem 'SystemTimer', '1.2.3', :platforms => :ruby_18
 

--- a/lib/tasks/resque.rake
+++ b/lib/tasks/resque.rake
@@ -3,6 +3,8 @@ require 'resque/tasks'
 task "resque:setup" do
   require File.join(File.dirname(__FILE__), '..', '..', 'config', 'environment')
   Rails.logger.info("event=resque_setup rails_env=#{Rails.env}")
+
+  Resque.after_fork = Proc.new { ActiveRecord::Base.establish_connection }
 end
 
 desc "Alias for resque:work (To run workers on Heroku)"


### PR DESCRIPTION
This corrects the first error in this pastebin: http://pastebin.com/AptJqZcT

Specifically, this is the error:

```
Exception: ActiveRecord::StatementInvalid
Error: PG::Error: ERROR: prepared statement "a3" already exists : SELECT DISTINCT(attr.attname) FROM pg_attribute attr INNER JOIN pg_depend dep ON attr.attrelid = dep.refobjid AND attr.attnum = dep.refobjsubid INNER JOIN pg_constraint cons ON attr.attrelid = cons.conrelid AND attr.attnum = cons.conkey[1] WHERE cons.contype = 'p' AND dep.refobjid = $1::regclass
```

That error prevented my pod from receiving any remote updates or messages.
