### PR TITLE
show your own reshare count but not allow for reshare of your own

### DIFF
--- a/public/javascripts/app/templates/post-viewer/feedback.handlebars
+++ b/public/javascripts/app/templates/post-viewer/feedback.handlebars
@@ -25,6 +25,15 @@
     {{/if}}
     {{reshares_count}}
   </a>
+{{else}}
+  <a class="label reshare-viewonly" title="{{#if user_reshare}} {{t "viewer.reshared"}} {{else}} {{t "viewer.reshare"}} {{/if}}">
+    {{#if user_reshare}}
+      <i class="icon-retweet icon-blue"></i>
+    {{else}}
+      <i class="icon-retweet icon-white"></i>
+    {{/if}}
+    {{reshares_count}}
+   </a>
 {{/if}}
 
 <a href="#" class="label comment" rel="invoke-interaction-pane" title="{{t "viewer.comment"}}">


### PR DESCRIPTION
When viewing your own post you can not see the reshare count in the single post view, this allows you to see that but not interact and reshare your own stuff.
