### PR TITLE
Using the orginial Gemfile to get rid of deprecation warning on class_inheritable_reader

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,7 @@ gem 'SystemTimer', '1.2.3', :platforms => :ruby_18
 
 # tags
 
-gem 'acts-as-taggable-on', :git => 'git://github.com/diaspora/acts-as-taggable-on.git'
+gem 'acts-as-taggable-on'
 
 # URIs and HTTP
 


### PR DESCRIPTION
 I was getting the deprecation warning from acts-as-taggable-on from diaspora fork. 
 The `class_inheritable_reader` from the diaspora fork on `line 34` of file `https://github.com/diaspora/acts-as-taggable-on/blob/master/lib/acts_as_taggable_on/acts_as_taggable_on.rb`. So i thought we could use the original gem which is regularly updated.
