### PR TITLE
Small translations of mobile "My Activity" and add translation "via mobile" for mobile posts

### DIFF
--- a/app/views/layouts/application.mobile.haml
+++ b/app/views/layouts/application.mobile.haml
@@ -53,7 +53,7 @@
           - if user_signed_in?
             #header-nav
               .activity-nav
-                = link_to(t('.my_activity'), activity_stream_path)
+                = link_to(t('streams.activity.title'), activity_stream_path)
             
             #nav_badges
               .badge{:id => "notification_badge"}            

--- a/app/views/shared/_post_info.mobile.haml
+++ b/app/views/shared/_post_info.mobile.haml
@@ -12,8 +12,7 @@
       - if post.activity_streams?
         = t('shared.stream_element.via', :link => link_to("#{post.provider_display_name}", post.actor_url)).html_safe
       - elsif post.provider_display_name == 'mobile'
-        = t('shared.stream_element.via', :link => nil)
-        mobile
+        = t('shared.stream_element.via_mobile', :link => nil)
     &ndash;
     %span.scope_scope
       - if post.public?

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -862,6 +862,7 @@ en:
       connect_to_comment: "Connect to this user to comment on their post"
       currently_unavailable: 'commenting currently unavailable'
       via: "via %{link}"
+      via_mobile: "via mobile"
       ignore_user: "Ignore %{name}"
       ignore_user_description: "Ignore and remove user from all aspects?"
       hide_and_mute: "Hide and mute post"


### PR DESCRIPTION
Now **"My Activity"** should be automatically translated :]

Add translation **"via mobile"** for mobile posts.
