### PR TITLE
Fix invite mail

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -25,6 +25,16 @@ class InvitationsController < ApplicationController
     redirect_to invite_code_path(invitation_code)
   end
 
+  def email
+    if params[:invitation_token]
+      # this is  for legacy invites.
+      user = User.find_by_invitation_token(params[:invitation_token])
+      @invitation_code = user.ugly_accept_invitation_code
+    else
+      @invitation_code = params[:invitation_code]
+    end
+    render 'notifier/invite', :layout => false
+  end
 
   def create
     inviter = EmailInviter.new(params[:email_inviter][:emails], current_user, params[:email_inviter])

--- a/db/migrate/20120328025842_remove_invitation_email_from_users.rb
+++ b/db/migrate/20120328025842_remove_invitation_email_from_users.rb
@@ -1,0 +1,17 @@
+class RemoveInvitationEmailFromUsers < ActiveRecord::Migration
+  def self.up
+    execute <<-SQL
+      UPDATE users
+      SET email = concat('invitemail_', id, '@example.org')
+      WHERE invitation_token IS NOT NULL
+    SQL
+  end
+
+  def self.down
+    execute <<-SQL
+      UPDATE users
+      SET email = (SELECT identifier FROM invitations WHERE invitations.recipient_id = users.id)
+      WHERE invitation_token IS NOT NULL
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120322223517) do
+ActiveRecord::Schema.define(:version => 20120328025842) do
 
   create_table "account_deletions", :force => true do |t|
     t.string  "diaspora_handle"

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -41,6 +41,13 @@ describe InvitationsController do
     end
   end
 
+  describe '#email' do
+    it 'succeeds' do
+      get :email, :invitation_code => "anycode"
+      response.should be_success
+    end
+  end
+
   describe '#new' do
     it 'renders' do
       sign_in :user, @user


### PR DESCRIPTION
I have added the email action for the display of the invitation e-mails.

The migration deletes all e-mail-addresses from invitation-accounts, so that they are no longer blocked.
