### PR TITLE
fix js error when not logged in and on root/landing page, app is undefined

### DIFF
--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -21,7 +21,7 @@ module LayoutHelper
     path = ENV['ASSET_HOST'].to_s + '/assets/'
     content_tag(:script) do
       <<-JS.html_safe
-        app.baseImageUrl("#{path}")
+        if(window.app) app.baseImageUrl("#{path}")
       JS
     end
   end


### PR DESCRIPTION
I am not sure with all the recent changes - I have not yet looked into them very much - if this is maybe a symptom of something else again. ;)
Nevertheless here's the fix for a js error, if you are logged out and on the root/landing page, where `app` is undefined but accessed.
