### PR TITLE
reset publisher css height when "cleared"

### DIFF
--- a/app/assets/javascripts/app/views/publisher_view.js
+++ b/app/assets/javascripts/app/views/publisher_view.js
@@ -67,7 +67,7 @@ app.views.Publisher = Backbone.View.extend({
   open : function() {
     $(this.el).removeClass('closed');
     this.$("#publisher_textarea_wrapper").addClass('active');
-    this.$("textarea.ac_input").css('min-height', '42px');
+    this.$("textarea").css('height', '42px');
 
     return this;
   },
@@ -75,7 +75,7 @@ app.views.Publisher = Backbone.View.extend({
   close : function() {
     $(this.el).addClass("closed");
     this.$("#publisher_textarea_wrapper").removeClass("active");
-    this.$("textarea.ac_input").css('min-height', '');
+    this.$("textarea").css('height', '');
 
     return this;
   }

--- a/spec/javascripts/app/views/publisher_view_spec.js
+++ b/spec/javascripts/app/views/publisher_view_spec.js
@@ -16,13 +16,19 @@ describe("app.views.Publisher", function() {
   });
 
   describe("#close", function() {
-    it("removes the 'active' class from the publisher element", function(){
-      $(this.view.el).removeClass("closed");
+    beforeEach(function() {
+      this.view.open($.Event());
+    });
 
-      expect($(this.view.el)).not.toHaveClass("closed");
+    it("removes the 'active' class from the publisher element", function(){
       this.view.close($.Event());
       expect($(this.view.el)).toHaveClass("closed");
     })
+
+    it("resets the element's height", function() {
+      this.view.close($.Event());
+      expect($(this.view.el).find("#status_message_fake_text").attr("style")).not.toContain("height");
+    });
   });
 
   describe("#clear", function() {


### PR DESCRIPTION
It seems the ominous ".ac_input" class was a leftover of something else, so the selector never worked.
Also setting "height" instead of "min-height", because that's what autoresize uses.

fixes #2867
