### PR TITLE
change concat() to || for pgSQL

### DIFF
--- a/db/migrate/20120328025842_remove_invitation_email_from_users.rb
+++ b/db/migrate/20120328025842_remove_invitation_email_from_users.rb
@@ -2,7 +2,7 @@ class RemoveInvitationEmailFromUsers < ActiveRecord::Migration
   def self.up
     execute <<-SQL
       UPDATE users
-      SET email = concat('invitemail_', id, '@example.org')
+      SET email = 'invitemail_' || id || '@example.org'
       WHERE invitation_token IS NOT NULL
     SQL
   end


### PR DESCRIPTION
There is no concat() in PostgreSQL. I think "||" is a standard operator and should work cross-platform (with MySQL). Correct me if I'm wrong.
