### PR TITLE
css should be delivered by asset pipeline for travis(?)

### DIFF
--- a/script/ci/before.sh
+++ b/script/ci/before.sh
@@ -9,8 +9,8 @@ echo "Start Xvfb"
 sh -e /etc/init.d/xvfb start
 
 # Regenerate css files
-echo "Regenerating CSS files"
-bundle exec sass -q --update public/stylesheets/sass/:public/stylesheets/
+#echo "Regenerating CSS files"
+#bundle exec sass -q --update public/stylesheets/sass/:public/stylesheets/
 
 # Create a database.yml for the right database
 echo "Setting up database.yml for $DB"


### PR DESCRIPTION
I am not sure exactly if that's supposed to work that way, but I guess it's not necessary to pre-generate the stylesheets for travis (anymore). 
If it is, though, at least the path(s) should be corrected. ;)
