### PR TITLE
create a dummy-participation js object, for the post to appear as followed by self

### DIFF
--- a/app/assets/javascripts/app/views/publisher_view.js
+++ b/app/assets/javascripts/app/views/publisher_view.js
@@ -39,6 +39,7 @@ app.views.Publisher = Backbone.View.extend({
           $(app.publisher.el).trigger('ajax:success');
         }
         if(app.stream) {
+          statusMessage.set({"user_participation": new app.models.Participation});
           app.stream.posts.add(statusMessage.toJSON());
         }
       }


### PR DESCRIPTION
bug mash roud 5, no. 1

This is really just a cosmetic fix, if the user actually tries to "unfollow", the action will fail, because it's only a dummy object.
It seems the participation created on the server is a federated object, even locally? So there is no chance of returning an actual participation object with the status message in a timely fashion, since it takes a little while to create it... at least I didn't get one with `@status_message.refresh` (I am not the great ruby/rails expert, so correct me, if I'm wrong)

fixes #2973
