### PR TITLE
fix jasmine unhappiness I introduced with #3088

### DIFF
--- a/spec/javascripts/app/views/comment_stream_view_spec.js
+++ b/spec/javascripts/app/views/comment_stream_view_spec.js
@@ -31,7 +31,16 @@ describe("app.views.CommentStream", function(){
 
   describe("createComment", function(){
     it("clears the new comment textarea", function(){
-      $(this.view.el).html($("<textarea/>", {"class" : 'comment_box'}).val("hey"))
+      var comment = {
+        "id": 1234,
+        "text": "hey",
+        "author": "not_null"
+      };
+      spyOn($, "ajax").andCallFake(function(params) {
+        params.success(comment);
+      });
+
+      $(this.view.el).html($("<textarea/>", {"class" : 'comment_box'}).val(comment.text))
       this.view.createComment()
       expect(this.view.$(".comment_box").val()).toBe("")
     })


### PR DESCRIPTION
this mocks a successful ajax response, so that the error callback doesn't get called
