### PR TITLE
Asset Sync causes asset precompilation to fail

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,7 +119,9 @@ group :assets do
   
   gem 'handlebars_assets'
   gem 'uglifier'
-  gem "asset_sync"
+  
+  # asset_sync is required as needed by application.rb
+  gem "asset_sync", :require => nil
 end
 
 gem 'jquery-rails'

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,9 +14,12 @@ end
 
 require 'rails/all'
 
+# Sanitize groups to make matching :assets easier
+RAILS_GROUPS = Rails.groups(:assets => %w(development test)).map { |group| group.to_sym }
+
 if defined?(Bundler)
   # If you precompile assets before deploying to production, use this line
-  Bundler.require(*Rails.groups(:assets => %w(development test)))
+  Bundler.require(*RAILS_GROUPS)
   # If you want your assets lazily compiled in production, use this line
   # Bundler.require(:default, :assets, Rails.env)
 end
@@ -89,4 +92,9 @@ module Diaspora
     config.assets.version = '1.0'
 
   end
+end
+
+# Only load asset_sync if S3 is configured
+if RAILS_GROUPS.include?(:assets) && ENV['AWS_ACCESS_KEY_ID']
+  require 'asset_sync'
 end


### PR DESCRIPTION
On a pod that isn't using S3, `rake assets:precompile` causes the following error

```
AssetSync: using default configuration from built-in initializer
rake aborted!
Fog provider can't be blank, Fog directory can't be blank

Tasks: TOP => assets:precompile:nondigest
(See full trace by running task with --trace)
```

Looking at the gem, it looks like the engine includes the rake task (which enhances assets:precompile automatically) regardless of whether or not it's configured properly. I can think of a workaround for this, but it's a quick and dirty hack. I'll try to attach a PR to this issue so you can see my solution. I tried putting the same code into an initializer but that appears to be too late to load the engine properly.

/cc @maxwell 
