### PR TITLE
made stream order deterministic

### DIFF
--- a/features/support/publishing_cuke_helpers.rb
+++ b/features/support/publishing_cuke_helpers.rb
@@ -1,8 +1,12 @@
 module PublishingCukeHelpers
   def make_post(text)
-    fill_in 'status_message_fake_text', :with => text
-    click_button :submit
-    wait_for_ajax_to_finish
+    @@last_post_time ||= Time.now
+    Timecop.travel @@last_post_time += 1.minute do
+      fill_in 'status_message_fake_text', :with => text
+      click_button :submit
+      wait_for_ajax_to_finish
+    end
+    Timecop.return
   end
 
   def click_and_post(text)


### PR DESCRIPTION
The reason for the randomly failing cuke on Travis is that when the posts have the same timestamp (which apparently sometimes happens) the order is undefined (or PK ASC?). This fixes this by secondly sorting by the posts id in the database. I'm not sure about the right place and the performance implications, thus the pull request.
