### PR TITLE
Update app/views/shared/_photo_area.mobile.haml

### DIFF
--- a/app/views/shared/_photo_area.mobile.haml
+++ b/app/views/shared/_photo_area.mobile.haml
@@ -9,7 +9,7 @@
         - if post.photos.size > 1
           .additional_photo_count
             = "+ #{post.photos.size-1}"
-        = link_to (image_tag post.photos.first.url(:thumb_large), :class => "stream-photo big-stream-photo"), photo_path(post.photos.first), :class => "stream-photo-link"
+        = image_tag post.photos.first.url(:thumb_large), :class => "stream-photo big-stream-photo"
   - elsif post.activity_streams?
     = image_tag post.image_url
 


### PR DESCRIPTION
no need for link to photo show page on mobile its long gone and just a source of a ton off 500 errors
