### PR TITLE
email-invitation translation error in subject and body

### DIFF
--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -40,7 +40,7 @@ class Notifier < ActionMailer::Base
     @invitation_code = invitation_code
 
     mail_opts = {:to => email, :from => AppConfig[:smtp_sender_address],
-                 :subject => I18n.t('notifier.invited!'),  
+                 :subject => I18n.t('notifier.invited_you', :name => @inviter.person.name),  
                  :host => AppConfig[:pod_uri].host}
 
     I18n.with_locale(locale) do

--- a/config/locales/diaspora/de.yml
+++ b/config/locales/diaspora/de.yml
@@ -488,7 +488,6 @@ de:
           Klick auf diesen Link um loszulegen
 
           %{invite_url}
-          <%= invite_code_url(@invitation_code)%>
 
 
           Alles Liebe,


### PR DESCRIPTION
~FIX: changed the translate pattern inside notifier.rb: correct mail subject will be translated

~Translate: changed the mail contents of the invitation mail: no weird html string below the invitecode url.
- M

this is my first git experience, ever. Please be patient, if something is wrong. Dunno, why the \lastline, whatever warning appears on de.yml - i never touched this line ;)
