### PR TITLE
add timecop capability to cucumber + firefox debugging steps

### DIFF
--- a/features/activity_stream.feature
+++ b/features/activity_stream.feature
@@ -9,7 +9,6 @@ Feature: The activity stream
     And I post "B- barack obama is your new bicycle"
     And I wait for 1 second
     And I post "C- barack obama is a square"
-    And I wait for 1 second
 
     When I go to the activity stream page
     Then "C- barack obama is a square" should be post 1

--- a/features/posts_from_main_page.feature
+++ b/features/posts_from_main_page.feature
@@ -26,6 +26,7 @@ Feature: posting from the main page
 
     Scenario: posting a message appends it to the top of the stream
       When I click the publisher and post "sup dog"
+      And I wait for 1 second
       And I click the publisher and post "hello there"
       Then I should see "hello there" as the first post in my stream
 

--- a/features/reshare.feature
+++ b/features/reshare.feature
@@ -18,7 +18,6 @@ Feature: public repost
     And I preemptively confirm the alert
     And I follow "Reshare"
     And I wait for the ajax to finish
-    And I sleep for 2 seconds
 
     When I am on "alice@alice.alice"'s page
     Then I should see "reshare this!"

--- a/features/reshare.feature
+++ b/features/reshare.feature
@@ -18,7 +18,7 @@ Feature: public repost
     And I preemptively confirm the alert
     And I follow "Reshare"
     And I wait for the ajax to finish
-    And I wait for 2 seconds
+    And I sleep for 2 seconds
 
     When I am on "alice@alice.alice"'s page
     Then I should see "reshare this!"

--- a/features/signs_up.feature
+++ b/features/signs_up.feature
@@ -34,6 +34,6 @@ Feature: new user registration
     And I have turned off jQuery effects
     And I wait for the popovers to appear
     And I click close on all the popovers
-    And I wait for 3 seconds
+    And I sleep for 3 seconds
     And I go to the home page
     Then I should not see "Welcome to Diaspora"

--- a/features/signs_up.feature
+++ b/features/signs_up.feature
@@ -34,6 +34,5 @@ Feature: new user registration
     And I have turned off jQuery effects
     And I wait for the popovers to appear
     And I click close on all the popovers
-    And I sleep for 3 seconds
     And I go to the home page
     Then I should not see "Welcome to Diaspora"

--- a/features/step_definitions/custom_web_steps.rb
+++ b/features/step_definitions/custom_web_steps.rb
@@ -187,7 +187,7 @@ Then 'I press the attached image' do
 end
 
 And "I wait for the popovers to appear" do
-  wait_until(30) { evaluate_script('$(".popover").length') == 3 }
+  wait_until(5) { evaluate_script('$(".popover").length') == 3 }
 end
 
 And /^I click close on all the popovers$/ do
@@ -195,6 +195,7 @@ And /^I click close on all the popovers$/ do
           function(index, element){ setTimeout(function(){ $(element).click()},time);
           time += 800;
  });")
+  wait_until(5) { evaluate_script('$(".popover").length') == 0 }
 end
 
 Then /^I should see first post deletion link$/ do

--- a/features/step_definitions/debug_steps.rb
+++ b/features/step_definitions/debug_steps.rb
@@ -4,6 +4,25 @@ When 'I debug' do
   true
 end
 
-When /^I wait for (\d+) seconds?$/ do |seconds|
+When /^I sleep for (\d+) seconds?$/ do |seconds|
   sleep seconds.to_i
+end
+
+When /^I open the error console$/ do
+  page.driver.browser.action.
+    key_down(:control).
+    key_down(:shift).
+    send_keys("j").
+    key_up(:shift).
+    key_up(:control).perform
+end
+
+
+When /^I open the web console$/ do
+  page.driver.browser.action.
+    key_down(:control).
+    key_down(:shift).
+    send_keys("k").
+    key_up(:shift).
+    key_up(:control).perform
 end

--- a/features/support/time_helpers.rb
+++ b/features/support/time_helpers.rb
@@ -1,0 +1,63 @@
+
+# from: https://gist.github.com/154616
+
+#require 'chronic'
+require 'timecop'
+
+module TemporalHelpers
+
+  # Travels to +time+ and lets the clock keep running.
+  # 
+  # If a block is given, executes the block at that
+  # time then returns to the present.
+  def travel_to(time, &block)
+    Timecop.travel parse_time(time), &block
+  end
+
+  def travel_seconds(sec, &block)
+    Timecop.travel sec, &block
+  end
+
+  # Travels to and freezes the clock at +time+.
+  # 
+  # If a block is given, executes the block at that
+  # time then returns to the present.
+  def freeze_time_at(time, &block)
+    Timecop.freeze parse_time(time), &block
+  end
+
+  # start the clock again
+  def continue_time
+    Timecop.return
+  end
+
+  private
+
+  def parse_time(time)
+    #Chronic.parse(time) ||
+    Time.parse(time)
+  end
+
+end
+
+World(TemporalHelpers)
+
+Given /^it is currently (.+)$/ do |time|
+  travel_to time
+end
+
+Given /^(?:I|we) wait for (\d+) seconds?$/ do |sec|
+  travel_seconds sec.to_i
+end
+
+Given /^time is frozen at (.+)$/ do |time|
+  freeze_time_at time
+end
+
+Given /^(?:I|we) jump in our Delorean and return to the present$/ do
+  Timecop.return
+end
+
+After do
+  Timecop.return
+end


### PR DESCRIPTION
This should make all cukes happy - especially those posting in rapid succession.

**_NOTE**_: the "I wait for X seconds" step now uses timecop to advance the simulated clock. If you actually want to use sleep, use the "I sleep for X seconds" step.
I changed the occurrences everywhere, but they should be removed anyway, since that is bad practice and for debugging only.
