### PR TITLE
Switch Google Maps provider for Map Marker to OpenStreetMap service

### DIFF
--- a/app/assets/templates/profile-info.jst.hbs
+++ b/app/assets/templates/profile-info.jst.hbs
@@ -7,7 +7,7 @@
     <div id="profile-stats">
         {{#if location}}
             <span class="stat">
-                <a href="http://maps.google.com/maps?q={{location}}" target="_blank">
+                <a href="http://nominatim.openstreetmap.org/search.php?q={{location}}" target="_blank">
                     <i class="icon-map-marker"></i>
                 </a>
                 {{location}}


### PR DESCRIPTION
Just a quick fix. This makes use of OpenStreetMap's Nominatim service. All I did was change the URL in the handlebars template, but after trying it out, it works great.

Just a nice little gotcha for our more privacy-concerned users.
