### PR TITLE
Updated acts-as-taggable-on gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,7 @@ gem 'SystemTimer', '1.2.3', :platforms => :ruby_18
 
 # tags
 
-gem 'acts-as-taggable-on', :git => 'git://github.com/diaspora/acts-as-taggable-on.git'
+gem 'acts-as-taggable-on', '~> 2.2.2'
 
 # URIs and HTTP
 


### PR DESCRIPTION
This should knock off `point 10` of the [Wishlist](https://github.com/diaspora/diaspora/wiki/Developer-Feature-Wishlist)
