### PR TITLE
Fix showpage CSS for wallpaper posts.

### DIFF
--- a/app/assets/stylesheets/new_styles/_base.scss
+++ b/app/assets/stylesheets/new_styles/_base.scss
@@ -308,7 +308,6 @@ article { //mood posts
 
 .photo-fill {
   @include background-cover();
-  z-index : -5000; //so the framer controls don't get lost
   position: absolute;
   top: 0;
   left: 0;

--- a/app/assets/stylesheets/new_styles/_interactions.scss
+++ b/app/assets/stylesheets/new_styles/_interactions.scss
@@ -6,7 +6,7 @@
   bottom: 0;
   left: 0;
   text-align: center;
-  z-index: 100;
+  z-index: 9001;
 }
 
 #post-reactions {


### PR DESCRIPTION
This fix makes hashtags and links on Wallpaper posts clickable when in single-post view. I've also altered the comment bar's divs so that it won't get lost under the photo-fill.

WHAT UP? ;)
