### PR TITLE
Adding a z-index to post interactions may have been totally premature. [ci skip]

### DIFF
--- a/app/assets/stylesheets/new_styles/_interactions.scss
+++ b/app/assets/stylesheets/new_styles/_interactions.scss
@@ -6,7 +6,6 @@
   bottom: 0;
   left: 0;
   text-align: center;
-  z-index: 9001;
 }
 
 #post-reactions {


### PR DESCRIPTION
Get rid of z-index: 9001 on #post-interactions. Having it made tooltips not show up, which is totally dumb. Removing it shows no issues that can be determined at this time.
