### PR TITLE
fix paragraph margin for comments and posts

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -1819,7 +1819,7 @@ ul#press_logos
     :position relative
     p
       :margin 0 0 0.8em
-    p:nth-last-child(2)
+    p:last-of-type
       :margin 0
 
     .expander


### PR DESCRIPTION
This works now for all cases. The old css didn't work for posts with a "show more" and comments without a "show more".
