### PR TITLE
fix oembed when empty [ci skip]

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -1841,7 +1841,7 @@ ul#press_logos
 
     .oembed
       :background image-url('ajax-loader2.gif') no-repeat center center
-      :display inline-block
+      :float left
       :max-width 100%
 
       .thumb


### PR DESCRIPTION
"float left" has the same effect as "display inline-block", but does not block space when the element is empty :)

Screenshots:
Before: http://coding4coffee.org/oembed-before.png
After: http://coding4coffee.org/oembed-after.png
