### PR TITLE
updated webmock, hopefully fix cucumber

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,7 +97,7 @@ gem 'acts-as-taggable-on', '~> 2.2.2'
 
 # URIs and HTTP
 
-gem 'addressable', '2.2.4', :require => 'addressable/uri'
+gem 'addressable', '~> 2.2', :require => 'addressable/uri'
 gem 'http_accept_language', '~> 1.0.2'
 gem 'typhoeus'
 
@@ -158,7 +158,7 @@ group :test do
   gem "rspec-rails", "~> 2.9.0" 
   gem 'selenium-webdriver', '2.22.0.rc1'
 
-  gem 'webmock', :require => false
+  gem 'webmock', '~> 1.7', :require => false
   gem 'sqlite3'
   gem 'mock_redis'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
       activemodel (>= 3.0.0)
       activesupport (>= 3.0.0)
       rack (>= 1.1.0)
-    addressable (2.2.4)
+    addressable (2.2.8)
     airbrake (3.0.9)
       activesupport
       builder
@@ -444,8 +444,8 @@ GEM
       rack (>= 1.0.0)
     warden (1.2.0)
       rack (>= 1.0)
-    webmock (1.6.2)
-      addressable (>= 2.2.2)
+    webmock (1.8.7)
+      addressable (>= 2.2.7)
       crack (>= 0.1.7)
     whenever (0.7.3)
       activesupport (>= 2.3.4)
@@ -463,7 +463,7 @@ DEPENDENCIES
   activerecord-import (~> 0.2.9)
   acts-as-taggable-on (~> 2.2.2)
   acts_as_api
-  addressable (= 2.2.4)
+  addressable (~> 2.2)
   airbrake
   asset_sync
   bootstrap-sass (~> 2.0.2)
@@ -549,7 +549,7 @@ DEPENDENCIES
   typhoeus
   uglifier
   unicorn (~> 4.3.0)
-  webmock
+  webmock (~> 1.7)
   whenever
   will_paginate
   yard

--- a/features/not_safe_for_work.feature
+++ b/features/not_safe_for_work.feature
@@ -52,7 +52,6 @@ Scenario: Resharing an nsfw post
   And I preemptively confirm the alert
   And I follow "Reshare"
   And I wait for the ajax to finish
-  And I follow "Stream"
-  And I wait for the ajax to finish
+  And I go to the home page
   Then I should have 2 nsfw posts
-  And I should not see "Sexy Senators Gone Wild!"
+  Then I should not see "Sexy Senators Gone Wild!"

--- a/spec/models/jobs/http_multi_spec.rb
+++ b/spec/models/jobs/http_multi_spec.rb
@@ -2,16 +2,17 @@ require 'spec_helper'
 
 describe Jobs::HttpMulti do
   before :all do
+    WebMock.disable_net_connect!(:allow_localhost => true)
     enable_typhoeus
   end
   after :all do
     disable_typhoeus
+    WebMock.disable_net_connect!
   end
 
   before do
     @people = [Factory(:person), Factory(:person)]
     @post_xml = Base64.encode64("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAH")
-
 
     @hydra = Typhoeus::Hydra.new
     @response = Typhoeus::Response.new(:code => 200, :headers => "", :body => "", :time => 0.2, :effective_url => 'http://foobar.com')
@@ -71,6 +72,8 @@ describe Jobs::HttpMulti do
     person = @people.first
     person.url = 'http://remote.net/'
     person.save
+
+    stub_request(:post, person.receive_url).to_return(:status=>200, :body=>"", :headers=>{})
     response = Typhoeus::Response.new(:code => 301,:effective_url => 'https://foobar.com', :headers_hash => {"Location" => person.receive_url.sub('http://', 'https://')}, :body => "", :time => 0.2)
     @hydra.stub(:post, person.receive_url).and_return(response)
 


### PR DESCRIPTION
This updates the webmock gem to 1.8.7 and removes the diaspora-client gem, since everything involving it is broken anyway and it blocked updating webmock.
I had to make a few adaptions to the `http_multi_spec.rb` to work with the new webmock, I don't see any easy way for that spec to not use Typhoeus/Hydra with the way it is currently used...

The `not_safe_for_work.feature` seemed to fail, because since the reshares are not appended to the stream anymore, there only is one post, not two, after resharing.
... correct me if I am wrong, but it also seems that the original post and the reshare are "collapsed" to only the reshare after the refresh(?).

Please gaze your watchful eyes upon these changes, and impart your all-knowingness to me.
