### PR TITLE
Render invitation email without a layout

### DIFF
--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -48,8 +48,8 @@ class Notifier < ActionMailer::Base
 
     I18n.with_locale(locale) do
       mail(mail_opts) do |format|
-        format.text
-        format.html
+        format.text { render :layout => nil }
+        format.html { render :layout => nil }
       end
     end
   end

--- a/features/accepts_invitation.feature
+++ b/features/accepts_invitation.feature
@@ -45,3 +45,4 @@ Feature: invitation acceptance
       And I fill in "email_inviter_emails" with "alex@example.com"
       And I press "Send an invitation"
       Then I should have 1 Devise email delivery
+      And I should not see "change your notification settings" in the last sent email

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -129,6 +129,11 @@ Then /^I should have (\d+) email delivery$/ do |n|
   ActionMailer::Base.deliveries.length.should == n.to_i
 end
 
+Then /^I should not see "([^\"]*)" in the last sent email$/ do |text|
+  email_text = Devise.mailer.deliveries.first.body.to_s
+  email_text = Devise.mailer.deliveries.first.html_part.body.raw_source if email_text.blank?
+  email_text.should_not match(text)
+end
 
 When /^"([^\"]+)" has posted a status message with a photo$/ do |email|
   user = User.find_for_database_authentication(:username => email)


### PR DESCRIPTION
Ideally, we'll probably want to add a layout for this email at some point, but this simplifies it to the bare minimum and gets rid of the "click here to change your notification settings" link.

fixes #3270
