### PR TITLE
fix another hashtag 'inconvenience'

### DIFF
--- a/lib/stream/tag.rb
+++ b/lib/stream/tag.rb
@@ -52,11 +52,11 @@ class Stream::Tag < Stream::Base
 
   def construct_post_query
     posts = StatusMessage
-    if user.present? 
+    if user.present?
       posts = posts.owned_or_visible_by_user(user)
     else
       posts = posts.all_public
     end
-    posts.tagged_with(tag_name)
+    posts.tagged_with(tag_name, :any => true)
   end
 end

--- a/lib/tasks/migrations.rake
+++ b/lib/tasks/migrations.rake
@@ -74,4 +74,39 @@ namespace :migrations do
     }
 
   end
+
+  # removes hashtags with uppercase letters and re-attaches
+  # the posts to the lowercase version
+  task :rewire_uppercase_hashtags => :environment do
+    evil_tags = ActsAsTaggableOn::Tag.where("lower(name) != name")
+    puts "found #{evil_tags.count} tags to convert..."
+
+    evil_tags.each_with_index do |tag, i|
+      good_tag = ActsAsTaggableOn::Tag.find_or_create_by_name(tag.name.downcase)
+      puts "++ '#{tag.name}' has #{tag.taggings.count} records attached"
+      deleteme = []
+
+      tag.taggings.each do |tagging|
+        deleteme << tagging
+      end
+
+      deleteme.each do |tagging|
+        #tag.taggings.delete(tagging)
+        good_tag.taggings << tagging
+      end
+
+      puts "-- converted '#{tag.name}' to '#{good_tag.name}' with #{deleteme.count} records"
+      puts "\n## #{i} tags processed\n\n" if (i % 50 == 0)
+    end
+  end
+
+  task :remove_uppercase_hashtags => :environment do
+    evil_tags = ActsAsTaggableOn::Tag.where("lower(name) != name")
+    evil_tags.each do |tag|
+      next if tag.taggings.count > 0 # non-ascii tags
+
+      puts "removing '#{tag.name}'..."
+      tag.destroy
+    end
+  end
 end


### PR DESCRIPTION
The change in `lib/stream/tag.rb` is so that the tag pages show everything again (fixes #3294).

Also I added two rake tasks, that clean up the DB from the upper-cased tags that were created while the acts_as_taggable_on wasn't running the way we wanted...

Please apply your brain juices to that, I have only tested it on a copy of my pods db and I can't say if it works with PgSQL...
