### PR TITLE
BMM #1, Adding long text before @mention breaks mentioned name highlighting

### DIFF
--- a/app/assets/stylesheets/mentions.css.scss
+++ b/app/assets/stylesheets/mentions.css.scss
@@ -71,13 +71,14 @@
     color: white;
     font-size: 14px;
     font-family: Arial, Helvetica, sans-serif;
-    left: 4px;
+    left: 0;
     line-height: normal;
     overflow: hidden;
-    padding: 6px 0px 3px;
+    padding: 4px;
     position: absolute;
     right: 0;
-    top: -2px;
+    top: 0;
+    width: 445px;
     white-space: pre-wrap;
     word-wrap: break-word;
 


### PR DESCRIPTION
jQuery Mentions Input creates it's own div to show a background for each mention you made. This bug dealt with the dimensions of that div not aligning correctly with the publisher's dimensions.
