### PR TITLE
BMM #4, The Publisher doesn’t expand after writing more than 30 lines of text

### DIFF
--- a/app/assets/javascripts/publisher.js
+++ b/app/assets/javascripts/publisher.js
@@ -210,7 +210,7 @@ var Publisher = {
       Publisher.hiddenInput().val(Publisher.input().val());
     }
 
-    Publisher.input().autoResize({'extraSpace' : 10});
+    Publisher.input().autoResize({ 'extraSpace' : 10, 'maxHeight' : Infinity });
     Publisher.input().bind('textchange', Publisher.textChange);
   }
 };


### PR DESCRIPTION
Pass Infinity as the maxHeight for jQuery autoResize.
