### PR TITLE
Make hashtags clickable in emails

### DIFF
--- a/lib/diaspora/markdownify_email.rb
+++ b/lib/diaspora/markdownify_email.rb
@@ -3,6 +3,7 @@ require Rails.root.join("app", "models", "acts_as_taggable_on", "tag")
 module Diaspora
   module Markdownify
     class Email < Redcarpet::Render::HTML
+      include Rails.application.routes.url_helpers
       TAG_REGEX = /(?:^|\s)#([#{ActsAsTaggableOn::Tag.tag_text_regexp}]+)/u
       def preprocess(text)
         process_tags(text)
@@ -16,7 +17,10 @@ module Diaspora
       def process_tags(text)
         return text unless text.match(TAG_REGEX)
         tags(text).each do |tag|
-          text.gsub!(/##{tag}/i, "\\##{tag}")
+          text.gsub!(/##{tag}/) do |tag|
+            opts = {:name => ActsAsTaggableOn::Tag.normalize(tag)}.merge(Rails.application.config.action_mailer.default_url_options)
+            "[#{tag}](#{tag_url(opts)})"
+          end
         end
         text
       end

--- a/spec/lib/diaspora/markdownify_email_spec.rb
+++ b/spec/lib/diaspora/markdownify_email_spec.rb
@@ -6,17 +6,17 @@ describe Diaspora::Markdownify::Email do
       @html = Diaspora::Markdownify::Email.new
     end
 
-    it 'should escape a hashtag' do
+    it 'should autolink a hashtag' do
       markdownified = @html.preprocess("#tag")
-      markdownified.should == "\\#tag"
+      markdownified.should == "[#tag](http://localhost:9887/tags/tag)"
     end
 
-    it 'should escape multiple hashtags' do
-      markdownified = @html.preprocess("There are #two #tags")
-      markdownified.should == "There are \\#two \\#tags"
+    it 'should autolink multiple hashtags' do
+      markdownified = @html.preprocess("There are #two #Tags")
+      markdownified.should == "There are [#two](http://localhost:9887/tags/two) [#Tags](http://localhost:9887/tags/tags)"
     end
 
-    it 'should not escape headers' do
+    it 'should not autolink headers' do
       markdownified = @html.preprocess("# header")
       markdownified.should == "# header"
     end
@@ -30,7 +30,7 @@ describe Diaspora::Markdownify::Email do
 
     it 'should render the message' do
       rendered = @markdown.render(@sample_text).strip
-      rendered.should == "<h1>Header</h1>\n\n<p>#messages containing #hashtags should render properly</p>"
+      rendered.should == "<h1>Header</h1>\n\n<p><a href=\"http://localhost:9887/tags/messages\">#messages</a> containing <a href=\"http://localhost:9887/tags/hashtags\">#hashtags</a> should render properly</p>"
     end
   end
 end

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -331,7 +331,7 @@ describe Notifier do
       mails = Notifier.admin("#Welcome to bureaucracy!", [bob])
       mails.length.should == 1
       mail = mails.first
-      mail.body.encoded.should match /#Welcome to bureaucracy!/
+      mail.body.encoded.should match "<p><a href=\"http://localhost:9887/tags/welcome\">#Welcome</a> to bureaucracy!</p>"
     end
   end
 end


### PR DESCRIPTION
Refactor the Redcarpet renderer created in c2bc7272f to parse hashtags into clickable links (for HTML emails only).
