### PR TITLE
Fix for YouTube Embeds in Show Pages [ci skip]

### DIFF
--- a/app/assets/stylesheets/new_styles/_base.scss
+++ b/app/assets/stylesheets/new_styles/_base.scss
@@ -98,7 +98,6 @@ a { color : $link-blue  }
     width: 857px;
     height: 480px;
     max-width: 100%;
-    max-height: 100%;
   }
 }
 


### PR DESCRIPTION
This is just a quick, one-line fix. It removes the max-height property for iframe in show pages, gets rid of the Chromium bug where YouTube videos appear in strange, elongated dimensions. Hopefully, this should close #3296
