### PR TITLE
Rails.root and File.join cleanup

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -1,4 +1,4 @@
-require File.join(Rails.root, 'lib','statistics')
+require Rails.root.join('lib', 'statistics')
 
 class AdminsController < ApplicationController
   before_filter :authenticate_user!

--- a/app/controllers/aspects_controller.rb
+++ b/app/controllers/aspects_controller.rb
@@ -91,7 +91,7 @@ class AspectsController < ApplicationController
     @contacts = @contacts_in_aspect + @contacts_not_in_aspect
 
     unless @aspect
-      render :file => "#{Rails.root}/public/404.html", :layout => false, :status => 404
+      render :file => Rails.root.join('public', '404.html').to_s, :layout => false, :status => 404
     else
       @aspect_ids = [@aspect.id]
       @aspect_contacts_count = @aspect.contacts.size

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -13,7 +13,7 @@ class HomeController < ApplicationController
         redirect_to stream_path
       end
     elsif is_mobile_device?
-      unless(File.exist?("#{Rails.root}/app/views/home/_show.mobile.erb"))
+      unless(File.exist?(Rails.root.join('app', 'views', 'home', '_show.mobile.erb')))
         redirect_to user_session_path
       else
         render :show, :layout => 'post'

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -2,7 +2,7 @@
 #   licensed under the Affero General Public License version 3 or later.  See
 #   the COPYRIGHT file.
 
-require File.join(Rails.root, "lib", 'stream', "person")
+require Rails.root.join("lib", 'stream', "person")
 
 class PeopleController < ApplicationController
   before_filter :authenticate_user!, :except => [:show, :last_post]
@@ -13,7 +13,7 @@ class PeopleController < ApplicationController
   respond_to :js, :only => [:tag_index]
 
   rescue_from ActiveRecord::RecordNotFound do
-    render :file => "#{Rails.root}/public/404.html", :layout => false, :status => 404
+    render :file => Rails.root.join('public', '404.html').to_s, :layout => false, :status => 404
   end
 
   helper_method :search_query

--- a/app/controllers/publics_controller.rb
+++ b/app/controllers/publics_controller.rb
@@ -2,11 +2,11 @@
 #   licensed under the Affero General Public License version 3 or later.  See
 #   the COPYRIGHT file.
 
-require File.join(Rails.root, 'lib', 'stream', 'public')
+require Rails.root.join('lib', 'stream', 'public')
 class PublicsController < ApplicationController
-  require File.join(Rails.root, '/lib/diaspora/parser')
-  require File.join(Rails.root, '/lib/postzord/receiver/public')
-  require File.join(Rails.root, '/lib/postzord/receiver/private')
+  require Rails.root.join('lib', 'diaspora', 'parser')
+  require Rails.root.join('lib', 'postzord', 'receiver', 'public')
+  require Rails.root.join('lib', 'postzord', 'receiver', 'private')
   include Diaspora::Parser
 
   # We use newrelic_ignore to prevent artifical RPM bloat; however,

--- a/app/controllers/streams_controller.rb
+++ b/app/controllers/streams_controller.rb
@@ -2,13 +2,13 @@
 #   licensed under the Affero General Public License version 3 or later.  See
 #   the COPYRIGHT file.
 
-require File.join(Rails.root, "lib", "stream", "aspect")
-require File.join(Rails.root, "lib", "stream", "multi")
-require File.join(Rails.root, "lib", "stream", "comments")
-require File.join(Rails.root, "lib", "stream", "likes")
-require File.join(Rails.root, "lib", "stream", "mention")
-require File.join(Rails.root, "lib", "stream", "followed_tag")
-require File.join(Rails.root, "lib", "stream", "activity")
+require Rails.root.join("lib", "stream", "aspect")
+require Rails.root.join("lib", "stream", "multi")
+require Rails.root.join("lib", "stream", "comments")
+require Rails.root.join("lib", "stream", "likes")
+require Rails.root.join("lib", "stream", "mention")
+require Rails.root.join("lib", "stream", "followed_tag")
+require Rails.root.join("lib", "stream", "activity")
 
 
 class StreamsController < ApplicationController

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,8 +1,8 @@
 #   Copyright (c) 2010-2011, Diaspora Inc.  This file is
 #   licensed under the Affero General Public License version 3 or later.  See
 #   the COPYRIGHT file.
-require File.join(Rails.root, 'app', 'models', 'acts_as_taggable_on', 'tag')
-require File.join(Rails.root, 'lib', 'stream', 'tag')
+require Rails.root.join('app', 'models', 'acts_as_taggable_on', 'tag')
+require Rails.root.join('lib', 'stream', 'tag')
 
 class TagsController < ApplicationController
   skip_before_filter :set_grammatical_gender

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,8 +3,8 @@
 #   the COPYRIGHT file.
 
 class UsersController < ApplicationController
-  require File.join(Rails.root, 'lib/diaspora/exporter')
-  require File.join(Rails.root, 'lib/collect_user_photos')
+  require Rails.root.join('lib', 'diaspora', 'exporter')
+  require Rails.root.join('lib', 'collect_user_photos')
 
   before_filter :authenticate_user!, :except => [:new, :create, :public, :user_photo]
 

--- a/app/helpers/markdownify_helper.rb
+++ b/app/helpers/markdownify_helper.rb
@@ -2,7 +2,7 @@
 #   licensed under the Affero General Public License version 3 or later.  See
 #   the COPYRIGHT file.
 
-require File.expand_path("#{Rails.root}/lib/diaspora/markdownify")
+require Rails.root.join('lib', 'diaspora', 'markdownify')
 
 module MarkdownifyHelper
   def markdownify(target, render_options={})

--- a/app/models/app_config.rb
+++ b/app/models/app_config.rb
@@ -3,7 +3,7 @@
 # the COPYRIGHT file.
 
 require 'uri'
-require File.join(Rails.root, 'lib', 'enviroment_configuration')
+require Rails.root.join('lib', 'enviroment_configuration')
 
 class AppConfig < Settingslogic
   def self.source_file_name
@@ -11,9 +11,9 @@ class AppConfig < Settingslogic
       puts "using remote application.yml"
       return ENV['application_yml']
     end
-    config_file = File.join(Rails.root, "config", "application.yml")
+    config_file = Rails.root.join("config", "application.yml")
     if !File.exists?(config_file) && (Rails.env == 'test' || Rails.env.include?("integration") || EnviromentConfiguration.heroku?)
-      config_file = File.join(Rails.root, "config", "application.yml.example")
+      config_file = Rails.root.join("config", "application.yml.example")
     end
     config_file
   end
@@ -96,7 +96,7 @@ HELP
   end
 
   def self.have_old_config_file?
-    File.exists?(File.join(Rails.root, "config", "app.yml")) || (File.exists?(File.join(Rails.root, "config", "app_config.yml")))
+    File.exists?(Rails.root.join("config", "app.yml")) || (File.exists?(Rails.root.join("config", "app_config.yml")))
   end
 
   def self.new_relic_app_name

--- a/app/models/jobs/base.rb
+++ b/app/models/jobs/base.rb
@@ -4,7 +4,7 @@
 
 module Jobs
   class Base
-    Dir["#{Rails.root}/app/models/jobs/mail/*.rb"].each {|file| require file }
+    Dir[Rails.root.join('app', 'models', 'jobs', 'mail', '*.rb')].each {|file| require file }
     
     #TODO these should be subclassed real exceptions
     DUMB_ERROR_MESSAGES = [

--- a/app/models/jobs/http_multi.rb
+++ b/app/models/jobs/http_multi.rb
@@ -3,7 +3,7 @@
 #   the COPYRIGHT file.
 
 require 'uri'
-require File.join(Rails.root, 'lib/hydra_wrapper')
+require Rails.root.join('lib', 'hydra_wrapper')
 
 module Jobs
   class HttpMulti < Base

--- a/app/models/jobs/notify_local_users.rb
+++ b/app/models/jobs/notify_local_users.rb
@@ -6,7 +6,7 @@ module Jobs
   class NotifyLocalUsers < Base
     @queue = :receive_local
 
-    require File.join(Rails.root, 'app/models/notification')
+    require Rails.root.join('app', 'models', 'notification')
 
     def self.perform(user_ids, object_klass, object_id, person_id)
 

--- a/app/models/jobs/publish_to_hub.rb
+++ b/app/models/jobs/publish_to_hub.rb
@@ -7,7 +7,7 @@ module Jobs
     @queue = :http_service
 
     def self.perform(sender_public_url)
-      require File.join(Rails.root, 'lib/pubsubhubbub')
+      require Rails.root.join('lib', 'pubsubhubbub')
       atom_url = sender_public_url + '.atom'
       Pubsubhubbub.new(AppConfig[:pubsub_server]).publish(atom_url)
     end

--- a/app/models/jobs/receive_encrypted_salmon.rb
+++ b/app/models/jobs/receive_encrypted_salmon.rb
@@ -3,7 +3,7 @@
 #   the COPYRIGHT file.
 
 
-require File.join(Rails.root, 'lib/postzord/receiver/private')
+require Rails.root.join('lib', 'postzord', 'receiver', 'private')
 module Jobs
   class ReceiveEncryptedSalmon < Base
     @queue = :receive_salmon

--- a/app/models/jobs/receive_local_batch.rb
+++ b/app/models/jobs/receive_local_batch.rb
@@ -2,8 +2,8 @@
 #   licensed under the Affero General Public License version 3 or later.  See
 #   the COPYRIGHT file.
 
-require File.join(Rails.root, 'lib/postzord/receiver/private')
-require File.join(Rails.root, 'lib/postzord/receiver/local_batch')
+require Rails.root.join('lib', 'postzord', 'receiver', 'private')
+require Rails.root.join('lib', 'postzord', 'receiver', 'local_batch')
 
 module Jobs
   class ReceiveLocalBatch < Base

--- a/app/models/jobs/receive_unencrypted_salmon.rb
+++ b/app/models/jobs/receive_unencrypted_salmon.rb
@@ -2,7 +2,7 @@
 #   licensed under the Affero General Public License version 3 or later.  See
 #   the COPYRIGHT file.
 
-require File.join(Rails.root, 'lib/postzord/receiver/public')
+require Rails.root.join('lib', 'postzord', 'receiver', 'public')
 
 module Jobs
   class ReceiveUnencryptedSalmon < Base

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -3,7 +3,7 @@
 #   the COPYRIGHT file.
 
 require 'uri'
-require File.join(Rails.root, 'lib/hcard')
+require Rails.root.join('lib', 'hcard')
 
 class Person < ActiveRecord::Base
   include ROXML

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -27,5 +27,5 @@ class Service < ActiveRecord::Base
   end
 
 end
-require File.join(Rails.root, 'app/models/services/facebook')
-require File.join(Rails.root, 'app/models/services/twitter')
+require Rails.root.join('app', 'models', 'services', 'facebook')
+require Rails.root.join('app', 'models', 'services', 'twitter')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,8 +2,8 @@
 #   licensed under the Affero General Public License version 3 or later.  See
 #   the COPYRIGHT file.
 
-require File.join(Rails.root, 'lib/salmon/salmon')
-require File.join(Rails.root, 'lib/postzord/dispatcher')
+require Rails.root.join('lib', 'salmon', 'salmon')
+require Rails.root.join('lib', 'postzord', 'dispatcher')
 
 class User < ActiveRecord::Base
   include Encryptor::Private

--- a/app/models/user/querying.rb
+++ b/app/models/user/querying.rb
@@ -2,7 +2,7 @@
 #   licensed under the Affero General Public License version 3 or later.  See
 #   the COPYRIGHT file.
 
-require File.join(Rails.root, 'lib', 'evil_query')
+require Rails.root.join('lib', 'evil_query')
 
 
 #TODO: THIS FILE SHOULD NOT EXIST, EVIL SQL SHOULD BE ENCAPSULATED IN EvilQueries,

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), '..', '..', 'lib', 'template_picker')
+require Rails.root.join('lib', 'template_picker')
 
 class PostPresenter
   attr_accessor :post, :current_user

--- a/app/views/home/show.html.haml
+++ b/app/views/home/show.html.haml
@@ -11,4 +11,4 @@
 
 - rescue
   :erb
-    <%= File.open(File.join(Rails.root, 'public/default.html')).read %>
+    <%= File.open(Rails.root.join('public', 'default.html')).read %>

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -24,7 +24,7 @@ USERNAME_BLACKLIST = ['admin', 'administrator', 'hostmaster', 'info', 'postmaste
 
 # Initialize the rails application
 Diaspora::Application.initialize!
-require File.join(Rails.root, 'lib', 'federation_logger')
+require Rails.root.join('lib', 'federation_logger')
 
 # allow token auth only for posting activitystream photos
 module Devise

--- a/config/initializers/1_intialize_app_config.rb
+++ b/config/initializers/1_intialize_app_config.rb
@@ -2,4 +2,4 @@
 # licensed under the Affero General Public License version 3 or later.  See
 # the COPYRIGHT file.
 
-require File.join(Rails.root, 'app', 'models', 'app_config')
+require Rails.root.join('app', 'models', 'app_config')

--- a/config/initializers/2_before_load_services.rb
+++ b/config/initializers/2_before_load_services.rb
@@ -6,7 +6,7 @@ def load_config_yaml filename
   YAML.load(ERB.new(File.read(filename)).result)
 end
 
-oauth_keys_file = "#{Rails.root}/config/oauth_keys.yml"
+oauth_keys_file = Rails.root.join('config', 'oauth_keys.yml').to_s
 
 
 SERVICES = load_config_yaml("#{oauth_keys_file}.example")

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -7,7 +7,7 @@ ENV["SSL_CERT_FILE"] = AppConfig[:ca_file]
 CarrierWave.configure do |config|
   if !Rails.env.test? && AppConfig[:s3_key] && AppConfig[:s3_secret] && AppConfig[:s3_bucket] && AppConfig[:s3_region]
     config.storage = :fog
-    config.cache_dir = "#{Rails.root}/tmp/uploads"
+    config.cache_dir = Rails.root.join('tmp', 'uploads').to_s
     config.fog_credentials = {
         :provider               => 'AWS',       
         :aws_access_key_id      => AppConfig[:s3_key],       

--- a/config/initializers/direction_detector.rb
+++ b/config/initializers/direction_detector.rb
@@ -2,4 +2,4 @@
 #   licensed under the Affero General Public License version 3 or later.  See
 #   the COPYRIGHT file.
 
-require File.join(Rails.root, 'lib/direction_detector')
+require Rails.root.join('lib', 'direction_detector')

--- a/config/initializers/load_mail_jobs.rb
+++ b/config/initializers/load_mail_jobs.rb
@@ -1,1 +1,1 @@
-Dir["#{Rails.root}/app/models/jobs/mail/*.rb"].each { |file| require file }
+Dir[Rails.root.join('app', 'models', 'jobs', 'mail', '*.rb')].each { |file| require file }

--- a/config/initializers/mailer_config.rb
+++ b/config/initializers/mailer_config.rb
@@ -1,7 +1,7 @@
 #   Copyright (c) 2010-2011, Diaspora Inc.  This file is
 #   licensed under the Affero General Public License version 3 or later.  See
 #   the COPYRIGHT file.
-require File.join(Rails.root, 'lib/messagebus/mailer')
+require Rails.root.join('lib', 'messagebus', 'mailer')
 
 Diaspora::Application.configure do
   config.action_mailer.default_url_options = {:protocol => AppConfig[:pod_uri].scheme,

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -36,6 +36,6 @@ end
 
 if AppConfig[:mount_resque_web]
   require 'resque/server'
-  require File.join(Rails.root, 'lib/admin_rack')
+  require Rails.root.join('lib', 'admin_rack')
   Resque::Server.use AdminRack
 end

--- a/db/migrate/20110217044519_undo_adding_indicies.rb
+++ b/db/migrate/20110217044519_undo_adding_indicies.rb
@@ -1,5 +1,5 @@
 class UndoAddingIndicies < ActiveRecord::Migration
-  require File.join(Rails.root, 'db/migrate/20110213052742_add_more_indicies')
+  require Rails.root.join('db', 'migrate', '20110213052742_add_more_indicies')
   def self.up
     AddMoreIndicies.down
   end

--- a/db/migrate/20110314043119_drop_import_tables.rb
+++ b/db/migrate/20110314043119_drop_import_tables.rb
@@ -1,4 +1,4 @@
-require File.join(Rails.root, 'db/migrate/20110105051803_create_import_tables')
+require Rails.root.join('db', 'migrate', '20110105051803_create_import_tables')
 class DropImportTables < ActiveRecord::Migration
   def self.up
     CreateImportTables.down

--- a/db/migrate/20110321205715_unprocessed_image_uploader.rb
+++ b/db/migrate/20110321205715_unprocessed_image_uploader.rb
@@ -1,4 +1,4 @@
-require File.join(Rails.root, 'db/migrate/20110319005509_add_processed_to_post')
+require Rails.root.join('db', 'migrate', '20110319005509_add_processed_to_post')
 class UnprocessedImageUploader < ActiveRecord::Migration
   def self.up
     AddProcessedToPost.down

--- a/db/migrate/20110603233202_drop_aspects_open.rb
+++ b/db/migrate/20110603233202_drop_aspects_open.rb
@@ -1,5 +1,5 @@
 class DropAspectsOpen < ActiveRecord::Migration
-  require File.join(Rails.root, "db", "migrate", "20110202015222_add_open_to_aspects")
+  require Rails.root.join("db", "migrate", "20110202015222_add_open_to_aspects")
   def self.up
     AddOpenToAspects.down
   end

--- a/db/migrate/20120107220942_move_recently_hidden_posts_to_user.rb
+++ b/db/migrate/20120107220942_move_recently_hidden_posts_to_user.rb
@@ -14,7 +14,7 @@ class ShareVisibility < ActiveRecord::Base
   belongs_to :contact
 end
 
-require File.join(File.dirname(__FILE__), '..', '..', 'lib', 'share_visibility_converter')
+require Rails.root.join('lib', 'share_visibility_converter')
 
 class MoveRecentlyHiddenPostsToUser < ActiveRecord::Migration
   def self.up

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,9 +10,9 @@
 #   cities = City.create([{ :name => 'Chicago' }, { :name => 'Copenhagen' }])
 #   Mayor.create(:name => 'Daley', :city => citie
 
-require File.join(File.dirname(__FILE__), "..", "config", "environment")
+require Rails.root.join('config', 'environment')
 require 'factory_girl_rails'
-require File.join(File.dirname(__FILE__), "..", "spec", "helper_methods")
+require Rails.root.join('spec', 'helper_methods')
 include HelperMethods
 
 alice = Factory(:user_with_aspect, :username => "alice", :password => 'evankorth')
@@ -47,8 +47,8 @@ Role.add_admin(bob.person)
 puts "done!"
 
 
-require File.join(File.dirname(__FILE__), '..', 'spec', 'support', 'fake_resque')
-require File.join(File.dirname(__FILE__), '..', 'spec', 'support', 'user_methods')
+require Rails.root.join('spec', 'support', 'fake_resque')
+require Rails.root.join('spec', 'support', 'user_methods')
 
 print "Seeding post data..."
 time_interval = 1000

--- a/features/step_definitions/uri-step.rb
+++ b/features/step_definitions/uri-step.rb
@@ -1,6 +1,6 @@
 Given /^configuration parameter (\w+) is ([^ ]+)$/ do |key, value|
   require Rails.root.join('config',  "initializers", "_load_app_config.rb")
-  app_value = AppConfig[ key.to_sym]
+  app_value = AppConfig[key.to_sym]
   assert_equal value, app_value,
      "You must set #{key} to #{value} and kill running server"
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -49,8 +49,8 @@ Spork.prefork do
   require File.join(File.dirname(__FILE__), "integration_sessions_controller")
   require File.join(File.dirname(__FILE__), "poor_mans_webmock")
 
-  require File.join(File.dirname(__FILE__), "..", "..", "spec", "helper_methods")
-  require File.join(File.dirname(__FILE__), "..", "..", "spec", "support","user_methods")
+  require Rails.root.join('spec', 'helper_methods')
+  require Rails.root.join('spec', 'support', 'user_methods')
   include HelperMethods
 
   # require 'webmock/cucumber'
@@ -61,7 +61,7 @@ Spork.prefork do
     AppConfig[:configured_services] << 'facebook'
   end
 
-  require File.join(File.dirname(__FILE__), "..", "..", "spec", "support", "fake_resque")
+  require Rails.root.join('spec', 'support', 'fake_resque')
 
   require File.join(File.dirname(__FILE__), 'run_resque_in_process')
 

--- a/lib/csv_generator.rb
+++ b/lib/csv_generator.rb
@@ -3,9 +3,9 @@ module CsvGenerator
   PATH = '/tmp/'
   BACKER_CSV_LOCATION = File.join('/usr/local/app/diaspora/', 'backer_list.csv')
   #BACKER_CSV_LOCATION = File.join('/home/ilya/workspace/diaspora/', 'backer_list.csv')
-  WAITLIST_LOCATION = File.join(Rails.root, 'config', 'mailing_list.csv')
-  OFFSET_LOCATION = File.join(Rails.root, 'config', 'email_offset')
-  UNSUBSCRIBE_LOCATION = File.join(Rails.root, 'config', 'unsubscribe.csv')
+  WAITLIST_LOCATION = Rails.root.join('config', 'mailing_list.csv')
+  OFFSET_LOCATION = Rails.root.join('config', 'email_offset')
+  UNSUBSCRIBE_LOCATION = Rails.root.join('config', 'unsubscribe.csv')
 
   def self.all_active_users
     file = self.filename("all_active_users")

--- a/lib/diaspora/taggable.rb
+++ b/lib/diaspora/taggable.rb
@@ -2,7 +2,7 @@
 #   licensed under the Affero General Public License version 3 or later.  See
 #   the COPYRIGHT file.
 
-require File.join(Rails.root, "app", "models", "acts_as_taggable_on", "tag")
+require Rails.root.join("app", "models", "acts_as_taggable_on", "tag")
 
 module Diaspora
   module Taggable

--- a/lib/enviroment_configuration.rb
+++ b/lib/enviroment_configuration.rb
@@ -9,7 +9,7 @@ module EnviromentConfiguration
   end
 
   def self.secret_token_initializer_is_not_present?
-    !File.exists?( File.join(Rails.root, 'config', 'initializers', 'secret_token.rb'))
+    !File.exists?( Rails.root.join('config', 'initializers', 'secret_token.rb'))
   end
 
   def self.prevent_fetching_community_spotlight?
@@ -27,7 +27,7 @@ module EnviromentConfiguration
       Rails.application.config.secret_token = ENV['SECRET_TOKEN'] 
     elsif secret_token_initializer_is_not_present?
       `rake generate:secret_token`
-      require  File.join(Rails.root, 'config', 'initializers', 'secret_token.rb')
+      require  Rails.root.join('config', 'initializers', 'secret_token.rb')
     else
       #do nothing
     end

--- a/lib/federation_logger.rb
+++ b/lib/federation_logger.rb
@@ -7,7 +7,7 @@ end
 
 if Rails.env.match(/integration/)
   puts "using federation logger"
-  logfile = File.open(File.join(Rails.root, "/log/#{Rails.env}_federation.log"), 'a')  #create log file
+  logfile = File.open(Rails.root.join("log", "#{Rails.env}_federation.log"), 'a')  #create log file
   logfile.sync = true  #automatically flushes data to file
   FEDERATION_LOGGER = FederationLogger.new(logfile)  #constant accessible anywhere
 else

--- a/lib/postzord/dispatcher.rb
+++ b/lib/postzord/dispatcher.rb
@@ -4,8 +4,8 @@
 
 
 class Postzord::Dispatcher
-  require File.join(Rails.root, 'lib/postzord/dispatcher/private')
-  require File.join(Rails.root, 'lib/postzord/dispatcher/public')
+  require Rails.root.join('lib', 'postzord', 'dispatcher', 'private')
+  require Rails.root.join('lib', 'postzord', 'dispatcher', 'public')
 
   attr_reader :sender, :object, :xml, :subscribers, :opts
 

--- a/lib/postzord/receiver.rb
+++ b/lib/postzord/receiver.rb
@@ -4,8 +4,8 @@
 
 
 class Postzord::Receiver
-  require File.join(Rails.root, 'lib/postzord/receiver/private')
-  require File.join(Rails.root, 'lib/postzord/receiver/public')
+  require Rails.root.join('lib', 'postzord', 'receiver', 'private')
+  require Rails.root.join('lib', 'postzord', 'receiver', 'public')
 
   def perform!
     self.receive!

--- a/lib/postzord/receiver/private.rb
+++ b/lib/postzord/receiver/private.rb
@@ -2,8 +2,8 @@
 #   licensed under the Affero General Public License version 3 or later.  See
 #   the COPYRIGHT file.
 
-require File.join(Rails.root, 'lib/webfinger')
-require File.join(Rails.root, 'lib/diaspora/parser')
+require Rails.root.join('lib', 'webfinger')
+require Rails.root.join('lib', 'diaspora', 'parser')
 
 class Postzord::Receiver::Private < Postzord::Receiver
 

--- a/lib/salmon/salmon.rb
+++ b/lib/salmon/salmon.rb
@@ -24,7 +24,7 @@ end
 
 # Verify documents secured with Magic Signatures
 module Salmon
-  autoload :Slap,             File.join(Rails.root, "lib", "salmon", "slap")
-  autoload :EncryptedSlap,    File.join(Rails.root, "lib", "salmon", "encrypted_slap")
-  autoload :MagicSigEnvelope, File.join(Rails.root, "lib", "salmon", "magic_sig_envelope")
+  autoload :Slap,             Rails.root.join("lib", "salmon", "slap")
+  autoload :EncryptedSlap,    Rails.root.join("lib", "salmon", "encrypted_slap")
+  autoload :MagicSigEnvelope, Rails.root.join("lib", "salmon", "magic_sig_envelope")
 end

--- a/lib/stream/base.rb
+++ b/lib/stream/base.rb
@@ -1,4 +1,4 @@
-require File.join(Rails.root, "lib", "publisher")
+require Rails.root.join("lib", "publisher")
 class Stream::Base
   TYPES_OF_POST_IN_STREAM = ['StatusMessage', 'Reshare', 'ActivityStreams::Photo']
 

--- a/lib/tasks/after_deploy.rake
+++ b/lib/tasks/after_deploy.rake
@@ -2,7 +2,7 @@ desc "revert custom landing page commit after heroku san deploys"
 task :after_deploy => :environment do
 
   # Perform this task only if custom landing page is not present in app/views/home/_show.html.haml
-  if (File.exist?(File.join(Rails.root, "app", "views", "home", "_show.html.erb")) || File.exist?(File.join(Rails.root, "app", "views", "home", "_show.mobile.erb"))) && system("git log | head -5 | grep 'custom\ landing\ page(s)'")
+  if (File.exist?(Rails.root.join("app", "views", "home", "_show.html.erb")) || File.exist?(Rails.root.join("app", "views", "home", "_show.mobile.erb"))) && system("git log | head -5 | grep 'custom\ landing\ page(s)'")
     puts "-----> resetting HEAD before custom landing page commit"
 
     system("git reset HEAD^") ? true : fail

--- a/lib/tasks/batch_inviter.rake
+++ b/lib/tasks/batch_inviter.rake
@@ -1,7 +1,7 @@
 #   Copyright (c) 2010-2011, Diaspora Inc.  This file is
 #   licensed under the Affero General Public License version 3 or later.  See
 #   the COPYRIGHT file.
-require File.join(Rails.root, 'lib', 'rake_helpers')
+require Rails.root.join('lib', 'rake_helpers')
 include RakeHelpers
 
 namespace :invites do
@@ -11,8 +11,8 @@ namespace :invites do
   task :send, :number, :test do |t, args|
    require File.join(File.dirname(__FILE__), '..', '..', 'config', 'environment')
 
-    filename = File.join(Rails.root, 'config', 'mailing_list.csv')
-    offset_filename = File.join(Rails.root, 'config', 'email_offset')
+    filename = Rails.root.join('config', 'mailing_list.csv')
+    offset_filename = Rails.root.join('config', 'email_offset')
     number_of_backers = args[:number] ? args[:number].to_i : 1000
 
     offset =  if File.exists?(offset_filename)
@@ -26,7 +26,7 @@ namespace :invites do
     finish_num = process_emails(filename, number_of_backers, offset, test)
 
     new_offset = offset + finish_num + 1
-    File.open(File.join(Rails.root, 'config', 'email_offset'), 'w') do |f|
+    File.open(Rails.root.join('config', 'email_offset'), 'w') do |f|
       f.write(new_offset)
     end
     puts "you ended on #{new_offset}"

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -30,8 +30,8 @@ namespace :ci do
     puts "Stopping virtual display..."
     `sh -e /etc/init.d/xvfb stop`
     puts "Cleaning up..."
-    FileUtils.rm_rf("#{Rails.root}/public/uploads/images")
-    FileUtils.rm_rf("#{Rails.root}/public/uploads/tmp")
+    FileUtils.rm_rf(Rails.root.join('public', 'uploads', 'images'))
+    FileUtils.rm_rf(Rails.root.join('public', 'uploads', 'tmp'))
     raise "tests failed!" unless exit_status == 0
     puts "All tests passed!"
   end

--- a/lib/tasks/cool_seed.rake
+++ b/lib/tasks/cool_seed.rake
@@ -1,7 +1,7 @@
 desc 'Seeds cool users'
 task :cool => :environment do
   require 'factory_girl_rails'
-  cool_people_yml = YAML.load(File.open(File.join(Rails.root, 'config', 'cool_people.yml')))
+  cool_people_yml = YAML.load(File.open(Rails.root.join('config', 'cool_people.yml')))
 
   cool_people_yml.each do |name, attributes|
 

--- a/lib/tasks/cucumber.rake
+++ b/lib/tasks/cucumber.rake
@@ -7,7 +7,7 @@
 
 unless ARGV.any? {|a| a =~ /^gems/} # Don't load anything when running the gems:* tasks
 
-vendored_cucumber_bin = Dir["#{Rails.root}/vendor/{gems,plugins}/cucumber*/bin/cucumber"].first
+vendored_cucumber_bin = Dir[Rails.root.join('vendor', '{gems,plugins}', 'cucumber*', 'bin', 'cucumber')].first
 $LOAD_PATH.unshift(File.dirname(vendored_cucumber_bin) + '/../lib') unless vendored_cucumber_bin.nil?
 
 begin

--- a/lib/tasks/generate_session_secret.rake
+++ b/lib/tasks/generate_session_secret.rake
@@ -2,7 +2,7 @@ namespace :generate do
   desc 'Generates a Session Secret Token'
   task :secret_token do
 
-  path = File.join(Rails.root, 'config', 'initializers', 'secret_token.rb')
+  path = Rails.root.join('config', 'initializers', 'secret_token.rb')
   secret = SecureRandom.hex(40)
   File.open(path, 'w') do |f|
     f.write <<"EOF"

--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -2,7 +2,7 @@
  #licensed under the Affero General Public License version 3 or later.  See
  #the COPYRIGHT file.
 
-require File.join(Rails.root, 'lib', 'enviroment_configuration')
+require Rails.root.join('lib', 'enviroment_configuration')
 
 namespace :heroku do
   HEROKU_CONFIG_ADD_COMMAND = "heroku config:add"

--- a/lib/tasks/migrations.rake
+++ b/lib/tasks/migrations.rake
@@ -6,7 +6,7 @@ namespace :migrations do
 
   desc 'copy all hidden share visibilities from share_visibilities to users. Can be run with the site still up.'
   task :copy_hidden_share_visibilities_to_users => [:environment] do
-    require File.join(Rails.root, 'lib', 'share_visibility_converter')
+    require Rails.root.join('lib', 'share_visibility_converter')
     ShareVisibilityConverter.copy_hidden_share_visibilities_to_users
   end
 

--- a/lib/tasks/stats.rake
+++ b/lib/tasks/stats.rake
@@ -1,9 +1,9 @@
-require File.join(Rails.root, 'lib', 'statistics' )
+require Rails.root.join('lib', 'statistics' )
 
 namespace :stats do
   desc 'Emails recent engagement statistics the admins'
   task :save_retention => :environment do
-    require File.join(Rails.root, 'app', 'mailers', 'notifier' )
+    require Rails.root.join('app', 'mailers', 'notifier' )
 
     return unless AppConfig[:admins].present? 
 
@@ -17,7 +17,7 @@ namespace :stats do
       end
     end
 
-    File.open(File.join(Rails.root, "tmp", "retention_stats_#{Time.now.strftime("%Y-%m-%d-%H:%M:%S-%Z")}.txt"), "w") do |file|
+    File.open(Rails.root.join("tmp", "retention_stats_#{Time.now.strftime("%Y-%m-%d-%H:%M:%S-%Z")}.txt"), "w") do |file|
       file << string
     end
   end
@@ -35,6 +35,6 @@ namespace :stats do
       end
     end
 
-    File.open("#{Rails.root}/tmp/top_actives.csv", 'w') {|f| f.write(string) }
+    File.open(Rails.root.join('tmp', 'top_actives.csv'), 'w') {|f| f.write(string) }
   end
 end

--- a/lib/webfinger.rb
+++ b/lib/webfinger.rb
@@ -1,5 +1,5 @@
-require File.join(Rails.root, 'lib/hcard')
-require File.join(Rails.root, 'lib/webfinger_profile')
+require Rails.root.join('lib', 'hcard')
+require Rails.root.join('lib', 'webfinger_profile')
 
 class Webfinger
   attr_accessor :host_meta_xrd, :webfinger_profile_xrd, 

--- a/script/get_config.rb
+++ b/script/get_config.rb
@@ -4,10 +4,11 @@
 # the COPYRIGHT file.
 
 require 'rubygems'
+require 'pathname'
 
 class Rails
   def self.root
-    File.expand_path(File.join(File.dirname(__FILE__), ".."))
+    @@root ||= Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), "..")))
   end
 
   def self.env
@@ -22,7 +23,7 @@ if ARGV.length >= 1
   setting_name = ARGV[0]
   if Rails.env == 'script_server' # load from the special script_server_config.yml file
     require 'yaml'
-    script_server_config_file = File.join(Rails.root, 'config', 'script_server.yml')
+    script_server_config_file = Rails.root.join('config', 'script_server.yml')
     begin
       print YAML.load_file(script_server_config_file)['script_server'][setting_name]
     rescue
@@ -34,7 +35,7 @@ if ARGV.length >= 1
     require 'active_support/core_ext/class/attribute_accessors'
     require 'active_support/core_ext/object/blank'
     require 'settingslogic'
-    require File.join(Rails.root, 'app', 'models', 'app_config')
+    require Rails.root.join('app', 'models', 'app_config')
     setting_name = setting_name.to_sym
     if (!AppConfig.respond_to?(setting_name) || AppConfig.send(setting_name).nil?) && AppConfig[setting_name].nil?
       $stderr.puts "Could not find setting #{ARGV[0]} for environment #{Rails.env}."

--- a/spec/controllers/photos_controller_spec.rb
+++ b/spec/controllers/photos_controller_spec.rb
@@ -19,7 +19,7 @@ describe PhotosController do
       @params = {
         :photo => {:aspect_ids => "all"},
         :qqfile => Rack::Test::UploadedFile.new(
-          File.join( Rails.root, "spec/fixtures/button.png" ),
+          Rails.root.join("spec", "fixtures", "button.png").to_s,
           "image/png"
         )
       }

--- a/spec/controllers/publics_controller_spec.rb
+++ b/spec/controllers/publics_controller_spec.rb
@@ -5,7 +5,7 @@
 require 'spec_helper'
 
 describe PublicsController do
-  let(:fixture_path) { File.join(Rails.root, 'spec', 'fixtures')}
+  let(:fixture_path) { Rails.root.join('spec', 'fixtures') }
   before do
     @user = alice
     @person = Factory(:person)

--- a/spec/lib/diaspora/exporter_spec.rb
+++ b/spec/lib/diaspora/exporter_spec.rb
@@ -3,7 +3,7 @@
 #   the COPYRIGHT file.
 
 require 'spec_helper'
-require File.join(Rails.root, 'lib/diaspora/exporter')
+require Rails.root.join('lib', 'diaspora', 'exporter')
 
 describe Diaspora::Exporter do
 

--- a/spec/lib/hcard_spec.rb
+++ b/spec/lib/hcard_spec.rb
@@ -3,7 +3,7 @@
 #   the COPYRIGHT file.
 
 require 'spec_helper'
-require File.join(Rails.root, 'lib/hcard')
+require Rails.root.join('lib', 'hcard')
 
 describe HCard do
   it 'should parse an hcard' do

--- a/spec/lib/postzord/dispatcher/private_spec.rb
+++ b/spec/lib/postzord/dispatcher/private_spec.rb
@@ -3,7 +3,7 @@
 #   the COPYRIGHT file.
 
 require 'spec_helper'
-require File.join(Rails.root, 'lib/postzord/dispatcher/private')
+require Rails.root.join('lib', 'postzord', 'dispatcher', 'private')
 
 describe Postzord::Dispatcher::Private do
 

--- a/spec/lib/postzord/dispatcher_spec.rb
+++ b/spec/lib/postzord/dispatcher_spec.rb
@@ -4,7 +4,7 @@
 
 require 'spec_helper'
 
-require File.join(Rails.root, 'lib/postzord/dispatcher')
+require Rails.root.join('lib', 'postzord', 'dispatcher')
 
 describe Postzord::Dispatcher do
   before do

--- a/spec/lib/postzord/receiver/local_batch_spec.rb
+++ b/spec/lib/postzord/receiver/local_batch_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require File.join(Rails.root, 'lib','postzord', 'receiver', 'local_batch')
+require Rails.root.join('lib', 'postzord', 'receiver', 'local_batch')
 
 describe Postzord::Receiver::LocalBatch do
   before do

--- a/spec/lib/postzord/receiver/private_spec.rb
+++ b/spec/lib/postzord/receiver/private_spec.rb
@@ -4,8 +4,8 @@
 
 require 'spec_helper'
 
-require File.join(Rails.root, 'lib/postzord')
-require File.join(Rails.root, 'lib/postzord/receiver/private')
+require Rails.root.join('lib', 'postzord')
+require Rails.root.join('lib', 'postzord', 'receiver', 'private')
 
 describe Postzord::Receiver::Private do
 

--- a/spec/lib/postzord/receiver/public_spec.rb
+++ b/spec/lib/postzord/receiver/public_spec.rb
@@ -4,8 +4,8 @@
 
 require 'spec_helper'
 
-require File.join(Rails.root, 'lib/postzord')
-require File.join(Rails.root, 'lib/postzord/receiver/public')
+require Rails.root.join('lib', 'postzord')
+require Rails.root.join('lib', 'postzord', 'receiver', 'public')
 
 describe Postzord::Receiver::Public do
   before do

--- a/spec/lib/postzord/receiver_spec.rb
+++ b/spec/lib/postzord/receiver_spec.rb
@@ -4,7 +4,7 @@
 
 require 'spec_helper'
 
-require File.join(Rails.root, 'lib/postzord/receiver')
+require Rails.root.join('lib', 'postzord', 'receiver')
 
 describe Postzord::Receiver do
   before do

--- a/spec/lib/publisher_spec.rb
+++ b/spec/lib/publisher_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 #NOTE;why is it not auto loadeded?
-require File.join(Rails.root, 'lib', 'publisher')
+require Rails.root.join('lib', 'publisher')
 
 describe Publisher do
   before do

--- a/spec/lib/pubsubhubbub_spec.rb
+++ b/spec/lib/pubsubhubbub_spec.rb
@@ -3,7 +3,7 @@
 #   the COPYRIGHT file.
 
 require 'spec_helper'
-require File.join(Rails.root, 'lib', 'pubsubhubbub')
+require Rails.root.join('lib', 'pubsubhubbub')
 
 describe Pubsubhubbub do
   describe '#publish' do

--- a/spec/lib/rake_helper_spec.rb
+++ b/spec/lib/rake_helper_spec.rb
@@ -3,11 +3,11 @@
 #   the COPYRIGHT file.
 
 require 'spec_helper'
-require File.join(Rails.root, 'lib/rake_helpers.rb')
+require Rails.root.join('lib', 'rake_helpers')
 include RakeHelpers
 describe RakeHelpers do
   before do
-    @csv = File.join(Rails.root, 'spec/fixtures/test.csv')
+    @csv = Rails.root.join('spec', 'fixtures', 'test.csv')
   end
   describe '#process_emails' do
     before do

--- a/spec/lib/statistics_spec.rb
+++ b/spec/lib/statistics_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require File.join(Rails.root, 'lib/statistics')
+require Rails.root.join('lib', 'statistics')
 
 describe Statistics do
 

--- a/spec/lib/stream/activity_spec.rb
+++ b/spec/lib/stream/activity_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require File.join(Rails.root, 'spec', 'shared_behaviors', 'stream')
+require Rails.root.join('spec', 'shared_behaviors', 'stream')
 
 describe Stream::Activity do
   before do

--- a/spec/lib/stream/base_spec.rb
+++ b/spec/lib/stream/base_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require File.join(Rails.root, 'spec', 'shared_behaviors', 'stream')
+require Rails.root.join('spec', 'shared_behaviors', 'stream')
 describe Stream::Base do
   before do
     @stream = Stream::Base.new(alice)

--- a/spec/lib/stream/comments_spec.rb
+++ b/spec/lib/stream/comments_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require File.join(Rails.root, 'spec', 'shared_behaviors', 'stream')
+require Rails.root.join('spec', 'shared_behaviors', 'stream')
 
 describe Stream::Comments do
   before do

--- a/spec/lib/stream/followed_tag_spec.rb
+++ b/spec/lib/stream/followed_tag_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require File.join(Rails.root, 'spec', 'shared_behaviors', 'stream')
+require Rails.root.join('spec', 'shared_behaviors', 'stream')
 
 describe Stream::FollowedTag do
   before do

--- a/spec/lib/stream/likes_spec.rb
+++ b/spec/lib/stream/likes_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require File.join(Rails.root, 'spec', 'shared_behaviors', 'stream')
+require Rails.root.join('spec', 'shared_behaviors', 'stream')
 
 describe Stream::Likes do
   before do

--- a/spec/lib/stream/mention_spec.rb
+++ b/spec/lib/stream/mention_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require File.join(Rails.root, 'spec', 'shared_behaviors', 'stream')
+require Rails.root.join('spec', 'shared_behaviors', 'stream')
 
 describe Stream::Mention do
   before do

--- a/spec/lib/stream/multi_spec.rb
+++ b/spec/lib/stream/multi_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require File.join(Rails.root, 'spec', 'shared_behaviors', 'stream')
+require Rails.root.join('spec', 'shared_behaviors', 'stream')
 
 describe Stream::Multi do
   before do

--- a/spec/lib/stream/person_spec.rb
+++ b/spec/lib/stream/person_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require File.join(Rails.root, 'spec', 'shared_behaviors', 'stream')
+require Rails.root.join('spec', 'shared_behaviors', 'stream')
 
 describe Stream::Person do
   before do

--- a/spec/lib/stream/public_spec.rb
+++ b/spec/lib/stream/public_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require File.join(Rails.root, 'spec', 'shared_behaviors', 'stream')
+require Rails.root.join('spec', 'shared_behaviors', 'stream')
 
 describe Stream::Public do
   before do

--- a/spec/lib/stream/tag_spec.rb
+++ b/spec/lib/stream/tag_spec.rb
@@ -3,7 +3,7 @@
 #   the COPYRIGHT file.
 
 require 'spec_helper'
-require File.join(Rails.root, 'spec', 'shared_behaviors', 'stream')
+require Rails.root.join('spec', 'shared_behaviors', 'stream')
 
 describe Stream::Tag do
   context 'with a user' do

--- a/spec/lib/webfinger_profile_spec.rb
+++ b/spec/lib/webfinger_profile_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe WebfingerProfile do
-  let(:webfinger_profile){File.open(File.join(Rails.root, "spec/fixtures/finger_xrd")).read.strip}
-  let(:not_diaspora_webfinger){File.open(File.join(Rails.root, "spec/fixtures/nonseed_finger_xrd")).read.strip}
+  let(:webfinger_profile){File.open(Rails.root.join("spec", "fixtures", "finger_xrd")).read.strip}
+  let(:not_diaspora_webfinger){File.open(Rails.root.join("spec", "fixtures", "nonseed_finger_xrd")).read.strip}
 
   let(:account){"tom@tom.joindiaspora.com"}
   let(:profile){ WebfingerProfile.new(account, webfinger_profile) }

--- a/spec/lib/webfinger_spec.rb
+++ b/spec/lib/webfinger_spec.rb
@@ -5,9 +5,9 @@
 require 'spec_helper'
 
 describe Webfinger do
-  let(:host_meta_xrd) { File.open(File.join(Rails.root, 'spec', 'fixtures', 'host-meta.fixture.html')).read }
-  let(:webfinger_xrd) { File.open(File.join(Rails.root, 'spec', 'fixtures', 'webfinger.fixture.html')).read }
-  let(:hcard_xml) { File.open(File.join(Rails.root, 'spec', 'fixtures', 'hcard.fixture.html')).read }
+  let(:host_meta_xrd) { File.open(Rails.root.join('spec', 'fixtures', 'host-meta.fixture.html')).read }
+  let(:webfinger_xrd) { File.open(Rails.root.join('spec', 'fixtures', 'webfinger.fixture.html')).read }
+  let(:hcard_xml) { File.open(Rails.root.join('spec', 'fixtures', 'hcard.fixture.html')).read }
   let(:account){'foo@bar.com'}
   let(:account_in_fixtures){"alice@localhost:9887"}
   let(:finger){Webfinger.new(account)}

--- a/spec/models/app_config_spec.rb
+++ b/spec/models/app_config_spec.rb
@@ -24,7 +24,7 @@ describe AppConfig do
       context "with old-style application.yml" do
         before do
           @original_source = AppConfig.source
-          AppConfig.source(File.join(Rails.root, "spec", "fixtures", "config", "old_style_app.yml"))
+          AppConfig.source(Rails.root.join("spec", "fixtures", "config", "old_style_app.yml"))
         end
         after do
           AppConfig.source(@original_source)
@@ -42,8 +42,8 @@ describe AppConfig do
       context "when source config file (i.e. config/application.yml) does not exist" do
         before do
           application_yml = AppConfig.source_file_name
-          @app_yml = File.join(Rails.root, "config", "app.yml")
-          @app_config_yml = File.join(Rails.root, "config", "app_config.yml")
+          @app_yml = Rails.root.join("config", "app.yml")
+          @app_config_yml = Rails.root.join("config", "app_config.yml")
           File.should_receive(:exists?).with(application_yml).at_least(:once).and_return(false)
         end
         after do

--- a/spec/models/jobs/publish_to_hub_spec.rb
+++ b/spec/models/jobs/publish_to_hub_spec.rb
@@ -3,7 +3,7 @@
 #   the COPYRIGHT file.
 
 require 'spec_helper'
-require "#{Rails.root}/lib/pubsubhubbub"
+require Rails.root.join('lib', 'pubsubhubbub')
 
 describe Jobs::PublishToHub do
   describe '.perform' do

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -3,7 +3,7 @@
 #   the COPYRIGHT file.
 
 require 'spec_helper'
-require File.join(Rails.root, "spec", "shared_behaviors", "relayable")
+require Rails.root.join("spec", "shared_behaviors", "relayable")
 
 describe Like do
   before do

--- a/spec/models/relayable_retraction_spec.rb
+++ b/spec/models/relayable_retraction_spec.rb
@@ -3,7 +3,7 @@
 #   the COPYRIGHT file.
 
 require 'spec_helper'
-require File.join(Rails.root, "spec", "shared_behaviors", "relayable")
+require Rails.root.join("spec", "shared_behaviors", "relayable")
 
 describe RelayableRetraction do
   before do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,7 +65,7 @@ Spork.prefork do
   end
 
   # Force fixture rebuild
-  FileUtils.rm_f(File.join(Rails.root, 'tmp', 'fixture_builder.yml'))
+  FileUtils.rm_f(Rails.root.join('tmp', 'fixture_builder.yml'))
 
   # Requires supporting files with custom matchers and macros, etc,
   # in ./support/ and its subdirectories.

--- a/spec/support/fixture_generation.rb
+++ b/spec/support/fixture_generation.rb
@@ -1,10 +1,10 @@
 module JasmineFixtureGeneration
   # Saves the markup to a fixture file using the given name
   def save_fixture(markup, name, fixture_path=nil )
-    fixture_path = File.join(Rails.root, 'tmp', 'js_dom_fixtures') unless fixture_path
+    fixture_path = Rails.root.join('tmp', 'js_dom_fixtures') unless fixture_path
     Dir.mkdir(fixture_path) unless File.exists?(fixture_path)
 
-    fixture_file = File.join(fixture_path, "#{name}.fixture.html")
+    fixture_file = fixture_path.join("#{name}.fixture.html")
     File.open(fixture_file, 'w') do |file|
       file.puts(markup)
     end


### PR DESCRIPTION
- `Rails.root` is a `Pathname`, so let's use `Rails.root.join`
- Clean up most of the remaining `File.join`s

I used `#to_s` wherever it looked like we wanted an actual string instead of a `Pathname`.

Let's not merge this just yet, I touched a lot of files, want to see what Travis says. :grin:
