### PR TITLE
Use https for git dependencies in the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'twitter', '2.0.2'
 
 # mail
 
-gem 'markerb', :git => 'git://github.com/plataformatec/markerb.git'
+gem 'markerb', :git => 'https://github.com/plataformatec/markerb.git'
 gem 'messagebus_ruby_api', '1.0.3'
 gem 'airbrake'
 gem 'newrelic_rpm'
@@ -53,7 +53,7 @@ group :heroku do
   gem 'unicorn', '~> 4.3.0', :require => false
 end
 
-gem 'settingslogic', :git => 'git://github.com/binarylogic/settingslogic.git'
+gem 'settingslogic', :git => 'https://github.com/binarylogic/settingslogic.git'
 # database
 
 gem "activerecord-import", "~> 0.2.9"
@@ -82,7 +82,7 @@ gem 'rails-i18n'
 
 gem 'nokogiri', '1.5.2'
 gem 'redcarpet', "2.1.1"
-gem 'roxml', :git => 'git://github.com/Empact/roxml.git', :ref => '7ea9a9ffd2338aaef5b0'
+gem 'roxml', :git => 'https://github.com/Empact/roxml.git', :ref => '7ea9a9ffd2338aaef5b0'
 gem 'ruby-oembed', '~> 0.8.7'
 
 # queue
@@ -93,7 +93,7 @@ gem 'SystemTimer', '1.2.3', :platforms => :ruby_18
 
 # tags
 
-gem 'acts-as-taggable-on', :git => "git://github.com/mbleigh/acts-as-taggable-on.git"
+gem 'acts-as-taggable-on', :git => "https://github.com/mbleigh/acts-as-taggable-on.git"
 
 # URIs and HTTP
 
@@ -138,7 +138,7 @@ gem 'faraday'
 gem 'faraday_middleware'
 
 
-gem 'jasmine', :git => 'git://github.com/pivotal/jasmine-gem.git'
+gem 'jasmine', :git => 'https://github.com/pivotal/jasmine-gem.git'
 ### GROUPS ####
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/Empact/roxml.git
+  remote: https://github.com/Empact/roxml.git
   revision: 7ea9a9ffd2338aaef5b04cb792060ae8c98f346a
   ref: 7ea9a9ffd2338aaef5b0
   specs:
@@ -8,20 +8,20 @@ GIT
       nokogiri (>= 1.3.3)
 
 GIT
-  remote: git://github.com/binarylogic/settingslogic.git
+  remote: https://github.com/binarylogic/settingslogic.git
   revision: 4884d455bf18d92723cb8190cfd2dbf87f3aafd5
   specs:
     settingslogic (2.0.8)
 
 GIT
-  remote: git://github.com/mbleigh/acts-as-taggable-on.git
+  remote: https://github.com/mbleigh/acts-as-taggable-on.git
   revision: d9b66b70e90352605e6f767e7c2b7a8859050655
   specs:
     acts-as-taggable-on (2.3.1)
       rails (~> 3.0)
 
 GIT
-  remote: git://github.com/pivotal/jasmine-gem.git
+  remote: https://github.com/pivotal/jasmine-gem.git
   revision: 1e075fbf5a69812fcc914c453f002ecf5bed38ab
   specs:
     jasmine (1.2.0)
@@ -31,7 +31,7 @@ GIT
       selenium-webdriver (>= 0.1.3)
 
 GIT
-  remote: git://github.com/plataformatec/markerb.git
+  remote: https://github.com/plataformatec/markerb.git
   revision: 93b1e8bea9b8fa89ef930f78ba562f596c022198
   specs:
     markerb (1.0.0)


### PR DESCRIPTION
This is useful if your development and/or production setup is behind a firewall and you can't use `git://`. Followup to #3358

If anyone (like me) really needs to use `git://`, see http://git.io/rewriting for a way to rewrite the URLs **_without**_ rewriting the Gemfile. :grin:
