### PR TITLE
Fix deprecation warning, :confirm option on links is deprecated

### DIFF
--- a/app/views/aspects/edit.html.haml
+++ b/app/views/aspects/edit.html.haml
@@ -20,7 +20,7 @@
   %br
   .bottom_submit_section
     .left
-      = button_to t('delete'), @aspect, :method => "delete", :confirm => t('.confirm_remove_aspect'), :class => 'button delete'
+      = button_to t('delete'), @aspect, :method => "delete", :data => { :confirm => t('.confirm_remove_aspect') }, :class => 'button delete'
       - if @aspect.contacts_visible
         = link_to image_tag('icons/padlock-open.png', :height => 16, :width => 16, :id => "contact_visibility_padlock", :class => 'open', :title => t('.aspect_list_is_visible')),
                   aspect_toggle_contact_visibility_path(@aspect), :method => :put, :remote => true

--- a/app/views/conversations/_show.haml
+++ b/app/views/conversations/_show.haml
@@ -4,7 +4,7 @@
 
 .conversation_participants
   .right
-    = link_to(image_tag('deletelabel.png'), conversation_visibility_path(conversation), :method => 'delete', :confirm => "#{t('.delete')}?", :title => t('.delete'))
+    = link_to(image_tag('deletelabel.png'), conversation_visibility_path(conversation), :method => 'delete', :data => { :confirm => "#{t('.delete')}?" }, :title => t('.delete'))
 
   %h3{ :class => direction_for(conversation.subject) }
     = conversation.subject

--- a/app/views/registrations/edit.html.haml
+++ b/app/views/registrations/edit.html.haml
@@ -24,5 +24,5 @@
   = f.submit t('.update')
 %h3 t('.cancel_my_account')
 %p
-  = t('.unhappy') #{link_to t('.cancel_my_account'), registration_path(resource_name), :confirm => t('are_you_sure'), :method => :delete}.
+  = t('.unhappy') #{link_to t('.cancel_my_account'), registration_path(resource_name), :data => { :confirm => t('are_you_sure') }, :method => :delete}.
 = link_to t('back'), :back

--- a/app/views/shared/_add_remove_services.haml
+++ b/app/views/shared/_add_remove_services.haml
@@ -10,7 +10,7 @@
         %b= service.provider
         = t('services.index.logged_in_as')
         %b= service.nickname
-        = link_to t('services.index.disconnect'), service_path(service), :confirm => t('services.index.really_disconnect', :service => service.provider), :method => :delete
+        = link_to t('services.index.disconnect'), service_path(service), :data => { :confirm => t('services.index.really_disconnect', :service => service.provider) }, :method => :delete
   - else
     = t('services.index.no_services')
 

--- a/app/views/tags/_followed_tags_listings.haml
+++ b/app/views/tags/_followed_tags_listings.haml
@@ -13,7 +13,7 @@
             - for tg in tags
               %li.unfollow{:id => "tag-following-#{tg.name}"}
                 .unfollow_icon.hidden
-                  = link_to image_tag("icons/monotone_close_exit_delete.png", :height => 16, :title => t('aspects.index.unfollow_tag', :tag => tg.name)), tag_tag_followings_path(:name => tg.name, :remote => true), :confirm => t('are_you_sure'), :method => :delete, :remote => true, :id => "unfollow_" + tg.name
+                  = link_to image_tag("icons/monotone_close_exit_delete.png", :height => 16, :title => t('aspects.index.unfollow_tag', :tag => tg.name)), tag_tag_followings_path(:name => tg.name, :remote => true), :data => { :confirm => t('are_you_sure') }, :method => :delete, :remote => true, :id => "unfollow_" + tg.name
                 = link_to "##{tg.name}", tag_path(:name => tg.name), :class => "tag_selector"
           %li
             = form_for TagFollowing.new do |tg|

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -224,4 +224,4 @@
               = f.label :close_account_password, t('.current_password'), :for => :close_account_password
               = f.password_field :current_password, :id => :close_account_password
             %p
-              = f.submit t('.close_account_text'), :confirm => t('are_you_sure_delete_account')
+              = f.submit t('.close_account_text'), :data => { :confirm => t('are_you_sure_delete_account') }


### PR DESCRIPTION
Use `:data => { :confirm => 'text' }` instead.

Letting Travis sanity-check this before merging.
