### PR TITLE
Federation logger stuff

### DIFF
--- a/config/environments/integration1.rb
+++ b/config/environments/integration1.rb
@@ -32,7 +32,7 @@ Diaspora::Application.configure do
         "<#{self.class.name} - tooooo long>"
       end
     end
-    [ActionController::Base, ActionDispatch::RemoteIp::RemoteIpGetter, OmniAuth::Strategy, Warden::Proxy].each do |klazz|
+    [ActionController::Base, OmniAuth::Strategy, Warden::Proxy].each do |klazz|
       klazz.send(:include, SmallInspect)
     end
   end

--- a/config/environments/integration2.rb
+++ b/config/environments/integration2.rb
@@ -32,7 +32,7 @@ Diaspora::Application.configure do
         "<#{self.class.name} - tooooo long>"
       end
     end
-    [ActionController::Base, ActionDispatch::RemoteIp::RemoteIpGetter, OmniAuth::Strategy, Warden::Proxy].each do |klazz|
+    [ActionController::Base, OmniAuth::Strategy, Warden::Proxy].each do |klazz|
       klazz.send(:include, SmallInspect)
     end
   end

--- a/lib/federation_logger.rb
+++ b/lib/federation_logger.rb
@@ -1,15 +1,118 @@
 #custom_logger.rb
-class FederationLogger < Logger
-  def format_message(severity, timestamp, progname, msg)
-    "#{Rails.env}-#{timestamp}: #{msg}\n"
+
+class ActiveSupport::BufferedLogger
+  def formatter=(formatter)
+    @log.formatter = formatter
   end
+end
+
+class Formatter
+  COLORS = {
+    'FG' => {
+      'black'  => '30',
+      'red'    => '31',
+      'green'  => '32',
+      'yellow' => '33',
+      'blue'   => '34',
+      'violet' => '35',
+      'cyan'   => '36',
+      'white'  => '37',
+    },
+    'BG' => {
+      'black'  => '40',
+      'red'    => '41',
+      'green'  => '42',
+      'yellow' => '43',
+      'blue'   => '44',
+      'violet' => '45',
+      'cyan'   => '46',
+      'white'  => '47',
+    }
+  }
+
+  DULL   = '0'
+  BRIGHT = '1'
+  NULL   = '00'
+
+  ESC   = "\e"
+  RESET = "#{ESC}[00;0;00m"
+  # example: \033[40;0;37m white text on black background
+
+  SEVERITY_TO_TAG_MAP   = {'DEBUG'=>'meh',   'INFO'=>'fyi',   'WARN'=>'hmm',    'ERROR'=>'wtf', 'FATAL'=>'omg', 'UNKNOWN'=>'???'}
+  SEVERITY_TO_COLOR_MAP = {'DEBUG'=>'white', 'INFO'=>'green', 'WARN'=>'yellow', 'ERROR'=>'red', 'FATAL'=>'red', 'UNKNOWN'=>'white'}
+
+  def initialize
+    @colors_enabled = true
+  end
+
+  def random
+    @random ||= COLORS['FG'].keys[Random.rand(8)]
+  end
+
+  def colors?
+    @colors_enabled
+  end
+
+  def fg name
+    COLORS['FG'][name]
+  end
+
+  def bg name
+    COLORS['BG'][name]
+  end
+
+  def colorize(message, c_fg='white', c_bg='black', strong=0)
+    if colors?
+      "#{ESC}[#{fg(c_fg)};#{bg(c_bg)};#{strong==0 ? DULL : BRIGHT}m#{message}#{RESET}"
+    else
+      message
+    end
+  end
+
+  def call(severity, time, progname, msg)
+    fmt_prefix = pretty_prefix(severity, time)
+    fmt_msg    = pretty_message(msg)
+
+    "#{fmt_prefix} #{fmt_msg}\n"
+  end
+
+  def pretty_prefix(severity, time)
+    color = SEVERITY_TO_COLOR_MAP[severity]
+    fmt_severity = colorize(sprintf("%-3s","#{SEVERITY_TO_TAG_MAP[severity]}"), color, 'black', 1)
+    fmt_time     = colorize(time.strftime("%s.%L"))
+    fmt_env      = colorize(Rails.env, random, 'black', 1)
+
+    "#{fmt_env} - #{fmt_time} [#{fmt_severity}] (pid:#{$$})"
+  end
+
+  def pretty_message msg
+    w = 130
+    txt_w = (w - Rails.env.size - 3)
+
+    # get the prefix without colors, just for the length
+    @colors_enabled = false
+    prefix = pretty_prefix("DEBUG", Time.now).size + 1
+    @colors_enabled = true # restore value
+
+    if (msg.size <= (w-prefix))
+      msg
+    else
+      output = msg.strip.scan(/.{1,#{txt_w}}/).flatten.map { |line| sprintf("%#{w}s", sprintf("%-#{txt_w}s", line)) }.join("\n")
+      "\n#{output}"
+    end
+  end
+
+end
+
+class FederationLogger < ActiveSupport::BufferedLogger
 end
 
 if Rails.env.match(/integration/)
   puts "using federation logger"
-  logfile = File.open(Rails.root.join("log", "#{Rails.env}_federation.log"), 'a')  #create log file
+  logfile = File.open(Rails.root.join("log", "federation_logger.log"), 'a')  #create log file
   logfile.sync = true  #automatically flushes data to file
   FEDERATION_LOGGER = FederationLogger.new(logfile)  #constant accessible anywhere
+  FEDERATION_LOGGER.formatter = Formatter.new
 else
   FEDERATION_LOGGER = Rails.logger
 end

--- a/lib/webfinger.rb
+++ b/lib/webfinger.rb
@@ -2,12 +2,12 @@ require Rails.root.join('lib', 'hcard')
 require Rails.root.join('lib', 'webfinger_profile')
 
 class Webfinger
-  attr_accessor :host_meta_xrd, :webfinger_profile_xrd, 
-                :webfinger_profile, :hcard, :hcard_xrd, :person, 
+  attr_accessor :host_meta_xrd, :webfinger_profile_xrd,
+                :webfinger_profile, :hcard, :hcard_xrd, :person,
                 :account, :ssl
 
   def initialize(account)
-    self.account = account 
+    self.account = account
     self.ssl = true
   end
 
@@ -56,7 +56,7 @@ class Webfinger
     else
       person = make_person_from_webfinger
     end
-    FEDERATION_LOGGER.info("successfully webfingered#{@account}") if person
+    FEDERATION_LOGGER.info("successfully webfingered #{@account}") if person
     person
   end
 
@@ -95,7 +95,7 @@ class Webfinger
 
   def webfinger_profile_xrd
     @webfinger_profile_xrd ||= get(webfinger_profile_url)
-    FEDERATION_LOGGER.info "#{@account} doesn't exists anymore" if @webfinger_profile_xrd == false
+    FEDERATION_LOGGER.warn "#{@account} doesn't exists anymore" if @webfinger_profile_xrd == false
     @webfinger_profile_xrd
   end
 


### PR DESCRIPTION
This PR contains a commit, which makes the federation logger envs work with rails 3.2.x, since the `ActionDispatch::RemoteIp::RemoteIpGetter` no longer seems to exist and produces an "Uninitialized constant" error.

The next commit updates the log formatter to rails 3.2, because it seems there were some changes in that area, too. It now features colors with 'advanced' formatting and writes the logs of both instances into the same file, because it was bugging me to have to keep two consoles open to monitor the federation events. ;)
(see screenshot)

The last commit modifies a few of the federation log messges, hopefully making them more readable...

I can submit the changes seperately or in any other combination, too, if preferred :P

![screenshot](http://img72.imageshack.us/img72/1851/loggercolors.png)
