### PR TITLE
User model -  mass-assignable attributes fix

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,8 +63,9 @@ class User < ActiveRecord::Base
   before_save :guard_unconfirmed_email,
               :save_person!
 
-
-  attr_accessible :getting_started,
+  attr_accessible :username,
+                  :email,
+                  :getting_started,
                   :password,
                   :password_confirmation,
                   :language,
@@ -73,7 +74,8 @@ class User < ActiveRecord::Base
                   :invitation_identifier,
                   :show_community_spotlight_in_stream,
                   :auto_follow_back,
-                  :auto_follow_back_aspect_id
+                  :auto_follow_back_aspect_id,
+                  :remember_me
 
 
   def self.all_sharing_with_person(person)


### PR DESCRIPTION
`:username`, `:email` and `:remember_me` should be mass-assignable.

I can see why the specs are passing, we're using Factories there, but I have no idea why the cukes are green when we have steps that exercise the new user registration form.

fixes #3377

Rails console output (before applying this patch):

```
1.9.3p125 :001 > u = User.new(username: 'example',
1.9.3p125 :002 >     email: 'user@example.com',
1.9.3p125 :003 >     password: 'password',
1.9.3p125 :004 >     password_confirmation: 'password')
WARNING: Can't mass-assign protected attributes: username, email
 => #<User id: nil, username: nil, # ...snip...
1.9.3p125 :005 > u.username
 => nil 
1.9.3p125 :006 > u.email
 => "" 
1.9.3p125 :007 > u.valid?
 => false 
```
