### PR TITLE
#2322 -- rotate uploaded images based on the meta-data

### DIFF
--- a/app/uploaders/unprocessed_image.rb
+++ b/app/uploaders/unprocessed_image.rb
@@ -17,6 +17,15 @@ class UnprocessedImage < CarrierWave::Uploader::Base
     model.random_string + File.extname(@filename) if @filename
   end
 
+  process :orient_image
+
+  def orient_image
+    manipulate! do |img|
+      img.auto_orient
+      img
+    end
+  end
+
   version :thumb_small
   version :thumb_medium
   version :thumb_large


### PR DESCRIPTION
This pull implements the code written by @brianshumate to rotate images based on the meta-data, instead of storing them on Diaspora sideways. It addresses Issue #2322.
