### PR TITLE
Fixed Issue #3382 - The comments under postings are missing when using t...

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -35,7 +35,7 @@ class TagsController < ApplicationController
     @stream = Stream::Tag.new(current_user, params[:name], :max_time => max_time, :page => params[:page])
 
     respond_with do |format|
-      format.json{ render :json => PostPresenter.collection_json(@stream.stream_posts, current_user) }
+      format.json { render :json => @stream.stream_posts.map { |p| LastThreeCommentsDecorator.new(PostPresenter.new(p, current_user)) }}
     end
   end
 

--- a/features/tags_and_comments.feature
+++ b/features/tags_and_comments.feature
@@ -1,0 +1,23 @@
+@javascript
+Feature: Issue #3382 The comments under postings are missing when using the #tags -view
+
+  Background:
+    Given a user named "Bob Jones" with email "bob@bob.bob"
+    And I sign in as "bob@bob.bob"
+    When I post "This is a post with a #tag"
+    And I wait for 1 second
+    And I am on the homepage
+
+  Scenario:
+    When I search for "#tag"
+    Then I should be on the tag page for "tag"
+    And I should see "This is a post with a #tag"
+
+  Scenario:
+    When I comment "this is a comment on my post" on "This is a post with a #tag"
+    And I wait for the ajax to finish
+    And I search for "#tag"
+    Then I should be on the tag page for "tag"
+    And I should see "this is a comment on my post"
+
+


### PR DESCRIPTION
Wrote cuke tests to reproduce the bug, then modified tags_controller.rb to fetch last 3 comments for each post with the LastThreeCommentsDecorator.
