### PR TITLE
fix client-side validations in registration form

### DIFF
--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -19,7 +19,7 @@
               <%= t('.sign_up') %>
             </h4>
 
-            <%= form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => {:class => "form-horizontal block-form", :autocomplete => "off"}, :validate => true) do |f| %>
+            <%= form_for(resource, :validate => true, :url => registration_path(resource_name), :html => {:class => "form-horizontal block-form", :autocomplete => "off"}) do |f| %>
                 <fieldset>
                   <div class="control-group">
                     <label class="control-label" for="user_email">

--- a/features/signs_up.feature
+++ b/features/signs_up.feature
@@ -36,3 +36,26 @@ Feature: new user registration
     And I wait for 3 seconds
     And I go to the home page
     Then I should not see "Welcome to Diaspora"
+
+  Scenario: user fills in bogus data - client side validation
+    When I log out manually
+    And I go to the new user registration page
+    And I fill in "user_username" with "§$%&(/&%$&/=)(/"
+    And I press "Continue"
+
+    Then the "user_username" field should have a validation error
+    And the "user_email" field should have a validation error
+    And the "user_password" field should have a validation error
+
+    When I fill in "user_username" with "valid_user"
+    And I fill in "user_email" with "this is not a valid email $%&/()("
+    And I press "Continue"
+
+    Then the "user_email" field should have a validation error
+    And the "user_password" field should have a validation error
+
+    When I fill in "user_email" with "valid@email.com"
+    And I fill in "user_password" with "1"
+    And I press "Continue"
+
+    Then the "user_password" field should have a validation error

--- a/features/step_definitions/custom_web_steps.rb
+++ b/features/step_definitions/custom_web_steps.rb
@@ -8,6 +8,10 @@ And /^I submit the form$/ do
   click_button :submit
 end
 
+Then /^the "([^"]*)" field should have a validation error$/ do |field|
+  find_field(field).has_xpath?(".//ancestor::div[contains(@class, 'control-group')]/div[contains(@class, 'field_with_errors')]")
+end
+
 And /^I expand the publisher$/ do
  click_publisher
 end

--- a/features/step_definitions/session_steps.rb
+++ b/features/step_definitions/session_steps.rb
@@ -39,3 +39,7 @@ end
 When /^I (?:log|sign) out$/ do
   logout
 end
+
+When /^I (?:log|sign) out manually$/ do
+  manual_logout
+end

--- a/features/support/user_cuke_helpers.rb
+++ b/features/support/user_cuke_helpers.rb
@@ -42,6 +42,7 @@ module UserCukeHelpers
     login_as @me.username, @me.password
   end
 
+  # checks the page content to see, if the login was successful
   def confirm_login
     wait_until { page.has_content?("#{@me.first_name} #{@me.last_name}") }
   end
@@ -50,6 +51,11 @@ module UserCukeHelpers
   def logout
     $browser.delete_cookie('_session', 'path=/') if $browser
     $browser.delete_all_visible_cookies if $browser
+  end
+
+  def manual_logout
+    find("#user_menu li:first-child a").click
+    find("#user_menu li:last-child a").click
   end
 end
 


### PR DESCRIPTION
We seem to have been suffering from the problem described (and solved) here: 
https://github.com/bcardarella/client_side_validations/issues/342#issuecomment-6384133

Devise was giving the form a different id as was expected from client_side_validations, thus the form was not validated before submitting.

Now the form can't be submitted unless all the inputs are filled out correctly, which should avoid falling back to server-side validation and returning to the form with the wrong layout.
