### PR TITLE
tell jQuery not to expect html when deleting photos in the publisher

### DIFF
--- a/app/views/photos/_new_photo.haml
+++ b/app/views/photos/_new_photo.haml
@@ -64,6 +64,7 @@
           var photo = $(this).closest('.publisher_photo');
           photo.addClass("dim");
           $.ajax({url: "photos/" + photo.children('img').attr('data-id'),
+                  dataType: 'json',
                   type: 'DELETE',
                   success: function() {
                             photo.fadeOut(400, function(){


### PR DESCRIPTION
This _might_ fix the problem on travis with the `features/posts_from_main_page.feature`.

The requests to delete a photo from the publisher per default set the http-accept header to html, which returns a redirect when finished. 
With the accept-header set to json, simply a success status code is returned and the weird cuke failure should not occur anymore.

manually it worked, running cukes locally, now - let's see what travis thinks...
