### PR TITLE
use default format in case a tablet device is detected

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,7 +227,7 @@ GEM
       i18n-inflector (~> 2.6)
       railties (~> 3.0)
     jasmine-core (1.2.0)
-    journey (1.0.3)
+    journey (1.0.4)
     jquery-rails (2.0.2)
       railties (>= 3.2.0, < 5.0)
       thor (~> 0.14)
@@ -307,7 +307,7 @@ GEM
     rack-cors (0.2.6)
       rack
     rack-google-analytics (0.10.0)
-    rack-mobile-detect (0.3.0)
+    rack-mobile-detect (0.4.0)
       rack
     rack-piwik (0.1.2)
     rack-pjax (0.5.9)
@@ -428,7 +428,7 @@ GEM
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)
       rack (>= 1.0.0)
-    thor (0.15.2)
+    thor (0.15.3)
     tilt (1.3.3)
     timecop (0.3.5)
     treetop (1.4.10)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,7 @@ class ApplicationController < ActionController::Base
   before_filter :set_locale
   before_filter :set_git_header if (AppConfig[:git_update] && AppConfig[:git_revision])
   before_filter :set_grammatical_gender
+  before_filter :tablet_device_falback
 
   inflection_method :grammatical_gender => :gender
 
@@ -103,6 +104,11 @@ class ApplicationController < ActionController::Base
 
   def grammatical_gender
     @grammatical_gender || nil
+  end
+
+  def tablet_device_falback
+    # we currently don't have any special tablet views...
+    request.format = :html if is_tablet_device?
   end
 
   def after_sign_in_path_for(resource)


### PR DESCRIPTION
mobile-fu wants to render the `:tablet` format, which we currently don't have, when a tablet device (like Blackberry Playbook) is detected. There doesn't seem to be an internal fallback mechanism, so I'm simply changing all `:tablet` requests to `:html` ...
fixes #3320

includes minor gem updates.

let's see what travis does.
