### PR TITLE
Add Code Climate badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Diaspora is a privacy-aware, personally-controlled, do-it-all open source social
 
 [![Build Status](https://secure.travis-ci.org/diaspora/diaspora.png)](http://travis-ci.org/diaspora/diaspora)
 [![Dependency Status](https://gemnasium.com/diaspora/diaspora.png?travis)](https://gemnasium.com/diaspora/diaspora)
+[![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/diaspora/diaspora)
 
 ************************
 Diaspora is currently going through a huge refactoring push, the code is changing fast!


### PR DESCRIPTION
Hello,

Code Climate is a service that hosts code quality metrics for Ruby apps. As of today, it's completely free for OSS. Someone has already added Diaspora, so you can view it's metrics at:

```
https://codeclimate.com/github/diaspora/diaspora
```

This pull request adds a badge (like Travis CI) linking to Code Climate so that contributors can view this.

Let me know if you have any questions!

Thanks,

-Bryan
