### PR TITLE
Fix error admins/weekly_user_stats

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -42,7 +42,7 @@ class AdminsController < ApplicationController
       # @segment = "#{@created_users_by_week[(params[:week])]}" 
       @counter = "#{@created_users_by_week[(params[:week])].count}"
     else
-      @segment = "date not found"
+      @counter = ""
     end
   end
 


### PR DESCRIPTION
Before this https://github.com/diaspora/diaspora/commit/c9e54700ff447645fad97ce945a0d33b367c06a7 ->  https://yourpod.com/admins/weekly_user_stats 

`amount of new users this week:`

After -> https://yourpod.com/admins/weekly_user_stats 

`otheramount of new users this week: %{count}zeroamount of new users this week: noneoneamount of new users this week: %{count}`

Now with this pull request -> https://yourpod.com/admins/weekly_user_stat

`amount of new users this week:`
