### PR TITLE
Change root_url to root_path

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -71,7 +71,7 @@
           %li= link_to '@joindiaspora', "http://twitter.com/joindiaspora"
           %li= link_to 'github', "https://github.com/diaspora/diaspora"
           %li= link_to t('layouts.header.blog'), "http://blog.joindiaspora.com"
-          %li= link_to t('layouts.header.code'), "#{root_url.chomp('/')}/source.tar.gz" unless request.url.match(/joindiaspora.com/)
+          %li= link_to t('layouts.header.code'), "#{root_path.chomp('/')}/source.tar.gz" unless request.url.match(/joindiaspora.com/)
           %li= link_to t('.whats_new'), 'https://github.com/diaspora/diaspora/wiki/Changelog'
           %li= link_to(t('layouts.application.toggle'), toggle_mobile_path)  if is_mobile_device?
         = image_tag 'branding/powered_by_diaspora.png', :height => "11px", :width => "145px"


### PR DESCRIPTION
I think this modification fixed problem with some pods with:

http://yourpod.com:3000/source.tar.gz (with root_url)

https://yourpod.com/source.tar.gz (with root_path)
