### PR TITLE
Fix for #3204 Mobile bookmark not working

### DIFF
--- a/app/views/status_messages/bookmarklet.mobile.haml
+++ b/app/views/status_messages/bookmarklet.mobile.haml
@@ -2,6 +2,7 @@
 -#   licensed under the Affero General Public License version 3 or later.  See
 -#   the COPYRIGHT file.
 
+= javascript_include_tag :jquery
 = javascript_include_tag :mobile
 
 :javascript


### PR DESCRIPTION
jQuery was not being loaded by mobile bookmarklet view. Added and bookmarklet now works.
