### PR TITLE
let the 'toggle mobile' link show in the footer

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -1348,6 +1348,11 @@ footer
       :margin
         :right 1em
 
+      &.separator
+        :margin-left -.35em
+        :margin-right .65em
+        @include opacity(.6)
+
       &:last-child
         :margin 0
     a

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -65,16 +65,7 @@
       %a{:id=>"back-to-top", :title=>"#{t('.back_to_top')}", :href=>"#"}
         &#8679;
 
-    %footer
-      .container
-        %ul#footer_nav
-          %li= link_to '@joindiaspora', "http://twitter.com/joindiaspora"
-          %li= link_to 'github', "https://github.com/diaspora/diaspora"
-          %li= link_to t('layouts.header.blog'), "http://blog.joindiaspora.com"
-          %li= link_to t('layouts.header.code'), "#{root_path.chomp('/')}/source.tar.gz" unless request.url.match(/joindiaspora.com/)
-          %li= link_to t('.whats_new'), 'https://github.com/diaspora/diaspora/wiki/Changelog'
-          %li= link_to(t('layouts.application.toggle'), toggle_mobile_path)  if is_mobile_device?
-        = image_tag 'branding/powered_by_diaspora.png', :height => "11px", :width => "145px"
+    = render :partial =>'shared/footer'
 
     = include_chartbeat
     = include_mixpanel_guid

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -1,0 +1,11 @@
+%footer
+  .container
+    %ul#footer_nav
+      %li= link_to '@joindiaspora', "http://twitter.com/joindiaspora"
+      %li= link_to 'github', "https://github.com/diaspora/diaspora"
+      %li= link_to t('layouts.header.blog'), "http://blog.joindiaspora.com"
+      %li= link_to t('layouts.application.whats_new'), 'https://github.com/diaspora/diaspora/wiki/Changelog'
+      %li.separator= "|"
+      %li= link_to(t('layouts.header.code'), "#{root_path.chomp('/')}/source.tar.gz", {:title => t('layouts.application.source_package')}) unless request.url.match(/joindiaspora.com/)
+      %li= link_to(t('layouts.application.toggle'), toggle_mobile_path)
+    = image_tag 'branding/powered_by_diaspora.png', :height => "11px", :width => "145px"

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -96,7 +96,7 @@ en:
       you_currently: "you currently have %{user_invitation} invites left %{link}"
       add_invites: "add invites"
       email_to: "Email to Invite"
-      users: 
+      users:
         zero: "%{count} users found"
         one: "%{count} user found"
         other: "%{count} users found"
@@ -406,6 +406,7 @@ en:
       public_feed: "Public Diaspora Feed for %{name}"
       your_aspects: "your aspects"
       back_to_top: "Back to top"
+      source_package: "download the source code package"
 
   likes:
     likes:


### PR DESCRIPTION
fixes #2700

Edit: I also grouped the links into 'diaspora-related' and 'pod-related'

![screenshot](http://img27.imageshack.us/img27/5547/diasporatogglemobilecom.png)
