### PR TITLE
Adding step definitions to facilitate merging of multiple consecutive "I...

### DIFF
--- a/features/signs_up.feature
+++ b/features/signs_up.feature
@@ -8,9 +8,7 @@ Feature: new user registration
     And I fill in "user_password" with "secret"
     And I press "Continue"
     Then I should be on the getting started page
-    And I should see "Well, hello there!"
-    And I should see "Who are you?"
-    And I should see "What are you into?"
+    And I should see "Well, hello there!" and "Who are you?" and "What are you into?"
 
   Scenario: new user goes through the setup wizard
     When I fill in the following:

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -105,12 +105,14 @@ Then /^(?:|I )should see JSON:$/ do |expected_json|
   expected.should == actual
 end
 
-Then /^(?:|I )should see "([^"]*)"(?: within "([^"]*)")?$/ do |text, selector|
-  with_scope(selector) do
-    if page.respond_to? :should
-      page.should have_content(text)
-    else
-      assert page.has_content?(text)
+Then /^(?:|I )should see (\".+?\"[\s]*)(?:[\s]+within[\s]* "([^"]*)")?$/ do |vars,selector|
+  vars.scan(/"([^"]+?)"/).flatten.each do |text|
+    with_scope(selector) do
+      if page.respond_to? :should
+        page.should have_content(text)
+      else
+        assert page.has_content?(text)
+      end
     end
   end
 end
@@ -126,12 +128,14 @@ Then /^(?:|I )should see \/([^\/]*)\/(?: within "([^"]*)")?$/ do |regexp, select
   end
 end
 
-Then /^(?:|I )should not see "([^"]*)"(?: within "([^"]*)")?$/ do |text, selector|
-  with_scope(selector) do
-    if page.respond_to? :should
-      page.should have_no_content(text)
-    else
-      assert page.has_no_content?(text)
+Then /^(?:|I )should not see (\".+?\"[\s]*)(?:[\s]+within[\s]* "([^"]*)")?$/ do |vars,selector|
+  vars.scan(/"([^"]+?)"/).flatten.each do |text|
+    with_scope(selector) do
+      if page.respond_to? :should
+        page.should have_no_content(text)
+      else
+        assert page.has_no_content?(text)
+      end
     end
   end
 end


### PR DESCRIPTION
Currently there are places where "I ( should | should not ) see  " kind of clauses are used multiple times consecutively. 

The new step definition should let the feature writer merge these into one. for example

I should see "a"
I should see "b"
I should see "c"

can be written as

I should see "a" and "b" and "c"

one selector is supported

I should see "a" within "selector"
I should see "b" within "selector"
I should see "c" within "selector"

can be written as 
I should see "a" and "b" and "c"  within "selector"

statements with different selectors cannot be merged this way.
