### PR TITLE
fix autolinking of links 

### DIFF
--- a/app/assets/javascripts/app/helpers/text_formatter.js
+++ b/app/assets/javascripts/app/helpers/text_formatter.js
@@ -26,9 +26,11 @@
 
       // process links
       // regex copied from: https://code.google.com/p/pagedown/source/browse/Markdown.Converter.js#1198 (and slightly expanded)
-      var linkRegex = /(\[.*\]:\s)?(<|\()((https?|ftp):\/\/[^\/'">\s][^'">\s]+?)(>|\))/gi;
+      var linkRegex = /(\[.*\]:\s)?(<|\()((?:(https?|ftp):\/\/[^\/'">\s]|www)[^'">\s]+?)(>|\))/gi;
       text = text.replace(linkRegex, function() {
         var unicodeUrl = arguments[3];
+        unicodeUrl = ( unicodeUrl.match(/^www/) ) ? ('http://' + unicodeUrl) : unicodeUrl;
+
         var addr = parse_url(unicodeUrl);
         if( !addr.host ) addr.host = ""; // must not be 'undefined'
 

--- a/spec/javascripts/app/helpers/text_formatter_spec.js
+++ b/spec/javascripts/app/helpers/text_formatter_spec.js
@@ -26,11 +26,16 @@ describe("app.helpers.textFormatter", function(){
     // This test will fail if our join is just (" ") -- an edge case that should be addressed.
 
     it("autolinks", function(){
-      var links = ["http://google.com",
+      var links = [
+        "http://google.com",
         "https://joindiaspora.com",
         "http://www.yahooligans.com",
         "http://obama.com",
-        "http://japan.co.jp"]
+        "http://japan.co.jp",
+        "www.mygreat-example-website.de",
+        "www.jenseitsderfenster.de",  // from issue #3468
+        "www.google.com"
+      ];
 
       // The join that would make this particular test fail:
       //
@@ -40,7 +45,7 @@ describe("app.helpers.textFormatter", function(){
       var wrapper = $("<div>").html(formattedText);
 
       _.each(links, function(link) {
-        var linkElement = wrapper.find("a[href='" + link + "']");
+        var linkElement = wrapper.find("a[href*='" + link + "']");
         expect(linkElement.text()).toContain(link);
         expect(linkElement.attr("target")).toContain("_blank");
       })


### PR DESCRIPTION
links that start with just www... and not a complete http://... were not autolinked, but actually falsely removed from the output.

... quick travis check

(fixes #3468)
