### PR TITLE
Give relayable retractions a chance to propagate locally before deleting the target

### DIFF
--- a/app/models/relayable_retraction.rb
+++ b/app/models/relayable_retraction.rb
@@ -33,6 +33,15 @@ class RelayableRetraction < SignedRetraction
     true
   end
 
+  def perform receiving_user
+    Rails.logger.debug "Performing relayable retraction for #{target_guid}"
+    if not self.parent_author_signature.nil? or self.parent.author.remote?
+      # Don't destroy a relayable unless the top-level owner has received it, otherwise it may not get relayed
+      self.target.destroy
+      Rails.logger.info("event=relayable_retraction status =complete target_type=#{self.target_type} guid =#{self.target_guid}")
+    end
+  end
+
   def receive(recipient, sender)
     if self.target.nil?
       Rails.logger.info("event=retraction status=abort reason='no post found' sender=#{sender.diaspora_handle} target_guid=#{target_guid}")


### PR DESCRIPTION
Addresses issue #3420

Added a `perform` method to the `relayable_retraction` model to override the method in `signed_retraction`. The method in `relayable_retraction` checks first if either `parent_author_signature` exists (meaning that the top-level post has received, signed, and relayed the retraction) or if the top-level post author is remote (meaning that no harm will be done if the target is destroyed immediately) before destroying the target.
