### PR TITLE
Changing cucumber steps to use tabular form where possible

### DIFF
--- a/features/blocks_user.feature
+++ b/features/blocks_user.feature
@@ -1,8 +1,10 @@
 @javascript
 Feature: Blocking a user from the stream
   Background:
-    Given a user named "Bob Jones" with email "bob@bob.bob"
-    And a user named "Alice Smith" with email "alice@alice.alice"
+    Given following users exist:
+      | username    | email             |
+      | Bob Jones   | bob@bob.bob       |
+      | Alice Smith | alice@alice.alice |
     And a user with email "bob@bob.bob" is connected with "alice@alice.alice"
     And Alice has a post mentioning Bob
     And I sign in as "bob@bob.bob"

--- a/features/closes_account.feature
+++ b/features/closes_account.feature
@@ -18,8 +18,10 @@ Feature: Close Account
     And I should see a flash message containing "Invalid email or password"
 
   Scenario: post display should not throw error when mention is removed for the user whose account is closed
-    Given a user named "Bob Jones" with email "bob@bob.bob"
-    And a user named "Alice Smith" with email "alice@alice.alice"
+    Given following users exist:
+      | username    | email             |
+      | Bob Jones   | bob@bob.bob       |
+      | Alice Smith | alice@alice.alice |
     And a user with email "bob@bob.bob" is connected with "alice@alice.alice"
     And Alice has a post mentioning Bob
 

--- a/features/comments.feature
+++ b/features/comments.feature
@@ -5,8 +5,10 @@ Feature: commenting
   I want to comment on her post
 
   Background:
-    Given a user named "Bob Jones" with email "bob@bob.bob"
-    And a user named "Alice Smith" with email "alice@alice.alice"
+    Given following users exist:
+      | username    | email             |
+      | Bob Jones   | bob@bob.bob       |
+      | Alice Smith | alice@alice.alice |
     And a user with email "bob@bob.bob" is connected with "alice@alice.alice"
     When "alice@alice.alice" has posted a status message with a photo
 

--- a/features/connects_users.feature
+++ b/features/connects_users.feature
@@ -2,9 +2,11 @@
 Feature: following and being followed
 
   Background:
-    Given a user with email "bob@bob.bob"
-    And a user with email "alice@alice.alice"
-
+    Given following users exist:
+      | email             |
+      | bob@bob.bob       |
+      | alice@alice.alice |
+    
     When I sign in as "bob@bob.bob"
     And I am on "alice@alice.alice"'s page
     And I add the person to my "Besties" aspect

--- a/features/follows_tags.feature
+++ b/features/follows_tags.feature
@@ -5,8 +5,10 @@ Feature: posting
   I want to see what humanity is saying about particular tags
 
   Background:
-    Given a user with username "bob"
-    And a user with username "alice"
+    Given following users exist:
+      | username   | 
+      | bob        |
+      | alice      |
 
     When I sign in as "bob@bob.bob"
     And I post a status with the text "I am da #boss"

--- a/features/mentions.feature
+++ b/features/mentions.feature
@@ -4,9 +4,11 @@ Feature: Mentions
   I want to mention another user and have a link to them
   To show people that this person exsists.
 
-  Scenario: A user mentions another user and it displays correctly 
-    Given a user named "Bob Jones" with email "bob@bob.bob"
-    And a user named "Alice Smith" with email "alice@alice.alice"
+  Scenario: A user mentions another user and it displays correctly
+    Given following users exist:
+      | username     | email             |
+      | Bob Jones    | bob@bob.bob       |
+      | Alice Smith  | alice@alice.alice |
     And a user with email "bob@bob.bob" is connected with "alice@alice.alice"
     And Alice has a post mentioning Bob
     When I sign in as "alice@alice.alice"

--- a/features/mentions_from_profile_page.feature
+++ b/features/mentions_from_profile_page.feature
@@ -6,13 +6,16 @@ Feature: mentioning a contact from their profile page
 
     Background:
       Given I am on the home page
-      And a user with username "bob"
-      And a user with username "alice"
+      And following users exist:
+        | username   |
+        | bob        |
+        | alice      |
 
       When I sign in as "bob@bob.bob"
       And a user with username "bob" is connected with "alice"
-      And I have an aspect called "PostingTo"
-      And I have an aspect called "NotPostingThingsHere"
+      And I have following aspects:
+        | PostingTo            |
+        | NotPostingThingsHere |
       And I have user with username "alice" in an aspect called "PostingTo"
       And I have user with username "alice" in an aspect called "NotPostingThingsHere"
 

--- a/features/not_safe_for_work.feature
+++ b/features/not_safe_for_work.feature
@@ -2,7 +2,9 @@
 Feature: Not safe for work
 
 Scenario: Setting not safe for work
-  Given a user named "pr0n king" with email "tommy@pr0n.xxx"
+  Given following users exist:
+    | username    | email             | 
+    | pr0n king   | tommy@pr0n.xxx    |
   And I sign in as "tommy@pr0n.xxx"
   When I go to the edit profile page
   And I should see the "you are safe for work" message

--- a/features/notifications.feature
+++ b/features/notifications.feature
@@ -5,9 +5,11 @@ Feature: Notifications
   I want to get notifications
 
   Background:
-    Given a user with email "bob@bob.bob"
-    And a user with email "alice@alice.alice"
-
+    Given That following users:
+      | email             |
+      | bob@bob.bob       |
+      | alice@alice.alice |
+    
   Scenario: someone shares with me
     When I sign in as "bob@bob.bob"
     And I am on "alice@alice.alice"'s page

--- a/features/oembed.feature
+++ b/features/oembed.feature
@@ -5,7 +5,9 @@ Feature: oembed
   I want the links in my posts be replaced by their oEmbed representation
 
   Background:
-    Given a user named "Alice Smith" with email "alice@alice.alice"
+    Given following user exists:
+      | username    | email             | 
+      | Alice Smith | alice@alice.alice |
     And I have several oEmbed data in cache
     When I sign in as "alice@alice.alice"
     And I am on the home page

--- a/features/posts_from_main_page.feature
+++ b/features/posts_from_main_page.feature
@@ -5,12 +5,15 @@ Feature: posting from the main page
     I want to tell the world I am eating a yogurt
 
     Background:
-      Given a user with username "bob"
-      And a user with username "alice"
+      Given following users exist:
+        | username   |
+        | bob        |
+        | alice      |
       And I sign in as "bob@bob.bob"
       And a user with username "bob" is connected with "alice"
-      And I have an aspect called "PostingTo"
-      And I have an aspect called "NotPostingThingsHere"
+      Given I have following aspects:
+        | PostingTo            |
+        | NotPostingThingsHere |
       And I have user with username "alice" in an aspect called "PostingTo"
       And I have user with username "alice" in an aspect called "NotPostingThingsHere"
       And I am on the home page

--- a/features/reshare.feature
+++ b/features/reshare.feature
@@ -5,8 +5,10 @@ Feature: public repost
   I want to reshare my friend's post
 
   Background:
-    Given a user named "Bob Jones" with email "bob@bob.bob"
-    And a user named "Alice Smith" with email "alice@alice.alice"
+    Given following users exist:
+      | username    | email             |
+      | Bob Jones   | bob@bob.bob       |
+      | Alice Smith | alice@alice.alice |
     And a user with email "bob@bob.bob" is connected with "alice@alice.alice"
 
   # should be covered in rspec, so testing that the post is added to

--- a/features/show_more.feature
+++ b/features/show_more.feature
@@ -5,7 +5,9 @@ Feature: collapsing and expanding long posts
     I want long posts to be collapsed and expand on click
 
     Background:
-      Given a user with username "bob"
+      Given that following user exists:
+        | username |
+        | bob      |
       And I sign in as "bob@bob.bob"
       And I am on the home page
 

--- a/features/signs_up.feature
+++ b/features/signs_up.feature
@@ -43,20 +43,23 @@ Feature: new user registration
         | user_username        | $%&(/&%$&/=)(/    |
     And I press "Continue"
 
-    Then the "user_username" field should have a validation error
-    And the "user_email" field should have a validation error
-    And the "user_password" field should have a validation error
+	  Then following fields should have validation errors:
+		    | user_username |
+		    | user_email    |
+		    | user_password |
 
     When I fill in the following:
         | user_username     | valid_user                        |
         | user_email        | this is not a valid email $%&/()( |
     And I press "Continue"
 
-    Then the "user_email" field should have a validation error
-    And the "user_password" field should have a validation error
+	  Then following fields should have validation errors:
+		    | user_email |
+		    | user_password |
 
     When I fill in the following:
         | user_email        | valid@email.com        |
         | user_password     | 1                      |
     And I press "Continue"
-    Then the "user_password" field should have a validation error
+	  Then following field should have validation error:
+		    | user_password |

--- a/features/step_definitions/custom_web_steps.rb
+++ b/features/step_definitions/custom_web_steps.rb
@@ -12,6 +12,13 @@ Then /^the "([^"]*)" field should have a validation error$/ do |field|
   find_field(field).has_xpath?(".//ancestor::div[contains(@class, 'control-group')]/div[contains(@class, 'field_with_errors')]")
 end
 
+
+Then /^following field[s]? should have validation error[s]?:$/ do |fields|
+  fields.raw.each do |field|
+    step %{the "#{field[0]}" field should have a validation error}
+  end
+end
+
 And /^I expand the publisher$/ do
  click_publisher
 end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -25,6 +25,20 @@ Given /^a nsfw user with email "([^\"]*)"$/ do |email|
   user.profile.update_attributes(:nsfw => true)
 end
 
+
+Given /^(?:|[tT]hat )?following user[s]?(?: exist[s]?)?:$/ do |table|
+  table.hashes.each do |hash|
+    if hash.has_key? "username" and hash.has_key? "email"
+      step %{a user named "#{hash['username']}" with email "#{hash['email']}"}
+    elsif hash.has_key? "username"
+      step %{a user with username "#{hash['username']}"} 
+    elsif hash.has_key? "email"
+      step %{a user with email "#{hash['email']}"}
+    end
+  end
+end
+
+
 Given /^I have been invited by an admin$/ do
   admin = Factory(:user)
   admin.invitation_code
@@ -50,6 +64,12 @@ end
 Given /^I have an aspect called "([^\"]*)"$/ do |aspect_name|
   @me.aspects.create!(:name => aspect_name)
   @me.reload
+end
+
+Given /^I have following aspect[s]?:$/ do |fields|
+  fields.raw.each do |field|
+    step %{I have an aspect called "#{field[0]}"}
+  end
 end
 
 When /^I have user with username "([^"]*)" in an aspect called "([^"]*)"$/ do |username, aspect|

--- a/features/stops_following_users.feature
+++ b/features/stops_following_users.feature
@@ -5,8 +5,10 @@ Feature: Unfollowing
   I want to be able to stop following people
 
   Background:
-    Given a user with email "bob@bob.bob"
-    And a user with email "alice@alice.alice"
+    Given following users:
+		| email             |
+		| bob@bob.bob       |
+		| alice@alice.alice |
     When I sign in as "bob@bob.bob"
     And I am on "alice@alice.alice"'s page
     And I add the person to my "Besties" aspect


### PR DESCRIPTION
Using tabular form for cucumber definitions where possible. 3 cases are covered in this pull request.
1. Given a user with  ......
2.  I should have aspect named ......
3. field x should have a validation error  ......
