### PR TITLE
Resque PID file, daemon mode

### DIFF
--- a/script/server
+++ b/script/server
@@ -105,7 +105,7 @@ fi
 # Start Diaspora
 
 if [ "$(bundle exec ruby ./script/get_config.rb 'single_process_mode?')" != "true" ]; then
-    QUEUE=* bundle exec rake resque:work&
+    PIDFILE=tmp/pids/resque.pid BACKGROUND=yes QUEUE=* bundle exec rake resque:work
 fi
 
 if [ "$(./script/get_config.rb enable_thin script_server)" = "true" ]; then


### PR DESCRIPTION
to have a better control of the resque process, let's let it create a pid file.

also use the daemon mode from resque and not the dirty & background task mode which still is able to write to stdout and sterr.
