### PR TITLE
fix travis build (like controller spec)

### DIFF
--- a/spec/controllers/likes_controller_spec.rb
+++ b/spec/controllers/likes_controller_spec.rb
@@ -111,9 +111,10 @@ describe LikesController do
         end
 
         it 'lets a user destroy their like' do
-          expect {
-            delete :destroy, :format => :json, id_field => @like.target_id, :id => @like.id
-          }.should change(Like, :count).by(-1)
+          current_user = controller.send(:current_user)
+          current_user.should_receive(:retract).with(@like)
+
+          delete :destroy, :format => :json, id_field => @like.target_id, :id => @like.id
           response.status.should == 204
         end
 


### PR DESCRIPTION
don't test for actually deleted likes, since they are not deleted immediately anymore

instead check whether the `retract` method was called, thus ensuring the federation process was started. 
the actual removal of the like should be tested in the federation context...

... travis checking
