### PR TITLE
Remove Git-submodule to import to Launchpad.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "pkg"]
-	path = pkg
-	url = http://github.com/diaspora/diaspora-packages.git


### PR DESCRIPTION
Trying to set up a PPA for Diaspora on Launchpad. This requires the code-base to be imported to Bazaar to upload to Launchpad and currently they do not support git sub-modules.
