### PR TITLE
#2769 let profile tag entry grow to size of input box

### DIFF
--- a/app/assets/stylesheets/vendor/autoSuggest.css
+++ b/app/assets/stylesheets/vendor/autoSuggest.css
@@ -111,10 +111,14 @@ ul.as-selections li.as-original input {
 	border: none;
 	outline: none;
 	font-size: 13px;
-	width: 120px;
+	width: auto;
 	height: 14px;
 	padding: 0;
   margin: 0;
+}
+
+ul.as-selections li.as-original.as-original{
+	width: auto;
 }
 
 ul.as-list {


### PR DESCRIPTION
This is to address issue #2769 . This based on the solution @shavit and committed to his repo (but looks like he never opened a PR). I found that what he provided didn't quite work but was very close and he saved me a lot of time.

This is just a simple display issue, on the Edit Profile page in the "Describe yourself in 5 words" - you can type quite a lot of text into one of these tags but they appear truncated presently due to a hardcoded pixel width on the input class. 

This commit changes the CSS to remove the truncation. There is no functional change - today you can enter lots of text you just will not see more than ~20 chars in the little tag box.

I've tested in Chrome and Firefox. 

In the image below, the first shows the system as we would see it today, and the other as we'd see it after the change.

![profile tags](http://i770.photobucket.com/albums/xx348/jhuffman42/profile-tag-pic.png)
