### PR TITLE
NSFW mobile come back

### DIFF
--- a/app/assets/stylesheets/mobile.css.scss
+++ b/app/assets/stylesheets/mobile.css.scss
@@ -76,7 +76,7 @@ body {
 .shield_wrapper{
     height: 100%;
     width: 100%;
-    background-color: grey;
+    background-color: LightGrey;
     position: absolute;
     border-radius: 5px;
     z-index: 2;

--- a/app/views/shared/_stream_element.mobile.haml
+++ b/app/views/shared/_stream_element.mobile.haml
@@ -3,11 +3,12 @@
 -#   the COPYRIGHT file.
 
 .stream_element{:data=>{:guid=>post.id}}
-  - if post.respond_to?(:nsfw?) && post.nsfw?
+  - if post.respond_to?(:nsfw) && post.nsfw
     .shield_wrapper
       .shield
-        = t("javascripts.stream.nsfw")
-        = link_to t('javascripts.stream.show'), '#'
+        %strong #NSFW 
+        | 
+        = link_to t('javascripts.stream.show_nsfw_post'), '#'
   
 
   - if post.is_a?(Reshare)


### PR DESCRIPTION
Fix #3139

I think the tag #NSFW must return to the mobile interface :]

![](https://jauspora.com/uploads/images/d81ed0c5a586dfba347b.png)
