### PR TITLE
lock gems for more safety

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,23 +7,23 @@ gem 'rails', '3.2.8'
 
 gem 'foreman', '0.57'
 
-gem 'thin', '~> 1.4.1',    :require => false
-gem 'rails_autolink'
+gem 'thin', '1.4.1',    :require => false
+gem 'rails_autolink', '1.0.9'
 
 # cross-origin resource sharing
 
-gem 'rack-cors', '~> 0.2.4', :require => 'rack/cors'
+gem 'rack-cors', '0.2.7', :require => 'rack/cors'
 
 # authentication
 
 gem 'devise', '1.5.3'
 
-gem 'remotipart', '~> 1.0'
+gem 'remotipart', '1.0.2'
 
 gem 'omniauth', '1.1.1'
-gem 'omniauth-facebook'
-gem 'omniauth-tumblr'
-gem 'omniauth-twitter'
+gem 'omniauth-facebook', '1.3.0'
+gem 'omniauth-tumblr', '1.0'
+gem 'omniauth-twitter', '0.0.11'
 
 gem 'twitter', '2.0.2'
 
@@ -31,33 +31,33 @@ gem 'twitter', '2.0.2'
 
 gem 'markerb', :git => 'https://github.com/plataformatec/markerb.git'
 gem 'messagebus_ruby_api', '1.0.3'
-gem 'airbrake'
-gem 'newrelic_rpm'
-gem "rpm_contrib", "~> 2.1.7"
+gem 'airbrake', '3.1.0'
+gem 'newrelic_rpm', '3.3.5'
+gem "rpm_contrib", '2.1.11'
 
 group :production do # we don't install these on travis to speed up test runs
   gem 'rails_admin', :git => 'git://github.com/halida/rails_admin.git'
   gem 'fastercsv', '1.5.5', :require => false
-  gem 'rack-ssl', :require => 'rack/ssl'
-  gem 'rack-rewrite', '~> 1.2.1', :require => false
+  gem 'rack-ssl', '1.3.2', :require => 'rack/ssl'
+  gem 'rack-rewrite', '1.2.1', :require => false
 
   # analytics
-  gem 'rack-google-analytics', :require => 'rack/google-analytics'
-  gem 'rack-piwik', :require => 'rack/piwik', :require => false
+  gem 'rack-google-analytics', '0.11.0', :require => 'rack/google-analytics'
+  gem 'rack-piwik', '0.1.3', :require => 'rack/piwik', :require => false
 end
 
 # configuration
 
 group :heroku do
   gem 'pg', '0.14.1'
-  gem 'unicorn', '~> 4.3.0', :require => false
+  gem 'unicorn', '4.3.1', :require => false
 end
 
 gem 'settingslogic', :git => 'https://github.com/binarylogic/settingslogic.git'
 # database
 
-gem "activerecord-import", "~> 0.2.9"
-gem 'foreigner', '~> 1.2.1'
+gem "activerecord-import", "0.2.9"
+gem 'foreigner', '1.2.1'
 gem 'mysql2', '0.3.11' if ENV['DB'].nil? || ENV['DB'] == 'all' || ENV['DB'] == 'mysql'
 gem 'pg', '0.14.1' if ENV['DB'] == 'all' || ENV['DB'] == 'postgres'
 gem 'sqlite3' if ENV['DB'] == 'all' || ENV['DB'] == 'sqlite'
@@ -65,13 +65,13 @@ gem 'sqlite3' if ENV['DB'] == 'all' || ENV['DB'] == 'sqlite'
 # file uploading
 
 gem 'carrierwave', '0.6.2'
-gem 'fog'
+gem 'fog', '1.4.0'
 gem 'mini_magick', '3.4'
 
 # JSON and API
 
-gem 'json'
-gem 'acts_as_api'
+gem 'json', '1.7.5'
+gem 'acts_as_api', '0.4'
 
 # localization
 
@@ -83,7 +83,7 @@ gem 'rails-i18n'
 gem 'nokogiri', '1.5.2'
 gem 'redcarpet', "2.1.1"
 gem 'roxml', :git => 'https://github.com/Empact/roxml.git', :ref => '7ea9a9ffd2338aaef5b0'
-gem 'ruby-oembed', '~> 0.8.7'
+gem 'ruby-oembed', '0.8.7'
 
 # queue
 
@@ -97,23 +97,23 @@ gem 'acts-as-taggable-on', '2.3.3'
 
 # URIs and HTTP
 
-gem 'addressable', '~> 2.2', :require => 'addressable/uri'
-gem 'http_accept_language', '~> 1.0.2'
-gem 'typhoeus', '~> 0.3.3'
+gem 'addressable', '2.3.2', :require => 'addressable/uri'
+gem 'http_accept_language', '1.0.2'
+gem 'typhoeus', '0.3.3'
 
 # views
 
 gem 'haml', '3.1.7'
-gem 'mobile-fu'
+gem 'mobile-fu', '1.1.0'
 
-gem 'will_paginate'
-gem 'client_side_validations'
-gem 'gon', '~> 4.0'
+gem 'will_paginate', '3.0.3'
+gem 'client_side_validations', '3.1.4'
+gem 'gon', '4.0.0'
 
 # assets
 
 group :assets do
-  gem 'bootstrap-sass', '~> 2.0.2'
+  gem 'bootstrap-sass', '2.0.3.1'
   gem 'sass-rails', '3.2.5'
 
   # Windows and OSX have an execjs compatible runtime built-in, Linux users should
@@ -123,19 +123,19 @@ group :assets do
 
   # gem 'therubyracer', :platform => :ruby
 
-  gem 'handlebars_assets'
-  gem 'uglifier'
+  gem 'handlebars_assets', '0.4.4'
+  gem 'uglifier', '1.3.0'
 
   # asset_sync is required as needed by application.rb
-  gem "asset_sync", :require => nil
+  gem "asset_sync", '0.4.2', :require => nil
 end
 
-gem 'jquery-rails'
+gem 'jquery-rails', '2.0.2'
 
 # web
 
-gem 'faraday'
-gem 'faraday_middleware'
+gem 'faraday', '0.8.1'
+gem 'faraday_middleware', '0.8.7'
 
 
 gem 'jasmine', :git => 'https://github.com/pivotal/jasmine-gem.git'
@@ -144,41 +144,41 @@ gem 'jasmine', :git => 'https://github.com/pivotal/jasmine-gem.git'
 group :test do
 
 
-  gem 'capybara', '~> 1.1.2'
+  gem 'capybara', '1.1.2'
   gem 'cucumber-rails', '1.3.0', :require => false
   gem 'database_cleaner', '0.8'
 
   gem 'timecop'
   gem 'factory_girl_rails', '1.7.0'
   gem 'fixture_builder', '0.3.4'
-  gem 'fuubar', '>= 1.0'
-  gem 'rspec-instafail', '>= 0.1.7', :require => false
-  gem 'selenium-webdriver', '~> 2.25'
+  gem 'fuubar', '1.0.0'
+  gem 'rspec-instafail', '0.2.4', :require => false
+  gem 'selenium-webdriver', '2.25.0'
 
-  gem 'webmock', '~> 1.7', :require => false
+  gem 'webmock', '1.8.7', :require => false
 
-  gem 'spork', '~> 1.0rc2'
-  gem 'guard-rspec'
-  gem 'guard-spork'
-  gem 'guard-cucumber'
+  gem 'spork', '1.0.0rc3'
+  gem 'guard-rspec', '0.7.3'
+  gem 'guard-spork', '0.8.0'
+  gem 'guard-cucumber', '1.0.0'
 
 end
 
 group :test, :development do
-  gem 'debugger', :platforms => :mri_19
-  gem "rspec-rails", "~> 2.10" 
+  gem 'debugger', '1.2.0', :platforms => :mri_19
+  gem "rspec-rails", "2.11.0" 
   gem 'ruby-debug', :platforms => :mri_18
 end
 
 group :development do
-  gem 'heroku'
+  gem 'heroku', '2.28.12'
   gem 'heroku_san', '3.0.4', :platforms => :mri_19
-  gem 'capistrano', :require => false
-  gem 'capistrano_colors', :require => false
-  gem 'capistrano-ext', :require => false
+  gem 'capistrano', '2.12.0', :require => false
+  gem 'capistrano_colors', '0.5.5', :require => false
+  gem 'capistrano-ext', '1.2.1', :require => false
   gem 'linecache', '0.46', :platforms => :mri_18
-  gem 'yard', :require => false
+  gem 'yard', '0.8.1', :require => false
 
   # for tracing AR object instantiation and memory usage per request
-  gem 'oink'
+  gem 'oink', '0.9.3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -465,89 +465,89 @@ PLATFORMS
 
 DEPENDENCIES
   SystemTimer (= 1.2.3)
-  activerecord-import (~> 0.2.9)
+  activerecord-import (= 0.2.9)
   acts-as-taggable-on (= 2.3.3)
-  acts_as_api
-  addressable (~> 2.2)
-  airbrake
-  asset_sync
-  bootstrap-sass (~> 2.0.2)
+  acts_as_api (= 0.4)
+  addressable (= 2.3.2)
+  airbrake (= 3.1.0)
+  asset_sync (= 0.4.2)
+  bootstrap-sass (= 2.0.3.1)
   bundler (> 1.1.0)
-  capistrano
-  capistrano-ext
-  capistrano_colors
-  capybara (~> 1.1.2)
+  capistrano (= 2.12.0)
+  capistrano-ext (= 1.2.1)
+  capistrano_colors (= 0.5.5)
+  capybara (= 1.1.2)
   carrierwave (= 0.6.2)
-  client_side_validations
+  client_side_validations (= 3.1.4)
   cucumber-rails (= 1.3.0)
   database_cleaner (= 0.8)
-  debugger
+  debugger (= 1.2.0)
   devise (= 1.5.3)
   factory_girl_rails (= 1.7.0)
-  faraday
-  faraday_middleware
+  faraday (= 0.8.1)
+  faraday_middleware (= 0.8.7)
   fastercsv (= 1.5.5)
   fixture_builder (= 0.3.4)
-  fog
-  foreigner (~> 1.2.1)
+  fog (= 1.4.0)
+  foreigner (= 1.2.1)
   foreman (= 0.57)
-  fuubar (>= 1.0)
-  gon (~> 4.0)
-  guard-cucumber
-  guard-rspec
-  guard-spork
+  fuubar (= 1.0.0)
+  gon (= 4.0.0)
+  guard-cucumber (= 1.0.0)
+  guard-rspec (= 0.7.3)
+  guard-spork (= 0.8.0)
   haml (= 3.1.7)
-  handlebars_assets
-  heroku
+  handlebars_assets (= 0.4.4)
+  heroku (= 2.28.12)
   heroku_san (= 3.0.4)
-  http_accept_language (~> 1.0.2)
+  http_accept_language (= 1.0.2)
   i18n-inflector-rails (~> 1.0)
   jasmine!
-  jquery-rails
-  json
+  jquery-rails (= 2.0.2)
+  json (= 1.7.5)
   linecache (= 0.46)
   markerb!
   messagebus_ruby_api (= 1.0.3)
   mini_magick (= 3.4)
-  mobile-fu
+  mobile-fu (= 1.1.0)
   mysql2 (= 0.3.11)
-  newrelic_rpm
+  newrelic_rpm (= 3.3.5)
   nokogiri (= 1.5.2)
-  oink
+  oink (= 0.9.3)
   omniauth (= 1.1.1)
-  omniauth-facebook
-  omniauth-tumblr
-  omniauth-twitter
+  omniauth-facebook (= 1.3.0)
+  omniauth-tumblr (= 1.0)
+  omniauth-twitter (= 0.0.11)
   pg (= 0.14.1)
-  rack-cors (~> 0.2.4)
-  rack-google-analytics
-  rack-piwik
-  rack-rewrite (~> 1.2.1)
-  rack-ssl
+  rack-cors (= 0.2.7)
+  rack-google-analytics (= 0.11.0)
+  rack-piwik (= 0.1.3)
+  rack-rewrite (= 1.2.1)
+  rack-ssl (= 1.3.2)
   rails (= 3.2.8)
   rails-i18n
   rails_admin!
-  rails_autolink
+  rails_autolink (= 1.0.9)
   redcarpet (= 2.1.1)
-  remotipart (~> 1.0)
+  remotipart (= 1.0.2)
   resque (= 1.22.0)
   resque-timeout (= 1.0.0)
   roxml!
-  rpm_contrib (~> 2.1.7)
-  rspec-instafail (>= 0.1.7)
-  rspec-rails (~> 2.10)
+  rpm_contrib (= 2.1.11)
+  rspec-instafail (= 0.2.4)
+  rspec-rails (= 2.11.0)
   ruby-debug
-  ruby-oembed (~> 0.8.7)
+  ruby-oembed (= 0.8.7)
   sass-rails (= 3.2.5)
-  selenium-webdriver (~> 2.25)
+  selenium-webdriver (= 2.25.0)
   settingslogic!
-  spork (~> 1.0rc2)
-  thin (~> 1.4.1)
+  spork (= 1.0.0rc3)
+  thin (= 1.4.1)
   timecop
   twitter (= 2.0.2)
-  typhoeus (~> 0.3.3)
-  uglifier
-  unicorn (~> 4.3.0)
-  webmock (~> 1.7)
-  will_paginate
-  yard
+  typhoeus (= 0.3.3)
+  uglifier (= 1.3.0)
+  unicorn (= 4.3.1)
+  webmock (= 1.8.7)
+  will_paginate (= 3.0.3)
+  yard (= 0.8.1)


### PR DESCRIPTION
…so that people accidentally running bundle update won't run into a too big harm as it would only update dependencies of dependencies (read: not our problem).

Also makes Gemnasium more useful. 
