### PR TITLE
css modification on the number of characters twiter, facebook and tumblr...

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -840,6 +840,8 @@ form p.checkbox_select
 
   .counter
     :position absolute
+    :font-size 13px
+    :padding-top 2px
   .warning
     :color orange
   .exceeded


### PR DESCRIPTION
With the latest changes these indicators (counter) have been erroneously modified.
# AFTER

![](https://jauspora.com/uploads/images/485c1b0b3ab5141a40c9.png)
# BEFORE

![](https://jauspora.com/uploads/images/ac1d29b5fdba82dc8350.png)
