### PR TITLE
reshare mobile doesnt show the original author - absolute_root - Fix: #3368

### DIFF
--- a/app/views/shared/_stream_element.mobile.haml
+++ b/app/views/shared/_stream_element.mobile.haml
@@ -12,7 +12,7 @@
   
 
   - if post.is_a?(Reshare)
-    = render 'reshares/reshare', :reshare => post, :post => post.root
+    = render 'reshares/reshare', :reshare => post, :post => post.absolute_root
 
   = render 'shared/photo_area', :post => post
 


### PR DESCRIPTION
Previous https://github.com/diaspora/diaspora/pull/3583

It was based on an erroneous question of the problem.

I thought the problem was when people reshared in the mobile web, but the problem really occurs when someone reshares on the web (not mobile) a publication that has been previously reshared (absolute_root) and try to see it from the web Mobile (root only).
#3368
