### PR TITLE
Removed unix-socket example line for now.

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -29,7 +29,6 @@ defaults: &defaults
   ## Leave it empty for the default ('redis://localhost:6379/0')
   ## You can specify a username and password in it, for example
   ## redis://user:password@remote_host:6379/0
-  ## You can also specify a unix socket URL like unix://tmp/redis.sock
   redis_url:
 
   ## Serve static assets via the appserver.


### PR DESCRIPTION
Just removed a misleading example from application.yml.example for redis unix-sockets. If I can find a better way to write app_config.rb to handle that I will send another pull.

I don't think a lot of people will be using unix-sockets for Redis though if not.
