### PR TITLE
Hotfix/3613 mobile bookmarklet broken

### DIFF
--- a/app/controllers/status_messages_controller.rb
+++ b/app/controllers/status_messages_controller.rb
@@ -11,7 +11,18 @@ class StatusMessagesController < ApplicationController
              :mobile,
              :json
 
-  layout 'blank', :only => [ :bookmarklet ]
+  layout :choose_layout
+  
+  # Define layout
+  def choose_layout
+    if action_name == 'bookmarklet'
+      if ! is_mobile_device?
+        return 'blank'
+      else
+        return 'application'
+      end
+    end
+  end
 
   # Called when a user clicks "Mention" on a profile page
   # @param person_id [Integer] The id of the person to be mentioned

--- a/app/controllers/status_messages_controller.rb
+++ b/app/controllers/status_messages_controller.rb
@@ -11,17 +11,16 @@ class StatusMessagesController < ApplicationController
              :mobile,
              :json
 
-  layout :choose_layout
+  layout :bookmarklet_layout, :only => :bookmarklet
   
-  # Define layout
-  def choose_layout
-    if action_name == 'bookmarklet'
-      if ! is_mobile_device?
-        return 'blank'
-      else
-        return 'application'
-      end
-    end
+  # Define bookmarklet layout depending on whether
+  # user is in mobile or desktop mode
+  def bookmarklet_layout
+    if request.format == :mobile
+      'application'
+    else
+      'blank'
+    end    
   end
 
   # Called when a user clicks "Mention" on a profile page

--- a/app/views/status_messages/bookmarklet.mobile.haml
+++ b/app/views/status_messages/bookmarklet.mobile.haml
@@ -18,4 +18,4 @@
   });
 
 - content_for(:head) do
-  = javascript_include_tag :mobile
+  = javascript_include_tag :jquery, :mobile


### PR DESCRIPTION
Mobile bookmarklet has been broken since bookmarklets started using layouts/blank. Modified layout selection to use layouts/application if we are a mobile browser. Also fixed missing jquery javascript include in bookmarklet.mobile.

Tried to write a spec but just couldn't figure out how to do an rspec test for a mobile client :) Any hints are welcome, I tried adding one to spec/controllers/status_messages_controller_spec.rb to test if submit button exists for a mobile client.
