### PR TITLE
Fix broken mobile bookmarklet, isse #3613

### DIFF
--- a/app/controllers/status_messages_controller.rb
+++ b/app/controllers/status_messages_controller.rb
@@ -11,7 +11,17 @@ class StatusMessagesController < ApplicationController
              :mobile,
              :json
 
-  layout 'blank', :only => [ :bookmarklet ]
+  layout :bookmarklet_layout, :only => :bookmarklet
+  
+  # Define bookmarklet layout depending on whether
+  # user is in mobile or desktop mode
+  def bookmarklet_layout
+    if request.format == :mobile
+      'application'
+    else
+      'blank'
+    end
+  end
 
   # Called when a user clicks "Mention" on a profile page
   # @param person_id [Integer] The id of the person to be mentioned

--- a/app/views/status_messages/bookmarklet.mobile.haml
+++ b/app/views/status_messages/bookmarklet.mobile.haml
@@ -18,4 +18,4 @@
   });
 
 - content_for(:head) do
-  = javascript_include_tag :mobile
+  = javascript_include_tag :jquery, :mobile


### PR DESCRIPTION
New attempt to fix broken mobile bookmarklet - previous pull was https://github.com/diaspora/diaspora/pull/3614.

Unless 0.0.1 release will be done soon, this would be a good candidate for a hotfix. Current functionality is broken and at least myself I would like to use the mobile bookmarklet daily - I am sure there are others.

Btw, I updated some bits of the git workflow wiki page - didn't remove the stuff about using git-flow - I guess it works ok for contributors also..
