### PR TITLE
Fix "if display_password_reset_link?" when diaspora.yml => enable_registrations: false

### DIFF
--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -9,7 +9,7 @@ module SessionsHelper
   end
 
   def display_registration_link?
-    !AppConfig.settings.enable_registrations? && devise_mapping.registerable? && controller_name != 'registrations'
+    AppConfig.settings.enable_registrations? && devise_mapping.registerable? && controller_name != 'registrations'
   end
 
   def display_password_reset_link?


### PR DESCRIPTION
When `enable_registrations: false` https://github.com/diaspora/diaspora/blob/develop/config/diaspora.yml.example#L145

`if display_registration_link?` is should be **false** not **tue** https://github.com/diaspora/diaspora/blob/develop/app/views/sessions/new.html.erb#L41 or mobile web https://github.com/diaspora/diaspora/blob/develop/app/views/sessions/new.mobile.haml#L43

This happens, for example https://pod.fulll.name/users/sign_in click on "_Sign up_"
