### PR TITLE
Fix "if display_password_reset_link?" when diaspora.yml => enable_registrations: false

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # 0.0.2.0pre
 
+Fix error with open/close registrations.
+Fix javascripts error in invitations facebox. 
+Fix css overflow problem in aspect dropdown on welcome page.
+
 # 0.0.1.1
 
 Fix syntax error in French Javascript pluralization rule.

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -9,7 +9,7 @@ module SessionsHelper
   end
 
   def display_registration_link?
-    !AppConfig.settings.enable_registrations? && devise_mapping.registerable? && controller_name != 'registrations'
+    AppConfig.settings.enable_registrations? && devise_mapping.registerable? && controller_name != 'registrations'
   end
 
   def display_password_reset_link?


### PR DESCRIPTION
Previous https://github.com/diaspora/diaspora/pull/3646

When `enable_registrations: false` https://github.com/diaspora/diaspora/blob/develop/config/diaspora.yml.example#L145

`if display_registration_link?` is should be **false** not **tue** https://github.com/diaspora/diaspora/blob/develop/app/views/sessions/new.html.erb#L41 or mobile web https://github.com/diaspora/diaspora/blob/develop/app/views/sessions/new.mobile.haml#L43

This happens, for example https://pod.fulll.name/users/sign_in click on "_Sign up_"

<hr>

<hr>

Add two fixs in Changelog.md:

1.- https://github.com/diaspora/diaspora/commit/81f48d6526dacde225fdef3ec51dc6c756c0676d
2.- https://github.com/diaspora/diaspora/commit/7be7ac31764bee7d9fb473239f22252ded207b98
