### PR TITLE
Refactor MessagesController

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -3,29 +3,25 @@
 #   the COPYRIGHT file.
 
 class MessagesController < ApplicationController
-  include ApplicationHelper
   before_filter :authenticate_user!
 
   respond_to :html, :mobile
   respond_to :json, :only => :show
 
   def create
-    cnv = Conversation.joins(:conversation_visibilities).where(:id => params[:conversation_id],
-                              :conversation_visibilities => {:person_id => current_user.person_id}).first
+    conversation = Conversation.find(params[:conversation_id])
 
-    if cnv
-      message = Message.new(:conversation_id => cnv.id, :text => params[:message][:text], :author => current_user.person)
-      
-      if message.save
-        Rails.logger.info("event=create type=comment user=#{current_user.diaspora_handle} status=success message=#{message.id} chars=#{params[:message][:text].length}")
-        Postzord::Dispatcher.build(current_user, message).post
-      else
-        flash[:error] = I18n.t('conversations.new_message.fail')
-      end
-      redirect_to conversations_path(:conversation_id => cnv.id)
+    message = conversation.messages.build(
+      :text   => params[:message][:text],
+      :author => current_user.person
+    )
+
+    if message.save
+      Rails.logger.info("event=create type=comment user=#{current_user.diaspora_handle} status=success message=#{message.id} chars=#{params[:message][:text].length}")
+      Postzord::Dispatcher.build(current_user, message).post
     else
-      render :nothing => true, :status => 422
+      flash[:error] = I18n.t('conversations.new_message.fail')
     end
+    redirect_to conversations_path(:conversation_id => conversation.id)
   end
-
 end

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -6,98 +6,113 @@ require 'spec_helper'
 
 describe MessagesController do
   before do
-    @user1 = alice
-    @user2 = bob
-
-    @aspect1 = @user1.aspects.first
-    @aspect2 = @user2.aspects.first
-
-    sign_in :user, @user1
+    sign_in :user, alice
   end
 
   describe '#create' do
     before do
-      @create_hash = {
-        :author => @user1.person,
-        :participant_ids => [@user1.contacts.first.person.id, @user1.person.id],
-        :subject => 'cool stuff',
-        :messages_attributes => [ {:author => @user1.person, :text => 'stuff'} ]
+      @conversation_params = {
+        :author              => alice.person,
+        :participant_ids     => [alice.contacts.first.person.id, alice.person.id],
+        :subject             => 'cool stuff',
+        :messages_attributes => [ {:author => alice.person, :text => 'stuff'} ]
       }
     end
 
     context "on my own post" do
       before do
-        @cnv = Conversation.create(@create_hash)
+        @conversation = Conversation.create!(@conversation_params)
       end
 
       context "with a valid message" do
         before do
-          @message_hash = {:conversation_id => @cnv.id, :message => {:text => "here is something else"}}
+          @message_params = {
+            :conversation_id => @conversation.id,
+            :message         => { :text => "here is something else" }
+          }
         end
 
         it 'redirects to conversation' do
-          lambda{
-            post :create, @message_hash
+          lambda {
+            post :create, @message_params
           }.should change(Message, :count).by(1)
-          response.code.should == '302'
-          response.should redirect_to(conversations_path(:conversation_id => @cnv))
+          response.status.should == 302
+          response.should redirect_to(conversations_path(:conversation_id => @conversation))
         end
       end
 
       context "with an empty message" do
         before do
-          @message_hash = {:conversation_id => @cnv.id, :message => {:text => " "}}
+          @message_params = {
+            :conversation_id => @conversation.id,
+            :message         => { :text => " " }
+          }
         end
 
-        it 'redirects to conversation' do
-          lambda{
-            post :create, @message_hash
-          }.should_not change(Message, :count).by(1)
-          response.code.should == '302'
-          response.should redirect_to(conversations_path(:conversation_id => @cnv))
+        it 'does not create the message' do
+          lambda {
+            post :create, @message_params
+          }.should_not change(Message, :count)
+          flash[:error].should be_present
         end
       end
     end
 
     context "on a post from a contact" do
       before do
-        @create_hash[:author] = @user2.person
-        @cnv = Conversation.create(@create_hash)
-        @message_hash = {:conversation_id => @cnv.id, :message => {:text => "here is something else"}}
+        @conversation_params[:author] = bob.person
+        @conversation = Conversation.create!(@conversation_params)
+        @message_params = {
+          :conversation_id => @conversation.id,
+          :message         => { :text => "here is something else" }
+        }
       end
 
       it 'comments' do
-        post :create, @message_hash
-        response.code.should == '302'
-        response.should redirect_to(conversations_path(:conversation_id => @cnv))
+        post :create, @message_params
+        response.status.should == 302
+        response.should redirect_to(conversations_path(:conversation_id => @conversation))
       end
 
       it "doesn't overwrite author_id" do
         new_user = FactoryGirl.create(:user)
-        @message_hash[:author_id] = new_user.person.id.to_s
-        post :create, @message_hash
-        Message.find_by_text(@message_hash[:message][:text]).author_id.should == @user1.person.id
+        @message_params[:author_id] = new_user.person.id.to_s
+
+        post :create, @message_params
+        created_message = Message.find_by_text(@message_params[:message][:text])
+        created_message.author.should == alice.person
       end
 
       it "doesn't overwrite id" do
-        old_message = Message.create(:text => "hello", :author_id => @user1.person.id, :conversation_id => @cnv.id)
-        @message_hash[:id] = old_message.id
-        post :create, @message_hash
+        old_message = Message.create!(
+          :text            => "hello",
+          :author_id       => alice.person.id,
+          :conversation_id => @conversation.id
+        )
+        @message_params[:id] = old_message.id
+
+        post :create, @message_params
         old_message.reload.text.should == 'hello'
       end
     end
 
     context 'on a post from a stranger' do
       before do
-        @create_hash[:author] = eve.person
-        @create_hash[:participant_ids] = [eve.person.id, bob.person.id]
-        @cnv = Conversation.create(@create_hash)
-        @message_hash = {:conversation_id => @cnv.id, :message => {:text => "here is something else"}}
+        conversation = Conversation.create!(
+          :author          => eve.person,
+          :participant_ids => [eve.person.id, bob.person.id]
+        )
+        @message_params = {
+          :conversation_id => conversation.id,
+          :message         => { :text => "here is something else" }
+        }
       end
 
-      it 'posts no comment' do
-        post :create, @message_hash
-        response.code.should == '422'
+      it 'does not create the message' do
+        lambda {
+          post :create, @message_params
+        }.should_not change(Message, :count)
+        flash[:error].should be_present
       end
     end
   end


### PR DESCRIPTION
- Remove inclusion of ApplicationHelper (anyone knows why it was included?)
- Simplify the lookup for the conversation. I am not sure why it was done that way before. I suppose it was joined with the visibilities to get no result in case the current user is not a participant of the conversation. The thing is that this validation is already on the Message model, where it belongs. So now if you hack the message html form action path to post to a conversation you're not a participant you get an "Invalid message" flash message, not the empty response with a 422 status code.
- Cleaner build for the message.

Tests:
- Clean the setup, no need for those instance variables.
- Clearer variables names, be verbose if we need to :)
- Other minor changes...
