### PR TITLE
Fix empty page after callback from service by redirecting to origin

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -30,6 +30,7 @@
 * Fix error with open/close registrations. [#3649](https://github.com/diaspora/diaspora/pull/3649)
 * Fix javascripts error in invitations facebox. [#3638](https://github.com/diaspora/diaspora/pull/3638)
 * Fix css overflow problem in aspect dropdown on welcome page. [#3637](https://github.com/diaspora/diaspora/pull/3637)
+* Fix empty page after authenticating with other services. [#3693](https://github.com/diaspora/diaspora/pull/3693)
 
 # 0.0.1.2
 

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -48,8 +48,12 @@ class ServicesController < ApplicationController
                                  :service_name => provider.camelize )
       end
     end
-
-    render :text => ("<script>window.close()</script>")
+    
+    if request.env['omniauth.origin'].nil?
+      render :text => ("<script>window.close()</script>")
+    else
+      redirect_to request.env['omniauth.origin']
+    end
   end
 
   def failure

--- a/app/views/shared/_add_remove_services.haml
+++ b/app/views/shared/_add_remove_services.haml
@@ -16,4 +16,4 @@
 
 - AppConfig.configured_services.each do |service|
   - unless @services.any?{|x| x.provider == service}
-    %h4= link_to t("services.index.connect_to_#{service}"), "#", :onclick => "window.open('/auth/#{service}', 'popup', 'height=400,width=500')"
+    %h4= link_to(t("services.index.connect_to_#{service}"), "/auth/#{service}")


### PR DESCRIPTION
Fixes empty page after authenticating with Facebook by redirecting to origin. In account setup this works correctly to keep the user in the getting started wizard as it should.

Since this breaks production functionality which is used by many of the people who register to Diaspora*, and which gives a very bad feel to how the software works by failing to complete the getting started wizard, I am suggesting this would be merged in as a hotfix.

Fixes #3283
