### PR TITLE
Always use basic Facebook Graph API to post messages, fixes public posts

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -31,6 +31,7 @@
 * Fix javascripts error in invitations facebox. [#3638](https://github.com/diaspora/diaspora/pull/3638)
 * Fix css overflow problem in aspect dropdown on welcome page. [#3637](https://github.com/diaspora/diaspora/pull/3637)
 * Fix empty page after authenticating with other services. [#3693](https://github.com/diaspora/diaspora/pull/3693)
+* Fix posting public posts to Facebook. [#2882](https://github.com/diaspora/diaspora/issues/2882), [#3650](https://github.com/diaspora/diaspora/issues/3650)
 
 # 0.0.1.2
 

--- a/app/models/services/facebook.rb
+++ b/app/models/services/facebook.rb
@@ -11,19 +11,11 @@ class Services::Facebook < Service
 
   def post(post, url='')
     Rails.logger.debug("event=post_to_service type=facebook sender_id=#{self.user_id}")
-    if post.public?
-      post_to_facebook("https://graph.facebook.com/me/joindiaspora:make", create_open_graph_params(post).to_param)
-    else
-      post_to_facebook("https://graph.facebook.com/me/feed", create_post_params(post).to_param)
-    end
+    post_to_facebook("https://graph.facebook.com/me/feed", create_post_params(post).to_param)
   end
 
   def post_to_facebook(url, body)
     Faraday.post(url, body)
-  end
-
-  def create_open_graph_params(post)
-    {:post => "#{AppConfig.pod_uri.to_s}#{short_post_path(post)}", :access_token => self.access_token}
   end
 
   def create_post_params(post)

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -56,7 +56,6 @@ defaults:
       enable: false
       app_id:
       secret:
-      open_graph_namespace: 'joindiaspora'
     twitter:
       enable: false
       key:

--- a/config/diaspora.yml.example
+++ b/config/diaspora.yml.example
@@ -252,9 +252,6 @@ configuration: ## Section
       #enable: true
       #app_id: 'abcdef'
       #secret: 'changeme'
-      ## this will be the namespace for your object,
-      ## it should be configured in your FB app
-      #open_graph_namespace: 
     
     ## OAuth credentials for Twitter:
     twitter: ## Section

--- a/spec/models/services/facebook_spec.rb
+++ b/spec/models/services/facebook_spec.rb
@@ -11,7 +11,7 @@ describe Services::Facebook do
 
   describe '#post' do
     it 'posts a status message to facebook' do
-      stub_request(:post, "https://graph.facebook.com/me/joindiaspora:make").
+      stub_request(:post, "https://graph.facebook.com/me/feed").
           to_return(:status => 200, :body => "", :headers => {})
       @service.post(@post)
     end
@@ -19,13 +19,13 @@ describe Services::Facebook do
     it 'swallows exception raised by facebook always being down' do
       pending "temporarily disabled to figure out while some requests are failing"
       
-      stub_request(:post,"https://graph.facebook.com/me/joindiaspora:make").
+      stub_request(:post,"https://graph.facebook.com/me/feed").
         to_raise(StandardError)
       @service.post(@post)
     end
 
     it 'should call public message' do
-      stub_request(:post, "https://graph.facebook.com/me/joindiaspora:make").
+      stub_request(:post, "https://graph.facebook.com/me/feed").
         to_return(:status => 200)
       url = "foo"
       @service.should_not_receive(:public_message)


### PR DESCRIPTION
Dropped posting to Facebook via their Open Graph API - it is just way too hard for anyone to set up. And it is not needed to post public posts to a users Facebook feed which is the main requirement here.

Should fix [#2882](https://github.com/diaspora/diaspora/issues/2882), [#3650](https://github.com/diaspora/diaspora/issues/3650) - or at least some of those issues.

IMHO this should be a hotfix - but I guess we should be soon ready for the next release looking at the milestone so I guess it could just go in develop?

Will update service set up page once this is merged - basically just need to drop the Open Graph stuff from there.

@MrZYX - #3670 pull kind of touches the same stuff, some of the changes to the opengraph posting is probably irrelevant if this is accepted.
