### PR TITLE
Only include url to post for twitter when post exceeds maximum length or contains photos

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@
 ## Features
 
 * Add password_confirmation field to registration page. [#3647](https://github.com/diaspora/diaspora/pull/3647)
+* When posting to Twitter, behaviour changed so that URL to post will only be added to the post when length exceeds 140 chars or post contains uploaded photos.
 
 ## Bug Fixes
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -12,15 +12,20 @@ class Service < ActiveRecord::Base
     service_strings.map{|s| "Services::#{s.titleize}"}
   end
 
-  def public_message(post, length, url = "")
+  def public_message(post, length, url = "", always_include_post_url = true)
     Rails.logger.info("Posting out to #{self.class}")
-    url = Rails.application.routes.url_helpers.short_post_url(post, :protocol => AppConfig.pod_uri.scheme, :host => AppConfig.pod_uri.authority)
-    space_for_url = 21 + 1
+    if post.text(:plain_text => true).length <= length && ! always_include_post_url
+        # include url to diaspora when posting only when it exceeds length
+        url = ""
+        space_for_url = 0
+    else
+        url = " " + Rails.application.routes.url_helpers.short_post_url(post, :protocol => AppConfig.pod_uri.scheme, :host => AppConfig.pod_uri.authority)
+        space_for_url = 21 + 1
+    end
     truncated = truncate(post.text(:plain_text => true), :length => (length - space_for_url))
-    truncated = "#{truncated} #{url}"
+    truncated = "#{truncated}#{url}"
     return truncated
   end
-
 
   def profile_photo_url
     nil

--- a/app/models/services/twitter.rb
+++ b/app/models/services/twitter.rb
@@ -22,7 +22,8 @@ class Services::Twitter < Service
       buffer_amt += (a_url.length - SHORTENED_URL_LENGTH)
     end
 
-    super(post, MAX_CHARACTERS + buffer_amt,  url)
+    #if photos, always include url, otherwise not for short posts
+    super(post, MAX_CHARACTERS + buffer_amt,  url, post.photos.any?)
   end
 
   def profile_photo_url

--- a/spec/models/services/twitter_spec.rb
+++ b/spec/models/services/twitter_spec.rb
@@ -4,7 +4,7 @@ describe Services::Twitter do
 
   before do
     @user = alice
-    @post = @user.post(:status_message, :text => "hello", :to =>@user.aspects.first.id)
+    @post = @user.post(:status_message, :text => "hello", :to =>@user.aspects.first.id, :photos => [])
     @service = Services::Twitter.new(:access_token => "yeah", :access_secret => "foobar")
     @user.services << @service
   end
@@ -36,20 +36,20 @@ describe Services::Twitter do
 
     it "should not truncate a short message" do
       short_message = SecureRandom.hex(20)
-      short_post = stub(:text => short_message )
-      @service.public_message(short_post, '').should include(short_message)
+      short_post = stub(:text => short_message, :photos => [])
+      @service.public_message(short_post, '').should match short_message
     end
 
     it "should truncate a long message" do
       long_message = SecureRandom.hex(220)
-      long_post = stub(:text => long_message, :id => 1 )
+      long_post = stub(:text => long_message, :id => 1, :photos => [])
       @service.public_message(long_post, '').should match long_message.first(100)
 
     end
 
     it "should not truncate a long message with an http url" do
       long_message = " http://joindiaspora.com/a-very-long-url-name-that-will-be-shortened.html " + @long_message_end
-      long_post = stub(:text => long_message, :id => 1 )
+      long_post = stub(:text => long_message, :id => 1, :photos => [])
       @post.text = long_message
       answer = @service.public_message(@post, '')
 
@@ -65,13 +65,43 @@ describe Services::Twitter do
 
     it "should truncate a long message with an ftp url" do
       long_message = @long_message_start + " ftp://joindiaspora.com/a-very-long-url-name-that-will-be-shortened.html " + @long_message_end
-      long_post = stub(:text => long_message, :id => 1 )
+      long_post = stub(:text => long_message, :id => 1, :photos => [])
       answer = @service.public_message(long_post, '')
 
       answer.should match /\.\.\./
     end
-
+    
+    it "should not truncate a message of maximum length" do
+        exact_size_message = SecureRandom.hex(70)
+        exact_size_post = stub(:text => exact_size_message, :id => 1, :photos => [])
+        answer = @service.public_message(exact_size_post, '')
+        
+        answer.should match exact_size_message
+    end
+    
   end
+  
+  describe "with photo" do
+    before do
+      @photos = [alice.build_post(:photo, :pending => true, :user_file=> File.open(photo_fixture_name)),
+                 alice.build_post(:photo, :pending => true, :user_file=> File.open(photo_fixture_name))]
+
+      @photos.each(&:save!)
+
+      @status_message = alice.build_post(:status_message, :text => "the best pebble.")
+        @status_message.photos << @photos
+
+      @status_message.save!
+      alice.add_to_streams(@status_message, alice.aspects)
+    end
+    
+    it "should include post url in short message with photos" do
+        answer = @service.public_message(@status_message, '')
+        answer.should include 'http'
+    end
+    
+  end
+  
   describe "#profile_photo_url" do
     it 'returns the original profile photo url' do
       user_stub = stub


### PR DESCRIPTION
One of the biggest gripes I have had with posting to Twitter from Diaspora\* is that even if I post a short status message it appends an url to the post. This makes people reading it think that the url actually contains something. Due to this I don't post short messages from Diaspora\* to Twitter :P 

So here is a fix (hopefully others think so too :)). URL is only added if message is over 140 chars OR contains photos.

![screenshot](http://i.imgur.com/wwdjc.png)
