### PR TITLE
Fix Invite link box shows on search results page even if invites have been turden off - Fix #3707

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -33,6 +33,7 @@
 * Fix css overflow problem in aspect dropdown on welcome page. [#3637](https://github.com/diaspora/diaspora/pull/3637)
 * Fix empty page after authenticating with other services. [#3693](https://github.com/diaspora/diaspora/pull/3693)
 * Fix posting public posts to Facebook. [#2882](https://github.com/diaspora/diaspora/issues/2882), [#3650](https://github.com/diaspora/diaspora/issues/3650)
+* Fix error with invite link box shows on search results page even if invites have been turned off. [#3708](https://github.com/diaspora/diaspora/pull/3708)
 
 # 0.0.1.2
 

--- a/app/views/people/index.html.haml
+++ b/app/views/people/index.html.haml
@@ -39,6 +39,7 @@
       = will_paginate(@people)
 
 .span-8.last
+- if AppConfig.settings.invitations.open?
   %h4
     = t('.couldnt_find_them_send_invite')
   = render "shared/invitations"


### PR DESCRIPTION
#3707

![](https://jauspora.com/uploads/images/43a678ce892386931918.png)
