### PR TITLE
Make Devise remember the session for 2 weeks

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -36,6 +36,7 @@
 * Fix empty page after authenticating with other services. [#3693](https://github.com/diaspora/diaspora/pull/3693)
 * Fix posting public posts to Facebook. [#2882](https://github.com/diaspora/diaspora/issues/2882), [#3650](https://github.com/diaspora/diaspora/issues/3650)
 * Fix error with invite link box shows on search results page even if invites have been turned off. [#3708](https://github.com/diaspora/diaspora/pull/3708)
+* Fix misconfiguration of Devise to allow the session to be remembered. [#3472](https://github.com/diaspora/diaspora/issues/3472)
 
 # 0.0.1.2
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -77,7 +77,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
-  # config.remember_for = 2.weeks
+  config.remember_for = 2.weeks
   
   # ==> Configuration for :validatable
   # Range for password length
@@ -89,7 +89,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again.
-  config.timeout_in = 1.day
+  # config.timeout_in = 1.day
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.


### PR DESCRIPTION
This will fix #3472.

With the current setup, Devise is forced to reset the session after 24h inactivity and/or at the end of the browser session. Now it's remembering the session for two weeks.
