### PR TITLE
Add simple background for unread messages/conversations mobile

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,7 @@
 * Add "My Activity" icon mobile -[Author Icon](http://www.gentleface.com/free_icon_set.html)-. [#3687](https://github.com/diaspora/diaspora/pull/3687)
 * Add password_confirmation field to registration page. [#3647](https://github.com/diaspora/diaspora/pull/3647)
 * When posting to Twitter, behaviour changed so that URL to post will only be added to the post when length exceeds 140 chars or post contains uploaded photos.
+* Add simple background for unread messages/conversations mobile. [#3712](https://github.com/diaspora/diaspora/pull/3712)
 
 ## Bug Fixes
 

--- a/app/assets/stylesheets/mobile.css.scss
+++ b/app/assets/stylesheets/mobile.css.scss
@@ -787,4 +787,8 @@ textarea#conversation_text {
 form#new_user.new_user input.btn {
   white-space: normal;
 }
+
+.unread {
+  background-color: #E6E6E6;
+}
     


### PR DESCRIPTION
I think this is more friendly.

Another with LightGrey https://github.com/diaspora/diaspora/pull/3724

![](https://jauspora.com/uploads/images/e8f71f4b3e00bd77031f.png)

![](https://jauspora.com/uploads/images/c08472ead3187a0c39e5.png)
