### PR TITLE
Issue #3663: [Refactor] Remove posts#new action

### DIFF
--- a/app/assets/javascripts/app/router.js
+++ b/app/assets/javascripts/app/router.js
@@ -1,7 +1,6 @@
 app.Router = Backbone.Router.extend({
   routes: {
     //new hotness
-    "posts/new" : "composer",
     "posts/:id": "singlePost",
     "posts/:id/next": "siblingPost",
     "posts/:id/previous": "siblingPost",
@@ -23,10 +22,6 @@ app.Router = Backbone.Router.extend({
 
     "people/:id": "stream",
     "u/:name": "stream"
-  },
-
-  composer : function(){
-    this.renderPage(function(){ return new app.pages.Composer()});
   },
 
   singlePost : function(id) {

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -24,10 +24,6 @@ class PostsController < ApplicationController
     end
   end
 
-  def new
-    redirect_to "/stream"
-  end
-
   def show
     mark_corresponding_notification_read if user_signed_in?
 

--- a/app/views/status_messages/new_bookmarklet.haml
+++ b/app/views/status_messages/new_bookmarklet.haml
@@ -1,5 +1,0 @@
--#   Copyright (c) 2010-2012, Diaspora Inc.  This file is
--#   licensed under the Affero General Public License version 3 or later.  See
--#   the COPYRIGHT file.
-
-%iframe{:src =>"/posts/new", :height => 500, :width => 980, :style => "border:none;"}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,8 +28,6 @@ Diaspora::Application.routes.draw do
     resources :comments, :only => [:new, :create, :destroy, :index]
   end
 
-  match "/framer" => redirect("/posts/new")
-
   get 'p/:id' => 'posts#show', :as => 'short_post'
   get 'posts/:id/iframe' => 'posts#iframe', :as => 'iframe'
 

--- a/spec/controllers/status_messages_controller_spec.rb
+++ b/spec/controllers/status_messages_controller_spec.rb
@@ -53,13 +53,6 @@ describe StatusMessagesController do
     end
   end
 
-  describe '#new_bookmarklet' do
-    it 'works' do
-      get :new_bookmarklet
-      response.should be_success
-    end
-  end
-
   describe '#new' do
     it 'succeeds' do
       get :new,

--- a/spec/controllers/status_messages_controller_spec.rb
+++ b/spec/controllers/status_messages_controller_spec.rb
@@ -34,7 +34,7 @@ describe StatusMessagesController do
       doc.xpath('//head').count.should equal 1
       doc.xpath('//body').count.should equal 1
 
-      save_fixture(html_for('body'), 'empty_bookmarklet') 
+      save_fixture(html_for('body'), 'empty_bookmarklet')
     end
 
     it 'accepts get params' do
@@ -84,35 +84,35 @@ describe StatusMessagesController do
       response.status.should == 302
       response.should be_redirect
     end
-    
+
     it 'creates with invalid html' do
       post :create, status_message_hash.merge(:status_message => { :text => "0123456789" * 7000 })
       response.status.should == 302
       response.should be_redirect
     end
-    
+
     it 'creates with valid json' do
       post :create, status_message_hash.merge(:format => 'json')
       response.status.should == 201
     end
-    
+
     it 'creates with invalid json' do
       post :create, status_message_hash.merge(:status_message => { :text => "0123456789" * 7000 }, :format => 'json')
       response.status.should == 403
     end
-    
+
     it 'creates with valid mobile' do
       post :create, status_message_hash.merge(:format => 'mobile')
       response.status.should == 302
       response.should be_redirect
     end
-    
+
     it 'creates with invalid mobile' do
       post :create, status_message_hash.merge(:status_message => { :text => "0123456789" * 7000 }, :format => 'mobile')
       response.status.should == 302
       response.should be_redirect
     end
-    
+
     it 'removes getting started from new users' do
       @controller.should_receive(:remove_getting_started)
       post :create, status_message_hash


### PR DESCRIPTION
This pull request addresses issue #3663 ( https://github.com/diaspora/diaspora/issues/3663 )

I removed the action in the controller, the route that pointed to it (as it was not used anymore), a view that wasn't used either, related code in backbone side (by the way Composer page didn't exist anymore). 

Finally I deleted a controller test on status_message that hit with a GET against new_bookmarklet (name of the view that I deleted). This route didn't even exist, the only reason why this test wasn't failing already is because of the way of Rails works while testing. Rails doesn't need an action to be defined as long as the template exists. I'll put my source reference in case someone, while reviewing this, asks himself the same questions that I ran through with this test (it was a tricky one to remove because it failed only when I removed the view and that seemed weird).

http://stackoverflow.com/questions/9428974/rspec-success-despite-action-and-route-not-defined

Also I've got rid of some not cool whitespaces in the way :-)
