### PR TITLE
Remove markdown formatting from service posts (excl. Tumblr)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,7 @@
 * Add "My Activity" icon mobile -[Author Icon](http://www.gentleface.com/free_icon_set.html)-. [#3687](https://github.com/diaspora/diaspora/pull/3687)
 * Add password_confirmation field to registration page. [#3647](https://github.com/diaspora/diaspora/pull/3647)
 * When posting to Twitter, behaviour changed so that URL to post will only be added to the post when length exceeds 140 chars or post contains uploaded photos.
+* Remove markdown formatting from post message when posting to Facebook or Twitter.
 
 ## Bug Fixes
 

--- a/app/helpers/markdownify_helper.rb
+++ b/app/helpers/markdownify_helper.rb
@@ -3,6 +3,7 @@
 #   the COPYRIGHT file.
 
 require Rails.root.join('lib', 'diaspora', 'markdownify')
+require 'redcarpet/render_strip'
 
 module MarkdownifyHelper
   def markdownify(target, render_options={})
@@ -44,6 +45,11 @@ module MarkdownifyHelper
     message = Diaspora::Taggable.format_tags(message, :no_escape => true)
 
     return message.html_safe
+  end
+  
+  def strip_markdown(text)
+    renderer = Redcarpet::Markdown.new(Redcarpet::Render::StripDown)
+    renderer.render(text)
   end
 
   def process_newlines(message)

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -4,7 +4,9 @@
 
 class Service < ActiveRecord::Base
   include ActionView::Helpers::TextHelper
-
+  require Rails.root.join('app', 'helpers', 'markdownify_helper')
+  include MarkdownifyHelper
+  
   belongs_to :user
   validates_uniqueness_of :uid, :scope => :type
 
@@ -12,9 +14,14 @@ class Service < ActiveRecord::Base
     service_strings.map{|s| "Services::#{s.titleize}"}
   end
 
-  def public_message(post, length, url = "", always_include_post_url = true)
+  def public_message(post, length, url = "", always_include_post_url = true, markdown = false)
     Rails.logger.info("Posting out to #{self.class}")
-    if post.text(:plain_text => true).length <= length && ! always_include_post_url
+    if ! markdown
+      post_text = strip_markdown(post.text(:plain_text => true))
+    else
+      post_text = post.text(:plain_text => true)
+    end
+    if post_text.length <= length && ! always_include_post_url
         # include url to diaspora when posting only when it exceeds length
         url = ""
         space_for_url = 0
@@ -22,7 +29,7 @@ class Service < ActiveRecord::Base
         url = " " + Rails.application.routes.url_helpers.short_post_url(post, :protocol => AppConfig.pod_uri.scheme, :host => AppConfig.pod_uri.authority)
         space_for_url = 21 + 1
     end
-    truncated = truncate(post.text(:plain_text => true), :length => (length - space_for_url))
+    truncated = truncate(post_text, :length => (length - space_for_url))
     truncated = "#{truncated}#{url}"
     return truncated
   end

--- a/app/models/services/facebook.rb
+++ b/app/models/services/facebook.rb
@@ -1,6 +1,8 @@
 require 'uri'
 class Services::Facebook < Service
   include Rails.application.routes.url_helpers
+  require Rails.root.join('app', 'helpers', 'markdownify_helper')
+  include MarkdownifyHelper
 
   OVERRIDE_FIELDS_ON_FB_UPDATE = [:contact_id, :person_id, :request_id, :invitation_id, :photo_url, :name, :username]
   MAX_CHARACTERS = 420
@@ -19,7 +21,7 @@ class Services::Facebook < Service
   end
 
   def create_post_params(post)
-    message = post.text(:plain_text => true)
+    message = strip_markdown(post.text(:plain_text => true))
     {:message => message, :access_token => self.access_token, :link => URI.extract(message, ['https', 'http']).first}
   end
 

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -21,4 +21,19 @@ describe Service do
   it 'by default has no profile photo url' do
     Service.new.profile_photo_url.should be_nil
   end
+  
+  it 'removes text formatting markdown from post text' do
+    service = Service.new()
+    message = "Text with some **bolded** and _italic_ parts."
+    post = stub(:text => message)
+    service.public_message(post, 200, '', false).should match "Text with some bolded and italic parts."
+  end
+  
+  it 'keeps markdown in post text when specified' do
+    service = Service.new()
+    message = "Text with some **bolded** and _italic_ parts."
+    post = stub(:text => message)
+    service.public_message(post, 200, '', false, true).should match 'Text with some \*\*bolded\*\* and _italic_ parts.'
+  end
+  
 end

--- a/spec/models/services/facebook_spec.rb
+++ b/spec/models/services/facebook_spec.rb
@@ -31,6 +31,14 @@ describe Services::Facebook do
       @service.should_not_receive(:public_message)
       @service.post(@post, url)
     end
+    
+    it 'removes text formatting markdown from post text' do
+      message = "Text with some **bolded** and _italic_ parts."
+      post = stub(:text => message)
+      post_params = @service.create_post_params(post)
+      post_params[:message].should match "Text with some bolded and italic parts."
+    end
+    
   end
 
   describe "#profile_photo_url" do

--- a/spec/models/services/twitter_spec.rb
+++ b/spec/models/services/twitter_spec.rb
@@ -27,7 +27,15 @@ describe Services::Twitter do
       @service.should_receive(:public_message).with(@post, url)
       @service.post(@post, url)
     end
+    
+    it 'removes text formatting markdown from post text' do
+      message = "Text with some **bolded** and _italic_ parts."
+      post = stub(:text => message, :photos => [])
+      @service.public_message(post, '').should match "Text with some bolded and italic parts."
+    end
+    
   end
+  
   describe "message size limits" do
     before :each do
       @long_message_start = SecureRandom.hex(25)


### PR DESCRIPTION
Remove by default markdown formatting from posts done via service, currently only used by Twitter. Remove markdown also from Facebook posts.

Tumblr not touched - it supports markdown.
