### PR TITLE
fix css error with intivation people block in search results

### DIFF
--- a/app/views/people/index.html.haml
+++ b/app/views/people/index.html.haml
@@ -38,9 +38,9 @@
 
       = will_paginate(@people)
 
-.span-8.last
 - if AppConfig.settings.invitations.open?
-  %h4
-    = t('.couldnt_find_them_send_invite')
-  = render "shared/invitations"
+  .span-8.last
+    %h4
+      = t('.couldnt_find_them_send_invite')
+    = render "shared/invitations"
 


### PR DESCRIPTION
My fault => https://github.com/diaspora/diaspora/pull/3708
# BEFORE

![](https://jauspora.com/uploads/images/029c16e427e9055ce653.png)
# AFTER with open invitations

![](https://jauspora.com/uploads/images/53b02d238b4ac30e273c.png)
# AFTER with close invitations

![](https://jauspora.com/uploads/images/fc418734f8f96f83c6d0.png)
