### PR TITLE
Fix notifications for private messages between local users, fixes #2321

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -41,6 +41,7 @@
 * Fix misconfiguration of Devise to allow the session to be remembered. [#3472](https://github.com/diaspora/diaspora/issues/3472)
 * Fix problem with show reshares_count in stream. [#3700](https://github.com/diaspora/diaspora/pull/3700)
 * Fix error with notifications count in mobile. [#3721](https://github.com/diaspora/diaspora/pull/3721)
+* Fix conversation unread message count bug. [#2321](https://github.com/diaspora/diaspora/issues/2321)
 
 ## Gem updates
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -59,13 +59,10 @@ class Message < ActiveRecord::Base
     self.conversation = parent
   end
 
-  def after_receive(user, person)
+  def increase_unread(user)
     if vis = ConversationVisibility.where(:conversation_id => self.conversation_id, :person_id => user.person.id).first
       vis.unread += 1
       vis.save
-      self
-    else
-      raise NotVisibleError.new("User #{user.id} with person #{user.person.id} is not allowed to see conversation #{conversation.id}!")
     end
   end
 

--- a/app/models/notifications/private_message.rb
+++ b/app/models/notifications/private_message.rb
@@ -8,7 +8,7 @@ class Notifications::PrivateMessage < Notification
   def self.make_notification(recipient, target, actor, notification_type)
     n = notification_type.new(:target => target,
                                :recipient_id => recipient.id)
-
+    target.increase_unread(recipient)
     n.actors << actor
     n
   end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -96,12 +96,12 @@ describe Message do
     let(:build_object) { Message.new(:author => @alice.person, :text => "ohai!", :conversation => @conversation) }
     it_should_behave_like 'it is relayable'
 
-    describe '#after_receive' do
+    describe '#increase_unread' do
       it 'increments the conversation visiblity for the conversation' do
        ConversationVisibility.where(:conversation_id => @object_by_recipient.reload.conversation.id,
                                                      :person_id => @local_luke.person.id).first.unread.should == 0
 
-        @object_by_recipient.receive(@local_luke, @local_leia.person)
+        @object_by_recipient.increase_unread(@local_luke)
         ConversationVisibility.where(:conversation_id => @object_by_recipient.reload.conversation.id,
                                                      :person_id => @local_luke.person.id).first.unread.should == 1
       end

--- a/spec/models/notifications/private_message_spec.rb
+++ b/spec/models/notifications/private_message_spec.rb
@@ -40,6 +40,31 @@ describe Notifications::PrivateMessage do
         @user2.should_receive(:mail)
         n.email_the_user(@msg, @user1.person)
       end
+      
+      it 'increases user unread count - author user 1' do
+        message = @cnv.messages.build(
+          :text   => "foo bar",
+          :author => @user1.person
+        )
+        message.save
+        n = Notifications::PrivateMessage.make_notification(@user2, message, @user1.person, Notifications::PrivateMessage)
+        
+        ConversationVisibility.where(:conversation_id => message.reload.conversation.id,
+            :person_id => @user2.person.id).first.unread.should == 1
+      end
+      
+      it 'increases user unread count - author user 2' do
+        message = @cnv.messages.build(
+          :text   => "foo bar",
+          :author => @user2.person
+        )
+        message.save
+        n = Notifications::PrivateMessage.make_notification(@user1, message, @user2.person, Notifications::PrivateMessage)
+        
+        ConversationVisibility.where(:conversation_id => message.reload.conversation.id,
+            :person_id => @user1.person.id).first.unread.should == 1
+      end
+      
     end
 end
  


### PR DESCRIPTION
Fixes notifications for private messages for local users. But I couldn't get specs from pull #3704 to work with this code change.

Any hints would be nice so those specs could be used. Otherwise will try to include specs tomorrow.
