### PR TITLE
3682 fix padlock images

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -27,6 +27,7 @@
 
 ## Bug Fixes
 
+* Fix image path for padlocks [#3682](https://github.com/diaspora/diaspora/pull/3682)
 * Fix posting to Facebook and Tumblr. Have a look at the updated [services guide](https://github.com/diaspora/diaspora/wiki/Howto-setup-services) for new Facebook instructions.
 * Fix overflow button in mobile reset password. [#3697](https://github.com/diaspora/diaspora/pull/3697)
 * Fix issue with interacted_at in post fetcher. [#3607](https://github.com/diaspora/diaspora/pull/3607)

--- a/app/views/aspects/toggle_contact_visibility.js.erb
+++ b/app/views/aspects/toggle_contact_visibility.js.erb
@@ -3,10 +3,10 @@ $(document).ready(function() {
   var padlockImg = $("#contact_visibility_padlock");
 
   if(padlockImg.hasClass('open')) {
-    padlockImg.attr('src', 'images/icons/padlock-closed.png');
+    padlockImg.attr('src', 'assets/icons/padlock-closed.png');
     padlockImg.attr('title', "<%= t('aspects.edit.aspect_list_is_not_visible') %>");
   } else {
-    padlockImg.attr('src', 'images/icons/padlock-open.png');
+    padlockImg.attr('src', 'assets/icons/padlock-open.png');
     padlockImg.attr('title', "<%= t('aspects.edit..aspect_list_is_visible') %>");
   }
   padlockImg.toggleClass('open');


### PR DESCRIPTION
This fixes issue #3682 by using the correct path to the padlocks images in the js.
