### PR TITLE
Feature/2704 fix aspects

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@
 
 * Force Typhoeus/cURL to use the CA bundle we query via the config. Also add a setting for extra verbose output.
 * Validate input on sending invitations, validate email format, send correct ones. [#3748](https://github.com/diaspora/diaspora/pull/3748), [#3271](https://github.com/diaspora/diaspora/issues/3271)
+* moved Aspects JS initializer to the correct place so aspect selection / deselection works again [#3737] (https://github.com/diaspora/diaspora/pull/3737)
 
 # 0.0.2.0
 

--- a/app/assets/javascripts/pages/streams-aspects.js
+++ b/app/assets/javascripts/pages/streams-aspects.js
@@ -1,4 +1,4 @@
-Diaspora.Pages.AspectsIndex = function() {
+Diaspora.Pages.StreamsAspects = function() {
   var self = this;
 
   this.subscribe("page/ready", function(evt, document) {

--- a/app/assets/javascripts/widgets/aspect-navigation.js
+++ b/app/assets/javascripts/widgets/aspect-navigation.js
@@ -43,6 +43,12 @@
 
     this.perform = function() {
       if (self.noneSelected()) {
+        // clear the posts
+        app.page.collection.reset();
+        app.page.render();
+
+        // toggle the button
+        this.calculateToggleText();
         return;
       } else {
         window.location = self.generateURL(); // hella hax

--- a/features/aspect_navigation.feature
+++ b/features/aspect_navigation.feature
@@ -7,11 +7,13 @@ Feature: Aspect navigation on the left menu
     Background:
       Given a user with username "bob"
       And I sign in as "bob@bob.bob"
+      And I have an aspect called "Others"
 
     Scenario: All aspects are selected by default
       When I go to the aspects page
       Then I should see "Besties" aspect selected
       Then I should see "Unicorns" aspect selected
+      Then I should see "Others" aspect selected
 
     Scenario: Aspects selection is remembered through site navigation
       When I go to the aspects page
@@ -20,3 +22,12 @@ Feature: Aspect navigation on the left menu
       And I go to the aspects page
       Then I should see "Besties" aspect selected
       Then I should see "Unicorns" aspect unselected
+      Then I should see "Others" aspect unselected
+
+    Scenario: Aspects selection can include one or more aspects
+      When I go to the aspects page
+      And I select only "Besties" aspect
+      And I select "Unicorns" aspect as well
+      Then I should see "Besties" aspect selected
+      Then I should see "Unicorns" aspect selected
+      Then I should see "Others" aspect unselected

--- a/features/step_definitions/aspects_steps.rb
+++ b/features/step_definitions/aspects_steps.rb
@@ -26,6 +26,14 @@ When /^I select only "([^"]*)" aspect$/ do |aspect_name|
   step %{I wait for the ajax to finish}
 end
 
+When /^I select "([^"]*)" aspect as well$/ do |aspect_name|
+  within('#aspect_nav') do
+    click_link aspect_name
+  end
+
+  step %{I wait for the ajax to finish}
+end
+
 When /^I should see "([^"]*)" aspect selected$/ do |aspect_name|
   aspect = @me.aspects.where(:name => aspect_name).first
   within("#aspect_nav") do


### PR DESCRIPTION
So I started out trying to improve on the changes by visualsayed in #3194 but it turns out changing things on the ruby / rails side was a total red herring, the problem was/is that none of the correct Aspect javascript was being activated, because the name of the page, at some point, changed from "AspectsIndex" to "StreamsAspects", presumably when the streams controller started taking over from other controllers.

Anyway, all that was need to fix #2704 was to rename the javascript file / page. I've also added a new cucumber test that fails without these changes, and slightly altered the behaviour of the "deselect all" link, because it annoyed me. If anyone has a better way to clear the stream, or thinks it's a bad idea, just say so =)
