### PR TITLE
add x-frame headers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,10 @@ gem 'rails_autolink', '1.0.9'
 
 gem 'rack-cors', '0.2.7', :require => 'rack/cors'
 
+# click-jacking protection
+
+gem 'rack-protection', '1.2'
+
 # authentication
 
 gem 'devise', '2.1.2'

--- a/config.ru
+++ b/config.ru
@@ -14,4 +14,6 @@ if defined?(Unicorn)
 end
 use Rack::Deflater
 use Rack::ChromeFrame, :minimum => 8
+use Rack::Protection::FrameOptions
+
 run Diaspora::Application


### PR DESCRIPTION
as described in issue #3534, without x-frame headers we are vulnerable to click-jacking. I used v 1.2 because sinatra already uses that version.
