### PR TITLE
3271 invitation email validation

### DIFF
--- a/app/views/invitations/new.html.haml
+++ b/app/views/invitations/new.html.haml
@@ -19,11 +19,13 @@
       = form_tag new_user_invitation_path  do
         %h4
           = t('email')
-        = text_field_tag 'email_inviter[emails]' ,nil, :title => t('.comma_separated_plz'), :placeholder => 'foo@bar.com, max@foo.com...'
+        = text_field_tag 'email_inviter[emails]', @invalid_emails, :title => t('.comma_separated_plz'), :placeholder => 'foo@bar.com, max@foo.com...'
+        %p
+          = t('invitations.create.note_already_sent', :emails => @valid_emails) unless @valid_emails.empty?
         %br
 
         %h4
-          = t('.language')	
+          = t('.language')
         = select_tag('email_inviter[locale]',  options_from_collection_for_select(available_language_options, "second", "first", :selected => current_user.language))
 
         %br

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -362,6 +362,8 @@ en:
       already_sent: "You already invited this person."
       already_contacts: "You are already connected with this person"
       own_address: "You can't send an invitation to your own address."
+      empty: "Please enter at least one email address."
+      note_already_sent: "Invitations have already been sent to: %{emails}"
     new:
       language: "Language"
       invite_someone_to_join: "Invite someone to join Diaspora!"
@@ -519,18 +521,18 @@ en:
     invite:
       message: |-
         Hello!
-        
+
         You have been invited to join Diaspora*!
-        
+
         Click this link to get started
-        
+
         [%{invite_url}][1]
-        
-        
+
+
         Love,
-        
+
         The Diaspora* email robot!
-        
+
         [1]: %{invite_url}
   people:
     zero: "no people"


### PR DESCRIPTION
For validating emails we used the Regexp '\b[A-Z0-9._%+-]+@[A-Z0-9.-]+.[A-Z]{2,4}\b'
taken from http://www.regular-expressions.info/email.html. If you want a different expression just let me know. 
The entered emails are split according to this validation method. The correct ones are delivered anyway and a notice/error informs the user about the status. 
Valid/Invalid Emails are stored in session variables that are used to repopulate the form. Invalid emails are put in the input field while valid ones appear just below with a notice. We've added two definitions to the locales/diaspora/en.yml file for use in flash messages/form.
The session variables are cleared after the first request to InvitationsController#new. 

Please let me now if you have any questions/if there are improvements I should implement.
