### PR TITLE
Revert xframe protection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,10 +12,6 @@ gem 'rails_autolink', '1.0.9'
 
 gem 'rack-cors', '0.2.7', :require => 'rack/cors'
 
-# click-jacking protection
-
-gem 'rack-protection', '1.2'
-
 # authentication
 
 gem 'devise', '2.1.2'

--- a/config.ru
+++ b/config.ru
@@ -14,6 +14,4 @@ if defined?(Unicorn)
 end
 use Rack::Deflater
 use Rack::ChromeFrame, :minimum => 8
-use Rack::Protection::FrameOptions
-
 run Diaspora::Application


### PR DESCRIPTION
This was causing comments to fail posting. Original PR here https://github.com/diaspora/diaspora/pull/3756. @Raven24 I found this by using git bisect to step through the commits, and I just started the server locally and checked to see if they would post or not. This would close #3751.
