### PR TITLE
Mark all unread post-related notifications as read, if one of this gets opened. Close #3665

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@
 * Add simple background for unread messages/conversations mobile. [#3724](https://github.com/diaspora/diaspora/pull/3724)
 * Add flash warning to conversation mobile, unification of flash warning with login and register mobile, and add support for flash warning to Opera browser. [#3686](https://github.com/diaspora/diaspora/pull/3686)
 * Add progress percentage to upload images. [#3740](https://github.com/diaspora/diaspora/pull/3740)
+* Mark all unread post-related notifications as read, if one of this gets opened. [#3787](https://github.com/diaspora/diaspora/pull/3787)
 
 ## Bug Fixes
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,4 @@
-  #   Copyright (c) 2010-2011, Diaspora Inc.  This file is
+#   Copyright (c) 2010-2011, Diaspora Inc.  This file is
 #   licensed under the Affero General Public License version 3 or later.  See
 #   the COPYRIGHT file.
 
@@ -25,7 +25,7 @@ class PostsController < ApplicationController
   end
 
   def show
-    mark_corresponding_notification_read if user_signed_in?
+    mark_corresponding_notifications_read if user_signed_in?
 
     respond_to do |format|
       format.html{ gon.post = PostPresenter.new(@post, current_user); render 'posts/show' }
@@ -77,7 +77,7 @@ class PostsController < ApplicationController
     current_user.retract(@post)
 
     respond_to do |format|
-      format.js { render 'destroy',:layout => false,  :format => :js }
+      format.js { render 'destroy',:layout => false, :format => :js }
       format.json { render :nothing => true, :status => 204 }
       format.any { redirect_to stream_path }
     end
@@ -104,10 +104,10 @@ class PostsController < ApplicationController
    request.format = :html if request.format == 'application/html+xml'
   end
 
-  def mark_corresponding_notification_read
-    if notification = Notification.where(:recipient_id => current_user.id, :target_id => @post.id, :unread => true).first
-      notification.unread = false
-      notification.save
+  def mark_corresponding_notifications_read
+    Notification.where(recipient_id: current_user.id, target_id: @post.id, unread: true).each do |n|
+      n.unread = false
+      n.save!
     end
   end
 end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -40,15 +40,14 @@ describe PostsController do
         response.should be_success
       end
 
-      it 'marks a corresponding notification as read' do
-        # Ensure that it doesn't mark a read notification as read
-        FactoryGirl.create(:notification, :recipient => alice, :target => @message, :unread => false)
+      it 'marks a corresponding notifications as read' do
+        FactoryGirl.create(:notification, :recipient => alice, :target => @message, :unread => true)
         note = FactoryGirl.create(:notification, :recipient => alice, :target => @message, :unread => true)
 
         expect {
           get :show, :id => @message.id
           note.reload
-        }.to change(note, :unread).from(true).to(false)
+        }.to change(Notification.where(:unread => true), :count).by(-2)
       end
 
       it 'succeeds with a AS/photo' do


### PR DESCRIPTION
#3665

Do you think of this change in the notifications? To me it seems logical
