### PR TITLE
Send TEXTAREA content instead of default message

### DIFF
--- a/app/views/tags/show.haml
+++ b/app/views/tags/show.haml
@@ -2,6 +2,8 @@
 -#   licensed under the Affero General Public License version 3 or later.  See
 -#   the COPYRIGHT file.
 
+- content_for :head do
+  = javascript_include_tag :home
 
 - content_for :page_title do
   - if @stream.tag_name


### PR DESCRIPTION
Add inclusion of home.js to correct post messages on example.org/tags/tagname page
