### PR TITLE
Fix reshare

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -37,6 +37,7 @@
 * Allow translation of "suggest member" of Community Spotlight. [#3791](https://github.com/diaspora/diaspora/issues/3791)
 * Resize deletelabel and ignoreuser images to align them [#3779](https://github.com/diaspora/diaspora/issues/3779)
 * Patch in Armenian pluralization rule until CLDR provides it.
+* Fix reshare a post multiple times[#3831](https://github.com/diaspora/diaspora/issues/3671)
 
 ## Gem Updates
 

--- a/app/assets/javascripts/app/models/post/interactions.js
+++ b/app/assets/javascripts/app/models/post/interactions.js
@@ -95,13 +95,19 @@ app.models.Post.Interactions = Backbone.Model.extend({
   reshare : function(){
     var interactions = this
       , reshare = this.post.reshare()
+      , flash = new Diaspora.Widgets.FlashMessages;
 
     reshare.save({}, {
       success : function(resp){
-        var flash = new Diaspora.Widgets.FlashMessages;
         flash.render({
           success: true,
           notice: Diaspora.I18n.t("reshares.successful")
+        });
+      },
+      error: function(resp){
+        flash.render({
+          success: false,
+          notice: Diaspora.I18n.t("reshares.duplicate")
         });
       }
     }).done(function(){
@@ -119,7 +125,8 @@ app.models.Post.Interactions = Backbone.Model.extend({
       , publicPost = this.post.get("public")
       , userIsNotAuthor = this.post.get("author").diaspora_id != app.currentUser.get("diaspora_id")
       , userIsNotRootAuthor = rootExists && (isReshare ? this.post.get("root").author.diaspora_id != app.currentUser.get("diaspora_id") : true)
+      , notReshared = this.reshares.length === 0;
 
-    return publicPost && app.currentUser.authenticated() && userIsNotAuthor && userIsNotRootAuthor;
+    return publicPost && app.currentUser.authenticated() && userIsNotAuthor && userIsNotRootAuthor && notReshared;
   }
 });

--- a/app/controllers/reshares_controller.rb
+++ b/app/controllers/reshares_controller.rb
@@ -7,8 +7,9 @@ class ResharesController < ApplicationController
     if @reshare.save
       current_user.add_to_streams(@reshare, current_user.aspects)
       current_user.dispatch_post(@reshare, :url => post_url(@reshare), :additional_subscribers => @reshare.root_author)
+      render :json => ExtremePostPresenter.new(@reshare, current_user), :status => 201
+    else
+      render :nothing => true, :status => 422
     end
-
-    render :json => ExtremePostPresenter.new(@reshare, current_user), :status => 201
   end
 end

--- a/features/reshare.feature
+++ b/features/reshare.feature
@@ -22,3 +22,4 @@ Feature: public repost
     And I wait for the ajax to finish
     Then I should see a flash message indicating success
     And I should see a flash message containing "successfully"
+    And I should not see a ".reshare" within ".feedback"

--- a/spec/controllers/reshares_controller_spec.rb
+++ b/spec/controllers/reshares_controller_spec.rb
@@ -7,7 +7,8 @@ describe ResharesController do
     }
 
     before do
-      @post_guid = FactoryGirl.create(:status_message, :public => true).guid
+      @post = FactoryGirl.create(:status_message, :public => true)
+      @post_guid = @post.guid
     end
 
     it 'requires authentication' do
@@ -40,6 +41,18 @@ describe ResharesController do
       it 'calls dispatch' do
         bob.should_receive(:dispatch_post).with(anything, hash_including(:additional_subscribers))
         post_request!
+      end
+
+      context 'resharing a reshared post' do
+        before do
+          FactoryGirl.create(:reshare, :root => @post, :author => bob.person)
+        end
+
+        it 'doesn\'t allow the user to reshare the post again' do
+          post_request!
+          response.code.should == '422'
+          response.body.strip.should be_empty
+        end
       end
     end
   end


### PR DESCRIPTION
Hi guys,

These pull request fixes issue #3671 and some other problems.
Basically what it does is to remove the  Reshare link after the user reshares the post by adding a new condition to this function https://github.com/marpo60/diaspora/pull/new/fix-reshare#L1R130. It asks if the post is reshared by the current user, so when the reshare model is saved, the reshare models is added to the reshare's collection in backbone and the 'change' event is triggered which causes the view to be re-rendered.

It looks a bit strange because the interactions are implemented as a collection in backbone but   , that collection should be empty or contain the reshare of the current user afaik.

This also brings back the error message in case you try to reshare the same post twice (the only way that it can happen is by having multiple tabs open at the same time).

Cheers!
