### PR TITLE
Logged out user streams options

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -27,6 +27,7 @@
 * Re-add hovercards [#3802](https://github.com/diaspora/diaspora/pull/3802)
 * Add images to notifications [#3821](https://github.com/diaspora/diaspora/pull/3821)
 * Show pod version in footer and updated the link to the changelog [#3822](https://github.com/diaspora/diaspora/pull/3822)
+* User interface enhancements [#3832](https://github.com/diaspora/diaspora/pull/3832), [#3839](https://github.com/diaspora/diaspora/pull/3839), [#3834](https://github.com/diaspora/diaspora/pull/3834).
 
 ## Bug Fixes
 

--- a/app/assets/templates/stream-element_tpl.jst.hbs
+++ b/app/assets/templates/stream-element_tpl.jst.hbs
@@ -1,10 +1,10 @@
 <div class="media">
 
-  {{#if current_user}}
+  {{#if loggedIn}}
     <div class="controls">
       {{#unless authorIsCurrentUser}}
         <a href="#" rel="nofollow" class="block_user">
-          <img src="{{imageUrl "icons/ignoreuser.png"}}"" alt="Ignoreuser" class="control_icon" title="{{t "ignore"}}" />
+          <img src="{{imageUrl "icons/ignoreuser.png"}}" alt="Ignoreuser" class="control_icon" title="{{t "ignore"}}" />
         </a>
         <a href="#" rel="nofollow" class="hide_post">
           <img src="{{imageUrl "deletelabel.png"}}" class="delete control_icon" title="{{t "stream.hide"}}" />

--- a/features/logged_out_browsing.feature
+++ b/features/logged_out_browsing.feature
@@ -12,6 +12,7 @@ Feature: Browsing Diaspora as a logged out user
     Scenario: Visiting a profile page
       When I am on "bob@bob.bob"'s page
       Then I should see "public stuff" within "body"
+      And page should not have ".media .controls"
 
     Scenario: Clicking Last Post
       When I am on "bob@bob.bob"'s page

--- a/features/step_definitions/custom_web_steps.rb
+++ b/features/step_definitions/custom_web_steps.rb
@@ -175,6 +175,10 @@ Then /^(?:|I )should not see a "([^\"]*)"(?: within "([^\"]*)")?$/ do |selector,
   end
 end
 
+Then /^page should (not )?have "([^\"]*)"$/ do |negate, selector|
+  page.has_css?(selector).should ( negate ? be_false : be_true )
+end
+
 When /^I wait for the ajax to finish$/ do
   wait_for_ajax_to_finish
 end


### PR DESCRIPTION
Non-logged users can see the stream options "Hide" and "Ignore".

If any option is issued (by clicking on them) server will respond with '401 Unauthorized' and message `{"error":"You need to sign in or sign up before continuing."}`, which is not displayed to the user.

This fix removes the options for non-logged users.
