### PR TITLE
Align close button images

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -2804,6 +2804,9 @@ a.toggle_selector
     :top -9px
     :right -5px
 
+    img
+      margin-top: 10px
+
   &:hover
     .close
       @include opacity(0.5)


### PR DESCRIPTION
While doing code review for someone else, I noticed that the "X" images on the popover were a bit off center, so I added this style to fix it.
