### PR TITLE
Issue #3672: Reshare alert box is appearing twice

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -52,6 +52,7 @@
 * Resize full scaled image to a specific width. [#3818](https://github.com/diaspora/diaspora/issues/3818)
 * Fix translation issue in contacts_helper [#3937](https://github.com/diaspora/diaspora/pull/3937)
 * Show timestamp hovering a timeago string (stream) [#3149](https://github.com/diaspora/diaspora/issues/3149)
+* Fix reshare and like a post on a single post view [#3672](https://github.com/diaspora/diaspora/issues/3672)
 
 ## Gem Updates
 

--- a/app/assets/javascripts/app/views/feedback_actions.js
+++ b/app/assets/javascripts/app/views/feedback_actions.js
@@ -1,5 +1,7 @@
 //=require "./feedback_view"
 app.views.FeedbackActions = app.views.Feedback.extend({
   id : "user-controls",
-  templateName : "feedback-actions"
+  templateName : "feedback-actions",
+  events: {},
+  initialize: function(){}
 });

--- a/features/reshare.feature
+++ b/features/reshare.feature
@@ -11,6 +11,18 @@ Feature: public repost
       | Alice Smith | alice@alice.alice |
     And a user with email "bob@bob.bob" is connected with "alice@alice.alice"
 
+  Scenario: Resharing a post from a single post page
+    Given "bob@bob.bob" has a public post with text "reshare this!"
+    And I sign in as "alice@alice.alice"
+    And I am on "bob@bob.bob"'s page
+    And I follow "Last Post"
+
+    And I preemptively confirm the alert
+    And I click on selector "a.reshare"
+    And I wait for the ajax to finish
+    Then I should see a flash message indicating success
+    And I should see a flash message containing "successfully"
+
   # should be covered in rspec, so testing that the post is added to
   # app.stream in jasmine should be enough coverage
   Scenario: When I reshare, it shows up on my profile page

--- a/spec/javascripts/app/views/feedback_actions_view_spec.js
+++ b/spec/javascripts/app/views/feedback_actions_view_spec.js
@@ -1,0 +1,55 @@
+describe("app.views.FeedbackActions", function(){
+  beforeEach(function(){
+    loginAs({id : -1, name: "alice", avatar : {small : "http://avatar.com/photo.jpg"}});
+
+    this.post = new app.models.Post({
+      "author": {
+        "diaspora_id": "alice@localhost:3000"
+      },
+      "post_type": "Reshare",
+      "public": true,
+      "root": {
+        "author":{"diaspora_id": null}
+      }
+    })
+
+    this.view = new app.views.PostViewerFeedback({model: this.post})
+  });
+
+  describe("FeedbackActions", function(){
+    it("reshares a post", function(){
+
+      spyOn(window, "confirm").andReturn(true)
+      spyOn(this.view.model.interactions, "reshare")
+
+      this.view.render()
+
+      this.view.$('.reshare').click()
+
+      expect(this.view.model.interactions.reshare.callCount).toBe(1)
+      expect(window.confirm.callCount).toBe(1)
+    });
+
+    it('cancels a reshare confirmation ', function(){
+      spyOn(window, "confirm").andReturn(false)
+      spyOn(this.view.model.interactions, "reshare")
+
+      this.view.render()
+
+      this.view.$('.reshare').click()
+
+      expect(this.view.model.interactions.reshare).not.toHaveBeenCalled();
+    });
+
+    it("likes a post", function(){
+      
+      spyOn(this.view.model.interactions, "toggleLike")
+
+      this.view.render()
+
+      this.view.$('.like').click()
+
+      expect(this.view.model.interactions.toggleLike.callCount).toBe(1)
+    })
+  })
+})


### PR DESCRIPTION
Fixes issue https://github.com/diaspora/diaspora/issues/3672

`PostViewerFeedback` extends `Feedback` (which attach listeners on `.reshare` and `.like`) but also has method `initViews` which creates a new `FeedbackActions`, this one also extends `Feedback`. 

`Feedback`'s `initialize` method calls `initViews`, thus attaching its listeners twice.

I override on FeedbackActions `initialize` and `events`
