### PR TITLE
Issue #3851: Profile pictures not centered

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -27,7 +27,7 @@
 * Re-add hovercards [#3802](https://github.com/diaspora/diaspora/pull/3802)
 * Add images to notifications [#3821](https://github.com/diaspora/diaspora/pull/3821)
 * Show pod version in footer and updated the link to the changelog [#3822](https://github.com/diaspora/diaspora/pull/3822)
-* User interface enhancements [#3832](https://github.com/diaspora/diaspora/pull/3832), [#3839](https://github.com/diaspora/diaspora/pull/3839), [#3834](https://github.com/diaspora/diaspora/pull/3834), [#3840](https://github.com/diaspora/diaspora/issues/3840), [#3846](https://github.com/diaspora/diaspora/issues/3846).
+* User interface enhancements [#3832](https://github.com/diaspora/diaspora/pull/3832), [#3839](https://github.com/diaspora/diaspora/pull/3839), [#3834](https://github.com/diaspora/diaspora/pull/3834), [#3840](https://github.com/diaspora/diaspora/issues/3840), [#3846](https://github.com/diaspora/diaspora/issues/3846), [#3851](https://github.com/diaspora/diaspora/issues/3851).
 
 ## Bug Fixes
 

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -1941,6 +1941,7 @@ ul#press_logos
     :height 35px
     :margin
       :right 10px
+      :bottom 10px
 
   &:hover:not(.selected)
     :background

--- a/app/assets/stylesheets/mobile.css.scss
+++ b/app/assets/stylesheets/mobile.css.scss
@@ -142,6 +142,12 @@ body {
   border-bottom: 1px solid #aaa;
 }
 
+.stream_element div.img img.avatar {
+  margin: 10px;
+}
+.stream_element .bd {
+  padding-top: 10px;
+}
 .photo_attachments {
   position: relative;
   left: 0;
@@ -660,13 +666,14 @@ display: inline-block;
 .message_count {
   border-radius: 2px 2px 2px 2px;
   float: right;
-  margin: 2px 2px 1px 5px;
+  margin: 10px 10px 1px 5px;
   padding: 0 2px 1px;
   position: relative;
   background-color: #999;
   color: #eee;
   font-size: 10px;
   line-height: 12px;
+
 }
 
 .conversation_participants img.avatar{
@@ -675,10 +682,15 @@ display: inline-block;
 	margin: 5px 0 5px 2px;
 }
 
+.conversations img.avatar{
+  margin: 10px;
+  float: left;
+}
+
 .unread_message_count {
   border-radius: 2px 2px 2px 2px;
   float: right;
-  margin: 2px 2px 1px 5px;
+  margin: 10px 2px 1px 5px;
   padding: 0 2px 1px;
   position: relative;
   background-color: #B11;
@@ -689,7 +701,7 @@ display: inline-block;
 
 .last_author {
   position: relative;
-  margin: 10px 5px 2px;
+  margin: 10px 10px 2px;
   float: right;
   font-size: 12px;
   color: #444;

--- a/app/views/notifications/index.mobile.haml
+++ b/app/views/notifications/index.mobile.haml
@@ -14,9 +14,8 @@
         - notes.each do |note|
           .stream_element{:data=>{:guid => note.id}, :class => "#{note.unread ? 'unread' : 'read'}"}
 
-            = person_image_link(note.actors.last)
-
             .content
+              =person_image_link(note.actors.last)
               %span.from
                 = notification_message_for(note)
               .time

--- a/app/views/people/_person.mobile.haml
+++ b/app/views/people/_person.mobile.haml
@@ -3,9 +3,9 @@
 -#   the COPYRIGHT file.
 
 .stream_element{:id => person.id}
-  = person_image_link(person)
 
   .content
+    =person_image_link(person)
     %span.from
       =person_link(person)
 


### PR DESCRIPTION
Fixes https://github.com/diaspora/diaspora/issues/3851

Notifications:
![diaspora-bug-ui-profile-picture-1](https://f.cloud.github.com/assets/1857707/77393/701c6ba6-613a-11e2-8034-33538f0aa07c.png)

Conversations:
![diaspora-bug-ui-mobile-inbox3](https://f.cloud.github.com/assets/1857707/77460/82f2525e-613f-11e2-86b1-dc477228f5d1.png)

![diaspora-bug-ui-mobile-inbox1](https://f.cloud.github.com/assets/1857707/77458/409e3d8c-613f-11e2-8925-1cee50562e01.png)

![diaspora-bug-ui-mobile-inbox4](https://f.cloud.github.com/assets/1857707/77484/9e3b8a10-6141-11e2-9b94-9eadd1a73d56.png)

Search:
![diaspora-bug-ui-profile-search](https://f.cloud.github.com/assets/1857707/77395/7aa68750-613a-11e2-8e14-73fd8b86516a.png)
