### PR TITLE
Fix services index view

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -41,6 +41,7 @@
 * Resize deletelabel and ignoreuser images to align them [#3779](https://github.com/diaspora/diaspora/issues/3779)
 * Patch in Armenian pluralization rule until CLDR provides it.
 * Fix reshare a post multiple times[#3831](https://github.com/diaspora/diaspora/issues/3671)
+* Fix services index view. [#3884](https://github.com/diaspora/diaspora/issues/3884)
 
 ## Gem Updates
 

--- a/app/views/shared/_add_remove_services.haml
+++ b/app/views/shared/_add_remove_services.haml
@@ -15,5 +15,5 @@
     = t('services.index.no_services')
 
 - AppConfig.configured_services.each do |service|
-  - unless @services.any?{|x| x.provider == service}
+  - unless @services.any?{|x| x.provider == service.to_s}
     %h4= link_to(t("services.index.connect_to_#{service}"), "/auth/#{service}")


### PR DESCRIPTION
Before
![Screenshot from 2013-01-24 20:07:08](https://f.cloud.github.com/assets/1080592/96096/a19fba3e-668f-11e2-99f6-b006698bfeec.png)
After
![Screenshot from 2013-01-24 20:22:18](https://f.cloud.github.com/assets/1080592/96100/b402b6c2-668f-11e2-8acf-a3d6ed395f1b.png)

Because, `:twitter == "twitter"` gives `false`. I believed that this gives `true`, did it change in recent versions of ruby? 
