### PR TITLE
Hovering a Timeago-String should show the Timestamp

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -51,6 +51,7 @@
 * Excesive padding with "user-controls" in single post view. [#3861](https://github.com/diaspora/diaspora/issues/3861)
 * Resize full scaled image to a specific width. [#3818](https://github.com/diaspora/diaspora/issues/3818)
 * Fix translation issue in contacts_helper [#3937](https://github.com/diaspora/diaspora/pull/3937)
+* Show timestamp hovering a timeago string (stream) [#3149](https://github.com/diaspora/diaspora/issues/3149)
 
 ## Gem Updates
 

--- a/app/assets/javascripts/app/helpers/handlebars-helpers.js
+++ b/app/assets/javascripts/app/helpers/handlebars-helpers.js
@@ -40,3 +40,7 @@ Handlebars.registerHelper('personImage', function(person, size, imageClass) {
     'title': _.escape(person.name)
   });
 });
+
+Handlebars.registerHelper('localTime', function(timestamp) {
+  return new Date(timestamp).toLocaleString();
+});

--- a/app/assets/javascripts/app/views/stream_post_views.js
+++ b/app/assets/javascripts/app/views/stream_post_views.js
@@ -20,7 +20,7 @@ app.views.StreamPost = app.views.Post.extend({
     "click .block_user": "blockUser"
   },
 
-  tooltipSelector : ".delete, .block_user, .post_scope, .ignore",
+  tooltipSelector : ".timeago, .delete, .block_user, .post_scope, .ignore",
 
   initialize : function(){
     this.model.bind('remove', this.remove, this);

--- a/app/assets/templates/stream-element_tpl.jst.hbs
+++ b/app/assets/templates/stream-element_tpl.jst.hbs
@@ -32,7 +32,7 @@
       <span class="details grey">
         -
         <a href="/posts/{{id}}">
-          <time class="timeago" datetime="{{created_at}}" />
+          <time class="timeago" data-original-title="{{{localTime created_at}}}" datetime="{{created_at}}" />
         </a>
 
         {{#if interactions.reshares_count}}

--- a/app/views/messages/_message.haml
+++ b/app/views/messages/_message.haml
@@ -9,7 +9,7 @@
     .bd
       = person_link(message.author, :class => 'author from')
       %time.timeago{:datetime => message.created_at}
-        = how_long_ago(message)
+        = t('ago', :time =>  time_ago_in_words(message.created_at))
 
       %div{ :class => direction_for(message.text) }
         = markdownify(message, :oembed => true)


### PR DESCRIPTION
Fixes https://github.com/diaspora/diaspora/issues/3149

Inbox:
![diaspora-bug-ui-timestamp](https://f.cloud.github.com/assets/1857707/100074/ef01cf0c-67e7-11e2-8d8f-98c19513c0a8.png)

I can't easily add a timestamp on the inbox with the currenly way it's working, neither tooltips (as below). But I fixed the timeago thing.

Stream:
![diaspora-bug-ui-timestamp1](https://f.cloud.github.com/assets/1857707/100075/fa1689e6-67e7-11e2-8ea5-e55fa2671562.png)

I added a tooltip format to the timestamp to keep it unified with the close and hide buttons. I think the timeago underline should be removed.
