### PR TITLE
fix #2339: set unicode-bidi property to prevent username to overlay the pubdate [ci skip]

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -367,6 +367,7 @@ ul.as-selections
 .stream_element
   a.author
     :font-weight bold
+    :unicode-bidi bidi-override
 
   .photo_attachments
     :margin


### PR DESCRIPTION
#2339

before:after
![diaspora-rtl-2339](https://f.cloud.github.com/assets/438944/100879/1a51e648-6882-11e2-890c-2a5596057881.jpg)
