### PR TITLE
don't join the tags table here, it makes the query slower

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@
 * Update and refactor the default public view `public/default.html` [#3811](https://github.com/diaspora/diaspora/issues/3811)
 * Write unicorn stderr and stdout [#3785](https://github.com/diaspora/diaspora/pull/3785)
 * Ported aspects to backbone [#3850](https://github.com/diaspora/diaspora/pull/3850)
+* Join tagging's table instead of tags to improve a bit the query [#3932](https://github.com/diaspora/diaspora/pull/3932)
 
 ## Features
 

--- a/app/models/status_message.rb
+++ b/app/models/status_message.rb
@@ -173,7 +173,7 @@ class StatusMessage < Post
 
   private
   def self.tag_stream(tag_ids)
-    joins(:tags).where(:tags => {:id => tag_ids})
+    joins(:taggings).where('taggings.tag_id IN (?)', tag_ids)
   end
 end
 


### PR DESCRIPTION
Hi guys, as discussed in the IRC, we were joining the tags table [here](https://github.com/diaspora/diaspora/blob/develop/app/models/status_message.rb#L176), which is unnecessary.

This should improve the performance of the /followed_tags page. I've taken some measurements on my local machine with [this](https://gist.github.com/4649079) script (takes quite some time to run) which is a variation of the seeds.

I have taken like 20 samples and in average the response time of the json is improved by 1 sec, I would change this anyway being the join unnecessary.

Cheers!
