### PR TITLE
Embed associated photos into the status message xml

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -105,6 +105,7 @@ everything is set up.
 * Load images via sprites [#4039](https://github.com/diaspora/diaspora/pull/4039)
 * Delete unnecessary javascript views. [#4059](https://github.com/diaspora/diaspora/pull/4059)
 * Cleanup of script/server
+* Attempt to stabilize federation of attached photos (fix [#3033](https://github.com/diaspora/diaspora/issues/3033)  [#3940](https://github.com/diaspora/diaspora/pull/3940)
 
 ## Bug fixes
 

--- a/app/models/status_message.rb
+++ b/app/models/status_message.rb
@@ -14,6 +14,7 @@ class StatusMessage < Post
   validates_length_of :text, :maximum => 65535, :message => I18n.t('status_messages.too_long', :count => 65535)
   xml_name :status_message
   xml_attr :raw_message
+  xml_attr :photos, :as => [Photo]
 
   has_many :photos, :dependent => :destroy, :foreign_key => :status_message_guid, :primary_key => :guid
 

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -38,3 +38,7 @@ module Devise
     end
   end
 end
+
+
+# Ensure Builder is loaded
+require 'active_support/builder' unless defined?(Builder)

--- a/spec/models/status_message_spec.rb
+++ b/spec/models/status_message_spec.rb
@@ -280,7 +280,7 @@ STR
       @message.text = text
       @message.to_xml.to_s.should include Builder::XChar.encode(text)
     end
-    
+
     it 'serializes the message' do
       @xml.should include "<raw_message>I hate WALRUSES!</raw_message>"
     end
@@ -304,6 +304,29 @@ STR
       end
       it 'marshals the diaspora_handle' do
         @marshalled.diaspora_handle.should == @message.diaspora_handle
+      end
+    end
+
+    context 'with some photos' do
+      before do
+        @message.photos << FactoryGirl.build(:photo)
+        @message.photos << FactoryGirl.build(:photo)
+        @xml = @message.to_xml.to_s
+      end
+
+      it 'serializes the photos' do
+        @xml.should include "photo"
+        @xml.should include @message.photos.first.remote_photo_path
+      end
+
+      describe '.from_xml' do
+        before do
+          @marshalled = StatusMessage.from_xml(@xml)
+        end
+
+        it 'marshals the photos' do
+          @marshalled.photos.size.should == 2
+        end
       end
     end
   end


### PR DESCRIPTION
This could stabilize photo federation and fix #3033.

I didn't remove federating the photos separately yet since this would break it when sending from a pod with this to one without this.

What do you guys think?
