### PR TITLE
Updated services in publisher to reflect the username of the service

### DIFF
--- a/app/views/shared/_publisher.html.haml
+++ b/app/views/shared/_publisher.html.haml
@@ -42,7 +42,7 @@
           %span#publisher_service_icons
             - if current_user.services
               - for service in current_user.services
-                = image_tag "social_media_logos/#{service.provider}-16x16.png", :title => service.provider.titleize, :class => "service_icon dim", :id =>"#{service.provider}", :maxchar => "#{service.class::MAX_CHARACTERS}"
+                = image_tag "social_media_logos/#{service.provider}-16x16.png", :title => "#{service.provider.titleize} (#{service.nickname})", :class => "service_icon dim", :id =>"#{service.provider}", :maxchar => "#{service.class::MAX_CHARACTERS}"
             = link_to (image_tag "icons/monotone_wrench_settings.png"), "#question_mark_pane", :class => 'question_mark', :rel => 'facebox', :title => t('shared.public_explain.manage')
 
           .dropdown{ ! current_user.getting_started? ? {:class => "hang_right"} : { :class => "hang_right", :title => popover_with_close_html("2. #{t('shared.public_explain.control_your_audience')}"), 'data-content'=> t('shared.public_explain.visibility_dropdown')} }


### PR DESCRIPTION
When showing multiple connected services of the same type it was impossible to ascertain which was which.  This minor adjustment adds the nickname of the connected service to the button, just like it is shown on the management page for connecting services.

![Twitter 1](http://puu.sh/1XgG5.jpg)
![Twitter 2](http://puu.sh/1XgGm.jpg)
![Facebook 1](http://puu.sh/1XgGe.jpg)
