### PR TITLE
Preserve line breaks in posts

### DIFF
--- a/app/assets/javascripts/app/helpers/handlebars-helpers.js
+++ b/app/assets/javascripts/app/helpers/handlebars-helpers.js
@@ -44,3 +44,8 @@ Handlebars.registerHelper('personImage', function(person, size, imageClass) {
 Handlebars.registerHelper('localTime', function(timestamp) {
   return new Date(timestamp).toLocaleString();
 });
+
+// replace new line characters with <br/> tags
+Handlebars.registerHelper('preserveLineBreaks', function(text) {
+  return text.replace(/(\r\n|\n|\r)/, '<br/>');
+});

--- a/app/assets/templates/status-message_tpl.jst.hbs
+++ b/app/assets/templates/status-message_tpl.jst.hbs
@@ -15,6 +15,6 @@
 {{/if}}
 
 <div class="collapsible">
-  {{{text}}}
+  {{{preserveLineBreaks text}}}
   <div class="oembed"></div>
 </div>


### PR DESCRIPTION
- add helper to replace line feed characters with BR tags
- update template to use helper

I'm still seeing the behavior described in this issue:
https://github.com/diaspora/diaspora/issues/1022

Even with adding line breaks when posting a status, the line breaks don't show up later in the stream.

I'm not sure how to write tests for these helpers and templates.  I'm also not familiar with this project so just let me know and I'll be more than happy to fix up this pull request..  Or maybe I'm trying to fix something that's not broken?

Thanks!
