### PR TITLE
limit ShareablesFromPerson queries to improve performance

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@
 * Ported aspects to backbone [#3850](https://github.com/diaspora/diaspora/pull/3850)
 * Join tagging's table instead of tags to improve a bit the query [#3932](https://github.com/diaspora/diaspora/pull/3932)
 * Refactor contacts/index view [#3937](https://github.com/diaspora/diaspora/pull/3937)
+* Limit queries in ShareablesFromPerson [#3968](https://github.com/diaspora/diaspora/pull/3968)
 
 ## Features
 

--- a/lib/evil_query.rb
+++ b/lib/evil_query.rb
@@ -116,16 +116,12 @@ module EvilQuery
     def make_relation!
       return querents_posts if @person == @querent.person
 
-      # persons_private_visibilities and persons_public_posts have no limit which is making shareable_ids gigantic.
-      # perhaps they should the arrays should be merged and sorted
-      # then the query at the bottom of this method can be paginated or something?
-
       shareable_ids = contact.present? ? fetch_ids!(persons_private_visibilities, "share_visibilities.shareable_id") : []
       shareable_ids += fetch_ids!(persons_public_posts, table_name + ".id")
 
       @class.where(:id => shareable_ids, :pending => false).
-          select('DISTINCT '+table_name+'.*').
-          order(table_name+".created_at DESC")
+          select('DISTINCT ' + table_name + '.*').
+          order(table_name + ".created_at DESC")
     end
 
     protected
@@ -143,11 +139,11 @@ module EvilQuery
     end
 
     def persons_private_visibilities
-      contact.share_visibilities.where(:hidden => false, :shareable_type => @class.to_s)
+      contact.share_visibilities.where(:hidden => false, :shareable_type => @class.to_s).limit(15)
     end
 
     def persons_public_posts
-      @person.send(table_name).where(:public => true).select(table_name+'.id')
+      @person.send(table_name).where(:public => true).select(table_name + '.id').limit(15)
     end
   end
 end


### PR DESCRIPTION
In this PR I added a limit to two queries to improve the performance of the request. The problem was that when this two queries were executed and depending on the number of posts the person has, a gigantic array was instantiated.

Cheers!
