### PR TITLE
Wrap text if too long in mobile notifications

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@
 * Include our custom fileuploader on the mobile site too. [#3994](https://github.com/diaspora/diaspora/pull/3994)
 * Move custom splash page logic into the controller [#3991](https://github.com/diaspora/diaspora/issues/3991)
 * Fixed removing images from publisher on the profile and tags pages. [#3995](https://github.com/diaspora/diaspora/pull/3995)
+* Wrap text if too long in mobile notifications. [#3990](https://github.com/diaspora/diaspora/pull/3990)
 
 # 0.0.3.0
 

--- a/app/assets/stylesheets/mobile.css.scss
+++ b/app/assets/stylesheets/mobile.css.scss
@@ -50,9 +50,13 @@ body {
       font-weight: bold;
     }
     margin-bottom: 2px;
-    height: 45px;
-    white-space: nowrap;
+    word-wrap: break-word;
     overflow: hidden;
+    .time_notif {
+      font-weight: normal;
+      float: right;
+      padding-right: 5px;
+    }
   }
 
   > .content,
@@ -165,6 +169,10 @@ body {
 #main_stream {
   margin-left: -10px;
   margin-right: -10px;
+  .from {
+    white-space: nowrap;
+    overflow: hidden;
+  }
 }
 
 .more-link {

--- a/app/views/notifications/index.mobile.haml
+++ b/app/views/notifications/index.mobile.haml
@@ -13,12 +13,11 @@
       %ul.notifications_for_day
         - notes.each do |note|
           .stream_element{:data=>{:guid => note.id}, :class => "#{note.unread ? 'unread' : 'read'}"}
-
             .content
               =person_image_link(note.actors.last)
-              %span.from
-                = notification_message_for(note)
-              .time
+            .from
+              = notification_message_for(note)
+              .time_notif
                 = time_ago_in_words(note.created_at)
 
   = will_paginate @notifications, :renderer => WillPaginate::ActionView::BootstrapLinkRenderer


### PR DESCRIPTION
My bad https://github.com/diaspora/diaspora/pull/3981
# Before

![Pantallazo-1](https://f.cloud.github.com/assets/1108789/169330/824646c8-7a1a-11e2-83ce-06928e4b3a07.png)
# After

![Pantallazo](https://f.cloud.github.com/assets/1108789/169331/88bb8982-7a1a-11e2-886d-557be6ba592f.png)
