### PR TITLE
Problem with the button to upload images on the mobile interface

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 ## Bug Fixes
 
 * exec foreman in ./script/server to replace the process so that we can Ctrl+C it again.
+* Include our custom fileuploader on the mobile site too. [#3994](https://github.com/diaspora/diaspora/pull/3994)
 
 # 0.0.3.0
 

--- a/app/assets/javascripts/mobile.js
+++ b/app/assets/javascripts/mobile.js
@@ -7,6 +7,7 @@
 //= require mbp-respond.min
 //= require mbp-helper
 //= require jquery.autoSuggest.custom
+//= require fileuploader-custom
 
 $(document).ready(function(){
 

--- a/app/views/profiles/_edit_public.mobile.haml
+++ b/app/views/profiles/_edit_public.mobile.haml
@@ -4,7 +4,6 @@
 
 - content_for :head do
   = javascript_include_tag :jquery
-  = javascript_include_tag :home
 
   :javascript
     $(document).ready(function () {


### PR DESCRIPTION
With this https://github.com/diaspora/diaspora/commit/4cbae601e8e7f12465e7371e1b2b6e6428e4d533#L4R40 

```
Uncaught ReferenceError: app is not defined home-5fe83ffd41c39b3acbd6f2a6762fbbcc.js:8

Uncaught TypeError: Cannot read property 'FileUploaderBasic' of undefined edit:6
```

![Captura de pantalla de 2013-02-20 13:36:53](https://f.cloud.github.com/assets/1108789/175840/040001ee-7b5c-11e2-8e9d-9dc3e6cef4ca.png)
