### PR TITLE
Install script failed if the repo is already cloned

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -381,6 +381,7 @@ git_stuff_check() {
   else
     run_or_error "git checkout master"
     run_or_error "git pull"
+    cd ..
   fi
   printf "\n"
 }


### PR DESCRIPTION
The script failed because we are trying to cd into the folder we're already.
So we need to set the current folder as if it's the first time we clone the repo.

/home/mtparet/.rvm/scripts/cd: line 45: cd: diaspora: No such file or directory
[error] -- executing 'cd "diaspora"' failed.
