### PR TITLE
remove diasporaforum dead link

### DIFF
--- a/app/views/shared/_right_sections.html.haml
+++ b/app/views/shared/_right_sections.html.haml
@@ -40,7 +40,7 @@
     %br
     %br
     %p
-      != t('aspects.index.help.tutorials_wiki_and_forum', :tutorial => link_to("Diasporial" , "http://diasporial.com/tutorials", :target => '_blank'), :wiki => link_to('Wiki','http://github.com/diaspora/diaspora/wiki', :target => '_blank'), :forum => link_to("Forum", "http://www.diasporaforum.org/", :target => '_blank'))
+      != t('aspects.index.help.tutorials_wiki_and_forum', :tutorial => link_to("Diasporial" , "http://diasporial.com/tutorials", :target => '_blank'), :wiki => link_to('Wiki','http://github.com/diaspora/diaspora/wiki', :target => '_blank'))
     %p
       != t('aspects.index.help.email_feedback', :link => link_to(t('aspects.index.help.email_link'), "mailto:feedback@joindiaspora.com"))
 


### PR DESCRIPTION
Remove link to diasporaforum.org, its been dead 5-6 months now.
