### PR TITLE
use rubygems 2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+gem 'bundler', '>= 1.3.0'
+
 gem 'rails', '3.2.12'
 
 gem 'foreman', '0.61'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -415,6 +415,7 @@ DEPENDENCIES
   addressable (= 2.3.2)
   asset_sync (= 0.5.4)
   bootstrap-sass (= 2.2.2.0)
+  bundler (>= 1.3.0)
   capistrano (= 2.12.0)
   capistrano_colors (= 0.5.5)
   capybara (= 1.1.3)

--- a/script/ci/before_install.sh
+++ b/script/ci/before_install.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Travis CI still includes 1.2.x by default
+gem install bundler --version '>= 1.3.0'
+
 # Ensure known RubyGems version
 envdir="$(readlink -e $(dirname $0))/../env"
 . "$envdir/ruby_env"

--- a/script/env/ruby_env
+++ b/script/env/ruby_env
@@ -1,3 +1,3 @@
-rubygems_version="1.8.25"
+rubygems_version="2.0.0"
 ruby_version="1.9.3-p385"
 gemset="diaspora"


### PR DESCRIPTION
Now [that 2.0.0 has been released](http://blog.rubygems.org/2013/02/24/2.0.0-released.html) the script should ensure the latest rubygems is running.

Use of rubygems 2.0.0 requires bundler >= 1.3.0 (as added to Gemfile).
