### PR TITLE
roxml should be loaded from rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,7 @@ gem 'rails-i18n', '0.7.2'
 
 gem 'nokogiri', '1.5.6'
 gem 'redcarpet', "2.2.2"
-gem 'roxml', :git => 'https://github.com/Empact/roxml.git', :ref => '7ea9a9ffd2338aaef5b0'
+gem 'roxml', '3.1.6'
 gem 'ruby-oembed', '0.8.8'
 
 # queue

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/Empact/roxml.git
-  revision: 7ea9a9ffd2338aaef5b04cb792060ae8c98f346a
-  ref: 7ea9a9ffd2338aaef5b0
-  specs:
-    roxml (3.1.6)
-      activesupport (>= 2.3.0)
-      nokogiri (>= 1.3.3)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -328,6 +319,9 @@ GEM
     resque-timeout (1.0.0)
       resque (~> 1.0)
     rmagick (2.13.2)
+    roxml (3.1.6)
+      activesupport (>= 2.3.0)
+      nokogiri (>= 1.3.3)
     rspec (2.12.0)
       rspec-core (~> 2.12.0)
       rspec-expectations (~> 2.12.0)
@@ -470,7 +464,7 @@ DEPENDENCIES
   resque (= 1.23.0)
   resque-timeout (= 1.0.0)
   rmagick (= 2.13.2)
-  roxml!
+  roxml (= 3.1.6)
   rspec-instafail (= 0.2.4)
   rspec-rails (= 2.12.2)
   ruby-oembed (= 0.8.8)


### PR DESCRIPTION
since the version of roxml referenced by the sha1 in the gemfile is available on rubygems, roxml should be loaded from there.
