### PR TITLE
Avoid redirect

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -65,7 +65,7 @@ class ApplicationController < ActionController::Base
 
   def set_diaspora_header
     headers['X-Diaspora-Version'] = AppConfig.version_string
-    
+
     if AppConfig.git_available?
       headers['X-Git-Update'] = AppConfig.git_update if AppConfig.git_update.present?
       headers['X-Git-Revision'] = AppConfig.git_revision if AppConfig.git_revision.present?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -132,6 +132,6 @@ class ApplicationController < ActionController::Base
   end
 
   def current_user_redirect_path
-    current_user.getting_started? ? getting_started_path : root_path
+    current_user.getting_started? ? getting_started_path : stream_path
   end
 end

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -79,7 +79,7 @@ describe RegistrationsController do
       it "redirects to the home path" do
         get :create, @valid_params
         response.should be_redirect
-        response.location.should match /^#{root_url}\??$/
+        response.location.should match /^#{stream_url}\??$/
       end
     end
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -18,17 +18,17 @@ describe SessionsController do
   end
 
   describe "#create" do
-    it "redirects to root_path for a non-mobile user" do
+    it "redirects to /stream for a non-mobile user" do
       post :create, {"user" => {"remember_me" => "0", "username" => @user.username, "password" => "evankorth"}}
       response.should be_redirect
-      response.location.should match /^#{root_url}\??$/
+      response.location.should match /^#{stream_url}\??$/
     end
 
     it "redirects to /stream for a mobile user" do
       @request.env['HTTP_USER_AGENT'] = 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8B117 Safari/6531.22.7'
       post :create, {"user" => {"remember_me" => "0", "username" => @user.username, "password" => "evankorth"}}
       response.should be_redirect
-      response.location.should match /^#{root_url}\??$/
+      response.location.should match /^#{stream_url}\??$/
     end
   end
 


### PR DESCRIPTION
Hey guys

This pull request tries to avoid an unnecessary request to home#show that will redirect again to stream#index.

Here is the commit that introduced this change: 
https://github.com/diaspora/diaspora/commit/bbd4ee

In the past it was done in this way because home#show action based on conditions would redirect to one way or other, but with the code as it stands right now this won't happen.

What do you think?
