### PR TITLE
Set max-age header to Amazon S3 resources

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@
 
 ## Refactor
 
+* Add a configuration entry to set max-age header to Amazon S3 resources. [#4048](https://github.com/diaspora/diaspora/pull/4048)
 * Refactor people_controller#show and photos_controller#index [#4002](https://github.com/diaspora/diaspora/issues/4002)
 
 ## Features

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -18,6 +18,7 @@ defaults:
       secret:
       bucket:
       region:
+      cache: true
     image_redirect_url:
     assets:
       serve: false

--- a/config/diaspora.yml.example
+++ b/config/diaspora.yml.example
@@ -75,6 +75,10 @@ configuration: ## Section
       #secret: 'changeme'
       #bucket: 'my_photos'
       #region: 'us-east-1'
+
+      # Use max-age header on Amazon S3 resources.
+      # this would set a max-age value of 1 year
+      #cache : true
     
     ## Related to S3 you can set a url to redirect all requests to uploaded
     ## images to another host. If you for example set

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -14,6 +14,10 @@ CarrierWave.configure do |config|
         :aws_secret_access_key  => AppConfig.environment.s3.secret.get,
         :region                 => AppConfig.environment.s3.region.get
     }
+    if AppConfig.environment.s3.cache?
+      config.fog_attributes['Cache-Control'] = 'max-age=31536000'
+    end
+
     config.fog_directory = AppConfig.environment.s3.bucket.get
   else
     config.storage = :file


### PR DESCRIPTION
Hey guys,

This improvement is made becuase we are not sending any cache header on amazon s3 resource. Causing several conditional request unnecessarily.

In order to do this I added a configuration entry that enables the user to decide to use this option. 

Nowadays the browser caches those images based on some heuristics
http://blog.httpwatch.com/2008/10/15/two-important-differences-between-firefox-and-ie-caching/

What do you think?
