### PR TITLE
fix reshares in single post-view

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@
 * Do not fail on receiving a SignedRetraction via the public route
 * Pass the real values to stderr_path and stdout_path in unicorn.rb since it runs a case statement on them.
 * Decode tag name before passing it into a TagFollowingAction [#4027](https://github.com/diaspora/diaspora/issues/4027)
+* Fix reshares in single post-view [#4056](https://github.com/diaspora/diaspora/issues/4056)
 
 ## Refactor
 

--- a/app/assets/javascripts/app/models/post/interactions.js
+++ b/app/assets/javascripts/app/models/post/interactions.js
@@ -125,7 +125,7 @@ app.models.Post.Interactions = Backbone.Model.extend({
       , publicPost = this.post.get("public")
       , userIsNotAuthor = this.post.get("author").diaspora_id != app.currentUser.get("diaspora_id")
       , userIsNotRootAuthor = rootExists && (isReshare ? this.post.get("root").author.diaspora_id != app.currentUser.get("diaspora_id") : true)
-      , notReshared = this.reshares.length === 0;
+      , notReshared = !this.userReshare();
 
     return publicPost && app.currentUser.authenticated() && userIsNotAuthor && userIsNotRootAuthor && notReshared;
   }

--- a/features/reshare.feature
+++ b/features/reshare.feature
@@ -9,10 +9,24 @@ Feature: public repost
       | username    | email             |
       | Bob Jones   | bob@bob.bob       |
       | Alice Smith | alice@alice.alice |
+      | Eve Doe     | eve@eve.eve       |
     And a user with email "bob@bob.bob" is connected with "alice@alice.alice"
 
   Scenario: Resharing a post from a single post page
     Given "bob@bob.bob" has a public post with text "reshare this!"
+    And I sign in as "alice@alice.alice"
+    And I am on "bob@bob.bob"'s page
+    And I follow "Last Post"
+
+    And I preemptively confirm the alert
+    And I click on selector "a.reshare"
+    And I wait for the ajax to finish
+    Then I should see a flash message indicating success
+    And I should see a flash message containing "successfully"
+
+  Scenario: Resharing a post from a single post page that is reshared
+    Given "bob@bob.bob" has a public post with text "reshare this!"
+    And the post with text "reshare this!" is reshared by "eve@eve.eve"
     And I sign in as "alice@alice.alice"
     And I am on "bob@bob.bob"'s page
     And I follow "Last Post"

--- a/features/step_definitions/posts_steps.rb
+++ b/features/step_definitions/posts_steps.rb
@@ -32,6 +32,11 @@ Given /^"([^"]*)" has a non public post with text "([^"]*)"$/ do |email, text|
   user.post(:status_message, :text => text, :public => false, :to => user.aspects)
 end
 
+And /^the post with text "([^"]*)" is reshared by "([^"]*)"$/ do |text, email|
+  user = User.find_by_email(email)
+  root = Post.find_by_text(text)
+  user.post(:reshare, :root_guid => root.guid, :public => true, :to => user.aspects)
+end
 
 When /^The user deletes their first post$/ do
   @me.posts.first.destroy


### PR DESCRIPTION
Fix for #4023

The behaviour of the reshares after this pull request is the following:
- A user can reshare a post from the stream and from the single post view (even if it was reshared by somebody else).
- In the stream, if you try to reshare a post that you already reshared you get the following flash message: "That good, huh?  You've already reshared that post!"
- If you open in one tab a post and reshare that post in the stream. If you try to reshare that post in the tab that shows the single post-view -without hitting refresh- you get the flash message: "That good, huh?  You've already reshared that post!"
  And it works the other way around.

A review is welcome!
