### PR TITLE
Fix confirmation at getting_started page

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,9 +2,10 @@
 
 ## Bug fixes
 
-* reset comment box height after posting a comment. [#4030](https://github.com/diaspora/diaspora/issues/4030)
-* fade long tag names. [#3899](https://github.com/diaspora/diaspora/issues/3899)
-* avoid posting empty comments. [#3836](https://github.com/diaspora/diaspora/issues/3836)
+* Fix cancel button on getting_started confirmation box [#4073](https://github.com/diaspora/diaspora/issues/4073)
+* Reset comment box height after posting a comment. [#4030](https://github.com/diaspora/diaspora/issues/4030)
+* Fade long tag names. [#3899](https://github.com/diaspora/diaspora/issues/3899)
+* Avoid posting empty comments. [#3836](https://github.com/diaspora/diaspora/issues/3836)
 * Delegate parent_author to the target of a RelayableRetraction
 * Do not fail on receiving a SignedRetraction via the public route
 * Pass the real values to stderr_path and stdout_path in unicorn.rb since it runs a case statement on them.

--- a/app/assets/javascripts/pages/users-getting-started.js
+++ b/app/assets/javascripts/pages/users-getting-started.js
@@ -34,19 +34,17 @@ Diaspora.Pages.UsersGettingStarted = function() {
     });
 
     $("#awesome_button").bind("click", function(evt){
-
       var confirmMessage = Diaspora.I18n.t("getting_started.no_tags");
+      var message = Diaspora.I18n.t("getting_started.preparing_your_stream");
+      var confirmation = true;
 
-      if(($("#as-selections-tags").find(".as-selection-item").length > 0) || confirm(confirmMessage)) {
-
-        /* flash message prompt */
-        var message = Diaspora.I18n.t("getting_started.preparing_your_stream");
-        Diaspora.page.flashMessages.render({success: true, notice: message});
-      } else {
-        /* flash message prompt */
-        var message = Diaspora.I18n.t("getting_started.alright_ill_wait");
-        Diaspora.page.flashMessages.render({success: true, notice: message});
+      if ($("#as-selections-tags").find(".as-selection-item").length <= 0) {
+        message = Diaspora.I18n.t("getting_started.alright_ill_wait");
+        confirmation = confirm(confirmMessage);
       }
+
+      Diaspora.page.flashMessages.render({success: true, notice: message});
+      return confirmation;
     });
 
     /* ------ */

--- a/features/signs_up.feature
+++ b/features/signs_up.feature
@@ -17,9 +17,16 @@ Feature: new user registration
       | profile_first_name | O             |
     And I preemptively confirm the alert
     And I follow "awesome_button"
-
     Then I should be on the stream page
     And I should not see "awesome_button"
+
+  Scenario: new user does not add any tags in setup wizard and cancel the alert
+    When I fill in the following:
+      | profile_first_name | some name     |
+    And I preemptively reject the alert
+    And I follow "awesome_button"
+    Then I should be on the getting started page
+    And I should see a flash message containing "Alright, I'll wait."
 
   Scenario: new user skips the setup wizard
     When I preemptively confirm the alert


### PR DESCRIPTION
When the tag field of the getting_started page is blank a confirmation message is displayed.

The cancel button of the confirmation was submitting the request anyway.
This pull request should fix that.
