### PR TITLE
Issue #3976: Send a profile update alongside a sharing notification

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@
 * Fix reshares in single post-view [#4056](https://github.com/diaspora/diaspora/issues/4056)
 * Fix mobile view of deleted reshares. [#4063](https://github.com/diaspora/diaspora/issues/4063)
 * Hide comment button in the mobile view when not signed in. [#4065](https://github.com/diaspora/diaspora/issues/4065)
+* Send profile alongside notification [#3976] (https://github.com/diaspora/diaspora/issues/3976)
 
 ## Refactor
 

--- a/app/models/user/connecting.rb
+++ b/app/models/user/connecting.rb
@@ -22,9 +22,14 @@ module User::Connecting
     if notification = Notification.where(:target_id => person.id).first
       notification.update_attributes(:unread=>false)
     end
-
+    
+    deliver_profile_update
     register_share_visibilities(contact)
     contact
+  end
+
+  def deliver_profile_update
+    Postzord::Dispatcher.build(self, profile).post
   end
 
   # This puts the last 100 public posts by the passed in contact into the user's stream.

--- a/spec/models/user/connecting_spec.rb
+++ b/spec/models/user/connecting_spec.rb
@@ -147,6 +147,13 @@ describe User::Connecting do
         contact.should_not_receive(:dispatch_request)
         alice.share_with(eve.person, a2)
       end
+
+      it 'posts profile' do
+        m = mock()
+        Postzord::Dispatcher.should_receive(:build).twice.and_return(m)
+        m.should_receive(:post).twice
+        alice.share_with(eve.person, alice.aspects.first)
+      end
     end
 
     it 'sets receiving' do


### PR DESCRIPTION
Inspired from looking at User::update_profile method. Let me know if this is way off track.
