### PR TITLE
Add inline-block directive to social_media_icons on publisher

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -772,6 +772,7 @@ form p.checkbox_select
       .social_media_logos-email-16x16,
       .social_media_logos-feed-16x16,
       .social_media_logos-website-16x16
+        :display inline-block
         :height 16px
         :width 16px
 


### PR DESCRIPTION
This fixes issue #4081
