### PR TITLE
Remove unnecessary navigation bar to access mobile site and Re-add flash warning to registrations mobile  - Only develop branch

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@
 * Hide comment button in the mobile view when not signed in. [#4065](https://github.com/diaspora/diaspora/issues/4065)
 * Send profile alongside notification [#3976] (https://github.com/diaspora/diaspora/issues/3976)
 * Fix off-center close button image on intro popovers [#3841](https://github.com/diaspora/diaspora/pull/3841)
+* Remove unnecessary navigation bar to access mobile site and re-add flash warning to registrations mobile. [#4085](https://github.com/diaspora/diaspora/pull/4085)
 
 ## Refactor
 
@@ -32,7 +33,7 @@
 * Add the ability to upload photos from the mobile site. [#4004](https://github.com/diaspora/diaspora/issues/4004)
 * Show timestamp when hovering on comment time-ago string. [#4042](https://github.com/diaspora/diaspora/issues/4042)
 * If sharing a post with photos to Facebook, always include URL to post [#3706](https://github.com/diaspora/diaspora/issues/3706)
-* Add multiphoto for mobile post. [#4065](https://github.com/diaspora/diaspora/issues/4065)
+* Add multiphoto for mobile post. [#4067](https://github.com/diaspora/diaspora/issues/4067)
 
 # 0.0.3.4
 

--- a/app/assets/stylesheets/mobile.css.scss
+++ b/app/assets/stylesheets/mobile.css.scss
@@ -388,8 +388,8 @@ footer {
     margin: 10px;
   }
   padding: {
-    top: 60px;
-    bottom: 30px;
+    top: 20px;
+    bottom: 20px;
   }
 }
 
@@ -903,6 +903,10 @@ textarea#conversation_text {
   text-shadow: 1px 1px 5px #666; 
 }
 
+.registrations {
+  margin: -45px;
+}
+
 form#new_user.new_user input.btn {
   white-space: normal;
 }
@@ -934,6 +938,10 @@ form#new_user.new_user input.btn {
   text-shadow: 1px 1px 20px rgb(126, 240, 77);
 }
 
+input#user_password, #user_username, #user_password_confirmation, #user_email {
+  height: 30px;
+}
+  
 #flash_notice,
 #flash_alert,
 #flash_error {
@@ -943,6 +951,32 @@ form#new_user.new_user input.btn {
   }
 }
 
+#session.message {
+  padding: 10px 12px 8px;
+}
+
+#registration.message {
+  padding: 1px
+}
+
+.session_mobile {
+  margin-top: -55px;
+}
+
+h1.session {
+  font-size: 40px; 
+  font-weight: 200;
+}
+
+.landing  {
+  padding: 20px;
+  margin: -10px -20px 10px -20px;
+  background-color:#4b4b4b;
+  box-shadow: 0 3px 40px rgba(0,0,0,0.8);
+  z-index: 10;
+  position: relative;
+  text-align: center;
+}
 
 form p.checkbox_select {
   position: relative;

--- a/app/views/registrations/new.mobile.haml
+++ b/app/views/registrations/new.mobile.haml
@@ -8,12 +8,14 @@
 
 :css
   div.navbar.navbar-fixed-top{ display:none;}
-  body{ padding: 10px;}
-  #flash_error .message{ padding: 1px 1px 1px;}
 
+.registrations
 .stream
   - flash.each do |name, msg|
     %p{:class => "registrations_#{name}"}= msg
+    #flash_alert.expose
+      %div{:class => "message", :id => "session"}= msg
+
   #login_form
     .login-container
       = form_for(resource, :as => resource_name, :html => {:class => 'new_user_form'}, :url => registration_path(resource_name), :validate => true) do |f|

--- a/app/views/sessions/new.mobile.haml
+++ b/app/views/sessions/new.mobile.haml
@@ -2,49 +2,47 @@
 -#   licensed under the Affero General Public License version 3 or later.  See
 -#   the COPYRIGHT file.
 
-= stylesheet_link_tag :mobile
-
 :css
-  body{ padding: 10px; margin: 0px 10px;}
-  #flash_alert .message{ padding: 10px 12px 8px;}
-  footer{ padding-top: 0;}
-  .landing{ padding: 20px; margin: -10px -20px 10px -20px; background-color:#4b4b4b; box-shadow: 0 3px 40px rgba(0,0,0,0.8); z-index: 10; position: relative; text-align: center;}
-  h1{ font-size: 40px; font-weight: 200;}
+  .navbar-fixed-top{display: none;}
 
-.landing
-  %h1
-    = "#{pod_name}"
-#main_stream.stream
-  - flash.each do |name, msg|
-    %p{:class => "login_#{name}"}= msg
+.session_mobile
+  .landing
+    %h1{:class =>"session"}
+      = "#{pod_name}"
 
-  #login_form
-    .login-container
-      = form_for(resource, :as => resource_name, :url => session_path(resource_name)) do |f|
-        %fieldset
-          %legend
-            = image_tag('branding/header-logo2x.png', :height => 40, :width => 40)
-            = t('devise.sessions.new.login').upcase
+  #main_stream.stream
+    - flash.each do |name, msg|
+      %p{:class => "login_#{name}"}= msg
+      #flash_alert.expose
+        %div{:class => "message", :id => "session"}= msg
+
+    #login_form
+      .login-container
+        = form_for(resource, :as => resource_name, :url => session_path(resource_name)) do |f|
+          %fieldset
+            %legend
+              = image_tag('branding/header-logo2x.png', :height => 40, :width => 40)
+              = t('devise.sessions.new.login').upcase
           
-          .control-group
-            = f.label :username, t('username').upcase
+            .control-group
+              = f.label :username, t('username').upcase
+              .controls
+                = f.text_field :username, :autofocus => true
+
+            .control-group
+              = f.label :password , t('password').upcase
+              .controls
+                = f.password_field :password
+
+              = hidden_field(:user, :remember_me, :value => 1)
+
             .controls
-              = f.text_field :username, :autofocus => true
+              = f.submit t('devise.sessions.new.sign_in'), :class => 'btn primary'
+              - if display_registration_link?
+                = link_to t('devise.shared.links.sign_up'), new_registration_path(resource_name), :class => 'btn primary', :style => "float: right;"
 
-          .control-group
-            = f.label :password , t('password').upcase
-            .controls
-              = f.password_field :password
+  %footer
+    - if display_password_reset_link?
+      = link_to t('devise.passwords.new.forgot_password'), new_password_path(resource_name)
 
-            = hidden_field(:user, :remember_me, :value => 1)
-
-          .controls
-            = f.submit t('devise.sessions.new.sign_in'), :class => 'btn primary'
-            - if display_registration_link?
-              = link_to t('devise.shared.links.sign_up'), new_registration_path(resource_name), :class => 'btn primary', :style => "float: right;"
-
-%footer
-  - if display_password_reset_link?
-    = link_to t('devise.passwords.new.forgot_password'), new_password_path(resource_name)
-
-  = link_to t('layouts.application.toggle'), toggle_mobile_path
+    = link_to t('layouts.application.toggle'), toggle_mobile_path


### PR DESCRIPTION
# Before

![Pantallazo_](https://f.cloud.github.com/assets/1108789/320959/2d8a2a4e-997f-11e2-8769-c7b543b8afa8.png)
# After

![Pantallazo-1](https://f.cloud.github.com/assets/1108789/320961/339203bc-997f-11e2-8af0-79a3d13a88c0.png)

And Remove excess `:css` 

<hr>

<hr>
# Before

![01](https://f.cloud.github.com/assets/1108789/321037/651edb14-9987-11e2-9638-32f3a01dd18d.png)

![02](https://f.cloud.github.com/assets/1108789/321045/e1003a52-9987-11e2-83ef-8bfc1f91a4fd.png)
# After

![03](https://f.cloud.github.com/assets/1108789/321041/9d3619cc-9987-11e2-82eb-9f66d8bf586f.png)

![04](https://f.cloud.github.com/assets/1108789/321042/a35f5ef8-9987-11e2-917b-014b8c9047af.png)

And Remove excess `:css` 
