### PR TITLE
add elastic beanstalk configuration

### DIFF
--- a/.ebextensions/diaspora.config
+++ b/.ebextensions/diaspora.config
@@ -1,0 +1,59 @@
+packages:
+  yum:
+    automake: []
+    libffi-devel: []
+    ImageMagick: []
+    git: []
+    patch: []
+    bison: []
+    libtool: []
+  rubygems:
+    rake: "10.0.3"
+option_settings:
+  - option_name: BUNDLE_WITHOUT
+    value: test:development:heroku
+  - option_name: DB
+    value: mysql
+  - option_name: ENVIRONMENT_CERTIFICATE_AUTHORITIES
+    value: /etc/pki/tls/certs/ca-bundle.crt
+files:
+  "/var/app/support/secret_token.rb":
+    mode: "000644"
+    owner: webapp
+    group: webapp
+    content: |
+      Rails.application.config.secret_token = ENV['RAILS_SECRET_TOKEN']
+    encoding: plain
+  "/var/app/support/database.yml":
+    mode: "000644"
+    owner: webapp
+    group: webapp
+    content: |
+      production:
+        adapter: mysql2
+        encoding: utf8
+        database: <%= ENV['RDS_DB_NAME'] %>
+        username: <%= ENV['RDS_USERNAME'] %>
+        password: <%= ENV['RDS_PASSWORD'] %>
+        host: <%= ENV['RDS_HOSTNAME'] %>
+        port: <%= ENV['RDS_PORT'] %>
+        charset: utf8
+        collation: utf8_bin
+    encoding: plain
+  "/opt/elasticbeanstalk/hooks/appdeploy/pre/03_copy_config_files.sh":
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      #!/usr/bin/env bash
+
+      . /opt/elasticbeanstalk/support/envvars
+
+      cd $EB_CONFIG_APP_ONDECK
+
+      mv $EB_CONFIG_APP_SUPPORT/secret_token.rb config/initializers/secret_token.rb
+      mv $EB_CONFIG_APP_SUPPORT/database.yml config/database.yml
+      mv config/diaspora.yml.example config/diaspora.yml
+
+      true
+    encoding: plain

--- a/.ebextensions/resque.config
+++ b/.ebextensions/resque.config
@@ -1,0 +1,62 @@
+option_settings:
+  - option_name: RESQUE_WORKERS
+    value: 2
+files:
+  "/etc/init/resque.conf":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      start on (started network-interface
+                or started network-manager
+                or started networking)
+
+      stop on (stopping network-interface
+               or stopping network-manager
+               or stopping networking)
+
+      pre-start script
+        . /opt/elasticbeanstalk/support/envvars
+        for i in `seq 1 $RESQUE_WORKERS`
+        do
+          start resque-worker ID=$i
+        done
+      end script
+    encoding: plain
+  "/etc/init/resque-worker.conf":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      stop on stopping resque
+
+      respawn
+      respawn limit 5 20
+
+      instance $ID
+
+      post-stop script
+        . /opt/elasticbeanstalk/support/envvars
+        export ID=$ID
+        export PIDFILE=$EB_CONFIG_APP_PIDS/resque-worker-$ID.pid
+        exec su - root -c "kill -s SIGQUIT `cat $PIDFILE` && rm -f $PIDFILE >> $EB_CONFIG_APP_LOGS/resque-worker-$ID.log 2>&1"
+      end script
+
+      script
+        . /opt/elasticbeanstalk/support/envvars
+        export ID=$ID
+        export PIDFILE=$EB_CONFIG_APP_PIDS/resque-worker-$ID.pid
+        echo $$ > $PIDFILE
+        chown $EB_CONFIG_APP_USER:$EB_CONFIG_APP_USER $PIDFILE
+        exec su - $EB_CONFIG_APP_USER -c "cd $EB_CONFIG_APP_CURRENT; PIDFILE=$PIDFILE QUEUE=* VERBOSE=1 bundle exec rake resque:work --trace >> $EB_CONFIG_APP_LOGS/resque-worker-$ID.log 2>&1"
+      end script
+    encoding: plain
+  "/opt/elasticbeanstalk/hooks/appdeploy/post/99_restart_resque.sh":
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      #!/usr/bin/env bash
+      stop resque
+      start resque
+    encoding: plain

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ dump.rdb
 # Ignore precompiled assets
 # Heroku or Capistrano can and should regenerate them on every deploy
 public/assets
+
+# Hide AWS secrets
+.elasticbeanstalk/


### PR DESCRIPTION
Base configuration necessary to deploy Diaspora\* on AWS Elastic Beanstalk.

Tested only on the x64 ruby 1.9.3 vm.
