### PR TITLE
Preview posts in stream

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -127,6 +127,7 @@ by them self.
 * Add multiphoto for mobile post. [#4065](https://github.com/diaspora/diaspora/issues/4065)
 * Add hotkeys to navigate in stream [#4089](https://github.com/diaspora/diaspora/pull/4089)
 * Add a brief explanatory text about external services connections to services index page [#3064](https://github.com/diaspora/diaspora/issues/3064)
+* Add a preview for posts in the stream [#4099](https://github.com/diaspora/diaspora/issues/4099)
 
 # 0.0.3.4
 

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -3112,3 +3112,11 @@ body
   :font-size small
   :text-align right
   :margin 5px 2px
+  
+.post_preview
+  :padding
+    :top 5px
+  :border
+    :bottom 3px solid #3f8fba !important
+  :background
+    :color #e8f7ff

--- a/app/views/photos/_new_photo.haml
+++ b/app/views/photos/_new_photo.haml
@@ -30,6 +30,7 @@
        onSubmit: function(id, fileName){
         $('#file-upload').addClass("loading");
         $('#publisher').find("input[type='submit']").attr('disabled','disabled');
+        $('#publisher').find("button.post_preview_button").attr('disabled','disabled');
 
         app.publisher.el_wrapper.addClass("with_attachments");
         $('#photodropzone').append(
@@ -61,6 +62,7 @@
             textarea = publisher.find('textarea');
 
         publisher.find("input[type='submit']").removeAttr('disabled');
+        publisher.find("button.post_preview_button").removeAttr('disabled');
 
         $('.x').bind('click', function(){
           var photo = $(this).closest('.publisher_photo');

--- a/app/views/shared/_publisher.html.haml
+++ b/app/views/shared/_publisher.html.haml
@@ -73,6 +73,9 @@
                 - for aspect in all_aspects
                   = aspect_dropdown_list_item(aspect, !all_aspects_selected?(selected_aspects) && selected_aspects.include?(aspect) )
 
+          %button{ :disabled => ("disabled" if publisher_hidden_text.blank?), :class => 'button post_preview_button'}
+            = t('.preview') 
+
           = status.submit t('.share'), :disabled => publisher_hidden_text.blank?, :class => 'button creation', :tabindex => 2
 
           .facebox_content

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -789,6 +789,7 @@ en:
     publisher:
       posting: "Posting..."
       share: "Share"
+      preview: "Preview"
       post_a_message_to: "Post a message to %{aspect}"
       make_public: "make public"
       all: "all"

--- a/features/post_preview.feature
+++ b/features/post_preview.feature
@@ -1,0 +1,52 @@
+@javascript
+Feature: preview posts in the stream
+    In order to test markdown without posting
+    As a user
+    I want to see a preview of my posts in the stream
+
+    Background:
+      Given following users exist:
+        | username     | email             |
+        | Bob Jones    | bob@bob.bob       |
+        | Alice Smith  | alice@alice.alice |
+      And a user with email "bob@bob.bob" is connected with "alice@alice.alice"
+      When I sign in as "bob@bob.bob"
+      And I am on the home page
+      Then I should not see any posts in my stream
+
+    Scenario: preview and post a text-only message
+      Given I expand the publisher
+      When I fill in the following:
+          | status_message_fake_text    | I am eating yogurt    |
+      And I press "Preview"
+      Then "I am eating yogurt" should be post 1
+      And the first post should be a preview
+      
+      When I fill in the following:
+          | status_message_fake_text    | This preview rocks    |
+      And I press "Preview"
+      Then "This preview rocks" should be post 1
+      And I should not see "I am eating a yogurt"
+      
+      When I fill in the following:
+          | status_message_fake_text    | I like rocks    |
+      And I press "Share"
+      And I wait for the ajax to finish
+      Then "I like rocks" should be post 1
+      And I should not see "This preview rocks"
+
+    Scenario: preview a photo with text
+      Given I expand the publisher
+      When I attach the file "spec/fixtures/button.png" to hidden element "file" within "#file-upload"
+      When I fill in the following:
+          | status_message_fake_text    | Look at this dog    |
+      And I press "Preview"
+      Then I should see a "img" within ".stream_element div.photo_attachments"
+      And I should see "Look at this dog" within ".stream_element"
+      
+    Scenario: preview a post with mentions
+      Given I expand the publisher
+      And I mention Alice in the publisher
+      And I press "Preview"
+      And I follow "Alice Smith"
+      Then I should see "Alice Smith"

--- a/features/step_definitions/mention_steps.rb
+++ b/features/step_definitions/mention_steps.rb
@@ -4,3 +4,8 @@ And /^Alice has a post mentioning Bob$/ do
   aspect = alice.aspects.where(:name => "Besties").first
   alice.post(:status_message, :text => "@{Bob Jones; #{bob.person.diaspora_handle}}", :to => aspect)
 end
+
+And /^I mention Alice in the publisher$/ do
+  alice = User.find_by_email 'alice@alice.alice'
+  fill_in 'status_message_fake_text', :with => "@{Alice Smith ; #{alice.person.diaspora_handle}}"
+end

--- a/features/step_definitions/post_preview_steps.rb
+++ b/features/step_definitions/post_preview_steps.rb
@@ -1,0 +1,3 @@
+Then /^the first post should be a preview$/ do
+  find(".post_preview .post-content").text.should == first_post_text
+end

--- a/features/support/publishing_cuke_helpers.rb
+++ b/features/support/publishing_cuke_helpers.rb
@@ -1,7 +1,7 @@
 module PublishingCukeHelpers
   def make_post(text)
     fill_in 'status_message_fake_text', :with => text
-    click_button :submit
+    find(".creation").click
     wait_for_ajax_to_finish
   end
 

--- a/spec/javascripts/app/views/publisher_view_spec.js
+++ b/spec/javascripts/app/views/publisher_view_spec.js
@@ -18,6 +18,10 @@ describe("app.views.Publisher", function() {
     it("hides the close button in standalone mode", function() {
       expect(this.view.$('#hide_publisher').is(':visible')).toBeFalsy();
     });
+    
+    it("hides the post preview button in standalone mode", function() {
+      expect(this.view.$('.post_preview_button').is(':visible')).toBeFalsy();
+    });
   });
 
   context("plain publisher", function() {
@@ -60,6 +64,13 @@ describe("app.views.Publisher", function() {
 
         this.view.clear($.Event());
         expect(this.view.close).toHaveBeenCalled();
+      })
+      
+      it("calls removePostPreview", function(){
+        spyOn(this.view, "removePostPreview");
+
+        this.view.clear($.Event());
+        expect(this.view.removePostPreview).toHaveBeenCalled();
       })
 
       it("clears all textareas", function(){


### PR DESCRIPTION
[#2108](https://github.com/diaspora/diaspora/issues/2108)

This will add a preview button to the publisher. When you press the button the current post will be presented in the stream. When you share the post the preview will disappear.

Just like the share button the preview button is disabled if there is nothing to post.

Currently not working:
- oEmbed [#2171](https://github.com/diaspora/diaspora/issues/2171)
