### PR TITLE
Mobile buttons are only clickable when scrolled to the top. Close #3847

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -114,6 +114,7 @@ by them self.
 * Fix off-center close button image on intro popovers [#3841](https://github.com/diaspora/diaspora/pull/3841)
 * Remove unnecessary dotted CSS borders. [#2940](https://github.com/diaspora/diaspora/issues/2940)
 * Fix default image url in profiles table. [#3795](https://github.com/diaspora/diaspora/issues/3795)
+* Fix mobile buttons are only clickable when scrolled to the top. [#4102](https://github.com/diaspora/diaspora/issues/4102)
 
 ## Features
 

--- a/app/assets/stylesheets/mobile.css.scss
+++ b/app/assets/stylesheets/mobile.css.scss
@@ -311,7 +311,6 @@ body {
 
 .navbar {
   @include box-shadow(0,1px,2px,#333);
-  padding: 0 20px;
 }
 
 .navbar-inner {
@@ -674,6 +673,8 @@ select {
   max-height: 45px !important;
   min-height: 45px !important;
   height: 45px !important;
+  margin-left: 0px !important;
+  margin-right: 0px !important;
   overflow: hidden;
 }
 


### PR DESCRIPTION
https://github.com/diaspora/diaspora/issues/3847

Problem:

>  I can't click the buttons after scrolling. Buttons only fires any action when the user is at the top of the page.

![](https://f.cloud.github.com/assets/1857707/141624/e9111584-7256-11e2-8aea-a6b72e4ccb75.png)
_image via issue_

This problem affects Chrome but not Firefox.

With last Chrome version 26.0.1410.58 and this pull resquest works fine.
