### PR TITLE
Include missing javascript in bookmarklet to fix uneditable post content

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -115,6 +115,7 @@ by them self.
 * Remove unnecessary dotted CSS borders. [#2940](https://github.com/diaspora/diaspora/issues/2940)
 * Fix default image url in profiles table. [#3795](https://github.com/diaspora/diaspora/issues/3795)
 * Fix mobile buttons are only clickable when scrolled to the top. [#4102](https://github.com/diaspora/diaspora/issues/4102)
+* Fix regression in bookmarklet causing uneditable post contents. [#4057](https://github.com/diaspora/diaspora/issues/4057)
 
 ## Features
 

--- a/app/views/status_messages/bookmarklet.html.haml
+++ b/app/views/status_messages/bookmarklet.html.haml
@@ -2,6 +2,8 @@
 -#   licensed under the Affero General Public License version 3 or later.  See
 -#   the COPYRIGHT file.
 
+= javascript_include_tag :home
+
 #new_status_message_pane
   .span-15.last
     %h4

--- a/spec/javascripts/bookmarklet-spec.js
+++ b/spec/javascripts/bookmarklet-spec.js
@@ -37,6 +37,16 @@ describe("bookmarklet", function() {
       });
     });
   });
+  
+  describe("modified prefilled bookmarklet", function(){
+    it('allows changing of post content', function(){
+      spec.loadFixture('prefilled_bookmarklet');
+      $('div.mentions > div').html('Foo Bar');
+      _.defer(function() {
+        expect($("#publisher #status_message_text").val()).toEqual("Foo Bar");
+      });
+    });
+  });
 
 
 


### PR DESCRIPTION
Regression introduced in commit ffc6c1102efdc5fa7d320a306d168d7feb3c191f. Fixes #4057

Lots of local jasmine tests fail (50 total) because of missing underscore fixtures, maybe.. Managed to write a failing test, will see what CI will say about it after code change.
