### PR TITLE
Fix reactions link on mobile broken. Close #3972

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -109,7 +109,7 @@ everything is set up.
 
 ## Bug fixes
 
-* fix mass aspect selection [#4127](https://github.com/diaspora/diaspora/pull/4127)
+* Fix mass aspect selection [#4127](https://github.com/diaspora/diaspora/pull/4127)
 * Fix posting functionality on tags show view [#4112](https://github.com/diaspora/diaspora/pull/4112)
 * Fix cancel button on getting_started confirmation box [#4073](https://github.com/diaspora/diaspora/issues/4073)
 * Reset comment box height after posting a comment. [#4030](https://github.com/diaspora/diaspora/issues/4030)
@@ -132,6 +132,7 @@ everything is set up.
 * Fix wrong message on infinite scroll on contacts page [#3681](https://github.com/diaspora/diaspora/issues/3681)
 * My Activity mobile doesn't show second page when clicking "more". [#4109](https://github.com/diaspora/diaspora/issues/4109)
 * Remove unnecessary navigation bar to access mobile site and re-add flash warning to mobile registrations. [#4085](https://github.com/diaspora/diaspora/pull/4085)
+* Fix broken reactions link on mobile page [#4125](https://github.com/diaspora/diaspora/pull/4125)
 
 ## Features
 

--- a/app/assets/javascripts/mobile.js
+++ b/app/assets/javascripts/mobile.js
@@ -98,7 +98,7 @@ $(document).ready(function(){
   });
 
   /* Show comments */
-  $(".show_comments", ".stream").bind("tap click", function(evt){
+  $("a.show_comments", ".stream").bind("tap click", function(evt){
     evt.preventDefault();
     var link = $(this),
         parent = link.closest(".bottom_bar").first(),

--- a/features/reactions_mobile.feature
+++ b/features/reactions_mobile.feature
@@ -1,0 +1,40 @@
+@javascript
+Feature: reactions mobile post
+  In order to navigate Diaspora*
+  As a mobile user
+  I want to react to posts
+
+  Background:
+    Given following users exist:
+      | username    | email             |
+      | Bob Jones   | bob@bob.bob       |
+      | Alice Smith | alice@alice.alice |
+    And a user with email "bob@bob.bob" is connected with "alice@alice.alice"
+    When "alice@alice.alice" has posted a status message with a photo
+    And I sign in as "bob@bob.bob"
+    And I toggle the mobile view
+
+  Scenario: like on a mobile post
+    When I should see "0 reactions" within ".show_comments"
+    And I click on selector "span.show_comments"
+    And I wait for the ajax to finish
+    And I preemptively confirm the alert
+    And I click on selector "a.image_link.like_action.inactive"
+    And I wait for the ajax to finish
+    Then I go to the stream page
+    And I should see "1 reaction" within ".show_comments"
+    And I click on selector "a.show_comments"
+    And I should see "1" within ".like_count"
+
+  Scenario: comment a mobile post
+    When I preemptively confirm the alert
+    And I click on selector "a.image_link.comment_action.inactive"
+    And I wait for the ajax to finish
+    And I fill in the following:
+        | text            | is that a poodle?    |
+    And I press "Comment"
+    And I wait for the ajax to finish
+    Then I go to the stream page
+    And I should see "1 reaction" within ".show_comments"
+    And I click on selector "a.show_comments"
+    And I should see "1" within ".comment_count"


### PR DESCRIPTION
#3972

Problem appears when you click on "0 reactions".

![](https://f.cloud.github.com/assets/1857707/139777/d94c27a8-7204-11e2-8e67-a7ecd9fa4af2.png)

_image via issue_
