### PR TITLE
Fix select & deselect all aspects check image

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -109,6 +109,7 @@ everything is set up.
 
 ## Bug fixes
 
+* fix mass aspect selection [#4127](https://github.com/diaspora/diaspora/pull/4127)
 * Fix posting functionality on tags show view [#4112](https://github.com/diaspora/diaspora/pull/4112)
 * Fix cancel button on getting_started confirmation box [#4073](https://github.com/diaspora/diaspora/issues/4073)
 * Reset comment box height after posting a comment. [#4030](https://github.com/diaspora/diaspora/issues/4030)

--- a/app/assets/javascripts/app/views/aspects_list_view.js
+++ b/app/assets/javascripts/app/views/aspects_list_view.js
@@ -28,12 +28,19 @@ app.views.AspectsList = app.views.Base.extend({
   toggleAll: function(evt){
     if (evt) { evt.preventDefault(); };
 
+    var aspects = this.$('li:not(:last)')
     if (this.collection.allSelected()) {
       this.collection.deselectAll();
-      this.$('li:not(:last)').removeClass("active");
+      aspects.removeClass("active");
+      aspects.each(function(i){
+        $(this).find('.icons-check_yes_ok').addClass('invisible');
+      });
     } else {
       this.collection.selectAll();
-      this.$('li:not(:last)').addClass("active");
+      aspects.addClass("active");
+      aspects.each(function(i){
+        $(this).find('.icons-check_yes_ok').removeClass('invisible');
+      });
     }
 
     this.toggleSelector();

--- a/features/aspect_navigation.feature
+++ b/features/aspect_navigation.feature
@@ -31,3 +31,10 @@ Feature: Aspect navigation on the left menu
       Then I should see "Besties" aspect selected
       Then I should see "Unicorns" aspect selected
       Then I should see "Others" aspect unselected
+
+    Scenario: Deselect all aspects
+      When I go to the aspects page
+      And I follow "Deselect all"
+      Then I should see "Besties" aspect unselected
+      Then I should see "Unicorns" aspect unselected
+      Then I should see "Others" aspect unselected

--- a/features/step_definitions/aspects_steps.rb
+++ b/features/step_definitions/aspects_steps.rb
@@ -38,12 +38,13 @@ When /^I should see "([^"]*)" aspect selected$/ do |aspect_name|
   aspect = @me.aspects.where(:name => aspect_name).first
   within("#aspect_nav") do
     page.has_css?("li.active[data-aspect_id='#{aspect.id}']").should be_true
+    page.has_no_css?("li.active[data-aspect_id='#{aspect.id}'] .invisible").should be_true
   end
 end
 
 When /^I should see "([^"]*)" aspect unselected$/ do |aspect_name|
   aspect = @me.aspects.where(:name => aspect_name).first
   within("#aspect_nav") do
-    page.has_css?("li[data-aspect_id='#{aspect.id}']:not(.active)").should be_true
+    page.has_css?("li[data-aspect_id='#{aspect.id}']:not(.active) .invisible").should be_true
   end
 end


### PR DESCRIPTION
Hey guys,

On current develop branch, when trying to select or deselect all aspects, the check icon that indicates that an aspect si selected is not showed correctly. This pull request add specs for the feature and a fix.

Cheers!

Juan.
