### PR TITLE
Fix tags ordering in chrome

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@
 * Don't use Pathname early to circumvent some rare initialization errors [#3816](https://github.com/diaspora/diaspora/issues/3816)
 * Don't error out in script/server if git is unavailable.
 * Fix post preview from tag pages [#4157](https://github.com/diaspora/diaspora/issues/4157)
+* Fix tags ordering in chrome [#4133](https://github.com/diaspora/diaspora/issues/4133)
 
 ## Features
 

--- a/app/assets/javascripts/app/collections/tag_followings.js
+++ b/app/assets/javascripts/app/collections/tag_followings.js
@@ -3,7 +3,7 @@ app.collections.TagFollowings = Backbone.Collection.extend({
   model: app.models.TagFollowing,
   url : "/tag_followings",
   comparator: function(first_tf, second_tf) {
-    return first_tf.get("name") < second_tf.get("name");
+    return  -first_tf.get("name").localeCompare(second_tf.get("name"));
   },
 
   create : function(model) {

--- a/spec/javascripts/app/collections/tag_following_collection_spec.js
+++ b/spec/javascripts/app/collections/tag_following_collection_spec.js
@@ -7,7 +7,7 @@ describe("app.collections.TagFollowings", function(){
     it("should compare in reverse order", function() {
       var a = new app.models.TagFollowing({name: "aaa"}),
           b = new app.models.TagFollowing({name: "zzz"})
-      expect(this.collection.comparator(a, b)).toBe(true)
+      expect(this.collection.comparator(a, b)).toBeGreaterThan(0)
     })
   })
 


### PR DESCRIPTION
Hi all,

fix for #3986, in chrome if you have more than 10 tags, they show up in the wrong order, I left a comment in the issue that pointed to a backbone issue, and implemented a solution from that.

Please review this and test it (I tried in linux and os X),

Cheers!
