### PR TITLE
add missing indent to correct logged-out-header container relative positioning 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -133,6 +133,7 @@ everything is set up.
 * My Activity mobile doesn't show second page when clicking "more". [#4109](https://github.com/diaspora/diaspora/issues/4109)
 * Remove unnecessary navigation bar to access mobile site and re-add flash warning to mobile registrations. [#4085](https://github.com/diaspora/diaspora/pull/4085)
 * Fix broken reactions link on mobile page [#4125](https://github.com/diaspora/diaspora/pull/4125)
+* Fix missing indent to correct logged-out-header container relative positioning [#4134](https://github.com/diaspora/diaspora/pull/4134)
 
 ## Features
 

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -5,10 +5,10 @@
 %header
     - unless current_user
         .container{:style => "position:relative;"}
-        = link_to content_tag(:div, nil, :class => 'branding-logo_small'), root_path
+            = link_to content_tag(:div, nil, :class => 'branding-logo_small'), root_path
 
-        %ul#landing_nav
-            %li= link_to '@joindiaspora', "http://twitter.com/joindiaspora"
-            %li= link_to 'github', "https://github.com/diaspora/diaspora"
-            %li= link_to t('.blog'), 'http://blog.joindiaspora.com/'
-            %li= link_to t('.login'), new_user_session_path, :class => 'login'
+            %ul#landing_nav
+                %li= link_to '@joindiaspora', "http://twitter.com/joindiaspora"
+                %li= link_to 'github', "https://github.com/diaspora/diaspora"
+                %li= link_to t('.blog'), 'http://blog.joindiaspora.com/'
+                %li= link_to t('.login'), new_user_session_path, :class => 'login'


### PR DESCRIPTION
Before
![image](https://f.cloud.github.com/assets/1795059/437013/b3657ad4-b085-11e2-8d1d-e8c52892bf5e.png)

After 
![image](https://f.cloud.github.com/assets/1795059/437017/dc268396-b085-11e2-8e95-20587ac2fa56.png)
