### PR TITLE
Feature/retract tweets when post retracted

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -122,7 +122,7 @@ everything is set up.
 * Fix reshares in single post-view [#4056](https://github.com/diaspora/diaspora/issues/4056)
 * Fix mobile view of deleted reshares. [#4063](https://github.com/diaspora/diaspora/issues/4063)
 * Hide comment button in the mobile view when not signed in. [#4065](https://github.com/diaspora/diaspora/issues/4065)
-* Send profile alongside notification [#3976] (https://github.com/diaspora/diaspora/issues/3976)
+* Send profile alongside notification [#3976](https://github.com/diaspora/diaspora/issues/3976)
 * Fix off-center close button image on intro popovers [#3841](https://github.com/diaspora/diaspora/pull/3841)
 * Remove unnecessary dotted CSS borders. [#2940](https://github.com/diaspora/diaspora/issues/2940)
 * Fix default image url in profiles table. [#3795](https://github.com/diaspora/diaspora/issues/3795)
@@ -136,7 +136,7 @@ everything is set up.
 
 ## Features
 
-* Deleting a post that was shared to Facebook now deletes it from Facebook too [#3980]( https://github.com/diaspora/diaspora/pull/3980)
+* Deleting a post that was shared to Facebook now deletes it from Facebook too [#3980](https://github.com/diaspora/diaspora/pull/3980)
 * Include reshares in a users public atom feed [#1781](https://github.com/diaspora/diaspora/issues/1781)
 * Add the ability to upload photos from the mobile site. [#4004](https://github.com/diaspora/diaspora/issues/4004)
 * Show timestamp when hovering on comment time-ago string. [#4042](https://github.com/diaspora/diaspora/issues/4042)
@@ -147,6 +147,7 @@ everything is set up.
 * Add a preview for posts in the stream [#4099](https://github.com/diaspora/diaspora/issues/4099)
 * Add shortcut key Shift to submit comments and publish posts. [#4096](https://github.com/diaspora/diaspora/pull/4096)
 * Show the service username in a tooltip next to the publisher icons [#4126](https://github.com/diaspora/diaspora/pull/4126)
+* Deleting a post that was shared to Twitter now deletes it from Twitter too [#4135](https://github.com/diaspora/diaspora/pull/4135)
 
 # 0.0.3.4
 

--- a/app/models/services/twitter.rb
+++ b/app/models/services/twitter.rb
@@ -9,8 +9,9 @@ class Services::Twitter < Service
   def post(post, url='')
     Rails.logger.debug("event=post_to_service type=twitter sender_id=#{self.user_id}")
     message = public_message(post, url)
-
-    client.update(message)
+    tweet = client.update(message)
+    post.tweet_id = tweet.id
+    post.save
   end
 
 
@@ -26,6 +27,15 @@ class Services::Twitter < Service
 
   def profile_photo_url
     client.user(nickname).profile_image_url_https("original")
+  end
+
+ def delete_post(service_post_id)
+    Rails.logger.debug("event=delete_from_service type=twitter sender_id=#{self.user_id}")
+    delete_from_twitter(service_post_id)
+  end
+
+  def delete_from_twitter(service_post_id)
+    client.status_destroy(service_post_id)
   end
 
   private

--- a/db/migrate/20130429073928_add_tweet_id_to_post.rb
+++ b/db/migrate/20130429073928_add_tweet_id_to_post.rb
@@ -1,0 +1,6 @@
+class AddTweetIdToPost < ActiveRecord::Migration
+  def change
+  	add_column :posts, :tweet_id, :string
+  	add_index :posts, :tweet_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130404211624) do
+ActiveRecord::Schema.define(:version => 20130429073928) do
 
   create_table "account_deletions", :force => true do |t|
     t.string  "diaspora_handle"
@@ -298,6 +298,7 @@ ActiveRecord::Schema.define(:version => 20130404211624) do
     t.string   "frame_name"
     t.boolean  "favorite",                            :default => false
     t.string   "facebook_id"
+    t.string   "tweet_id"
   end
 
   add_index "posts", ["author_id", "root_guid"], :name => "index_posts_on_author_id_and_root_guid", :unique => true
@@ -307,6 +308,7 @@ ActiveRecord::Schema.define(:version => 20130404211624) do
   add_index "posts", ["root_guid"], :name => "index_posts_on_root_guid"
   add_index "posts", ["status_message_guid", "pending"], :name => "index_posts_on_status_message_guid_and_pending"
   add_index "posts", ["status_message_guid"], :name => "index_posts_on_status_message_guid"
+  add_index "posts", ["tweet_id"], :name => "index_posts_on_tweet_id"
   add_index "posts", ["type", "pending", "id"], :name => "index_posts_on_type_and_pending_and_id"
 
   create_table "profiles", :force => true do |t|

--- a/lib/postzord/dispatcher.rb
+++ b/lib/postzord/dispatcher.rb
@@ -151,8 +151,11 @@ class Postzord::Dispatcher
       end
     end
     if @object.instance_of?(SignedRetraction)
-      services.select { |service| service.respond_to? :delete_post }.each do |service|
+      services.select { |service| service.provider == "facebook" }.each do |service|
         Workers::DeletePostFromService.perform_async(service.id, @object.target.facebook_id)
+      end
+      services.select { |service| service.provider == "twitter" }.each do |service|
+        Workers::DeletePostFromService.perform_async(service.id, @object.target.tweet_id)
       end
     end
   end

--- a/spec/lib/postzord/dispatcher_spec.rb
+++ b/spec/lib/postzord/dispatcher_spec.rb
@@ -321,7 +321,7 @@ describe Postzord::Dispatcher do
 
       it "doesn't queue a job if we can't delete the post from the service" do
         retraction = SignedRetraction.build(alice, FactoryGirl.create(:status_message))
-        service = Services::Twitter.new(access_token: "nope")
+        service = Services::Tumblr.new(access_token: "nope")
         mailman = Postzord::Dispatcher.build(alice, retraction,  :url => "http://joindiaspora.com/p/123", :services => [service])
 
         Workers::DeletePostFromService.should_not_receive(:perform_async).with(anything, anything)

--- a/spec/models/services/twitter_spec.rb
+++ b/spec/models/services/twitter_spec.rb
@@ -10,19 +10,28 @@ describe Services::Twitter do
   end
 
   describe '#post' do
+
+    before do
+      Twitter::Client.any_instance.stub(:update) { Twitter::Tweet.new(id: "1234") }
+    end
+
     it 'posts a status message to twitter' do
       Twitter::Client.any_instance.should_receive(:update).with(instance_of(String))
       @service.post(@post)
     end
 
-     it 'swallows exception raised by twitter always being down' do
+    it 'sets the tweet_id on the post' do
+      @service.post(@post)
+      @post.tweet_id.should match "1234"
+    end    
+
+    it 'swallows exception raised by twitter always being down' do
       pending
       Twitter::Client.any_instance.should_receive(:update).and_raise(StandardError)
       @service.post(@post)
     end
 
     it 'should call public message' do
-      Twitter::Client.any_instance.stub(:update)
       url = "foo"
       @service.should_receive(:public_message).with(@post, url)
       @service.post(@post, url)


### PR DESCRIPTION
Based on the work of #3980 this extends to delete twitter posts also.

I'm not exactly happy with how dispatcher is handling this right now (check for twitter, check for fb, etc.) and am completely open to ideas on cleaning that up.

Both of these (#3980 and this PR) also make the assumption only 1 account is connected. It is possible to get more than 1 connected in D*, but I think (because the UI blocks it) we're only meant to have 1 of search service connected?
