### PR TITLE
fix for #3999: always show hovercards

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@
 * Add back-to-top button on tag and user pages [#4185](https://github.com/diaspora/diaspora/issues/4185)
 * Fix reopened issue by changing the comment/post submit keyboard sortcut to ctrl+enter from shift+enter [#3897](https://github.com/diaspora/diaspora/issues/3897)
 * Show medium avatar in hovercard [#4203](https://github.com/diaspora/diaspora/pull/4203)
+* Always show hovercards. [#3999](https://github.com/diaspora/diaspora/issue/3999)
 
 ## Features
 

--- a/app/assets/javascripts/app/helpers/handlebars-helpers.js
+++ b/app/assets/javascripts/app/helpers/handlebars-helpers.js
@@ -17,13 +17,10 @@ Handlebars.registerHelper('linkToPerson', function(context, block) {
 });
 
 
-// allow hovercards for users that are not the current user.
+// allow hovercards for all users
 // returns the html class name used to trigger hovercards.
 Handlebars.registerHelper('hovercardable', function(person) {
-  if( app.currentUser.get('guid') != person.guid ) {
-    return 'hovercardable';
-  }
-  return '';
+  return 'hovercardable';
 });
 
 Handlebars.registerHelper('personImage', function(person, size, imageClass) {


### PR DESCRIPTION
Fix for [#3999](https://github.com/diaspora/diaspora/issues/3999). Now hovercards also appear for the current user.
