### PR TITLE
Feature/retract tweets when post retracted

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,7 +10,7 @@
 
 ## Features
 
-* Deleting a post that was shared to Twitter now deletes it from Twitter too [#4135](https://github.com/diaspora/diaspora/pull/4135)
+* Deleting a post that was shared to Twitter now deletes it from Twitter too [#4156](https://github.com/diaspora/diaspora/pull/4156)
 
 # 0.1.0.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@
 
 ## Features
 
+* Deleting a post that was shared to Twitter now deletes it from Twitter too [#4135](https://github.com/diaspora/diaspora/pull/4135)
 
 # 0.1.0.0
 
@@ -139,7 +140,7 @@ everything is set up.
 * Fix reshares in single post-view [#4056](https://github.com/diaspora/diaspora/issues/4056)
 * Fix mobile view of deleted reshares. [#4063](https://github.com/diaspora/diaspora/issues/4063)
 * Hide comment button in the mobile view when not signed in. [#4065](https://github.com/diaspora/diaspora/issues/4065)
-* Send profile alongside notification [#3976] (https://github.com/diaspora/diaspora/issues/3976)
+* Send profile alongside notification [#3976](https://github.com/diaspora/diaspora/issues/3976)
 * Fix off-center close button image on intro popovers [#3841](https://github.com/diaspora/diaspora/pull/3841)
 * Remove unnecessary dotted CSS borders. [#2940](https://github.com/diaspora/diaspora/issues/2940)
 * Fix default image url in profiles table. [#3795](https://github.com/diaspora/diaspora/issues/3795)
@@ -159,7 +160,7 @@ everything is set up.
 
 ## Features
 
-* Deleting a post that was shared to Facebook now deletes it from Facebook too [#3980]( https://github.com/diaspora/diaspora/pull/3980)
+* Deleting a post that was shared to Facebook now deletes it from Facebook too [#3980](https://github.com/diaspora/diaspora/pull/3980)
 * Include reshares in a users public atom feed [#1781](https://github.com/diaspora/diaspora/issues/1781)
 * Add the ability to upload photos from the mobile site. [#4004](https://github.com/diaspora/diaspora/issues/4004)
 * Show timestamp when hovering on comment time-ago string. [#4042](https://github.com/diaspora/diaspora/issues/4042)
@@ -211,7 +212,6 @@ everything is set up.
 * twitter 4.5.0 -> 4.6.2
 * uglifier 1.3.0 -> 2.0.1
 * unicorn 4.6.0 -> 4.6.2
-
 
 # 0.0.3.4
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -37,6 +37,10 @@ class Service < ActiveRecord::Base
     nil
   end
 
+  def delete_post(post)
+    #don't do anything (should be overriden by service extensions)
+  end
+
 end
 require 'services/facebook'
 require 'services/twitter'

--- a/app/models/services/facebook.rb
+++ b/app/models/services/facebook.rb
@@ -37,9 +37,11 @@ class Services::Facebook < Service
    "https://graph.facebook.com/#{self.uid}/picture?type=large&access_token=#{URI.escape(self.access_token)}"
   end
 
-  def delete_post(service_post_id)
-    Rails.logger.debug("event=delete_from_service type=facebook sender_id=#{self.user_id}")
-    delete_from_facebook("https://graph.facebook.com/#{service_post_id}/", {:access_token => self.access_token})
+  def delete_post(post)
+    if post.present? && post.facebbook_id.present?
+      Rails.logger.debug("event=delete_from_service type=facebook sender_id=#{self.user_id}")
+      delete_from_facebook("https://graph.facebook.com/#{post.facebook_id}/", {:access_token => self.access_token})
+    end
   end
 
   def delete_from_facebook(url, body)

--- a/app/models/services/twitter.rb
+++ b/app/models/services/twitter.rb
@@ -29,9 +29,11 @@ class Services::Twitter < Service
     client.user(nickname).profile_image_url_https("original")
   end
 
- def delete_post(service_post_id)
-    Rails.logger.debug("event=delete_from_service type=twitter sender_id=#{self.user_id}")
-    delete_from_twitter(service_post_id)
+  def delete_post(post)
+    if post.present? && post.tweet_id.present?
+      Rails.logger.debug("event=delete_from_service type=twitter sender_id=#{self.user_id}")
+      delete_from_twitter(post.tweet_id)
+    end
   end
 
   def delete_from_twitter(service_post_id)

--- a/app/models/services/twitter.rb
+++ b/app/models/services/twitter.rb
@@ -9,8 +9,9 @@ class Services::Twitter < Service
   def post(post, url='')
     Rails.logger.debug("event=post_to_service type=twitter sender_id=#{self.user_id}")
     message = public_message(post, url)
-
-    client.update(message)
+    tweet = client.update(message)
+    post.tweet_id = tweet.id
+    post.save
   end
 
 
@@ -26,6 +27,15 @@ class Services::Twitter < Service
 
   def profile_photo_url
     client.user(nickname).profile_image_url_https("original")
+  end
+
+ def delete_post(service_post_id)
+    Rails.logger.debug("event=delete_from_service type=twitter sender_id=#{self.user_id}")
+    delete_from_twitter(service_post_id)
+  end
+
+  def delete_from_twitter(service_post_id)
+    client.status_destroy(service_post_id)
   end
 
   private

--- a/app/workers/delete_post_from_service.rb
+++ b/app/workers/delete_post_from_service.rb
@@ -6,9 +6,10 @@ module Workers
   class DeletePostFromService < Base
     sidekiq_options queue: :http_service
 
-    def perform(service_id, service_post_id)
+    def perform(service_id, post_id)
       service = Service.find_by_id(service_id)
-      service.delete_post(service_post_id)
+      post = Post.find_by_id(post_id)
+      service.delete_post(post)
     end
   end
 end

--- a/db/migrate/20130429073928_add_tweet_id_to_post.rb
+++ b/db/migrate/20130429073928_add_tweet_id_to_post.rb
@@ -1,0 +1,6 @@
+class AddTweetIdToPost < ActiveRecord::Migration
+  def change
+  	add_column :posts, :tweet_id, :string
+  	add_index :posts, :tweet_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130404211624) do
+ActiveRecord::Schema.define(:version => 20130429073928) do
 
   create_table "account_deletions", :force => true do |t|
     t.string  "diaspora_handle"
@@ -307,6 +307,7 @@ ActiveRecord::Schema.define(:version => 20130404211624) do
     t.string   "frame_name"
     t.boolean  "favorite",                            :default => false
     t.string   "facebook_id"
+    t.string   "tweet_id"
   end
 
   add_index "posts", ["author_id", "root_guid"], :name => "index_posts_on_author_id_and_root_guid", :unique => true
@@ -316,6 +317,7 @@ ActiveRecord::Schema.define(:version => 20130404211624) do
   add_index "posts", ["root_guid"], :name => "index_posts_on_root_guid"
   add_index "posts", ["status_message_guid", "pending"], :name => "index_posts_on_status_message_guid_and_pending"
   add_index "posts", ["status_message_guid"], :name => "index_posts_on_status_message_guid"
+  add_index "posts", ["tweet_id"], :name => "index_posts_on_tweet_id"
   add_index "posts", ["type", "pending", "id"], :name => "index_posts_on_type_and_pending_and_id"
 
   create_table "profiles", :force => true do |t|

--- a/lib/postzord/dispatcher.rb
+++ b/lib/postzord/dispatcher.rb
@@ -151,8 +151,11 @@ class Postzord::Dispatcher
       end
     end
     if @object.instance_of?(SignedRetraction)
-      services.select { |service| service.respond_to? :delete_post }.each do |service|
+      services.select { |service| service.provider == "facebook" }.each do |service|
         Workers::DeletePostFromService.perform_async(service.id, @object.target.facebook_id)
+      end
+      services.select { |service| service.provider == "twitter" }.each do |service|
+        Workers::DeletePostFromService.perform_async(service.id, @object.target.tweet_id)
       end
     end
   end

--- a/lib/postzord/dispatcher.rb
+++ b/lib/postzord/dispatcher.rb
@@ -145,17 +145,12 @@ class Postzord::Dispatcher
     if @object.respond_to?(:public) && @object.public
       deliver_to_hub
     end
-    if @object.instance_of?(StatusMessage)
-      services.each do |service|
+    services.each do |service|
+      if @object.instance_of?(StatusMessage)
         Workers::PostToService.perform_async(service.id, @object.id, url)
       end
-    end
-    if @object.instance_of?(SignedRetraction)
-      services.select { |service| service.provider == "facebook" }.each do |service|
-        Workers::DeletePostFromService.perform_async(service.id, @object.target.facebook_id)
-      end
-      services.select { |service| service.provider == "twitter" }.each do |service|
-        Workers::DeletePostFromService.perform_async(service.id, @object.target.tweet_id)
+      if @object.instance_of?(SignedRetraction)
+        Workers::DeletePostFromService.perform_async(service.id, @object.target.id)
       end
     end
   end

--- a/spec/lib/postzord/dispatcher_spec.rb
+++ b/spec/lib/postzord/dispatcher_spec.rb
@@ -321,7 +321,7 @@ describe Postzord::Dispatcher do
 
       it "doesn't queue a job if we can't delete the post from the service" do
         retraction = SignedRetraction.build(alice, FactoryGirl.create(:status_message))
-        service = Services::Twitter.new(access_token: "nope")
+        service = Services::Tumblr.new(access_token: "nope")
         mailman = Postzord::Dispatcher.build(alice, retraction,  :url => "http://joindiaspora.com/p/123", :services => [service])
 
         Workers::DeletePostFromService.should_not_receive(:perform_async).with(anything, anything)

--- a/spec/lib/postzord/dispatcher_spec.rb
+++ b/spec/lib/postzord/dispatcher_spec.rb
@@ -318,15 +318,7 @@ describe Postzord::Dispatcher do
         Workers::DeletePostFromService.should_receive(:perform_async).with(anything, anything)
         mailman.post
       end
-
-      it "doesn't queue a job if we can't delete the post from the service" do
-        retraction = SignedRetraction.build(alice, FactoryGirl.create(:status_message))
-        service = Services::Tumblr.new(access_token: "nope")
-        mailman = Postzord::Dispatcher.build(alice, retraction,  :url => "http://joindiaspora.com/p/123", :services => [service])
-
-        Workers::DeletePostFromService.should_not_receive(:perform_async).with(anything, anything)
-        mailman.post
-      end
+      
     end
 
     describe '#and_notify_local_users' do

--- a/spec/models/services/twitter_spec.rb
+++ b/spec/models/services/twitter_spec.rb
@@ -10,19 +10,28 @@ describe Services::Twitter do
   end
 
   describe '#post' do
+
+    before do
+      Twitter::Client.any_instance.stub(:update) { Twitter::Tweet.new(id: "1234") }
+    end
+
     it 'posts a status message to twitter' do
       Twitter::Client.any_instance.should_receive(:update).with(instance_of(String))
       @service.post(@post)
     end
 
-     it 'swallows exception raised by twitter always being down' do
+    it 'sets the tweet_id on the post' do
+      @service.post(@post)
+      @post.tweet_id.should match "1234"
+    end    
+
+    it 'swallows exception raised by twitter always being down' do
       pending
       Twitter::Client.any_instance.should_receive(:update).and_raise(StandardError)
       @service.post(@post)
     end
 
     it 'should call public message' do
-      Twitter::Client.any_instance.stub(:update)
       url = "foo"
       @service.should_receive(:public_message).with(@post, url)
       @service.post(@post, url)


### PR DESCRIPTION
Closes & replaces #4135.  Based on the work of #3980 this extends to delete twitter posts also.

Both of these (#3980 and this PR) also make the assumption only 1 account is connected. It is possible to get more than 1 connected in D*, but I think (because the UI blocks it) we're only meant to have 1 of search service connected?
