### PR TITLE
Fix for #4174: Post iframe src url

### DIFF
--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -20,7 +20,7 @@ module PostsHelper
   def post_iframe_url(post_id, opts={})
     opts[:width] ||= 516
     opts[:height] ||= 315 
-    host = AppConfig.pod_uri.site
+    host = AppConfig.pod_uri.authority
    "<iframe src='#{Rails.application.routes.url_helpers.post_url(post_id, :host => host)}' width='#{opts[:width]}px' height='#{opts[:height]}px' frameBorder='0'></iframe>".html_safe
   end
 end

--- a/spec/helpers/posts_helper_spec.rb
+++ b/spec/helpers/posts_helper_spec.rb
@@ -1,0 +1,21 @@
+#   Copyright (c) 2010-2011, Diaspora Inc.  This file is
+#   licensed under the Affero General Public License version 3 or later.  See
+#   the COPYRIGHT file.
+
+require 'spec_helper'
+
+describe PostsHelper do
+  describe '#post_iframe_url' do
+    before do
+      @post = FactoryGirl.create(:status_message)
+    end
+
+    it "returns an iframe tag" do
+      post_iframe_url(@post.id).should include "iframe"
+    end
+
+    it "returns an iframe containing the post" do
+      post_iframe_url(@post.id).should include "src='http://localhost:9887#{post_path(@post)}'"
+    end
+  end
+end


### PR DESCRIPTION
Fixes #4174.  Uses the 'authority' addressable helper method to build the post url.  
Cheers :)
