### PR TITLE
Changed post/comment submit keyboard shortcut to ctrl+enter

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -167,6 +167,7 @@ everything is set up.
 * Fix missing indent to correct logged-out-header container relative positioning [#4134](https://github.com/diaspora/diaspora/pull/4134)
 * Private post dont show error 404 when you are not authorized on mobile page [#4129](https://github.com/diaspora/diaspora/issues/4129)
 * Show 404 instead of 500 if a not signed in user wants to see a non public or non existing post.
+* Fix reopened issue by changing the comment/post submit keyboard sortcut to ctrl+enter from shift+enter [#3897](https://github.com/diaspora/diaspora/issues/3897)
 
 ## Features
 

--- a/app/assets/javascripts/app/views/comment_stream_view.js
+++ b/app/assets/javascripts/app/views/comment_stream_view.js
@@ -53,7 +53,7 @@ app.views.CommentStream = app.views.Base.extend({
   },
 
   keyDownOnCommentBox: function(evt) {
-    if(evt.keyCode == 13 && evt.shiftKey) {
+    if(evt.keyCode == 13 && evt.ctrlKey) {
       this.$("form").submit()
       return false;
     }

--- a/app/assets/javascripts/app/views/publisher_view.js
+++ b/app/assets/javascripts/app/views/publisher_view.js
@@ -210,7 +210,7 @@ app.views.Publisher = Backbone.View.extend(_.extend(
   },
 
   keyDown : function(evt) {
-    if( evt.keyCode == 13 && evt.shiftKey ) {
+    if( evt.keyCode == 13 && evt.ctrlKey ) {
       this.$("form").submit();
       this.open();
       return false;

--- a/spec/javascripts/app/views/comment_stream_view_spec.js
+++ b/spec/javascripts/app/views/comment_stream_view_spec.js
@@ -94,14 +94,14 @@ describe("app.views.CommentStream", function(){
       expect(submitCallback).not.toHaveBeenCalled();
     })
     
-    it("should submit the form when enter is pressed with shift", function(){
+    it("should submit the form when enter is pressed with ctrl", function(){
       this.view.render();
       var form = this.view.$("form")
       var submitCallback = jasmine.createSpy().andReturn(false);
       form.submit(submitCallback);
       
       var e = $.Event("keydown", { keyCode: 13 });
-      e.shiftKey = true;
+      e.ctrlKey = true;
       this.view.keyDownOnCommentBox(e);
       
       expect(submitCallback).toHaveBeenCalled();

--- a/spec/javascripts/app/views/publisher_view_spec.js
+++ b/spec/javascripts/app/views/publisher_view_spec.js
@@ -116,14 +116,14 @@ describe("app.views.Publisher", function() {
     });
 
     describe("publishing a post with keyboard", function(){
-      it("should submit the form when shift+enter is pressed", function(){
+      it("should submit the form when ctrl+enter is pressed", function(){
         this.view.render();
         var form = this.view.$("form")
         var submitCallback = jasmine.createSpy().andReturn(false);
         form.submit(submitCallback);
       
         var e = $.Event("keydown", { keyCode: 13 });
-        e.shiftKey = true;
+        e.ctrlKey = true;
         this.view.keyDown(e);
       
         expect(submitCallback).toHaveBeenCalled();


### PR DESCRIPTION
Changed post/comment submit keyboard shortcut to ctrl+enter from shift+enter

Fixes reopened #3897
