### PR TITLE
Add user_id index for contacts table

### DIFF
--- a/db/migrate/20130530135826_add_user_index_to_contacts.rb
+++ b/db/migrate/20130530135826_add_user_index_to_contacts.rb
@@ -1,0 +1,5 @@
+class AddUserIndexToContacts < ActiveRecord::Migration
+  def change
+    add_index :contacts, :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130429073928) do
+ActiveRecord::Schema.define(:version => 20130530135826) do
 
   create_table "account_deletions", :force => true do |t|
     t.string  "diaspora_handle"
@@ -86,6 +86,7 @@ ActiveRecord::Schema.define(:version => 20130429073928) do
 
   add_index "contacts", ["person_id"], :name => "index_contacts_on_person_id"
   add_index "contacts", ["user_id", "person_id"], :name => "index_contacts_on_user_id_and_person_id", :unique => true
+  add_index "contacts", ["user_id"], :name => "index_contacts_on_user_id"
 
   create_table "conversation_visibilities", :force => true do |t|
     t.integer  "conversation_id",                :null => false


### PR DESCRIPTION
Done mainly because Profile.subscribers does a join across contacts
using where user_id clause.  It gets slow when there's a lot of contacts.

An issue when dispatching a profile update to massive number of contacts https://github.com/diaspora/diaspora/blob/develop/lib/postzord/dispatcher.rb#L87
https://github.com/diaspora/diaspora/blob/develop/app/models/profile.rb#L54
