### PR TITLE
Add back-to-top button on tag and user pages

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@
 * Fix post preview from tag pages [#4157](https://github.com/diaspora/diaspora/issues/4157)
 * Fix tags ordering in chrome [#4133](https://github.com/diaspora/diaspora/issues/4133)
 * Fix src URL for oEmbed iFrame [#4178](https://github.com/diaspora/diaspora/pull/4178)
+* Add back-to-top button on tag and user pages [#4185](https://github.com/diaspora/diaspora/issues/4185)
 
 ## Features
 

--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -36,3 +36,6 @@
 
     #paginate
       %span.loader.hidden
+
+  %a{:id=>"back-to-top", :title=>"#{t('layouts.application.back_to_top')}", :href=>"#"}
+    &#8679;

--- a/app/views/tags/show.haml
+++ b/app/views/tags/show.haml
@@ -41,4 +41,6 @@
     #main_stream.stream
 
     #paginate
-
+  
+  %a{:id=>"back-to-top", :title=>"#{t('layouts.application.back_to_top')}", :href=>"#"}
+    &#8679;


### PR DESCRIPTION
This fixes [#4185](https://github.com/diaspora/diaspora/issues/4185)
