### PR TITLE
Don't show hovercards for current user in comments

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@
 * Fix reopened issue by changing the comment/post submit keyboard sortcut to ctrl+enter from shift+enter [#3897](https://github.com/diaspora/diaspora/issues/3897)
 * Show medium avatar in hovercard [#4203](https://github.com/diaspora/diaspora/pull/4203)
 * Fix posting to Twitter [#2758](https://github.com/diaspora/diaspora/issues/2758)
+* Don't show hovercards for current user in comments [#3999](https://github.com/diaspora/diaspora/issues/3999)
 
 ## Features
 

--- a/app/assets/templates/comment_tpl.jst.hbs
+++ b/app/assets/templates/comment_tpl.jst.hbs
@@ -13,9 +13,11 @@
     </div>
   {{/if}}
 
-  <a href="/people/{{author.guid}}" class="author author-name {{hovercardable this}}">
-    {{author.name}}
-  </a>
+  {{#with author}}
+    <a href="/people/{{guid}}" class="author author-name {{hovercardable this}}">
+      {{name}}
+    </a>
+  {{/with}}
 
   <div class="collapsible comment-content">
     {{{text}}}


### PR DESCRIPTION
Fix for [#3999](https://github.com/diaspora/diaspora/issues/3999). Don't show hovercards for the current user in comments.
