### PR TITLE
Add loading indicator on tag pages, remove second one from profile page

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,7 @@
 * Unify hide and ignore [#3828](https://github.com/diaspora/diaspora/issues/3828)
 * Remove alpha branding [#4196](https://github.com/diaspora/diaspora/issues/4196)
 * Fix dynamic loading of asset_sync
+* Add loading indicator on tag pages, remove the second one from the profile page [#4041](https://github.com/diaspora/diaspora/issues/4041)
 
 ## Features
 

--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -35,7 +35,6 @@
           = t('.ignoring', :name => @person.first_name)
 
     #paginate
-      %span.loader.hidden
 
   %a{:id=>"back-to-top", :title=>"#{t('layouts.application.back_to_top')}", :href=>"#"}
     &#8679;

--- a/app/views/tags/show.haml
+++ b/app/views/tags/show.haml
@@ -41,6 +41,7 @@
     #main_stream.stream
 
     #paginate
-  
+      %span.loader.hidden
+
   %a{:id=>"back-to-top", :title=>"#{t('layouts.application.back_to_top')}", :href=>"#"}
     &#8679;


### PR DESCRIPTION
Fixes [#4041](https://github.com/diaspora/diaspora/issues/4041) but I don't understand why. Why does the tag page need a <code>%span.loader.hidden</code> and the profile page doesn't?
