### PR TITLE
Change image to ajax-loader when closing lightbox

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@
 * Fix deleting a post from Facebook [#4290](https://github.com/diaspora/diaspora/pull/4290)
 * Display notices a little bit longer to help on sign up errors [#4274](https://github.com/diaspora/diaspora/issues/4274)
 * Fix user contact sharing/receiving [#4163](https://github.com/diaspora/diaspora/issues/4163)
+* Change image to ajax-loader when closing lightbox [#3229](https://github.com/diaspora/diaspora/issues/3229)
 
 ## Features
 * Admin: add option to find users under 13 (COPPA) [#4252](https://github.com/diaspora/diaspora/pull/4252)

--- a/app/assets/javascripts/widgets/lightbox.js
+++ b/app/assets/javascripts/widgets/lightbox.js
@@ -151,6 +151,8 @@ jQuery.fn.center = (function() {
     this.resetLightbox = function() {
       self.lightbox.hide();
       self.body.removeClass("lightboxed");
+      self.image.attr("src", "assets/ajax-loader2.gif");
+      self.imageset.html("");
     };
 
     this.set = function(opts) {


### PR DESCRIPTION
This could fix #3229. I was not able to reproduce the bug on my dev-server because the images are opened too fast (from localhost).

Steps to reproduce the bug:
1. Upload a few big images and post them all together in one post (loading them from the server should take a while)
2. Click on the first image to open the lightbox.
3. Close the lightbox
4. Click on another image to open the lightbox.

You shouldn't be able to see the first image. Instead there should be a loader or you should see the second image.
