### PR TITLE
Fix hashtags that start a line when posting to Facebook or Twitter

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -26,6 +26,7 @@
 * Fix login for short passwords [#4123](https://github.com/diaspora/diaspora/issues/4123)
 * Add loading indicator on tag pages, remove the second one from the profile page [#4041](https://github.com/diaspora/diaspora/issues/4041)
 * Leaving the `to` field blank when sending a private message causes a server error [#4227](https://github.com/diaspora/diaspora/issues/4227)
+* Fix hashtags that start a line when posting to Facebook or Twitter [#3768](https://github.com/diaspora/diaspora/issues/3768) [#4154](https://github.com/diaspora/diaspora/issues/4154)
 
 ## Features
 

--- a/app/helpers/markdownify_helper.rb
+++ b/app/helpers/markdownify_helper.rb
@@ -3,9 +3,9 @@
 #   the COPYRIGHT file.
 
 module MarkdownifyHelper
-  def markdownify(target, render_options={})
 
-    markdown_options = {
+  def markdown_options
+    {
       :autolink            => true,
       :fenced_code_blocks  => true,
       :space_after_headers => true,
@@ -13,6 +13,9 @@ module MarkdownifyHelper
       :tables              => true,
       :no_intra_emphasis   => true,
     }
+  end
+
+  def markdownify(target, render_options={})
 
     render_options[:filter_html] = true
     render_options[:hard_wrap] ||= true
@@ -45,7 +48,7 @@ module MarkdownifyHelper
   end
 
   def strip_markdown(text)
-    renderer = Redcarpet::Markdown.new(Redcarpet::Render::StripDown, :autolink => true)
+    renderer = Redcarpet::Markdown.new(Redcarpet::Render::StripDown, markdown_options)
     renderer.render(text).strip
   end
 

--- a/spec/helpers/markdownify_helper_spec.rb
+++ b/spec/helpers/markdownify_helper_spec.rb
@@ -83,12 +83,22 @@ describe MarkdownifyHelper do
         formatted = markdownify(message)
         formatted.should == %{<p>Test <a href="/tags/tag" class="tag">#tag</a>?<br>\n<a href="https://joindiaspora.com" target="_blank">https://joindiaspora.com</a></p>\n}
       end
+      
+      it 'should process text with a header' do
+        message = "# I love markdown"
+        markdownify(message).should match "I love markdown"
+      end
     end
   end
   
   describe "#strip_markdown" do
     it 'does not remove markdown in links' do
       message = "some text and here comes http://exampe.org/foo_bar_baz a link"
+      strip_markdown(message).should match message
+    end
+    
+    it 'does not destroy hashtag that starts a line' do
+      message = "#hashtag message"
       strip_markdown(message).should match message
     end
   end


### PR DESCRIPTION
Fixing by applying all the same options to strip_markdown as applying to markdownify.

Fixes #3768 and #4154
