### PR TITLE
Show the user if a contact is sharing with them when viewing their profile page

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -622,6 +622,17 @@ form.new_comment
       h4
         :font-weight bold
 
+  #sharing_message
+    :font-size smaller
+    :align middle
+
+    span
+      :vertical-align middle
+
+    img
+      :vertical-align middle
+      :margin 0.5em
+
 #photo_container
   :text
     :align center

--- a/app/helpers/people_helper.rb
+++ b/app/helpers/people_helper.rb
@@ -87,4 +87,13 @@ module PeopleHelper
       return Rails.application.routes.url_helpers.person_path(person, opts)
     end
   end
+
+  def sharing_message(person, contact)
+    if contact.sharing?
+      content_tag(:div, :class => 'info') do
+        image_tag('icons/check_yes_ok.png') +
+        content_tag(:span, I18n.t('people.helper.is_sharing', :name => person.name))
+      end
+    end
+  end
 end

--- a/app/helpers/people_helper.rb
+++ b/app/helpers/people_helper.rb
@@ -90,7 +90,7 @@ module PeopleHelper
 
   def sharing_message(person, contact)
     if contact.sharing?
-      content_tag(:div, :class => 'info') do
+      content_tag(:div, :id => 'sharing_message') do
         image_tag('icons/check_yes_ok.png') +
         content_tag(:span, I18n.t('people.helper.is_sharing', :name => person.name))
       end

--- a/app/views/people/_profile_sidebar.html.haml
+++ b/app/views/people/_profile_sidebar.html.haml
@@ -5,6 +5,11 @@
 #profile
   .profile_photo
     = person_image_link(person, :size => :thumb_large, :to => :photos)
+  - if contact.sharing?
+    .info
+      = image_tag('icons/check_yes_ok.png')
+      = person.name
+      is sharing with you
 
   - if user_signed_in?
     - if person != current_user.person

--- a/app/views/people/_profile_sidebar.html.haml
+++ b/app/views/people/_profile_sidebar.html.haml
@@ -5,14 +5,11 @@
 #profile
   .profile_photo
     = person_image_link(person, :size => :thumb_large, :to => :photos)
-  - if contact.sharing?
-    .info
-      = image_tag('icons/check_yes_ok.png')
-      = person.name
-      is sharing with you
 
   - if user_signed_in?
     - if person != current_user.person
+      = sharing_message(@person, @contact)
+
       - if @contact && @contact.receiving?
         %br
         = link_to t('people.show.mention'), new_status_message_path(:person_id => @person.id), :class => 'button', :rel => 'facebox'

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -593,6 +593,7 @@ en:
     helper:
       results_for: " results for %{params}"
       people_on_pod_are_aware_of: " people on pod are aware of"
+      is_sharing: "%{name} is sharing with you"
     aspect_list:
       edit_membership: "edit aspect membership"
     add_contact_small:

--- a/spec/helpers/people_helper_spec.rb
+++ b/spec/helpers/people_helper_spec.rb
@@ -117,5 +117,25 @@ describe PeopleHelper do
       local_or_remote_person_path(@person).should == person_path(@person)
     end
   end
-end
 
+  describe '#sharing_message' do
+    before do
+      @contact = FactoryGirl.create(:contact, :person => @person)
+    end
+
+    context 'when the contact is sharing' do
+      it 'shows the sharing message' do
+        message = I18n.t('people.helper.is_sharing', :name => @person.name)
+        @contact.stub(:sharing?).and_return(true)
+        sharing_message(@person, @contact).should include(message)
+      end
+    end
+
+    context 'when the contact is not sharing' do
+      it 'does not show the sharing message' do
+        @contact.stub(:sharing?).and_return(false)
+        sharing_message(@person, @contact).should be_blank
+      end
+    end
+  end
+end


### PR DESCRIPTION
I was expecting #2948 to be more than just editing a template. Since I am not a web designer, I did my best to not make this notice look horrible. Is there a better place to display this information on the user's profile page?
