### PR TITLE
Show avatar of recent user in conversation list

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -26,6 +26,7 @@
 * Fix login for short passwords [#4123](https://github.com/diaspora/diaspora/issues/4123)
 * Add loading indicator on tag pages, remove the second one from the profile page [#4041](https://github.com/diaspora/diaspora/issues/4041)
 * Leaving the `to` field blank when sending a private message causes a server error [#4227](https://github.com/diaspora/diaspora/issues/4227)
+* Show avatar of recent user in conversation list [#4237](https://github.com/diaspora/diaspora/issues/4237)
 
 ## Features
 

--- a/app/views/conversations/_conversation.haml
+++ b/app/views/conversations/_conversation.haml
@@ -6,7 +6,8 @@
   .stream_element.conversation{:data=>{:guid=>conversation.id}, :class => ('unread' if unread_counts[conversation.id].to_i > 0)}
     .media
       .img
-        = person_image_tag(conversation.author)
+        - if authors[conversation.id].present?
+          = person_image_tag(authors[conversation.id])
 
       .bg
         = render(:partial => 'conversation_subject',


### PR DESCRIPTION
Fixes #4237. This PR changes the avatar in the conversation list from the creator of the conversation to the most recent user who posted something in the conversation.
