### PR TITLE
Remove restriction on guid length

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 * Drop misleading fallback donation form. [Proposal](https://www.loomio.org/discussions/1045?proposal=2722)
 * Update Typhoeus to 0.6.3 and refactor HydraWrapper. [#4162](https://github.com/diaspora/diaspora/pull/4162)
 * Bump recomended Ruby version to 1.9.3-p448, see [Ruby news](http://www.ruby-lang.org/en/news/2013/06/27/hostname-check-bypassing-vulnerability-in-openssl-client-cve-2013-4073/).
+* Remove length restriciton on GUIDs in the database schema [#4249](https://github.com/diaspora/diaspora/pull/4249)
 
 ## Bug fixes
 

--- a/db/migrate/20130613203350_remove_limit_from_root_guid_in_posts.rb
+++ b/db/migrate/20130613203350_remove_limit_from_root_guid_in_posts.rb
@@ -1,0 +1,9 @@
+class RemoveLimitFromRootGuidInPosts < ActiveRecord::Migration
+  def up
+    change_column :posts, :root_guid, :string
+  end
+
+  def down
+    change_column :posts, :root_guid, :string, limit: 30
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130429073928) do
+ActiveRecord::Schema.define(:version => 20130613203350) do
 
   create_table "account_deletions", :force => true do |t|
     t.string  "diaspora_handle"
@@ -213,7 +213,7 @@ ActiveRecord::Schema.define(:version => 20130429073928) do
     t.text   "data",                 :null => false
   end
 
-  add_index "o_embed_caches", ["url"], :name => "index_o_embed_caches_on_url", :length => {"url"=>255}
+  add_index "o_embed_caches", ["url"], :name => "index_o_embed_caches_on_url"
 
   create_table "participations", :force => true do |t|
     t.string   "guid"
@@ -297,7 +297,7 @@ ActiveRecord::Schema.define(:version => 20130429073928) do
     t.string   "provider_display_name"
     t.string   "actor_url"
     t.string   "objectId"
-    t.string   "root_guid",             :limit => 30
+    t.string   "root_guid"
     t.string   "status_message_guid"
     t.integer  "likes_count",                         :default => 0
     t.integer  "comments_count",                      :default => 0


### PR DESCRIPTION
This is more a request for comments than a pull request

I think it would be a good idea to switch GUID generation to UUIDs: https://github.com/MrZYX/diaspora/compare/uuid However our current database schema limits their length too much, so it would be a change breaking federation, the earliest point where we could do it is the next major release. What we could already do though is removing that restriction, reducing the impact in the migration phase.
