### PR TITLE
Feature/4182 render markdown in mails

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -43,6 +43,7 @@
 * Leaving the `to` field blank when sending a private message causes a server error [#4227](https://github.com/diaspora/diaspora/issues/4227)
 * Fix hashtags that start a line when posting to Facebook or Twitter [#3768](https://github.com/diaspora/diaspora/issues/3768) [#4154](https://github.com/diaspora/diaspora/issues/4154)
 * Show avatar of recent user in conversation list [#4237](https://github.com/diaspora/diaspora/issues/4237)
+* Render markdown content for prettier email subjects and titles [#4182](https://github.com/diaspora/diaspora/issues/4182)
 
 ## Features
 

--- a/app/helpers/notifier_helper.rb
+++ b/app/helpers/notifier_helper.rb
@@ -6,7 +6,8 @@ module NotifierHelper
   def post_message(post, opts={})
     opts[:length] ||= 200
     if post.respond_to? :formatted_message
-      message = truncate(post.formatted_message(:plain_text => true), :length => opts[:length])
+      message = strip_markdown(post.formatted_message(:plain_text => true))
+      message = truncate(message, :length => opts[:length])
       message = process_newlines(message) if opts[:process_newlines]
       message
     else
@@ -19,7 +20,8 @@ module NotifierHelper
   # @return [String] The truncated and formatted comment.
   def comment_message(comment, opts={})
     opts[:length] ||= 600
-    text = truncate(comment.text, :length => opts[:length])
+    text = strip_markdown(comment.text)
+    text = truncate(text, :length => opts[:length])
     text = process_newlines(text) if opts[:process_newlines]
     text
   end

--- a/app/mailers/notification_mailers/also_commented.rb
+++ b/app/mailers/notification_mailers/also_commented.rb
@@ -1,6 +1,7 @@
 module NotificationMailers
   class AlsoCommented < NotificationMailers::Base
     include ActionView::Helpers::TextHelper
+    include MarkdownifyHelper
 
     attr_accessor :comment
     delegate :post, to: :comment, prefix: true
@@ -10,7 +11,7 @@ module NotificationMailers
 
       if mail?
         @headers[:from] = "\"#{@comment.author_name} (Diaspora*)\" <#{AppConfig.mail.sender_address}>"
-        @headers[:subject] = truncate(@comment.comment_email_subject, :length => TRUNCATION_LEN)
+        @headers[:subject] = truncate(strip_markdown(@comment.comment_email_subject.squish), :length => TRUNCATION_LEN)
         @headers[:subject] = "Re: #{@headers[:subject]}"
       end
     end

--- a/app/mailers/notification_mailers/comment_on_post.rb
+++ b/app/mailers/notification_mailers/comment_on_post.rb
@@ -1,6 +1,7 @@
 module NotificationMailers
   class CommentOnPost < NotificationMailers::Base
     include ActionView::Helpers::TextHelper
+    include MarkdownifyHelper
 
     attr_accessor :comment
 
@@ -8,7 +9,7 @@ module NotificationMailers
       @comment = Comment.find(comment_id)
 
       @headers[:from] = "\"#{@comment.author_name} (Diaspora*)\" <#{AppConfig.mail.sender_address}>"
-      @headers[:subject] = truncate(@comment.comment_email_subject, :length => TRUNCATION_LEN)
+      @headers[:subject] = truncate(strip_markdown(@comment.comment_email_subject.squish), :length => TRUNCATION_LEN)
       @headers[:subject] = "Re: #{@headers[:subject]}"
     end
   end

--- a/spec/helpers/notifier_helper_spec.rb
+++ b/spec/helpers/notifier_helper_spec.rb
@@ -6,15 +6,50 @@ require 'spec_helper'
 
 describe NotifierHelper do
   include MarkdownifyHelper
-  
-  describe '#comment_message' do
+
+  describe '#post_message' do
     before do
-      @comment = FactoryGirl.create(:comment)
+      # post for truncate test
+      @post = FactoryGirl.create(:status_message)
+      @post.text = "hi dude! "*10
+      @truncated_post = "hi dude! hi dude! hi dude! hi dude! hi dude! hi dude! hi dude! hi dude! hi du..."
+      # post for markdown test
+      @markdown_post = FactoryGirl.create(:status_message)
+      @markdown_post.text = "[link](http://diasporafoundation.org) **bold text** *other text*"
+      @striped_markdown_post = "link bold text other text"
     end
 
-    it 'truncates the comment' do
-      opts = {:length => 2}
-      comment_message(@comment, opts).should == truncate(@comment.text, opts)
+    it 'truncates in the post' do
+      opts = {:length => @post.text.length - 10}
+      post_message(@post, opts).should == @truncated_post
+    end
+
+    it 'strip markdown in the post' do
+      opts = {:length => @markdown_post.text.length}
+      post_message(@markdown_post, opts).should == @striped_markdown_post
+    end
+  end
+
+  describe '#comment_message' do
+    before do
+      # comment for truncate test
+      @comment = FactoryGirl.create(:comment)
+      @comment.text = "hi dude! "*10
+      @truncated_comment = "hi dude! hi dude! hi dude! hi dude! hi dude! hi dude! hi dude! hi dude! hi d..."
+      # comment for markdown test
+      @markdown_comment = FactoryGirl.create(:comment)
+      @markdown_comment.text = "[link](http://diasporafoundation.org) **bold text** *other text*"
+      @striped_markdown_comment = "link bold text other text"
+    end
+
+    it 'truncates in the comment' do
+      opts = {:length => @comment.text.length - 10}
+      comment_message(@comment, opts).should == @truncated_comment
+    end
+
+    it 'strip markdown in the comment' do
+      opts = {:length => @markdown_comment.text.length}
+      comment_message(@markdown_comment, opts).should == @striped_markdown_comment
     end
   end
 end

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Notifier do
   include ActionView::Helpers::TextHelper
+  include MarkdownifyHelper
 
   let(:person) { FactoryGirl.create(:person) }
 
@@ -214,7 +215,7 @@ describe Notifier do
   end
 
   context "comments" do
-    let(:commented_post) {bob.post(:status_message, :text => "It's really sunny outside today, and this is a super long status message!  #notreally", :to => :all)}
+    let(:commented_post) {bob.post(:status_message, :text => "### Headline \r\n It's **really** sunny outside today, and this is a super long status message!  #notreally", :to => :all)}
     let(:comment) { eve.comment!(commented_post, "Totally is")}
 
     describe ".comment_on_post" do
@@ -228,8 +229,8 @@ describe Notifier do
         comment_mail["From"].to_s.should == "\"#{eve.name} (Diaspora*)\" <#{AppConfig.mail.sender_address}>"
       end
 
-      it 'SUBJECT: has a snippet of the post contents' do
-        comment_mail.subject.should == "Re: #{truncate(commented_post.raw_message, :length => 70)}"
+      it 'SUBJECT: has a snippet of the post contents, without markdown and without newlines' do
+        comment_mail.subject.should == "Re: Headline It's really sunny outside today, and this is a super long ..."
       end
 
       context 'BODY' do
@@ -269,8 +270,8 @@ describe Notifier do
         comment_mail["From"].to_s.should == "\"#{eve.name} (Diaspora*)\" <#{AppConfig.mail.sender_address}>"
       end
 
-      it 'SUBJECT: has a snippet of the post contents' do
-        comment_mail.subject.should == "Re: #{truncate(commented_post.raw_message, :length => 70)}"
+      it 'SUBJECT: has a snippet of the post contents, without markdown and without newlines' do
+        comment_mail.subject.should == "Re: Headline It's really sunny outside today, and this is a super long ..."
       end
 
       context 'BODY' do


### PR DESCRIPTION
Thats the bugfix for the issue [#4182](https://github.com/diaspora/diaspora/issues/4182).

Thank you @MrZYX for your help!! 

Known Bug: strip_markdown ignores images with markdown
