### PR TITLE
Consider Markdown header as post title

### DIFF
--- a/app/assets/javascripts/app/pages/post-viewer.js
+++ b/app/assets/javascripts/app/pages/post-viewer.js
@@ -74,10 +74,10 @@ app.pages.PostViewer = app.views.Base.extend({
 
   postRenderTemplate : function() {
     if(this.model.get("title")){
-	// formats title to html...
-	var html_title = app.helpers.textFormatter(this.model.get("title"), this.model)
-	//... and converts html to plain text 
-	document.title = $('<div>').html(html_title).text(); 
+      // formats title to html...
+      var html_title = app.helpers.textFormatter(this.model.get("title"), this.model);
+      //... and converts html to plain text 
+      document.title = $('<div>').html(html_title).text(); 
     }
   },
 

--- a/app/assets/javascripts/app/pages/post-viewer.js
+++ b/app/assets/javascripts/app/pages/post-viewer.js
@@ -73,7 +73,12 @@ app.pages.PostViewer = app.views.Base.extend({
   },
 
   postRenderTemplate : function() {
-    if(this.model.get("title")){ document.title = this.model.get("title"); }
+    if(this.model.get("title")){
+	// formats title to html...
+	var html_title = app.helpers.textFormatter(this.model.get("title"), this.model)
+	//... and converts html to plain text 
+	document.title = $('<div>').html(html_title).text(); 
+    }
   },
 
   commentAnywhere : function(evt) {

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -10,6 +10,14 @@ module PostsHelper
       I18n.t "posts.show.reshare_by", :author => post.author_name
     else
       if post.text.present?
+        title = post.text(:plain_text => true).match(/^((([^\n\r]*)(\r?\n)(-+|=+)(\r?\n|$))|(\#{1,6}[[:space:]]+([^\n\r]+?)\#*(\r?\n|$)))/)
+        unless title.nil?
+          unless title[3].nil?
+            return title[3]
+          else
+            return title[8]
+          end
+        end
         truncate(post.text(:plain_text => true), :length => opts.fetch(:length, 20))
       elsif post.respond_to?(:photos) && post.photos.present?
         I18n.t "posts.show.photos_by", :count => post.photos.size, :author => post.author_name

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -10,16 +10,18 @@ module PostsHelper
       I18n.t "posts.show.reshare_by", :author => post.author_name
     else
       if post.text.present?
-        reg = /\A(?:  # Regexp to match a Markdown header present on first line and retrieve its content for :
-              (?<setext_content>.{1,80})\n(?:={1,80}|-{1,80})(?:\r?\n|$)              # Setext-style header
+        if opts.has_key?(:length)
+           truncate(post.text(:plain_text => true), :length => opts.fetch(:length))
+        elsif /\A(?:  # Regexp to match a Markdown header present on first line :
+              (?<setext_content>.{1,200}\n(?:={1,200}|-{1,200}))(?:\r?\n|$)           # Setext-style header
                   |                                                                   # or
-              \#{1,6}[[:blank:]](?<atx_content>.{1,80})(?<![\#\r])                    # Atx-style header
-               )/x    # 80 is the max size of title
-        if reg =~ post.text(:plain_text => true)
-          return $~[:setext_content].strip unless $~[:setext_content].nil?
-          return $~[:atx_content].strip unless $~[:atx_content].nil?
+              (?<atx_content>\#{1,6}\s.{1,200})(?:\r?\n|$)                            # Atx-style header
+               )/x   =~  post.text(:plain_text => true)
+          return setext_content unless setext_content.nil?
+          return atx_content unless atx_content.nil?
+        else
+          truncate(post.text(:plain_text => true), :length => 20 )
         end
-        truncate(post.text(:plain_text => true), :length => opts.fetch(:length, 20))
       elsif post.respond_to?(:photos) && post.photos.present?
         I18n.t "posts.show.photos_by", :count => post.photos.size, :author => post.author_name
       end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -10,13 +10,14 @@ module PostsHelper
       I18n.t "posts.show.reshare_by", :author => post.author_name
     else
       if post.text.present?
-        title = post.text(:plain_text => true).match(/^((([^\n\r]*)(\r?\n)(-+|=+)(\r?\n|$))|(\#{1,6}[[:space:]]+([^\n\r]+?)\#*(\r?\n|$)))/)
-        unless title.nil?
-          unless title[3].nil?
-            return title[3]
-          else
-            return title[8]
-          end
+        reg = /\A(?:  # Regexp to match a Markdown header present on first line and retrieve its content for :
+              (?<setext_content>.{1,80})\n(?:={1,80}|-{1,80})(?:\r?\n|$)              # Setext-style header
+                  |                                                                   # or
+              \#{1,6}[[:blank:]](?<atx_content>.{1,80})(?<![\#\r])                    # Atx-style header
+               )/x    # 80 is the max size of title
+        if reg =~ post.text(:plain_text => true)
+          return $~[:setext_content].strip unless $~[:setext_content].nil?
+          return $~[:atx_content].strip unless $~[:atx_content].nil?
         end
         truncate(post.text(:plain_text => true), :length => opts.fetch(:length, 20))
       elsif post.respond_to?(:photos) && post.photos.present?
@@ -27,7 +28,7 @@ module PostsHelper
 
   def post_iframe_url(post_id, opts={})
     opts[:width] ||= 516
-    opts[:height] ||= 315 
+    opts[:height] ||= 315
     host = AppConfig.pod_uri.authority
    "<iframe src='#{Rails.application.routes.url_helpers.post_url(post_id, :host => host)}' width='#{opts[:width]}px' height='#{opts[:height]}px' frameBorder='0'></iframe>".html_safe
   end

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -1,4 +1,7 @@
 class PostPresenter
+  include PostsHelper
+  include ActionView::Helpers::TextHelper
+
   attr_accessor :post, :current_user
 
   def initialize(post, current_user = nil)
@@ -54,7 +57,7 @@ class PostPresenter
   end
 
   def title
-    @post.text.present? ? @post.text(:plain_text => true) : I18n.translate('posts.presenter.title', :name => @post.author_name)
+    @post.text.present? ? post_page_title(@post) : I18n.translate('posts.presenter.title', :name => @post.author_name)
   end
 
   def template_name #kill me, lol, I should be client side

--- a/spec/helpers/posts_helper_spec.rb
+++ b/spec/helpers/posts_helper_spec.rb
@@ -5,6 +5,42 @@
 require 'spec_helper'
 
 describe PostsHelper do
+
+  describe '#post_page_title' do
+    before do
+      @sm = FactoryGirl.create(:status_message)
+    end
+
+    context 'with posts with text' do
+      context 'when :length is passed in parameters' do
+        it 'returns string of size less or equal to :length' do
+          @sm = stub(:text => "## My title\n Post content...")
+          string_size = 12
+          post_page_title(@sm, :length => string_size ).size.should <= string_size
+        end
+      end
+      context 'when :length is not passed in parameters' do
+        context 'with a Markdown header of less than 200 characters on first line'do
+          it 'returns atx style header' do
+            @sm = stub(:text => "## My title\n Post content...")
+            post_page_title(@sm).should == "## My title"
+          end
+          it 'returns setext style header' do
+            @sm = stub(:text => "My title \n======\n Post content...")
+            post_page_title(@sm).should ==  "My title \n======"
+          end
+        end
+        context 'without a Markdown header of less than 200 characters on first line 'do
+          it 'truncates posts to the 20 first characters' do
+            @sm = stub(:text => "Very, very, very long post")
+            post_page_title(@sm).should == "Very, very, very ..."
+          end
+        end
+      end
+    end
+  end
+
+
   describe '#post_iframe_url' do
     before do
       @post = FactoryGirl.create(:status_message)

--- a/spec/javascripts/app/pages/post-viewer_spec.js
+++ b/spec/javascripts/app/pages/post-viewer_spec.js
@@ -1,0 +1,12 @@
+describe("app.Pages.PostViewer", function(){
+  describe("postRenderTemplate", function(){
+    beforeEach(function(){
+      this.view = new app.pages.PostViewer({id : 4});
+    })
+    it('translates post title from Markdown to plain text and pushes it in document.title', function () {
+      this.view.model.set({title : "### My [Markdown](url) *title*" });
+      this.view.postRenderTemplate();
+      expect(document.title).toEqual("My Markdown title");
+    })
+  })
+});

--- a/spec/javascripts/app/pages/post-viewer_spec.js
+++ b/spec/javascripts/app/pages/post-viewer_spec.js
@@ -1,12 +1,14 @@
 describe("app.Pages.PostViewer", function(){
   describe("postRenderTemplate", function(){
     beforeEach(function(){
-      this.view = new app.pages.PostViewer({id : 4});
+      app.setPreload('post', factory.post({frame_name : "note"}).attributes);
+      this.page = new app.pages.PostViewer({id : 2});
     })
     it('translates post title from Markdown to plain text and pushes it in document.title', function () {
-      this.view.model.set({title : "### My [Markdown](url) *title*" });
-      this.view.postRenderTemplate();
+      this.page.model.set({title : "### My [Markdown](url) *title*" });
+      this.page.postRenderTemplate();
       expect(document.title).toEqual("My Markdown title");
     })
   })
 });
+

--- a/spec/presenters/post_presenter_spec.rb
+++ b/spec/presenters/post_presenter_spec.rb
@@ -76,12 +76,28 @@ describe PostPresenter do
   end
   
   describe '#title' do 
-    it 'includes the text if it is present' do
-      @sm = stub(:text => "lalalalalalala", :author => bob.person)
-      @presenter.post = @sm
-      @presenter.title.should == @sm.text
-    end
+    context 'with posts with text' do
+      context 'with a Markdown header of less than 200 characters on first line'do
+        it 'returns atx style header' do
+          @sm = stub(:text => "## My title\n Post content...")
+          @presenter.post = @sm
+          @presenter.title.should == "## My title"
+        end
 
+        it 'returns setext style header' do
+          @sm = stub(:text => "My title \n======\n Post content...")
+          @presenter.post = @sm
+          @presenter.title.should == "My title \n======"
+        end
+      end
+      context 'without a Markdown header of less than 200 characters on first line 'do
+        it 'truncates post to the 20 first characters' do
+          @sm = stub(:text => "Very, very, very long post")
+          @presenter.post = @sm
+          @presenter.title.should == "Very, very, very ..."
+        end
+      end
+    end
     context 'with posts without text' do
       it ' displays a messaage with the post class' do
 


### PR DESCRIPTION
Post titles are currently considered (for text posts) as the first 17 characters of the post. When a Markdown header is set at the top of the post, I propose to choose its content as post title. In all other cases the old behavior is chosen.

Example of post :

> # Header #
> is considered as title

Title value is `# Header #\r\nis co...` with the old behavior but `Header` with this PR.

Headers of the following form (setext-style) are also considered :

> Header
>  =====

or

> Header
>  ----------
