### PR TITLE
Hotfix/4163 user sharing issue

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 ## Bug fixes
 * Don't focus comment form on 'show n more comments' [#4265](https://github.com/diaspora/diaspora/issues/4265)
 * Do not render mobile photo view for none-existing photos [#4194](https://github.com/diaspora/diaspora/issues/4194)
+* Fix user contact sharing/receiving [#4163](https://github.com/diaspora/diaspora/issues/4163)
 
 ## Features
 * Admin: add option to find users under 13 (COPPA) [#4252](https://github.com/diaspora/diaspora/pull/4252)

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -44,7 +44,7 @@ class Contact < ActiveRecord::Base
   }
 
   scope :only_sharing, lambda {
-    sharing.where(:receiving => false)
+    receiving.where(:sharing => false)
   }
 
   def destroy_notifications

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -76,10 +76,10 @@ class Request
     Rails.logger.info("event=receive payload_type=request sender=#{self.sender} to=#{self.recipient}")
 
     contact = user.contacts.find_or_initialize_by_person_id(self.sender.id)
-    contact.sharing = true
+    contact.receiving = true
     contact.save
     
-    user.share_with(person, user.auto_follow_back_aspect) if user.auto_follow_back && !contact.receiving
+    user.share_with(person, user.auto_follow_back_aspect) if user.auto_follow_back && !contact.sharing
 
     self
   end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -79,15 +79,15 @@ describe Contact do
     end
 
     describe 'only_sharing' do
-      it 'returns contacts with sharing true and receiving false' do
+      it 'returns contacts with sharing false and receiving true' do
         lambda {
           alice.contacts.create!(:receiving => true, :sharing => true, :person => FactoryGirl.build(:person))
           alice.contacts.create!(:receiving => false, :sharing => true, :person => FactoryGirl.build(:person))
           alice.contacts.create!(:receiving => false, :sharing => true, :person => FactoryGirl.build(:person))
           alice.contacts.create!(:receiving => true, :sharing => false, :person => FactoryGirl.build(:person))
         }.should change{
-          Contact.receiving.count
-        }.by(2)
+          Contact.only_sharing.count
+        }.by(1)
       end
     end
     

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -68,11 +68,13 @@ describe Request do
   describe '#receive' do
     it 'creates a contact' do
       request = Request.diaspora_initialize(:from => alice.person, :to => eve.person, :into => @aspect)
+
       lambda{
         request.receive(eve, alice.person)
       }.should change{
         eve.contacts(true).size
       }.by(1)
+
     end
 
     it 'sets mutual if a contact already exists' do
@@ -87,10 +89,11 @@ describe Request do
 
     end
 
-    it 'sets sharing' do
-      Request.diaspora_initialize(:from => eve.person, :to => alice.person,
-                                  :into => eve.aspects.first).receive(alice, eve.person)
-      alice.contact_for(eve.person).should be_sharing
+    it 'sets receiving' do
+        Request.diaspora_initialize(:from => eve.person, :to => alice.person,
+                                    :into => eve.aspects.first).receive(alice, eve.person);
+
+        alice.contact_for(eve.person).should be_receiving 
     end
     
     it 'shares back if auto_following is enabled' do
@@ -101,7 +104,7 @@ describe Request do
       Request.diaspora_initialize(:from => eve.person, :to => alice.person,
                                   :into => eve.aspects.first).receive(alice, eve.person)
       
-      eve.contact_for(alice.person).should be_sharing
+      alice.contact_for(eve.person).should be_sharing
     end
     
     it 'shares not back if auto_following is not enabled' do
@@ -121,7 +124,7 @@ describe Request do
       alice.save
       
       contact = FactoryGirl.build:contact, :user => alice, :person => eve.person,
-                                  :receiving => true, :sharing => false
+                                :receiving => true, :sharing => true 
       contact.save
       
       alice.should_not_receive(:share_with)

--- a/spec/models/user/connecting_spec.rb
+++ b/spec/models/user/connecting_spec.rb
@@ -27,16 +27,16 @@ describe User::Connecting do
         }.by(-1)
       end
 
-      it 'removes a contacts receiving flag' do
-        bob.contacts.find_by_person_id(alice.person.id).should be_receiving
+      it 'removes a contacts sharing flag' do
+        bob.contacts.find_by_person_id(alice.person.id).should be_sharing
         bob.remove_contact(bob.contact_for(alice.person))
-        bob.contacts(true).find_by_person_id(alice.person.id).should_not be_receiving
+        bob.contacts(true).find_by_person_id(alice.person.id).should_not be_sharing
       end
     end
 
     describe '#disconnected_by' do
       it 'calls remove contact' do
-        bob.should_receive(:remove_contact).with(bob.contact_for(alice.person))
+        bob.should_receive(:remove_contact).with(bob.contact_for(alice.person), {:received => true})
         bob.disconnected_by(alice.person)
       end
 
@@ -138,10 +138,10 @@ describe User::Connecting do
         alice.share_with(eve.person, alice.aspects.first)
       end
 
-      it 'does not dispatch a request if contact already marked as receiving' do
+      it 'does not dispatch a request if contact already marked as sharing' do
         a2 = alice.aspects.create(:name => "two")
 
-        contact = alice.contacts.create(:person => eve.person, :receiving => true)
+        contact = alice.contacts.create(:person => eve.person, :sharing => true)
         alice.contacts.stub!(:find_or_initialize_by_person_id).and_return(contact)
 
         contact.should_not_receive(:dispatch_request)
@@ -156,9 +156,9 @@ describe User::Connecting do
       end
     end
 
-    it 'sets receiving' do
+    it 'sets sharing' do
       alice.share_with(eve.person, alice.aspects.first)
-      alice.contact_for(eve.person).should be_receiving
+      alice.contact_for(eve.person).should be_sharing
     end
 
     it "should mark the corresponding notification as 'read'" do


### PR DESCRIPTION
Fix for #4163. The sharing/receiving flags on contacts were getting set badly. Was able to reproduce both bugs reported here consistently and test that this fix solves both of them. 

The two bugs were:

1) Incorrect "Only Sharing With Me" Aspect View
2) userA shares with userB. userB shares with userA. userA stops sharing with userB. userB, who still shares with userA, no longer sees userA in aspects.
