### PR TITLE
Fix error in facebook service delete_post

### DIFF
--- a/app/models/services/facebook.rb
+++ b/app/models/services/facebook.rb
@@ -34,7 +34,7 @@ class Services::Facebook < Service
   end
 
   def delete_post(post)
-    if post.present? && post.facebbook_id.present?
+    if post.present? && post.facebook_id.present?
       Rails.logger.debug("event=delete_from_service type=facebook sender_id=#{self.user_id}")
       delete_from_facebook("https://graph.facebook.com/#{post.facebook_id}/", {:access_token => self.access_token})
     end

--- a/spec/models/services/facebook_spec.rb
+++ b/spec/models/services/facebook_spec.rb
@@ -4,7 +4,7 @@ describe Services::Facebook do
 
   before do
     @user = alice
-    @post = @user.post(:status_message, :text => "hello", :to =>@user.aspects.first.id, :public =>true, :facebook_id => "23456", :photos => [])
+    @post = @user.post(:status_message, :text => "hello", :to =>@user.aspects.first.id, :public =>true, :photos => [])
     @service = Services::Facebook.new(:access_token => "yeah")
     @user.services << @service
   end
@@ -18,19 +18,19 @@ describe Services::Facebook do
 
     it 'swallows exception raised by facebook always being down' do
       pending "temporarily disabled to figure out while some requests are failing"
-      
+
       stub_request(:post,"https://graph.facebook.com/me/feed").
         to_raise(StandardError)
       @service.post(@post)
     end
-    
+
     it 'removes text formatting markdown from post text' do
       message = "Text with some **bolded** and _italic_ parts."
       post = stub(:text => message, :photos => [])
       post_params = @service.create_post_params(post)
       post_params[:message].should match "Text with some bolded and italic parts."
     end
-    
+
     it 'does not add post link when no photos' do
       message = "Text with some **bolded** and _italic_ parts."
       post = stub(:text => message, :photos => [])
@@ -44,9 +44,9 @@ describe Services::Facebook do
       @service.post(@post)
       @post.facebook_id.should match "12345"
     end
-    
+
   end
-  
+
   describe "with photo" do
     before do
       @photos = [alice.build_post(:photo, :pending => true, :user_file=> File.open(photo_fixture_name)),
@@ -60,29 +60,31 @@ describe Services::Facebook do
       @status_message.save!
       alice.add_to_streams(@status_message, alice.aspects)
     end
-    
+
     it "should include post url in message with photos" do
       post_params = @service.create_post_params(@status_message)
       post_params[:message].should include 'http'
     end
-    
+
   end
 
   describe "#profile_photo_url" do
     it 'returns a large profile photo url' do
       @service.uid = "abc123"
       @service.access_token = "token123"
-      @service.profile_photo_url.should == 
+      @service.profile_photo_url.should ==
       "https://graph.facebook.com/abc123/picture?type=large&access_token=token123"
     end
   end
 
   describe '#delete_post' do
     it 'removes a post from facebook' do
-      stub_request(:delete, "https://graph.facebook.com/#{@post.facebook_id}/?access_token=#{@service.access_token}").
-	to_return(:status => 200)
+      @post.facebook_id = "2345"
+      url="https://graph.facebook.com/#{@post.facebook_id}/"
+      stub_request(:delete, "#{url}?access_token=#{@service.access_token}").to_return(:status => 200)
+      @service.should_receive(:delete_from_facebook).with(url, {access_token: @service.access_token})
 
-      @service.delete_post(@post.facebook_id)
+      @service.delete_post(@post)
     end
   end
 end


### PR DESCRIPTION
Fixes a small error in the facebook post deletion that crept in and stopped it from deleting posts.
