### PR TITLE
fixes issue 4274 flash-messages stay longer

### DIFF
--- a/app/assets/javascripts/widgets/flash-messages.js
+++ b/app/assets/javascripts/widgets/flash-messages.js
@@ -8,7 +8,9 @@
 
     this.animateMessages = function() {
       var flashMessages = $("#flash_notice, #flash_error, #flash_alert");
-      flashMessages.addClass("expose")
+      flashMessages.addClass("expose");
+      flashMessages.delay(8000);
+			flashMessages.fadeTo(200, 0.5);
     };
 
     this.render = function(result) {

--- a/app/assets/stylesheets/_flash_messages.scss
+++ b/app/assets/stylesheets/_flash_messages.scss
@@ -15,7 +15,7 @@
   color: #666;
 
   &.expose {
-    @include animation(expose, 5s)
+    @include animation(expose, 10s)
   }
 
   .message {


### PR DESCRIPTION
Hello,

the flash messages stay now twice as long and fade to 50% after some time, before they vanish again.
