### PR TITLE
Tumblr posts should be deleted when users delete their originating Diaspora post.

### DIFF
--- a/app/models/services/tumblr.rb
+++ b/app/models/services/tumblr.rb
@@ -17,14 +17,17 @@ class Services::Tumblr < Service
   end
 
   def post(post, url='')
-    consumer = OAuth::Consumer.new(consumer_key, consumer_secret, :site => 'http://api.tumblr.com')
-    access = OAuth::AccessToken.new(consumer, self.access_token, self.access_secret)
-    
     body = build_tumblr_post(post, url)
-    user_info = JSON.parse(access.get("/v2/user/info").body)
+    user_info = JSON.parse(client.get("/v2/user/info").body)
     blogs = user_info["response"]["user"]["blogs"].map { |blog| URI.parse(blog['url']) }
+    tumblr_ids = {}
     blogs.each do |blog|
-      access.post("/v2/blog/#{blog.host}/post", body)
+      resp = client.post("/v2/blog/#{blog.host}/post", body)
+      if resp.code == "201"
+        tumblr_ids[blog.host.to_s] = JSON.parse(resp.body)["response"]["id"]
+      end
+    post.tumblr_ids = tumblr_ids.to_json
+    post.save
     end
   end
 
@@ -39,6 +42,26 @@ class Services::Tumblr < Service
     end
     html += post.text
     html += "\n\n[original post](#{url})"
+  end
+
+  def delete_post(post)
+    if post.present? && post.tumblr_ids.present?
+      Rails.logger.debug("event=delete_from_service type=tumblr sender_id=#{self.user_id}")
+      tumblr_posts = JSON.parse(post.tumblr_ids)
+      tumblr_posts.each do |blog_name,post_id|
+        delete_from_tumblr(blog_name, post_id)
+      end
+    end
+  end
+
+  def delete_from_tumblr(blog_name, service_post_id)
+    client.post("/v2/blog/#{blog_name}/post/delete", "id" => service_post_id)
+  end
+
+  private
+  def client
+    @consumer ||= OAuth::Consumer.new(consumer_key, consumer_secret, :site => 'http://api.tumblr.com')
+    @client ||= OAuth::AccessToken.new(@consumer, self.access_token, self.access_secret)
   end
 end
 

--- a/db/migrate/20130801063213_add_tumblr_post_ids_to_posts.rb
+++ b/db/migrate/20130801063213_add_tumblr_post_ids_to_posts.rb
@@ -1,0 +1,5 @@
+class AddTumblrPostIdsToPosts < ActiveRecord::Migration
+  def change
+    add_column :posts, :tumblr_ids, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130717104359) do
+ActiveRecord::Schema.define(:version => 20130801063213) do
 
   create_table "account_deletions", :force => true do |t|
     t.string  "diaspora_handle"
@@ -213,7 +213,7 @@ ActiveRecord::Schema.define(:version => 20130717104359) do
     t.text   "data",                 :null => false
   end
 
-  add_index "o_embed_caches", ["url"], :name => "index_o_embed_caches_on_url", :length => {"url"=>767}
+  add_index "o_embed_caches", ["url"], :name => "index_o_embed_caches_on_url", :length => {"url"=>255}
 
   create_table "participations", :force => true do |t|
     t.string   "guid"
@@ -308,6 +308,7 @@ ActiveRecord::Schema.define(:version => 20130717104359) do
     t.boolean  "favorite",                            :default => false
     t.string   "facebook_id"
     t.string   "tweet_id"
+    t.text     "tumblr_ids"
   end
 
   add_index "posts", ["author_id", "root_guid"], :name => "index_posts_on_author_id_and_root_guid", :unique => true

--- a/spec/models/services/tumblr_spec.rb
+++ b/spec/models/services/tumblr_spec.rb
@@ -10,12 +10,29 @@ describe Services::Tumblr do
   end
 
   describe '#post' do
-    it 'posts a status message to tumblr' do
-      response = mock
-      response.stub(:body).and_return('{"response": {"user": {"blogs": [{"url": "http://foo.tumblr.com"}]}}}')
-      OAuth::AccessToken.any_instance.should_receive(:get).with("/v2/user/info").and_return(response)
+    it 'posts a status message to tumblr and saves the returned ids' do
+      response = mock(body: '{"response": {"user": {"blogs": [{"url": "http://foo.tumblr.com"}]}}}')
+      OAuth::AccessToken.any_instance.should_receive(:get)
+      .with("/v2/user/info")
+      .and_return(response)
+
+      response = mock(code: "201", body: '{"response": {"id": "bla"}}')
       OAuth::AccessToken.any_instance.should_receive(:post)
+      .with("/v2/blog/foo.tumblr.com/post", @service.build_tumblr_post(@post, ''))
+      .and_return(response)
+
+      @post.should_receive(:tumblr_ids=).with({"foo.tumblr.com" => "bla"}.to_json)
+
       @service.post(@post)
+    end
+  end
+
+  describe '#delete_post' do
+    it 'removes posts from tumblr' do
+      stub_request(:post, "http://api.tumblr.com/v2/blog/foodbar.tumblr.com/post/delete").
+        to_return(:status => 200)
+
+      @service.delete_post(@post)
     end
   end
 end


### PR DESCRIPTION
This implements cascading deletion for Tumblr posts created through Diaspora's Tumblr service. (I realize there's no spec file attached; I don't know much about them, [and SOMEONE is encouraging me to send a pull request early](https://github.com/diaspora/diaspora/issues/3938#issuecomment-21774273)….) ;)
