### PR TITLE
add missing translation services_explanation #4338

### DIFF
--- a/config/locales/diaspora/de.yml
+++ b/config/locales/diaspora/de.yml
@@ -799,6 +799,7 @@ de:
       logged_in_as: "angemeldet als"
       no_services: "Du hast noch keine Dienste verbunden."
       really_disconnect: "Verbindung mit %{service} entfernen?"
+      services_explanation: "Die Verbindung mit Diensten ermöglicht es dir deine Beiträge auch bei diesen zu veröffentlichen, wenn du in Diaspora postest."
     inviter:
       click_link_to_accept_invitation: "Öffne diesen Link, um die Einladung zu akzeptieren:"
       join_me_on_diaspora: "Folge mir auf DIASPORA*"

--- a/config/locales/diaspora/de_formal.yml
+++ b/config/locales/diaspora/de_formal.yml
@@ -791,7 +791,7 @@ de_formal:
       logged_in_as: "angemeldet als"
       no_services: "Sie haben noch keine Dienste verbunden."
       really_disconnect: "Verbindung mit %{service} entfernen?"
-      services_explanation: "Wenn Sie sich mit anderen Diensten verbinden, erhalten Sie die Möglichkeit ihre Beiträge auch dort zu veröffentlichen, indem Sie in Diaspora schreiben."
+      services_explanation: "Wenn Sie sich mit anderen Diensten verbinden, erhalten Sie die Möglichkeit Ihre Beiträge auch dort zu veröffentlichen, wenn Sie in Diaspora schreiben."
     inviter:
       click_link_to_accept_invitation: "Öffnen Sie diesen Link, um die Einladung zu akzeptieren:"
       join_me_on_diaspora: "Folgen Sie mir auf DIASPORA*"


### PR DESCRIPTION
issue  #4338 

This text is now being translated in the German versions (Deutsch and Deutsch(Sie)):
"Connecting to services gives you the ability to publish your posts to them as you write them in Diaspora."
