### PR TITLE
Bumped omniauth-wordpress gem to 0.2.0 for compatability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,7 @@ gem 'omniauth-facebook', '1.4.1'
 gem 'omniauth-tumblr',   '1.1'
 gem 'omniauth-twitter',  '1.0.0'
 gem 'twitter',           '4.8.1'
-gem 'omniauth-wordpress','0.1.1', github: 'readmill/omniauth-wordpress'
+gem 'omniauth-wordpress','0.2.0'
 
 # Tags
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: git://github.com/readmill/omniauth-wordpress.git
-  revision: 32ac451f564e5189a863cb5db16aad2d48f7a638
-  specs:
-    omniauth-wordpress (0.1.1)
-      omniauth-oauth2 (~> 1.1.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -256,6 +249,8 @@ GEM
     omniauth-twitter (1.0.0)
       multi_json (~> 1.3)
       omniauth-oauth (~> 1.0)
+    omniauth-wordpress (0.2.0)
+      omniauth-oauth2 (~> 1.1.0)
     opengraph_parser (0.2.3)
       addressable
       nokogiri
@@ -475,7 +470,7 @@ DEPENDENCIES
   omniauth-facebook (= 1.4.1)
   omniauth-tumblr (= 1.1)
   omniauth-twitter (= 1.0.0)
-  omniauth-wordpress (= 0.1.1)!
+  omniauth-wordpress (= 0.2.0)
   opengraph_parser (= 0.2.3)
   rack-cors (= 0.2.8)
   rack-google-analytics (= 0.11.0)


### PR DESCRIPTION
Took out the git dependency. The author of the omniauth-wordpress gem bumped the version to work with the latest oauth2 gem.
