### PR TITLE
Improve mobile usability

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,7 @@
 * Fix user contact sharing/receiving [#4163](https://github.com/diaspora/diaspora/issues/4163)
 * Change image to ajax-loader when closing lightbox [#3229](https://github.com/diaspora/diaspora/issues/3229)
 * Fix pointer cursor on the file upload button [#4349](https://github.com/diaspora/diaspora/pull/4349)
+* Improve mobile usability [#4354](https://github.com/diaspora/diaspora/pull/4354)
 
 ## Features
 * Admin: add option to find users under 13 (COPPA) [#4252](https://github.com/diaspora/diaspora/pull/4252)

--- a/app/assets/stylesheets/mobile.css.scss
+++ b/app/assets/stylesheets/mobile.css.scss
@@ -331,21 +331,31 @@ body {
 #nav_badges {
   display: inline-block;
   float: right;
-  padding: 4px 12px;  
-}
-  #nav_badges a:hover {
-    text-decoration: none; }
-  #nav_badges .badge {
+  padding: 4px 12px;
+  
+  a:hover {
+    text-decoration: none;
+  }
+  
+  .badge {
     position: relative;
     display: inline;
     margin-left: 3px;
     padding: 8px 3px;
-      padding-bottom: 9px;
+    padding-bottom: 9px;
     font-weight: bold;
     font-size: smaller;
-    width: 28px; }
-    #nav_badges .badge:hover .badge_count {
-      background-color: #bd0902; }
+    width: 28px;
+  }
+  
+  .badge:hover .badge_count {
+      background-color: #bd0902;
+  }
+  
+  a {
+    padding: 5px 0px;
+  }
+}
 
 .badge_count {
   -moz-border-radius: 2px 2px 2px 2px;
@@ -546,6 +556,7 @@ footer {
   left: 0;
   top: 40px;
   width: 100%;
+  min-height: 220px;
 
   fieldset {
     padding: 10px;
@@ -627,10 +638,6 @@ select {
   bottom: 10px;
   right: 10px;
   line-height: 16px;
-}
-
-.new_status_message {
-  min-height: 300px;
 }
 
 .reshare {


### PR DESCRIPTION
This PR improve mobile version:
It's easier to click on the link to compose a new message
**Before**
![compose-before](https://f.cloud.github.com/assets/930064/916735/ced27a66-fe95-11e2-9e15-4c27fd8df868.png)
**After**
![compose-after](https://f.cloud.github.com/assets/930064/916736/d06bfbea-fe95-11e2-8e8f-497dd3470f28.png)

The publish button and the upload photo button is now at 220px instead of 300px from the top: they are not masked by the mobile keyboard anymore.
![buttons-after](https://f.cloud.github.com/assets/930064/916740/ef157526-fe95-11e2-9f87-51c54076d033.png)
