### PR TITLE
Correct grammar error in Locator feature - fix 4357

### DIFF
--- a/config/locales/javascript/javascript.en.yml
+++ b/config/locales/javascript/javascript.en.yml
@@ -41,7 +41,7 @@ en:
       at_least_one_aspect: "You must publish to at least one aspect"
       limited: "Limited - your post will only be seen by people you are sharing with"
       public: "Public - your post will be visible to everyone and found by search engines"
-      near_from: "Near from: <%= location %>"
+      near_from: "Posted from: <%= location %>"
     infinite_scroll:
       no_more: "No more posts."
       no_more_contacts: "No more contacts."


### PR DESCRIPTION
My first attempt at a commit. Simply correcting a grammatical error in the Locator feature - 'Near from' becomes 'Posted from'.

I hope I have done this correctly. Please forgive me if not.
