### PR TITLE
Change contact list on profile page

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@
 * Port the Rails application to strong_parameters in preparation to the upgrade to Rails 4 [#4143](https://github.com/diaspora/diaspora/issues/4143)
 * Refactor left bar side menu, improve tag autosuggestion design [#4271](https://github.com/diaspora/diaspora/issues/4271), [#4316](https://github.com/diaspora/diaspora/pull/4316)
 * Extract and factorize the header css in a new file, fix ugly header in registration [#4389](https://github.com/diaspora/diaspora/pull/4389)
+* Move contact list on profile to profile information, show user his own contacts on profile [#4360](https://github.com/diaspora/diaspora/pull/4360)
 
 ## Bug fixes
 * Check twitter write access before adding/authorizing it for a user. [#4124](https://github.com/diaspora/diaspora/issues/4124)

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -2073,6 +2073,7 @@ ul#requested-scopes
   :line-height 16px
   :text-align center
   @include border-radius(4px)
+  :margin-top 1px
   :color #999
   :background
     :color #eee
@@ -2166,7 +2167,7 @@ ul.left_nav
     :display none
     &:hover
       @include opacity(1)
-    
+
   a.home_selector
     .item_count
       :float right

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -142,6 +142,7 @@ class PeopleController < ApplicationController
       @contact = current_user.contact_for(@person)
       @aspect = :profile
       @contacts_of_contact = @contact.contacts.paginate(:page => params[:page], :per_page => (params[:limit] || 15))
+      @contacts_of_contact_count = @contact.contacts.count
       @hashes = hashes_for_people @contacts_of_contact, @aspects
     else
       flash[:error] = I18n.t 'people.show.does_not_exist'

--- a/app/views/people/_profile_sidebar.html.haml
+++ b/app/views/people/_profile_sidebar.html.haml
@@ -33,19 +33,19 @@
             %div{ :class => direction_for(person.location) }
               = markdownify(person.location, :oembed => true, :newlines => true)
 
-        %li
-          - unless person.gender.blank?
+        - unless person.gender.blank?
+          %li
             %h4
               =t('.gender')
             = person.gender
 
-        %li
-          - unless person.birthday.blank?
+        - unless person.birthday.blank?
+          %li
             %h4
               =t('.born')
             = birthday_format(person.birthday)
-        %li
-          - if @photos.present?
+        - if @photos.present?
+          %li
             %h4
               = t('_photos')
               .item_count
@@ -55,5 +55,26 @@
             %br
               = link_to t('layouts.header.view_all'),  person_photos_path(person)
   
-          %br
-          %br
+        - if person == current_user.person
+          %li#contacts_of_contact
+            %h4
+              = t('_contacts')
+              .item_count
+                = my_contacts_count
+            .section.contact_pictures
+              - current_user.contacts.limit(8).each do |contact|
+                = person_image_link contact.person, :size => :thumb_small
+            %p.see_all= link_to t('people.show.see_all'), contacts_path
+        - elsif @contact.persisted? && @contacts_of_contact_count > 0
+          %li#contacts_of_contact
+            %h4 
+              = t('_contacts')
+              .item_count
+                = @contacts_of_contact_count
+            .section.contact_pictures
+              -@contacts_of_contact.limit(8).each do |person|
+                = person_image_link person, :size => :thumb_small
+              %p.see_all= link_to t('people.show.see_all'), person_contacts_path(@person)
+
+        %br
+        %br

--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -15,16 +15,6 @@
 .span-6
   = render :partial => 'people/profile_sidebar', :locals => {:person => @person, :contact => @contact }
 
-  - if user_signed_in? && @contact.persisted? && @contacts_of_contact_count > 0
-    .span-5.last#contacts_of_contact
-      .section.contact_pictures
-        %h4
-          = t('contacts', :count => @contacts_of_contact_count)
-        - @contacts_of_contact.each do |person|
-          = person_image_link person
-      - if @contacts_of_contact_count > 8
-        %p.see_all= link_to t('.see_all'), person_contacts_path(@person)
-
 .span-18.last
   .stream_container
     = render 'people/sub_header', :person => @person, :contact => @contact

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -586,10 +586,10 @@ en:
     profile_sidebar:
       remove_contact: "remove contact"
       edit_my_profile: "Edit my profile"
-      bio: "bio"
-      location: "location"
-      gender: "gender"
-      born: "birthday"
+      bio: "Bio"
+      location: "Location"
+      gender: "Gender"
+      born: "Birthday"
       in_aspects: "in aspects"
       remove_from: "Remove %{name} from %{aspect}?"
     helper:

--- a/features/contacts.feature
+++ b/features/contacts.feature
@@ -1,0 +1,40 @@
+@javascript
+Feature: show contacts
+
+  Background:
+    Given following users exist:
+      | username      | email               |
+      | Bob Jones     | bob@bob.bob         |
+      | Alice Smith   | alice@alice.alice   |
+      | Robert Grimm  | robert@grimm.grimm  |
+    And I sign in as "robert@grimm.grimm"
+    And I am on "alice@alice.alice"'s page
+    And I add the person to my "Unicorns" aspect
+
+  Scenario: see own contacts on profile
+    When I am on "robert@grimm.grimm"'s page
+    And I press the first "a" within ".section.contact_pictures"
+    Then I should see "Alice Smith"
+
+  Scenario: see contacts of a visible aspect list 
+    When I am on "bob@bob.bob"'s page
+    And I add the person to my "Unicorns" aspect
+    And I sign out
+    And I sign in as "alice@alice.alice"
+    And I am on "robert@grimm.grimm"'s page
+    And I press the first "a" within ".section.contact_pictures"
+    Then I should see "Bob Jones"
+
+  Scenario: don't see contacts of an invisible aspect list 
+    When I am on "bob@bob.bob"'s page
+    And I add the person to my "Unicorns" aspect
+    And I am on the contacts page
+    And I follow "Unicorns"
+    And I follow "add contacts to Unicorns"
+    And I press the first "a.contact_visibility_link" in the modal window
+    And I press "Done" in the modal window
+    And I sign out
+
+    And I sign in as "alice@alice.alice"
+    And I am on "robert@grimm.grimm"'s page
+    Then I should not see "Contacts" within "#profile_information"


### PR DESCRIPTION
This will change the contact list on the profile page. If you look at your own profile a list of 8 contacts will be shown and under the list is a 'see all'-link to your own contacts-page. If you are on another users profile and the user shares a list of contacts with you, you will see the list the same way, with a link to the users contacts-page.

All in all the contacts are now part of the profile information.

![diaspora_profile003](https://f.cloud.github.com/assets/3798614/923687/a783e5c2-ff52-11e2-8443-e7f3fab91c43.png)
