### PR TITLE
Feature/4347 add photo link to leftsidebar

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -55,7 +55,7 @@
 * Uncheck 'make contacts visible to each other' by default when adding new aspect. [#4343](https://github.com/diaspora/diaspora/issues/4343)
 * Add possibility to ask for Bitcoin donations [#4375](https://github.com/diaspora/diaspora/pull/4375)
 * Remove posts, comments and private conversations from the mobile site. [#4408](https://github.com/diaspora/diaspora/pull/4408) [#4409](https://github.com/diaspora/diaspora/pull/4409)
-
+* Added a link to user photos and thumbnails are shown in the left side bar [#4347](https://github.com/diaspora/diaspora/issues/4347)
 
 # 0.1.1.0
 

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -2068,6 +2068,19 @@ ul#requested-scopes
     .scope-description
       :display none
 
+.item_count
+  :width 16px
+  :line-height 16px
+  :text-align center
+  @include border-radius(4px)
+  :color #999
+  :background
+    :color #eee
+  :display inline-block
+  :font
+    :size 11px
+    :weight 700
+
 ul.left_nav
   :margin 0
     :bottom 15px
@@ -2100,9 +2113,7 @@ ul.left_nav
 
     > a:not(.sub_selected)
       :color #333
-      .contact_count
-        :font
-          :weight 700
+      .item_count
         :color #666
 
   a.aspect_selector,
@@ -2155,22 +2166,9 @@ ul.left_nav
     :display none
     &:hover
       @include opacity(1)
-
-  .contact_count
-    :width 16px
-    :line-height 16px
-    :text-align center
-    @include border-radius(4px)
-    :margin-top 1px
-    :color #999
-    :background
-      :color #eee
-    :display inline-block
-    :font
-      :size 11px
-
+    
   a.home_selector
-    .contact_count
+    .item_count
       :float right
 
   ul.sub_nav

--- a/app/assets/stylesheets/rtl.css.scss
+++ b/app/assets/stylesheets/rtl.css.scss
@@ -297,7 +297,7 @@ ul.comments li.posted .controls .delete {
   left: 10px;
 }
 
-ul.left_nav .contact_count, ul.left_nav .edit {
+ul.left_nav .item_count, ul.left_nav .edit {
   float: left;
 }
 

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -81,7 +81,7 @@ class PeopleController < ApplicationController
     @aspect = :profile
     @stream = Stream::Person.new(current_user, @person, :max_time => max_time)
     @profile = @person.profile
-    @photos = Photo.where(author_id: @profile.id).limit(3).order('created_at desc')
+    @photos = Photo.where(author_id: @profile.id).order('created_at desc')
     unless params[:format] == "json" # hovercard
       if current_user
         @block = current_user.blocks.where(:person_id => @person.id).first

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -81,7 +81,7 @@ class PeopleController < ApplicationController
     @aspect = :profile
     @stream = Stream::Person.new(current_user, @person, :max_time => max_time)
     @profile = @person.profile
-
+    @photos = Photo.where(author_id: @profile.id).limit(3).order('created_at desc')
     unless params[:format] == "json" # hovercard
       if current_user
         @block = current_user.blocks.where(:person_id => @person.id).first

--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -14,7 +14,7 @@ class PhotosController < ApplicationController
   def index
     @post_type = :photos
     @person = Person.find_by_guid(params[:person_id])
-    @photos = Photo.where(author_id: @person.id).limit(3).order('created_at desc')
+    @photos = Photo.where(author_id: @person.id).order('created_at desc')
     if @person
       @contact = current_user.contact_for(@person)
 

--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -14,7 +14,7 @@ class PhotosController < ApplicationController
   def index
     @post_type = :photos
     @person = Person.find_by_guid(params[:person_id])
-
+    @photos = Photo.where(author_id: @person.id).limit(3).order('created_at desc')
     if @person
       @contact = current_user.contact_for(@person)
 

--- a/app/views/contacts/_aspect_listings.haml
+++ b/app/views/contacts/_aspect_listings.haml
@@ -6,7 +6,7 @@
   %li.all_aspects{:class => ("active" if params["set"] != "all" && params["set"] != "only_sharing" && !@spotlight)}
     %a.home_selector{:href => contacts_path, :class => ("sub_selected" if params["a_id"])}
       = t('contacts.index.my_contacts')
-      .contact_count
+      .item_count
         = my_contacts_count
 
     %ul.sub_nav
@@ -15,7 +15,7 @@
           .icons-check_yes_ok{:class => ("invisible" if params["a_id"].to_i != aspect.id) }
           %a.community_aspect_selector{:href => contacts_path(:a_id => aspect.id)}
             = aspect
-          .contact_count
+          .item_count
             = aspect.contacts.size
 
       %li
@@ -24,7 +24,7 @@
   %li.all_contacts{:class => ("active" if params["set"] == "all" || params["set"] == "only_sharing")}
     %a.home_selector{:href => contacts_path(:set => "all"), :class => ("sub_selected" if params["set"] == "only_sharing")}
       = t('contacts.index.all_contacts')
-      .contact_count
+      .item_count
         = all_contacts_count
 
     %ul.sub_nav
@@ -32,6 +32,6 @@
         .icons-check_yes_ok{:class => ("invisible" if params["set"] == "only_sharing")}
         %a.community_aspect_selector{:href => contacts_path(:set => "only_sharing")}
           = t('contacts.index.only_sharing_with_me')
-        .contact_count
+        .item_count
           = only_sharing_count
 

--- a/app/views/people/_profile_sidebar.html.haml
+++ b/app/views/people/_profile_sidebar.html.haml
@@ -18,7 +18,8 @@
       %br
       %br
     -if contact.sharing? || person == current_user.person
-      %ul#profile_information
+      %ul#aspect_nav.left_nav
+      
         - unless person.bio.blank?
           %li
             %h4
@@ -47,7 +48,10 @@
           - unless @photos.blank?
             %h4
               = t('_photos')
-            - for photo in @photos
+            .contact_count
+              = " #{@photos.count}"
+            - @thumbs = @photos.limit(3)
+            - for photo in @thumbs
               = image_tag(photo.url(:thumb_small))
             %br
               = link_to t('layouts.header.view_all'),  person_photos_path(person)

--- a/app/views/people/_profile_sidebar.html.haml
+++ b/app/views/people/_profile_sidebar.html.haml
@@ -45,13 +45,12 @@
               =t('.born')
             = birthday_format(person.birthday)
         %li
-          - unless @photos.blank?
+          - if @photos.present?
             %h4
               = t('_photos')
               .item_count
                 = "#{@photos.count}"
-            - @thumbs = @photos.limit(3)
-            - for photo in @thumbs
+            - @photos.limit(3).each do |photo|
               = image_tag(photo.url(:thumb_small))
             %br
               = link_to t('layouts.header.view_all'),  person_photos_path(person)

--- a/app/views/people/_profile_sidebar.html.haml
+++ b/app/views/people/_profile_sidebar.html.haml
@@ -44,5 +44,14 @@
               =t('.born')
             = birthday_format(person.birthday)
 
+        %li
+          - unless @photos.blank?
+            %h4
+              = link_to t('_photos'),  person_photos_path(person)
+            - for photo in @photos
+              = image_tag(photo.url(:thumb_small))
+
+
+
           %br
           %br

--- a/app/views/people/_profile_sidebar.html.haml
+++ b/app/views/people/_profile_sidebar.html.haml
@@ -43,15 +43,14 @@
             %h4
               =t('.born')
             = birthday_format(person.birthday)
-
         %li
           - unless @photos.blank?
             %h4
-              = link_to t('_photos'),  person_photos_path(person)
+              = t('_photos')
             - for photo in @photos
               = image_tag(photo.url(:thumb_small))
-
-
-
+            %br
+              = link_to t('layouts.header.view_all'),  person_photos_path(person)
+  
           %br
           %br

--- a/app/views/people/_profile_sidebar.html.haml
+++ b/app/views/people/_profile_sidebar.html.haml
@@ -18,7 +18,7 @@
       %br
       %br
     -if contact.sharing? || person == current_user.person
-      %ul#aspect_nav.left_nav
+      %ul#profile_information
       
         - unless person.bio.blank?
           %li
@@ -48,8 +48,8 @@
           - unless @photos.blank?
             %h4
               = t('_photos')
-            .contact_count
-              = " #{@photos.count}"
+              .item_count
+                = "#{@photos.count}"
             - @thumbs = @photos.limit(3)
             - for photo in @thumbs
               = image_tag(photo.url(:thumb_small))

--- a/features/profile_photos.feature
+++ b/features/profile_photos.feature
@@ -7,16 +7,16 @@ Feature: show photos
       | Bob Jones     | bob@bob.bob         |
       | Alice Smith   | alice@alice.alice   |
       | Robert Grimm  | robert@grimm.grimm  |
-    And I sign in as "robert@grimm.grimm"
+    And I sign in as "robert@grimm.grimm" 
 
     Given I expand the publisher
-    And I have turned off jQuery effects
-    And I attach the file "spec/fixtures/button.png" to hidden "file" within "#file-upload"
-    And I press "Share"
+    	And I have turned off jQuery effects
+    	And I attach the file "spec/fixtures/button.png" to hidden "file" within "#file-upload"
+    	And I press "Share"
     
     Scenario: see my own photos
-      When I follow "View all" 
-      And I am on "robert@grimm.grimm"'s page   
+      When I am on "robert@grimm.grimm"'s page 
+      And I follow "View all" 
       Then I should be on person_photos page
     
     Scenario: I cannot see photos of people who don't share with me

--- a/features/profile_photos.feature
+++ b/features/profile_photos.feature
@@ -1,0 +1,27 @@
+@javascript
+Feature: show photos
+
+  Background:
+    Given following users exist:
+      | username      | email               |
+      | Bob Jones     | bob@bob.bob         |
+      | Alice Smith   | alice@alice.alice   |
+      | Robert Grimm  | robert@grimm.grimm  |
+    And I sign in as "robert@grimm.grimm"
+
+    Given I expand the publisher
+    And I have turned off jQuery effects
+    And I attach the file "spec/fixtures/button.png" to hidden "file" within "#file-upload"
+    And I press "Share"
+    
+    Scenario: see my own photos
+      And I am on "robert@grimm.grimm"'s page   
+      When I follow "View all" 
+      Then I should be on person_photos page
+    
+    Scenario: I cannot see photos of people who don't share with me
+      When I sign in as "alice@alice.alice"
+      And I am on "robert@grimm.grimm"'s page
+      Then I should not see "photos" within "div#profile"
+
+

--- a/features/profile_photos.feature
+++ b/features/profile_photos.feature
@@ -15,8 +15,8 @@ Feature: show photos
     And I press "Share"
     
     Scenario: see my own photos
-      And I am on "robert@grimm.grimm"'s page   
       When I follow "View all" 
+      And I am on "robert@grimm.grimm"'s page   
       Then I should be on person_photos page
     
     Scenario: I cannot see photos of people who don't share with me

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -1,6 +1,8 @@
 module NavigationHelpers
   def path_to(page_name)
     case page_name
+      when /^person_photos page$/
+         person_photos_path(@me.person)
       when /^the home(?: )?page$/
         stream_path
       when /^step (\d)$/


### PR DESCRIPTION
solving issue #4347 by creating a link, in the left side menu, to the photos uploaded by a user in their user profile, 
and below the link to photos show the thumbnails of the last 3 photos.
We also renamed contact_count to item_count, because now it is also used to show the total number of photos.
