### PR TITLE
Updated Facebook character limit.

### DIFF
--- a/app/models/services/facebook.rb
+++ b/app/models/services/facebook.rb
@@ -3,7 +3,7 @@ class Services::Facebook < Service
   include MarkdownifyHelper
 
   OVERRIDE_FIELDS_ON_FB_UPDATE = [:contact_id, :person_id, :request_id, :invitation_id, :photo_url, :name, :username]
-  MAX_CHARACTERS = 420
+  MAX_CHARACTERS = 63206 
 
   def provider
     "facebook"


### PR DESCRIPTION
Simply updating the MAX_CHARACTERS figure for Facebook to 63,206, which has been their limit as of Nov 2011.

I don't know how to do tests, but as it's only updating a figure I imagine it won't break anything. I hope not! If there are any problems, ignore this.
