### PR TITLE
Remove placeholders for name fields in settings (no more Sofaer)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -35,6 +35,7 @@
 * Adjust Facebook character limit to reality [#4380](https://github.com/diaspora/diaspora/issues/4380)
 * Restore truncated URLs when posting to Twitter [#4211](https://github.com/diaspora/diaspora/issues/4211)
 * Fix mobile search tags [#4392](https://github.com/diaspora/diaspora/issues/4392)
+* Remove placeholders for name fields in settings (no more Sofaer) [#4385](https://github.com/diaspora/diaspora/pull/4385)
 
 ## Features
 * Admin: add option to find users under 13 (COPPA) [#4252](https://github.com/diaspora/diaspora/pull/4252)

--- a/app/views/profiles/_edit_public.haml
+++ b/app/views/profiles/_edit_public.haml
@@ -42,10 +42,10 @@
 %h4
   = t('profiles.edit.your_name')
 = label_tag 'profile[first_name]', t('profiles.edit.first_name')
-= text_field_tag 'profile[first_name]', profile.first_name, :placeholder => "Raphael"
+= text_field_tag 'profile[first_name]', profile.first_name
 
 = label_tag 'profile[first_name]', t('profiles.edit.last_name')
-= text_field_tag 'profile[last_name]', profile.last_name, :placeholder => "Sofaer"
+= text_field_tag 'profile[last_name]', profile.last_name
 
 %br
 

--- a/app/views/profiles/_edit_public.mobile.haml
+++ b/app/views/profiles/_edit_public.mobile.haml
@@ -49,10 +49,10 @@
 %h4
   = t('profiles.edit.your_name')
 = label_tag 'profile[first_name]', t('profiles.edit.first_name')
-= text_field_tag 'profile[first_name]', profile.first_name, :placeholder => "Raphael"
+= text_field_tag 'profile[first_name]', profile.first_name
 
 = label_tag 'profile[first_name]', t('profiles.edit.last_name')
-= text_field_tag 'profile[last_name]', profile.last_name, :placeholder => "Sofaer"
+= text_field_tag 'profile[last_name]', profile.last_name
 
 %br
 


### PR DESCRIPTION
This fix https://github.com/diaspora/diaspora/issues/3648 (but there is two issues pointed in this page)
