### PR TITLE
Add header to the single post view

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -49,6 +49,7 @@
 * Implement tag search autocomplete in header search box [#4169](https://github.com/diaspora/diaspora/issues/4169)
 * Uncheck 'make contacts visible to each other' by default when adding new aspect. [#4343](https://github.com/diaspora/diaspora/issues/4343)
 * Add possibility to ask for Bitcoin donations [#4375](https://github.com/diaspora/diaspora/pull/4375)
+* Add the header to the single post view
 
 
 # 0.1.1.0

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -5,15 +5,8 @@
 @import 'new_styles/_spinner'
 @import 'sidebar.css.scss'
 @import 'header.css.scss'
+@import 'sprites.css.scss'
 
-/* ===== sprites ===== */
-
-@import 'icons/*.png'
-@import 'branding/*.png'
-@import 'social_media_logos/*.png'
-@include all-icons-sprites
-@include all-branding-sprites
-@include all-social_media_logos-sprites
 /* ====== media ====== */
 .media
   :margin 10px

--- a/app/assets/stylesheets/bootstrap-headerfix.sass
+++ b/app/assets/stylesheets/bootstrap-headerfix.sass
@@ -1,0 +1,15 @@
+// A temporary fix for displaying the header in the single post view.
+// Should be removed once everything uses Bootstrap.
+
+header
+  .container
+    width: 950px
+    .header-nav
+      span
+        a
+          font-weight: bold
+          font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif
+          font-size: 13px
+    li
+      font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif
+      font-size: 13px

--- a/app/assets/stylesheets/header.css.scss
+++ b/app/assets/stylesheets/header.css.scss
@@ -9,6 +9,7 @@ body > header {
   height: 26px;
   position: fixed;
   width: 100%;
+  min-width: 620px;
   top: 0;
   left: 0;
   border-bottom: 1px solid #000;

--- a/app/assets/stylesheets/header.css.scss
+++ b/app/assets/stylesheets/header.css.scss
@@ -1,3 +1,5 @@
+body > #container { margin-top: 50px; } /* to avoid being hidden under the header in the SPV */
+
 body > header {
   @include box-shadow(0,1px,3px,rgba(0,0,0,0.9));
   background: url('header-bg.png') rgb(40,35,35);

--- a/app/assets/stylesheets/new-templates.css.scss
+++ b/app/assets/stylesheets/new-templates.css.scss
@@ -4,6 +4,7 @@
 
 /* core */
 @import 'new_styles/flash_messages';
+@import 'sprites.css.scss';
 @import 'header.css.scss';
 
 @import 'new_styles/base';

--- a/app/assets/stylesheets/new_styles/_base.scss
+++ b/app/assets/stylesheets/new_styles/_base.scss
@@ -86,7 +86,7 @@ a { color : $link-blue  }
   display: table;
   position: absolute;
 
-  height: 100%;
+  height: 93%;
   width: 100%;
 
   img,

--- a/app/assets/stylesheets/sprites.css.scss
+++ b/app/assets/stylesheets/sprites.css.scss
@@ -1,0 +1,7 @@
+/* ===== sprites ===== */
+@import 'icons/*.png';
+@import 'branding/*.png';
+@import 'social_media_logos/*.png';
+@include all-icons-sprites;
+@include all-branding-sprites;
+@include all-social_media_logos-sprites;

--- a/app/assets/templates/post-viewer_tpl.jst.hbs
+++ b/app/assets/templates/post-viewer_tpl.jst.hbs
@@ -1,16 +1,4 @@
 <div id="author-info"></div>
-
-<div id="top-right-nav">
-    <a href="/" id="home-button">
-        <span class="label label-inverse">
-            <i class="icon-home icon-white"></i>
-            <span>
-                {{t "viewer.home"}}
-            </span>
-        </span>
-    </a>
-</div>
-
-<div id="post-content"> </div>
-<div id="post-nav"> </div>
-<div id="post-interactions"> </div>
+<div id="post-content"></div>
+<div id="post-nav"></div>
+<div id="post-interactions"></div>

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -9,7 +9,7 @@ class PostsController < ApplicationController
   before_filter :set_format_if_malformed_from_status_net, :only => :show
   before_filter :find_post, :only => [:show, :next, :previous, :interactions]
 
-  layout 'application'
+  layout 'with_header'
   before_filter -> { @css_framework = :bootstrap }
 
   respond_to :html,

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -9,7 +9,6 @@ class PostsController < ApplicationController
   before_filter :set_format_if_malformed_from_status_net, :only => :show
   before_filter :find_post, :only => [:show, :next, :previous, :interactions]
 
-  layout 'with_header'
   before_filter -> { @css_framework = :bootstrap }
 
   respond_to :html,
@@ -27,7 +26,7 @@ class PostsController < ApplicationController
     mark_corresponding_notifications_read if user_signed_in?
 
     respond_to do |format|
-      format.html{ gon.post = PostPresenter.new(@post, current_user); render 'posts/show' }
+      format.html{ gon.post = PostPresenter.new(@post, current_user); render 'posts/show', layout: 'with_header' }
       format.xml{ render :xml => @post.to_diaspora_xml }
       format.mobile{render 'posts/show' }
       format.json{ render :json => PostPresenter.new(@post, current_user) }

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -56,7 +56,8 @@ module LayoutHelper
 
   def include_base_css_framework(use_bootstrap=false)
     if use_bootstrap || @aspect == :getting_started
-      stylesheet_link_tag 'bootstrap-complete'
+      stylesheet_link_tag('bootstrap-complete') +
+      stylesheet_link_tag('bootstrap-headerfix')
     else
       stylesheet_link_tag 'blueprint', :media => 'screen'
     end


### PR DESCRIPTION
This PR adds the header to the SPV. It includes a hack to override default bootstrap style to fit blueprint one.
