### PR TITLE
SPV photo background removal,

### DIFF
--- a/lib/template_picker.rb
+++ b/lib/template_picker.rb
@@ -28,7 +28,7 @@ class TemplatePicker
   end
 
   def photo_backdrop?
-    post.photos.size == 1 
+    false # No backdrop, ever.
   end
 
   def status?

--- a/spec/lib/template_picker_spec.rb
+++ b/spec/lib/template_picker_spec.rb
@@ -24,9 +24,9 @@ describe TemplatePicker do
   end
 
   describe '#status_with_photo_backdrop?' do
-    it 'is true if the post contains a single photo and text' do
+    it 'is false even if the post contains a single photo and text' do
       @post_stubs.merge!(:photos => stub(:size => 1))
-      TemplatePicker.new(post).should be_status_with_photo_backdrop
+      TemplatePicker.new(post).should_not be_status_with_photo_backdrop
     end
   end
 
@@ -37,9 +37,9 @@ describe TemplatePicker do
   end
 
   describe '#photo_backdrop?' do
-    it 'is true if the post contains only one photo' do
+    it 'is false even if the post contains only one photo' do
       @post_stubs.merge!(:photos => stub(:size => 1))
-      TemplatePicker.new(post).should be_photo_backdrop
+      TemplatePicker.new(post).should_not be_photo_backdrop
     end
 
   end
@@ -51,7 +51,8 @@ describe TemplatePicker do
   end
 
   describe 'factories' do
-    TemplatePicker::TEMPLATES.each do |template|
+    # No photo_backdrop for now.
+    (TemplatePicker::TEMPLATES - ['status_with_photo_backdrop', 'photo_backdrop']).each do |template|
       describe "#{template} factory" do
         it 'works' do
           post = FactoryGirl.build(template.to_sym, :author => alice.person)


### PR DESCRIPTION
This is about https://github.com/diaspora/diaspora/issues/3741.

It deactivates the photo backdrop feature by always returning false when asked if the current template should return a photo backdrop. I did not want to completely remove the backdrop templates, as I think they might be needed again in the future.
