### PR TITLE
Fix photos in spv and always show visibility of post

### DIFF
--- a/app/assets/stylesheets/entypo.css.scss
+++ b/app/assets/stylesheets/entypo.css.scss
@@ -19,6 +19,14 @@
     content: '\e718';
   }
 
+  &.globe:before {
+    content: '\1f30e';
+  }
+
+  &.lock:before {
+    content: '\1f512';
+  }
+
   &.red {
     color: #A40802;
   }
@@ -38,5 +46,9 @@
 
   &.middle {
     font-size: 1.5em;
+  }
+
+  &.small {
+    font-size: 1.2em;
   }
 }

--- a/app/assets/stylesheets/single-post-view.css.scss
+++ b/app/assets/stylesheets/single-post-view.css.scss
@@ -56,14 +56,17 @@
   }
   border-right: solid 1px #cccccc;
   padding-right: 10px;
+  
   #body {
     margin-left: 20px;
     padding-top: 20px;
     width: auto;
     .photo_attachments {
       padding-bottom: 10px;
+      text-align: center;
       img {
-        display: block;
+        &.big_stream_photo { display: block; }
+        display: inline;
         margin-left: auto;
         margin-right: auto;
         padding-bottom: 5px;

--- a/app/assets/templates/single-post-viewer/single-post-actions_tpl.jst.hbs
+++ b/app/assets/templates/single-post-viewer/single-post-actions_tpl.jst.hbs
@@ -1,8 +1,10 @@
 <div class='pull-right'>
   <span class='public-info'>
-    {{#unless public}}
-      <i class="icon-lock icon-grey"> </i>
-    {{/unless}}
+    {{#if public}}
+      <i class="entypo globe small"> </i>
+    {{else}}
+      <i class="entypo lock small"> </i>
+    {{/if}}
   </span>
   <span class="post-time">
     <time datetime="{{created_at}}" title="{{localTime created_at}}" />


### PR DESCRIPTION
Rearranges the photos in the SPV (#4421) and always show the visibilty of a post (#4422)
![spv-photos](https://f.cloud.github.com/assets/3798614/1010567/7a1be52e-0b4d-11e3-9625-bead9afb5454.png)

While working on this I found out that there is another bug with the photos: There are just 8 displayed photos even if the post has a lot more. This bug also exists in the stream.
