### PR TITLE
Add 'no comments' message to SPV

### DIFF
--- a/app/assets/stylesheets/single-post-view.css.scss
+++ b/app/assets/stylesheets/single-post-view.css.scss
@@ -102,6 +102,15 @@
       margin: 0;
     }
   }
+  .no_comments {
+    padding-top: 10px;
+    padding-bottom: 10px;
+    background-color: #eee;
+    text-align: center;
+    @include border-radius(4px);
+    margin-bottom: 30px;
+  }
+
   textarea {
     width: 95%;
   }

--- a/app/assets/templates/single-post-viewer/single-post-interactions_tpl.jst.hbs
+++ b/app/assets/templates/single-post-viewer/single-post-interactions_tpl.jst.hbs
@@ -35,6 +35,10 @@
       <i class='entypo comment middle gray'></i>
     </div>
   </div>
+{{else}}
+  <div class='no_comments'>
+    <h4>{{t "comments.no_comments" }}</h4>
+  </div>
 {{/if}}
 <div id='comments'>
 </div>

--- a/config/locales/javascript/javascript.en.yml
+++ b/config/locales/javascript/javascript.en.yml
@@ -63,6 +63,7 @@ en:
     comments:
       show: "show all comments"
       hide: "hide comments"
+      no_comments: "There are no comments yet."
     reshares:
       duplicate: "That good, huh?  You've already reshared that post!"
       successful: "The post was successfully reshared!"


### PR DESCRIPTION
In the SPV we have a completely white right side if there are no comments and no other interactions. Here is how it will look like when merging this PR:
![no_comments_spv](https://f.cloud.github.com/assets/3798614/1013340/0f4c93e6-0b85-11e3-9061-d7119551a4a1.png)
