### PR TITLE
Fixing Invite code input width to be same across browsers

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -1905,6 +1905,10 @@ h1.tag
     :margin
       :bottom 25px
 
+    #invite_code
+      :width 100%
+      @include box-sizing(border-box)
+
 .subtle
   :color #888
   :font


### PR DESCRIPTION
- It was wide on firefox and narrow on chrome
- This fits it within the parent's padding on all browsers
