### PR TITLE
Collapsing aspects_list and followed_tags when they aren't active

### DIFF
--- a/app/assets/javascripts/app/router.js
+++ b/app/assets/javascripts/app/router.js
@@ -57,6 +57,7 @@ app.Router = Backbone.Router.extend({
 
     $("#main_stream").html(app.page.render().el);
     $('#selected_aspect_contacts .content').html(streamFacesView.render().el);
+    this.hideInactiveStreamLists();
   },
 
   photos : function() {
@@ -69,9 +70,9 @@ app.Router = Backbone.Router.extend({
     this.stream();
 
     app.tagFollowings = new app.collections.TagFollowings();
-    var followedTagsView = new app.views.TagFollowingList({collection: app.tagFollowings});
-    $("#tags_list").replaceWith(followedTagsView.render().el);
-    followedTagsView.setupAutoSuggest();
+    this.followedTagsView = new app.views.TagFollowingList({collection: app.tagFollowings});
+    $("#tags_list").replaceWith(this.followedTagsView.render().el);
+    this.followedTagsView.setupAutoSuggest();
 
     app.tagFollowings.reset(gon.preloads.tagFollowings);
 
@@ -81,12 +82,13 @@ app.Router = Backbone.Router.extend({
           );
       $("#author_info").prepend(followedTagsAction.render().el)
     }
+    this.hideInactiveStreamLists();
   },
 
   aspects : function(){
     app.aspects = new app.collections.Aspects(app.currentUser.get('aspects'));
-    var aspects_list =  new app.views.AspectsList({ collection: app.aspects });
-    aspects_list.render();
+    this.aspects_list =  new app.views.AspectsList({ collection: app.aspects });
+    this.aspects_list.render();
     this.aspects_stream();
   },
 
@@ -104,6 +106,15 @@ app.Router = Backbone.Router.extend({
 
     $("#main_stream").html(app.page.render().el);
     $('#selected_aspect_contacts .content').html(streamFacesView.render().el);
-  }
+    this.hideInactiveStreamLists();
+  },
+
+  hideInactiveStreamLists: function() {
+    if(this.aspects_list && Backbone.history.fragment != "aspects")
+      this.aspects_list.hideAspectsList();
+
+    if(this.followedTagsView && Backbone.history.fragment != "followed_tags")
+      this.followedTagsView.hideFollowedTags();
+  },
 });
 

--- a/app/assets/javascripts/app/views/aspects_list_view.js
+++ b/app/assets/javascripts/app/views/aspects_list_view.js
@@ -56,5 +56,9 @@ app.views.AspectsList = app.views.Base.extend({
 
   updateStreamTitle: function() {
     $('.stream_title').text(this.collection.toSentence());
-  }
+  },
+
+  hideAspectsList: function() {
+    this.$el.empty();
+  },
 })

--- a/app/assets/javascripts/app/views/tag_following_list_view.js
+++ b/app/assets/javascripts/app/views/tag_following_list_view.js
@@ -71,6 +71,9 @@ app.views.TagFollowingList = app.views.Base.extend({
     this.$el.prepend(new app.views.TagFollowing({
       model: tag
     }).render().el);
-  }
-  
+  },
+
+  hideFollowedTags: function() {
+    this.$el.empty();
+  },
 });

--- a/spec/javascripts/app/router_spec.js
+++ b/spec/javascripts/app/router_spec.js
@@ -32,4 +32,45 @@ describe('app.Router', function () {
       expect(tag_following_action).toHaveBeenCalledWith({tagText: 'somethingwithcapitalletters'});
     });
   });
+
+  describe("when routing to /stream and hiding inactive stream lists", function() {
+    it('calls hideInactiveStreamLists', function () {
+      var hideInactiveStreamLists = spyOn(app.router, 'hideInactiveStreamLists').andCallThrough();
+      spyOn(window.history, 'pushState').andCallFake(function (data, title, url) {
+        var route = app.router._routeToRegExp("stream");
+        var args = app.router._extractParameters(route, url.replace(/^\//, ""));
+        app.router.stream(args[0]);
+      });
+      app.router.navigate('/stream');
+      expect(hideInactiveStreamLists).toHaveBeenCalled();
+    });
+
+    it('hides the aspects list', function(){
+      var aspects = new app.collections.Aspects([{ name: 'Work', selected: true  }]);
+      var aspectsListView = new app.views.AspectsList({collection: aspects});
+      var hideAspectsList = spyOn(aspectsListView, 'hideAspectsList').andCallThrough();
+      app.router.aspects_list = aspectsListView;
+      spyOn(window.history, 'pushState').andCallFake(function (data, title, url) {
+        var route = app.router._routeToRegExp("stream");
+        var args = app.router._extractParameters(route, url.replace(/^\//, ""));
+        app.router.stream(args[0]);
+      });
+      app.router.navigate('/stream');
+      expect(hideAspectsList).toHaveBeenCalled();
+    });
+
+    it('hides the followed tags view', function(){
+      var tagFollowings = new app.collections.TagFollowings();
+      var followedTagsView = new app.views.TagFollowingList({collection: tagFollowings});
+      var hideFollowedTags = spyOn(followedTagsView, 'hideFollowedTags').andCallThrough();
+      app.router.followedTagsView = followedTagsView;
+      spyOn(window.history, 'pushState').andCallFake(function (data, title, url) {
+        var route = app.router._routeToRegExp("stream");
+        var args = app.router._extractParameters(route, url.replace(/^\//, ""));
+        app.router.stream(args[0]);
+      });
+      app.router.navigate('/stream');
+      expect(hideFollowedTags).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
- Each time a stream is rendered, other lists are emtied
- Using Backbone.history.fragment to detect active stream
- hideInactiveStreamLists is best pushed into a before/after filter
- Fixes https://github.com/diaspora/diaspora/issues/4459
