### PR TITLE
Disable 'Mark all as read' for notifications when everything is read

### DIFF
--- a/app/assets/javascripts/app/app.js
+++ b/app/assets/javascripts/app/app.js
@@ -40,6 +40,7 @@ var app = {
     this.setupHeader();
     this.setupBackboneLinks();
     this.setupGlobalViews();
+    this.setupDisabledLinks();
   },
 
   hasPreload : function(prop) {
@@ -107,7 +108,13 @@ var app = {
   instrument : function(type, name, object, callback) {
     if(!window.mixpanel) { return }
     window.mixpanel[type](name, object, callback)
-  }
+  },
+
+  setupDisabledLinks: function() {
+    $("a.disabled").click(function(event) {
+      event.preventDefault();
+    });
+  },
 };
 
 $(function() {

--- a/app/assets/javascripts/widgets/notifications.js
+++ b/app/assets/javascripts/widgets/notifications.js
@@ -22,7 +22,12 @@
           .next(".hidden")
           .removeClass("hidden");
       });
-      self.notificationMenu.find('a#mark_all_read_link').click(function() {
+      self.notificationMenu.find('a#mark_all_read_link').click(function(event) {
+        if ($(event.target).hasClass("disabled")) {
+          event.preventDefault();
+          return false;
+        }
+
         $.ajax({
           url: "/notifications/read_all",
           type: "GET",

--- a/app/assets/javascripts/widgets/notifications.js
+++ b/app/assets/javascripts/widgets/notifications.js
@@ -23,11 +23,6 @@
           .removeClass("hidden");
       });
       self.notificationMenu.find('a#mark_all_read_link').click(function(event) {
-        if ($(event.target).hasClass("disabled")) {
-          event.preventDefault();
-          return false;
-        }
-
         $.ajax({
           url: "/notifications/read_all",
           type: "GET",
@@ -44,6 +39,7 @@
             self.resetCount();
           }
         });
+        $(event.target).addClass("disabled");
         return false;
       });
     });

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -52,6 +52,13 @@ a
     :color $blue
     :text
       :decoration underline
+  &.disabled
+    :color $link-disabled-grey
+    :cursor default
+  &.disabled.button:hover
+    :color $link-disabled-grey
+    :cursor default
+    :background #f7f7f7
 
 p
   :word-wrap break-word

--- a/app/assets/stylesheets/colors.css.scss
+++ b/app/assets/stylesheets/colors.css.scss
@@ -7,6 +7,7 @@ $border-grey: #DDDDDD;
 $background-grey: #EEEEEE;
 $header-grey: #939393;
 $link-grey: #777777;
+$link-disabled-grey: #999999;
 $text-grey: #999999;
 
 $white: white;

--- a/app/assets/stylesheets/header.css.scss
+++ b/app/assets/stylesheets/header.css.scss
@@ -133,7 +133,6 @@ body > header {
       a { color: $blue; }
       a.disabled {
         color: $link-disabled-grey;
-        pointer-events: none;
         cursor: default;
       }
 

--- a/app/assets/stylesheets/header.css.scss
+++ b/app/assets/stylesheets/header.css.scss
@@ -131,6 +131,11 @@ body > header {
       }
 
       a { color: $blue; }
+      a.disabled {
+        color: $link-disabled-grey;
+        pointer-events: none;
+        cursor: default;
+      }
 
       .header {
         padding: 10px;

--- a/app/assets/templates/header_tpl.jst.hbs
+++ b/app/assets/templates/header_tpl.jst.hbs
@@ -45,7 +45,7 @@
         <div class="header">
           <div class="right">
 
-            <a href="#" id="mark_all_read_link">
+            <a href="#" id="mark_all_read_link" class="{{#unless current_user.notifications_count}}disabled{{/unless}}">
               {{t "header.mark_all_as_read"}}
             </a>
             |

--- a/app/views/notifications/index.html.haml
+++ b/app/views/notifications/index.html.haml
@@ -5,7 +5,7 @@
         = @unread_notification_count
       = t('.notifications')
   .span-8.last
-    = link_to t('.mark_all_as_read'), notifications_read_all_path, :class => 'button'
+    = link_to t('.mark_all_as_read'), notifications_read_all_path, :class => "button #{'disabled' unless @unread_notification_count > 0}"
   .span-24.last
     .stream.notifications
       - @group_days.each do |day, notes|


### PR DESCRIPTION
- This action needn't be performed when all notifications are read,
  hence disabling it is a good practice
- Added a link-disabled-color
- Used css pointer-events to disable clicking on the link

![image](https://f.cloud.github.com/assets/1003238/1047626/233f9694-1073-11e3-8578-08bc84c51cd8.png)
