### PR TITLE
Adjusting the description of the 404 message, in order to avoid having

### DIFF
--- a/app/views/errors/not_public.haml
+++ b/app/views/errors/not_public.haml
@@ -9,6 +9,6 @@
     404
 
   #content
-    = t('error_messages.post_not_public')
+    = t('error_messages.post_not_public_or_not_exist')
     %br
     = t('error_messages.login_try_again', :login_link => new_user_session_path).html_safe

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -81,6 +81,7 @@ en:
       invalid_fields: "Invalid Fields"
       correct_the_following_errors_and_try_again: "Correct the following errors and try again."
     post_not_public: "The post you are trying to view is not public!"
+    post_not_public_or_not_exist: "The post you are trying to view is not public, or does not exist!"
     login_try_again: "Please <a href='%{login_link}'>login</a> and try again."
 
   admins:

--- a/features/step_definitions/message_steps.rb
+++ b/features/step_definitions/message_steps.rb
@@ -10,7 +10,7 @@ Then /^I should see the "(.*)" message$/ do |message|
            when 'you are nsfw'
              I18n.translate('profiles.edit.you_are_nsfw')
            when 'post not public'
-             I18n.translate('error_messages.post_not_public')
+             I18n.translate('error_messages.post_not_public_or_not_exist')
            else
              raise "muriel, you don't have that message key, add one here"
            end


### PR DESCRIPTION
to specify why users got a 404, and possibly leaking information while doing this

See discussion in #3717 for rationale on not implementing specific HTTP codes
This solves around #3717 and #3728
