### PR TITLE
change bitcoin_wallet_id to bitcoin_address

### DIFF
--- a/app/views/shared/_donatepod.html.haml
+++ b/app/views/shared/_donatepod.html.haml
@@ -11,7 +11,6 @@
       %option{:value => "Box o' Joe"} Box o' Joe : $20.00USD
     %input{:name => "currency_code", :type => "hidden", :value => "USD"}
     %input{:name => "submit", :type => "submit", :value => t('aspects.index.donate')}
-- if AppConfig.settings.bitcoin_wallet_id.present?
+- if AppConfig.bitcoin_donation_address
   Bitcoin:
-  %input{:type => "text", :id => "bitcoin_address", :value => AppConfig.settings.bitcoin_wallet_id, :readonly => true}
-  
+  %input{:type => "text", :id => "bitcoin_address", :value => AppConfig.bitcoin_donation_address, :readonly => true}

--- a/app/views/shared/_right_sections.html.haml
+++ b/app/views/shared/_right_sections.html.haml
@@ -67,7 +67,7 @@
   .content
     != t('bookmarklet.explanation', :link => link_to(t('bookmarklet.post_something'), magic_bookmarklet_link))
 
-- if AppConfig.settings.paypal_hosted_button_id.present? || AppConfig.settings.bitcoin_wallet_id.present?
+- if AppConfig.settings.paypal_hosted_button_id.present? || AppConfig.bitcoin_donation_address
   .section
     .title
       .icons-coffee

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -59,7 +59,7 @@ defaults:
       open: true
       count: 25
     paypal_hosted_button_id:
-    bitcoin_wallet_id:
+    bitcoin_address:
     community_spotlight:
       enable: false
       suggest_email:

--- a/config/diaspora.yml.example
+++ b/config/diaspora.yml.example
@@ -237,9 +237,9 @@ configuration: ## Section
     #paypal_hosted_button_id: ""
     
     ## Bitcoin donations
-    ## You can provide the bitcoin address here to kindly ask
+    ## You can provide a bitcoin address here to kindly ask
     ## your users for donations to run their pod.
-    #bitcoin_wallet_id: ""
+    #bitcoin_address: ""
     
     ## Community Spotlight
     ## The community spotlight gives new users a starting point on who

--- a/features/desktop/donations.feature
+++ b/features/desktop/donations.feature
@@ -11,6 +11,6 @@ Feature: donations
     And I sign in as "alice@alice.alice"
 
   Scenario: Bitcoin donations
-    Given I have configured a Bitcoin wallet
+    Given I have configured a Bitcoin address
     And I am on the home page
-    Then I should see the Bitcoin wallet ID
+    Then I should see the Bitcoin address

--- a/features/step_definitions/custom_web_steps.rb
+++ b/features/step_definitions/custom_web_steps.rb
@@ -271,10 +271,10 @@ When /^I focus the "([^"]+)" field$/ do |field|
   find_field(field).click
 end
 
-Given /^I have configured a Bitcoin wallet$/ do
-  AppConfig.settings.bitcoin_wallet_id = "AAAAAA"
+Given /^I have configured a Bitcoin address$/ do
+  AppConfig.settings.bitcoin_address = "AAAAAA"
 end
 
-Then /^I should see the Bitcoin wallet ID$/ do
+Then /^I should see the Bitcoin address$/ do
   find("#bitcoin_address")['value'].should == "AAAAAA"
 end

--- a/lib/configuration_methods.rb
+++ b/lib/configuration_methods.rb
@@ -109,6 +109,17 @@ module Configuration
       ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
     end
 
+    def bitcoin_donation_address
+      if AppConfig.settings.bitcoin_wallet_id.present?
+        $stderr.puts "WARNING: bitcoin_wallet_id is now bitcoin_address. Change in diaspora.yml."
+        return AppConfig.settings.bitcoin_wallet_id
+      end
+
+      if AppConfig.settings.bitcoin_address.present?
+        AppConfig.settings.bitcoin_address
+      end
+    end
+
     private
 
     def get_git_info


### PR DESCRIPTION
It is better to call it an address than a wallet ID, because the latter may confuse Bitcoin users who conflate the two. [They are not the same.](http://bitcoin.stackexchange.com/questions/13059/whats-the-difference-between-a-wallet-and-an-address/)
