### PR TITLE
Prevent overflow of strings too long on single page view

### DIFF
--- a/app/assets/stylesheets/single-post-view.css.scss
+++ b/app/assets/stylesheets/single-post-view.css.scss
@@ -63,6 +63,7 @@
     width: auto;
     p {
       margin: 0 0 1em 0;
+      word-wrap: break-word;
     }
     .photo_attachments {
       padding-bottom: 10px;
@@ -103,6 +104,7 @@
     padding-bottom: 10px;
     p {
       margin: 0 0 1em 0;
+      word-wrap: break-word;
       &:last-child {
         margin-bottom: 0;
       }


### PR DESCRIPTION
I added the word-wrap property to prevent overflow of strings too long. 

![word-wrap-spv](https://f.cloud.github.com/assets/914785/1063208/9638e03e-1298-11e3-9586-6a250694e5d3.jpg)
