### PR TITLE
Fix issue #4499: changed :width in .item_count to :min-width

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -1976,7 +1976,7 @@ ul#requested-scopes
       :display none
 
 .item_count
-  :width 16px
+  :min-width 16px
   :line-height 16px
   :text-align center
   :float right


### PR DESCRIPTION
This fixes the issue with the light grey background not spanning more than two digits (#4499).
