### PR TITLE
Fix mentions in notification emails

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@
 * Disable submit button in sign up form after submission to avoid email already exists error [#4506](https://github.com/diaspora/diaspora/issues/4506)
 * Do not pull the 404 pages assets from Amazon S3 [#4501](https://github.com/diaspora/diaspora/pull/4501)
 * Fix counter background does not cover more than 2 digits on profile [#4499](https://github.com/diaspora/diaspora/issues/4499)
+* Fix mentions in notification emails [#4294](https://github.com/diaspora/diaspora/issues/4294)
 
 ## Features
 * Add oEmbed content to the mobile view [#4343](https://github.com/diaspora/diaspora/pull/4353)

--- a/app/helpers/notifier_helper.rb
+++ b/app/helpers/notifier_helper.rb
@@ -1,5 +1,5 @@
 module NotifierHelper
-  
+
   # @param post [Post] The post object.
   # @param opts [Hash] Optional hash.  Accepts :length and :process_newlines parameters.
   # @return [String] The truncated and formatted post.
@@ -9,7 +9,7 @@ module NotifierHelper
       message = strip_markdown(post.formatted_message(:plain_text => true))
       message = truncate(message, :length => opts[:length])
       message = process_newlines(message) if opts[:process_newlines]
-      message
+      message.html_safe
     else
       I18n.translate 'notifier.a_post_you_shared'
     end

--- a/app/helpers/people_helper.rb
+++ b/app/helpers/people_helper.rb
@@ -36,7 +36,7 @@ module PeopleHelper
     opts[:class] ||= ""
     opts[:class] << " self" if defined?(user_signed_in?) && user_signed_in? && current_user.person == person
     remote_or_hovercard_link = Rails.application.routes.url_helpers.person_path(person).html_safe
-    "<a data-hovercard='#{remote_or_hovercard_link}' #{person_href(person)} class='#{opts[:class]}' #{ ("target=" + opts[:target]) if opts[:target]}>#{h(person.name)}</a>".html_safe
+    "<a data-hovercard='#{remote_or_hovercard_link}' #{person_href(person, absolute: true)} class='#{opts[:class]}' #{ ("target=" + opts[:target]) if opts[:target]}>#{h(person.name)}</a>".html_safe
   end
 
   def last_visible_post_for(person, current_user=nil)


### PR DESCRIPTION
Issue #4294 :
- Set the post as html_safe so the mention link is not added as text
- Changed the mention url to be absolute so it works from email
