### PR TITLE
Add help link

### DIFF
--- a/app/views/shared/_right_sections.html.haml
+++ b/app/views/shared/_right_sections.html.haml
@@ -41,6 +41,7 @@
     %br
     %p
       != t('aspects.index.help.tutorials_and_wiki',
+           :faq => link_to(t('_help'), faq_getting_help_path),
            :tutorial => link_to(t('aspects.index.help.tutorial_link_text'), "https://diasporafoundation.org/tutorials", :target => '_blank'),
            :wiki => link_to('Wiki','http://wiki.diasporafoundation.org', :target => '_blank'), :target => '_blank')
 

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -240,7 +240,7 @@ en:
         tag_bug: "bug"
         feature_suggestion: "... have a %{link} suggestion?"
         tag_feature: "feature"
-        tutorials_and_wiki: "%{tutorial} & %{wiki}: Help for your first steps."
+        tutorials_and_wiki: "%{faq}, %{tutorial} & %{wiki}: Help for your first steps."
         tutorial_link_text: "Tutorials"
         email_feedback: "%{link} your feedback, if you prefer"
         email_link: "Email"


### PR DESCRIPTION
This PR add a link to the new /help page to the "Help" section of the right side panel.

WIP: it doesn't work and I don't get why, it's the first time I touch to translations so if I did something wrong please tell me.
