### PR TITLE
Remove last post link

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 * Batch insert posts into stream collection for a small speedup [#4341](https://github.com/diaspora/diaspora/pull/4351)
 * Ported fileuploader to Backbone and refactored publisher views [#4480](https://github.com/diaspora/diaspora/pull/4480)
 * Refactor 404.html, fix [#4078](https://github.com/diaspora/diaspora/issues/4078)
+* Remove the (now useless) last post link from the user profile. [#4540](https://github.com/diaspora/diaspora/pull/4540)
 
 ## Bug fixes
 * Highlight down arrow at the user menu on hover [#4441](https://github.com/diaspora/diaspora/pull/4441)

--- a/app/helpers/people_helper.rb
+++ b/app/helpers/people_helper.rb
@@ -39,12 +39,6 @@ module PeopleHelper
     "<a data-hovercard='#{remote_or_hovercard_link}' #{person_href(person)} class='#{opts[:class]}' #{ ("target=" + opts[:target]) if opts[:target]}>#{h(person.name)}</a>".html_safe
   end
 
-  def last_visible_post_for(person, current_user=nil)
-    unless Post.visible_from_author(person, current_user).empty?
-      link_to(t('people.last_post'), last_post_person_path(person.to_param))
-    end
-  end
-
   def person_image_tag(person, size = :thumb_small)
     image_tag(person.profile.image_url(size), :alt => person.name, :class => 'avatar', :title => person.name, 'data-person_id' => person.id)
   end

--- a/app/views/people/_sub_header.html.haml
+++ b/app/views/people/_sub_header.html.haml
@@ -15,7 +15,6 @@
     = person.name
   %span.diaspora_handle
     = person.diaspora_handle
-    = last_visible_post_for person
 
   .description
     - if !person.tag_string.blank? && user_signed_in?

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -796,7 +796,6 @@ en:
       edit_membership: "edit aspect membership"
     add_contact_small:
       add_contact_from_tag: "add contact from tag"
-    last_post: "Last Post"
     add_contact:
       invited_by: "you were invited by"
 

--- a/features/desktop/logged_out_browsing.feature
+++ b/features/desktop/logged_out_browsing.feature
@@ -14,11 +14,6 @@ Feature: Browsing Diaspora as a logged out user
       Then I should see "public stuff" within "body"
       And page should not have ".media .controls"
 
-    Scenario: Clicking Last Post
-      When I am on "bob@bob.bob"'s page
-      And I follow "Last Post"
-      Then I should see "public stuff" within "body"
-
     Scenario: Visiting a post show page
       When I view "bob@bob.bob"'s first post
       Then I should see "public stuff" within "body"

--- a/features/desktop/reshare.feature
+++ b/features/desktop/reshare.feature
@@ -16,8 +16,7 @@ Feature: public repost
     Given "bob@bob.bob" has a public post with text "reshare this!"
     And I sign in as "alice@alice.alice"
     And I am on "bob@bob.bob"'s page
-    And I follow "Last Post"
-
+    And I open the show page of the "reshare this!" post
     And I click on selector "a.reshare"
     And I confirm the alert
     Then I should see a flash message indicating success
@@ -28,8 +27,7 @@ Feature: public repost
     And the post with text "reshare this!" is reshared by "eve@eve.eve"
     And I sign in as "alice@alice.alice"
     And I am on "bob@bob.bob"'s page
-    And I follow "Last Post"
-
+    And I open the show page of the "reshare this!" post
     And I click on selector "a.reshare"
     And I confirm the alert
     Then I should see a flash message indicating success

--- a/spec/helpers/people_helper_spec.rb
+++ b/spec/helpers/people_helper_spec.rb
@@ -60,26 +60,6 @@ describe PeopleHelper do
     end
   end
 
-  describe '#last_visible_post_for' do
-    before do
-      @person = FactoryGirl.create(:person)
-    end
-
-    it "doesn't show a link, if the person has no visible posts" do
-      last_visible_post_for(@person).should be_blank
-    end
-
-    it "doesn't show a link, if the person has posts but none visible" do
-      post = FactoryGirl.create(:status_message, :author => @person)
-      last_visible_post_for(@person).should be_blank
-    end
-
-    it "shows the link, if the person has at least one visible post" do
-      post = FactoryGirl.create(:status_message, :author => @person, :public => true)
-      last_visible_post_for(@person).should include last_post_person_path(@person.to_param)
-    end
-  end
-
   describe "#person_href" do
     it "calls local_or_remote_person_path and passes through the options" do
       opts = {:absolute => true}


### PR DESCRIPTION
Remove the (now useless) last post link from the user profile.
