### PR TITLE
Strip markdown from title in spv

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -29,6 +29,7 @@
 * Add a white background to images shown in the lightbox [#4475](https://github.com/diaspora/diaspora/issues/4475)
 * Refactor getting_started page, test if facebook is available, fix [#4520](https://github.com/diaspora/diaspora/issues/4520)
 * Avoid publishing empty posts [#4542](https://github.com/diaspora/diaspora/pull/4542)
+* Strip markdown from page title when loading the singe post view
 
 ## Features
 * Add oEmbed content to the mobile view [#4343](https://github.com/diaspora/diaspora/pull/4353)

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -3,6 +3,8 @@
 #   the COPYRIGHT file.
 
 module PostsHelper
+    include MarkdownifyHelper
+
   def post_page_title(post, opts={})
     if post.is_a?(Photo)
       I18n.t "posts.show.photos_by", :count => 1, :author => post.status_message_author_name
@@ -17,8 +19,8 @@ module PostsHelper
                   |                                                                   # or
               (?<atx_content>\#{1,6}\s.{1,200})(?:\r?\n|$)                            # Atx-style header
                )/x   =~  post.text(:plain_text => true)
-          return setext_content unless setext_content.nil?
-          return atx_content unless atx_content.nil?
+          return strip_markdown(setext_content) unless setext_content.nil?
+          return strip_markdown(atx_content) unless atx_content.nil?
         else
           truncate(post.text(:plain_text => true), :length => 20 )
         end

--- a/spec/helpers/posts_helper_spec.rb
+++ b/spec/helpers/posts_helper_spec.rb
@@ -21,13 +21,13 @@ describe PostsHelper do
       end
       context 'when :length is not passed in parameters' do
         context 'with a Markdown header of less than 200 characters on first line'do
-          it 'returns atx style header' do
+          it 'returns title without markdown-syntax in case of atx style header' do
             @sm = stub(:text => "## My title\n Post content...")
-            post_page_title(@sm).should == "## My title"
+            post_page_title(@sm).should == "My title"
           end
-          it 'returns setext style header' do
+          it 'returns title without markdown-syntax in case of setext style header' do
             @sm = stub(:text => "My title \n======\n Post content...")
-            post_page_title(@sm).should ==  "My title \n======"
+            post_page_title(@sm).should ==  "My title"
           end
         end
         context 'without a Markdown header of less than 200 characters on first line 'do

--- a/spec/presenters/post_presenter_spec.rb
+++ b/spec/presenters/post_presenter_spec.rb
@@ -78,16 +78,16 @@ describe PostPresenter do
   describe '#title' do 
     context 'with posts with text' do
       context 'with a Markdown header of less than 200 characters on first line'do
-        it 'returns atx style header' do
+        it 'returns title without markdown-syntax in case of atx style header' do
           @sm = stub(:text => "## My title\n Post content...")
           @presenter.post = @sm
-          @presenter.title.should == "## My title"
+          @presenter.title.should == "My title"
         end
 
-        it 'returns setext style header' do
+        it 'returns title without markdown-syntax in case of setext style header' do
           @sm = stub(:text => "My title \n======\n Post content...")
           @presenter.post = @sm
-          @presenter.title.should == "My title \n======"
+          @presenter.title.should == "My title"
         end
       end
       context 'without a Markdown header of less than 200 characters on first line 'do


### PR DESCRIPTION
I added strip_markdown in the posts helper for pretty page-titles while loading the single post view.
