### PR TITLE
initial commit for conversations rewrite

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -220,10 +220,17 @@ class User < ActiveRecord::Base
     model_class.diaspora_initialize(opts)
   end
 
-  def dispatch_post(post, opts={})
-    FEDERATION_LOGGER.info("user:#{self.id} dispatching #{post.class}:#{post.guid}")
-    Postzord::Dispatcher.defer_build_and_post(self, post, opts)
+  def dispatch!(dispatchable, opts={})
+    unless dispatchable.respond_to?(:guid)
+      raise ArgumentError, "dispatchable object '#{dispatchable.class}' doesn't respond to '#guid'"
+    end
+
+    FEDERATION_LOGGER.info("user:#{self.id} dispatching #{dispatchable.class}:#{dispatchable.guid}")
+
+    # queue the actual dispatching with the background worker
+    Postzord::Dispatcher.defer_build_and_post(self, dispatchable, opts)
   end
+  alias_method :dispatch_post, :dispatch!
 
   def update_post(post, post_hash={})
     if self.owns? post

--- a/app/presenters/author_presenter.rb
+++ b/app/presenters/author_presenter.rb
@@ -1,0 +1,20 @@
+
+class AuthorPresenter < BasePresenter
+  def base_hash
+    { id: id,
+      guid: guid,
+      name: name,
+      diaspora_id: diaspora_handle
+    }
+  end
+
+  def full_hash
+    base_hash.merge({
+      avatar: {
+        small: profile.image_url(:thumb_small),
+        medium: profile.image_url(:thumb_medium),
+        large: profile.image_url(:thumb_large)
+      }
+    })
+  end
+end

--- a/app/presenters/base_presenter.rb
+++ b/app/presenters/base_presenter.rb
@@ -1,5 +1,24 @@
 class BasePresenter
-  def self.as_collection(collection)
-    collection.map{|object| self.new(object).as_json}
+  def self.new(arg)
+    return NilPresenter.new if arg.nil?
+    super
+  end
+
+  def self.as_collection(collection, method=:as_json)
+    collection.map{ |object| self.new(object).send(method) }
+  end
+
+  def initialize(presentable)
+    @presentable = presentable
+  end
+
+  def method_missing(method, *args)
+    @presentable.send(method, *args) if @presentable.respond_to?(method)
+  end
+
+  class NilPresenter
+    def method_missing(method, *args)
+      nil
+    end
   end
 end

--- a/app/presenters/conversation_presenter.rb
+++ b/app/presenters/conversation_presenter.rb
@@ -1,0 +1,24 @@
+
+class ConversationPresenter < BasePresenter
+  # base hash contains only direct attributes, no associated or delegated ones
+  # include only items needed for *presentation*
+  def base_hash
+    { id: id,
+      guid: guid,
+      subject: subject,
+      updated_at: updated_at
+    }
+  end
+
+  # full hash includes the base hash and associated or delegated attributes
+  def full_hash
+    base_hash.merge({
+      author: AuthorPresenter.new(author).full_hash,
+      last_author: AuthorPresenter.new(last_author).full_hash,
+      message_count: messages.size,
+      participant_count: participants.size,
+      participants: AuthorPresenter.as_collection(participants, :full_hash)
+    })
+  end
+
+end

--- a/app/presenters/message_presenter.rb
+++ b/app/presenters/message_presenter.rb
@@ -1,0 +1,16 @@
+
+class MessagePresenter < BasePresenter
+  def base_hash
+    { id: id,
+      guid: guid,
+      text: text,
+      updated_at: updated_at
+    }
+  end
+
+  def full_hash
+    base_hash.merge({
+      author: AuthorPresenter.new(author).full_hash
+    })
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,11 @@ Diaspora::Application.routes.draw do
     mount Sidekiq::Web => '/sidekiq', :as => 'sidekiq'
   end
 
+  # Backbone JSON interface
+  constraints Diaspora::Backbone::Constraint.new do
+    mount Diaspora::Backbone::Endpoints, at: '/'
+  end
+
   get "/atom.xml" => redirect('http://blog.diasporafoundation.org/feed/atom') #too many stupid redirects :()
 
   get 'oembed' => 'posts#oembed', :as => 'oembed'
@@ -209,7 +214,7 @@ Diaspora::Application.routes.draw do
 
   # Help
   get 'help' => 'help#getting_help', :as => 'faq_getting_help'
-  
+
   scope path: "/help/faq", :controller => :help, :as => 'faq' do
     get :account_and_data_management
     get :aspects

--- a/lib/diaspora/backbone/auth_helpers.rb
+++ b/lib/diaspora/backbone/auth_helpers.rb
@@ -1,0 +1,43 @@
+
+module Diaspora::Backbone
+  module AuthHelpers
+
+    module Helpers
+      def authenticate!
+        @current_user = request.env['warden'].authenticate
+        redirect '/unauthenticated' unless @current_user
+      end
+
+      def authenticated?
+        request.env['warden'].authenticated?
+      end
+
+      def current_user
+        @current_user ||= request.env['warden'].user
+      end
+    end
+
+    def self.registered(app)
+      app.helpers AuthHelpers::Helpers
+
+      if Rails.env.test?
+        use Rack::Session::Cookie, key: Rails.application.config.session_options[:key],
+                                   secret: Rails.application.config.secret_token
+
+        app.use Warden::Manager do |m|
+          m.default_scope = Devise.default_scope
+          m.failure_app = Diaspora::Application
+        end
+
+        Warden::Manager.before_failure do |env, opts|
+          env['REQUEST_METHOD'] = "GET"
+        end
+      end
+
+      app.get "/unauthenticated" do
+        request.env['warden'].custom_failure!
+        halt_401_unauthorized
+      end
+    end
+  end
+end

--- a/lib/diaspora/backbone/base.rb
+++ b/lib/diaspora/backbone/base.rb
@@ -1,0 +1,58 @@
+
+module Diaspora::Backbone
+  class Base < ::Sinatra::Base
+
+    set :show_exceptions, false
+
+    before do
+      content_type :json
+    end
+
+    helpers do
+      def json(object)
+        hash = if object.is_a?(Hash) || object.is_a?(Array)
+                 object
+               elsif object.respond_to?(:full_hash)
+                 object.full_hash
+               elsif object.respond_to?(:base_hash)
+                 object.base_hash
+               else
+                 object.to_h
+               end
+
+        JSON.dump(hash)
+      end
+    end
+
+    register AuthHelpers
+    register ErrorHelpers
+    register ParamHelpers
+    register PaginationHelpers
+
+    get "/" do
+      json({message: "This is the internal diaspora* Backbone.js API\n"+
+                     "It is SUBJECT TO CHANGE WITHOUT NOTICE and NOT INTENDED FOR USE WITH EXTERNAL PROGRAMS!"})
+    end
+
+    # add fallback routes
+    get "/*" do
+      halt_404_not_found
+    end
+
+    post "/*" do
+      halt_404_not_found
+    end
+
+    put "/*" do
+      halt_404_not_found
+    end
+
+    patch "/*" do
+      halt_404_not_found
+    end
+
+    delete "/*" do
+      halt_404_not_found
+    end
+  end
+end

--- a/lib/diaspora/backbone/constraint.rb
+++ b/lib/diaspora/backbone/constraint.rb
@@ -1,0 +1,9 @@
+
+module Diaspora::Backbone
+  class Constraint
+    def matches?(request)
+      accept = request.headers['Accept']
+      (accept && accept == "application/vnd.diaspora.backbone+json")
+    end
+  end
+end

--- a/lib/diaspora/backbone/endpoints.rb
+++ b/lib/diaspora/backbone/endpoints.rb
@@ -1,0 +1,68 @@
+
+module Diaspora::Backbone
+  class Endpoints < Base
+
+    get "/conversations" do
+      authenticate!
+      data = current_user.conversations.includes(participants: :profile)
+      json(ConversationPresenter.as_collection(paginate(data), :full_hash))
+    end
+
+    post "/conversations" do
+      authenticate!
+      halt_400_bad_request unless params.has_key?('contact_ids') &&
+                                  params['contact_ids'].is_a?(Array)
+
+      begin
+        opts = protected_params
+                 .require(:conversation)
+                 .permit( :subject, message: :text)
+      rescue
+        halt_400_bad_request
+      end
+
+      participant_ids = current_user.contacts.where(id: params['contact_ids']).pluck(:person_id)
+      opts[:participant_ids] = participant_ids
+
+      conversation = current_user.build_conversation(opts)
+      halt_400_bad_request unless conversation.save
+
+      current_user.dispatch!(conversation)
+      json(ConversationPresenter.new(conversation))
+    end
+
+    delete "/conversations/:id/visibility" do
+      authenticate!
+      visibility = current_user.conversation_visibilities.where(conversation_visibilities: { conversation_id: params[:id] }).first
+      halt_404_not_found unless visibility.present? && visibility.destroy
+
+      200
+    end
+
+    get "/conversations/:id/messages" do
+      authenticate!
+      conversation = current_user.conversations.includes(messages: { author: :profile }, participants: :profile).where(id: params[:id]).first
+      halt_404_not_found unless conversation.present?
+
+      json(MessagePresenter.as_collection(paginate(conversation.messages), :full_hash))
+    end
+
+    post "/conversations/:id/messages" do
+      authenticate!
+      conversation = current_user.conversations.where(id: params[:id]).first
+      halt_404_not_found unless conversation.present?
+
+      begin
+        opts = protected_params.require(:message).permit(:text)
+      rescue
+        halt_400_bad_request
+      end
+
+      message = current_user.build_message(conversation, opts)
+      halt_400_bad_request unless message.save
+
+      current_user.dispatch!(message)
+      json(MessagePresenter.new(message))
+    end
+  end
+end

--- a/lib/diaspora/backbone/error_helpers.rb
+++ b/lib/diaspora/backbone/error_helpers.rb
@@ -1,0 +1,43 @@
+
+module Diaspora::Backbone
+  module ErrorHelpers
+    module Helpers
+      def error_msg(msg, note=nil)
+        data = { message: msg }
+        data[:notice] = note unless note.nil?
+        json(data)
+      end
+
+      def halt_400_bad_request(msg=nil)
+        halt 400, error_msg("Bad request!", msg)
+      end
+
+      def halt_401_unauthorized
+        halt 401, error_msg("Unauthorized!")
+      end
+
+      def halt_404_not_found
+        halt 404, error_msg("Not found!")
+      end
+
+      def halt_405_not_allowed
+        halt 405, error_msg("Not allowed!")
+      end
+
+      def halt_500_server_error
+        halt 500, error_msg("Internal server error!")
+      end
+    end
+
+    def self.registered(app)
+      app.helpers ErrorHelpers::Helpers
+
+      app.error do
+        # TODO add some sort of logging facility here...
+        puts env['sinatra.error']
+        puts env['sinatra.error'].backtrace
+        halt_500_server_error
+      end
+    end
+  end
+end

--- a/lib/diaspora/backbone/pagination_helpers.rb
+++ b/lib/diaspora/backbone/pagination_helpers.rb
@@ -1,0 +1,52 @@
+
+module Diaspora::Backbone
+  module PaginationHelpers
+    module Helpers
+
+      def paginate(relation)
+        @paginated = relation.paginate(page: page, per_page: per_page)
+        set_pagination_header
+        @paginated
+      end
+
+      private
+
+      def page
+        p = params[:page].to_i
+        p.between?(1, Float::INFINITY) ? p : 1
+      end
+
+      def per_page
+        max = 50
+        if p = params[:per_page].to_i
+          if p.between?(1, max)
+            p
+          elsif p > max
+            max
+          elsif p < 1
+            15
+          end
+        else
+          15
+        end
+      end
+
+      def set_pagination_header
+        request_url = request.url.split("?")[0]
+
+        links = []
+        links << %(<#{request_url}?page=#{@paginated.previous_page.to_s}&per_page=#{per_page}>; rel="prev") if @paginated.previous_page
+        links << %(<#{request_url}?page=#{@paginated.next_page.to_s}&per_page=#{per_page}>; rel="next") if @paginated.next_page
+        links << %(<#{request_url}?page=1&per_page=#{per_page}>; rel="first")
+        links << %(<#{request_url}?page=#{@paginated.total_pages.to_s}&per_page=#{per_page}>; rel="last")
+
+        headers "Link" => links.join(",")
+      end
+
+    end
+
+    def self.registered(app)
+      app.helpers PaginationHelpers::Helpers
+    end
+  end
+end

--- a/lib/diaspora/backbone/param_helpers.rb
+++ b/lib/diaspora/backbone/param_helpers.rb
@@ -1,0 +1,76 @@
+
+module Diaspora::Backbone
+  module ParamHelpers
+
+    class ParamsHash
+      def initialize(hash)
+        @_hash = stringify_keys(hash)
+      end
+
+      def require(key)
+        key = key.to_s
+        return ParamsHash.new(@_hash[key]) if @_hash.has_key?(key)
+        raise ParamMissing
+      end
+
+      def permit(*filters)
+        params = {}
+        filters.each do |f|
+          case f
+          when Symbol, String
+            permit_scalar(params, f)
+          when Hash then
+            permit_hash(params, stringify_keys(f))
+          end
+        end
+
+        # these keys already exist as symbols in the respective `#permit` calls,
+        # so there is no symbol leakage to be expected here
+        symbolize_keys(params)
+      end
+
+      private
+
+      def permit_scalar(params, key)
+        key = key.to_s
+        params[key] = @_hash[key] if @_hash.has_key?(key)
+      end
+
+      def permit_hash(params, filter)
+        @_hash.select { |k, v| filter.keys.include?(k) }.each_pair do |k ,v|
+          params[k] = ParamsHash.new(v).permit(filter[k])
+        end
+      end
+
+      # taken from Rails ActiveSupport Hash core_ext
+      def transform_keys(hash)
+        result = {}
+        hash.each_key do |k|
+          result[yield(k)] = hash[k]
+        end
+        result
+      end
+
+      def stringify_keys(hash)
+        transform_keys(hash) { |k| k.to_s }
+      end
+
+      def symbolize_keys(hash)
+        transform_keys(hash) { |k| k.to_sym rescue k }
+      end
+
+      class ParamMissing < IndexError
+      end
+    end
+
+    module Helpers
+      def protected_params
+        ParamsHash.new(params)
+      end
+    end
+
+    def self.registered(app)
+      app.helpers ParamHelpers::Helpers
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -218,7 +218,7 @@ FactoryGirl.define do
   end
 
   factory(:conversation_with_message, parent: :conversation) do
-    after(:build) do |c|
+    after(:create) do |c|
       msg = FactoryGirl.build(:message)
       msg.conversation_id = c.id
       c.participants << msg.author
@@ -235,6 +235,7 @@ FactoryGirl.define do
     after(:build) do |msg|
       c = FactoryGirl.build(:conversation)
       c.participants << msg.author
+      c.save
       msg.conversation_id = c.id
     end
   end

--- a/spec/lib/diaspora/backbone/endpoints_spec.rb
+++ b/spec/lib/diaspora/backbone/endpoints_spec.rb
@@ -1,0 +1,318 @@
+
+require 'spec_helper'
+require 'rack/test'
+
+def parse_json(content)
+  JSON.parse(content, symbolize_names: true)
+end
+
+RSpec::Matchers.define :be_json do
+  match do |actual|
+    actual.header["Content-Type"].include?("application/json")
+  end
+end
+
+RSpec::Matchers.define :be_successful do |payload|
+  match do |actual|
+    result = true
+
+    unless actual.body.empty?
+      body = parse_json(actual.body)
+      result = true
+      payload.each do |key, val|
+        result = (result && body[key].include?(val)) if val.is_a?(String)
+      end unless payload.nil?
+    end
+
+    (actual.status == 200 && result)
+  end
+end
+
+RSpec::Matchers.define :be_404 do
+  match do |actual|
+    (actual.status == 404 &&
+     parse_json(actual.body)[:message] == "Not found!")
+  end
+end
+
+RSpec::Matchers.define :be_401 do
+  match do |actual|
+    (actual.status == 401 &&
+     parse_json(actual.body)[:message] == "Unauthorized!")
+  end
+end
+
+RSpec::Matchers.define :be_400 do
+  match do |actual|
+    (actual.status == 400 &&
+     parse_json(actual.body)[:message] == "Bad request!")
+  end
+end
+
+
+describe Diaspora::Backbone::Endpoints do
+  include Warden::Test::Helpers
+  Warden.test_mode!
+
+  let(:browser) { Rack::Test::Session.new(Rack::MockSession.new(described_class, "backbone.test")) }
+  # beware: this is cached within the same example!
+  # use `browser.last_response` if you have to follow a redirect or send multiple requests
+  let(:response) { browser.last_response }
+
+  after do
+    Warden.test_reset!
+  end
+
+  context "base" do
+    it "responds with json at the root" do
+      browser.get("/")
+      response.should be_successful({message: "internal diaspora* Backbone.js API"})
+      response.should be_json
+    end
+
+    it "responds with 404 json at misc paths" do
+      browser.get("/abc")
+      browser.last_response.should be_404
+      browser.last_response.should be_json
+
+      browser.get("/a-b-c")
+      browser.last_response.should be_404
+      browser.last_response.should be_json
+
+      browser.get("/a/b/c")
+      browser.last_response.should be_404
+      browser.last_response.should be_json
+    end
+  end
+
+  context "conversations" do
+    describe "GET" do
+      before do
+        @user_empty = FactoryGirl.create(:user)
+        @user = FactoryGirl.create(:user)
+        @c1 = FactoryGirl.create(:conversation, author: @user.person)
+        @c2 = FactoryGirl.create(:conversation, author: @user.person)
+      end
+
+      it "fails if not logged in" do
+        browser.get("/conversations")
+        browser.follow_redirect!
+        browser.last_response.should be_401
+      end
+
+      it "returns an empty array if the user has no conversations" do
+        login_as(@user_empty)
+        browser.get("/conversations")
+
+        response.should be_json
+        response.should be_successful
+        parse_json(response.body).should eql []
+      end
+
+      it "returns the conversations as json" do
+        login_as(@user)
+        browser.get("/conversations")
+
+        response.should be_json
+        response.should be_successful
+        parse_json(response.body).map { |c| c[:id] }.should include(@c1.id, @c2.id)
+      end
+    end
+
+    describe "POST" do
+      before do
+        @create_hash = {
+          contact_ids: [alice.contacts.pluck(:id)],
+          conversation: {
+            subject: "test subject",
+            text: "test text test text", # this is not the actual text
+            message: {
+              text: "asdf test asdf text" # this is the actual text
+            }
+          }
+        }
+      end
+
+      it "fails if not logged in" do
+        browser.post("/conversations", {})
+        browser.follow_redirect!
+        browser.last_response.should be_401
+      end
+
+      it "fails if the params are incomplete" do
+        login_as(alice)
+        browser.post("/conversations", {not_a_conversation: true})
+        response.should be_400
+      end
+
+      it "creates a conversation" do
+        login_as(alice)
+        lambda {
+          browser.post("/conversations", @create_hash)
+        }.should change(Conversation, :count).by(1)
+        parse_json(response.body)[:subject].should eql("test subject")
+      end
+
+      it "creates a message" do
+        login_as(alice)
+        lambda {
+          browser.post("/conversations", @create_hash)
+        }.should change(Message, :count).by(1)
+      end
+
+      it "sets the author to the logged in user" do
+        login_as(alice)
+        browser.post("/conversations", @create_hash)
+        parse_json(response.body)[:author][:id].should eql(alice.person.id)
+      end
+
+      it "dispatches the conversation" do
+        login_as(alice)
+        alice.should_receive(:dispatch!)
+        browser.post("/conversations", @create_hash)
+      end
+    end
+
+    describe "DELETE" do
+      before do
+        @conversation = FactoryGirl.create(:conversation_with_message, author: bob.person)
+      end
+
+      it "fails if not logged in" do
+        lambda {
+          browser.delete("/conversations/#{@conversation.id}/visibility")
+        }.should_not change(ConversationVisibility, :count)
+        browser.follow_redirect!
+        browser.last_response.should be_401
+      end
+
+      it "deletes the visibility" do
+        login_as(bob)
+        lambda {
+          browser.delete("/conversations/#{@conversation.id}/visibility")
+        }.should change(ConversationVisibility, :count).by(-1)
+        response.should be_successful
+      end
+
+      it "doesn't destroy other users visibilities" do
+        login_as(alice)
+        lambda {
+          browser.delete("/conversations/#{@conversation.id}/visibility")
+        }.should_not change(ConversationVisibility, :count)
+        response.should_not be_successful
+      end
+    end
+
+    context "messages" do
+      describe "GET" do
+        before do
+          @conv_no_msg  = FactoryGirl.create(:conversation, author: bob.person)
+          @conversation = FactoryGirl.create(:conversation_with_message, author: alice.person)
+        end
+
+        it "fails if not logged in" do
+          browser.get("/conversations/#{@conversation.id}/messages")
+          browser.follow_redirect!
+          browser.last_response.should be_401
+        end
+
+        it "responds with 404 when a conversation can't be found" do
+          login_as(eve)
+          browser.get("/conversations/#{@conv_no_msg.id}/messsages")
+
+          response.should be_404
+          response.should be_json
+        end
+
+        it "returns an empty array if the users conversation has no messages" do
+          login_as(bob)
+          browser.get("/conversations/#{@conv_no_msg.id}/messages")
+
+          response.should be_json
+          response.should be_successful
+          parse_json(response.body).should eql []
+        end
+
+        it "returns the messages as json" do
+          login_as(alice)
+          browser.get("/conversations/#{@conversation.id}/messages")
+
+          response.should be_json
+          response.should be_successful
+          parse_json(response.body).map { |m| m[:id] }.should include(*@conversation.messages.pluck(:id))
+        end
+      end
+
+      describe "POST" do
+        before do
+          @conv = FactoryGirl.create(:conversation, author: eve.person)
+          @create_hash = { message: { text: "testing message text" } }
+        end
+
+        it "fails if not logged in" do
+          browser.post("/conversations/#{@conv.id}/messages", {})
+          browser.follow_redirect!
+          browser.last_response.should be_401
+        end
+
+        it "responds with 404 when conversation can't be found" do
+          login_as(alice)
+          browser.post("/conversations/#{@conv.id}/messages", {})
+
+          response.should be_404
+          response.should be_json
+        end
+
+        it "fails if the params are incomplete" do
+          login_as(eve)
+          browser.post("/conversations/#{@conv.id}/messages", {not_a_message: true})
+          response.should be_400
+        end
+
+        it "creates a message on one's own conversation" do
+          login_as(eve)
+          lambda {
+            browser.post("/conversations/#{@conv.id}/messages", @create_hash)
+          }.should change(@conv.messages, :count).by(1)
+          parse_json(response.body)[:text].should eql("testing message text")
+        end
+
+        it "sets the author to the logged in user" do
+          login_as(eve)
+          browser.post("/conversations/#{@conv.id}/messages", @create_hash)
+          parse_json(response.body)[:author][:id].should eql(eve.person.id)
+        end
+
+        it "dispatches the conversation" do
+          login_as(eve)
+          eve.should_receive(:dispatch!)
+          browser.post("/conversations/#{@conv.id}/messages", @create_hash)
+        end
+
+        context "different user" do
+          before do
+            @conv.participants << bob.person
+            @conv.save
+          end
+
+          it "creates a message on someone else's conversation" do
+            login_as(bob)
+            lambda {
+              browser.post("/conversations/#{@conv.id}/messages", @create_hash)
+            }.should change(@conv.messages, :count).by(1)
+          end
+
+          it "sets the other user's authorship" do
+            login_as(bob)
+            @create_hash[:message][:text] += " by bob"
+            browser.post("/conversations/#{@conv.id}/messages", @create_hash)
+
+            result = parse_json(response.body)
+            result[:author][:id].should eql(bob.person.id)
+            result[:text].should eql("testing message text by bob")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -552,6 +552,19 @@ describe User do
     end
   end
 
+  describe '#dispatch!' do
+    it 'passes stuff to the dispatcher' do
+      p = FactoryGirl.create(:status_message, author: bob.person, public: true)
+      Postzord::Dispatcher.should_receive(:defer_build_and_post).with(bob, p, anything()).once
+
+      bob.dispatch!(p)
+    end
+
+    it 'raises when the object has no guid' do
+      expect { bob.dispatch!({}) }.to raise_error
+    end
+  end
+
   describe '#notify_if_mentioned' do
     before do
       @post = FactoryGirl.build(:status_message, :author => bob.person)


### PR DESCRIPTION
This is my latest brain-storming...
- introducing new (JSON-only) private API for backbone.js requests - utilizing a vendor-specific `Accept` header for the request
- using a mounted Sinatra app to keep overhead as small as possible - the Rack stack will have been set up by Rails, only the test env requires some manual Rack stacking
- making presenters more versatile ( - `#base_hash` mustn't require associated records, `#full_hash` may include them)

TODO:
- JS
- UI
  (duh...)

please comment and brainstorm with me, whether this makes any sense...
