### PR TITLE
Put the stream first in the left menu

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@
 * Refactor the Twitter service model [#4387](https://github.com/diaspora/diaspora/pull/4387)
 * Refactor ConversationsController#create, move more stuff to User model [#4551](https://github.com/diaspora/diaspora/pull/4551)
 * Refactor MessagesController#create, move stuff to User model [#4556](https://github.com/diaspora/diaspora/pull/4556)
+* Reorder the left bar side menu to put the stream first [#4569](https://github.com/diaspora/diaspora/pull/4569)
 
 ## Bug fixes
 * Highlight down arrow at the user menu on hover [#4441](https://github.com/diaspora/diaspora/pull/4441)

--- a/app/assets/stylesheets/sidebar.css.scss
+++ b/app/assets/stylesheets/sidebar.css.scss
@@ -3,6 +3,7 @@ $bluebg: #e7f2f7;
 #home_user_badge {
 	min-height: 50px;
 	margin-bottom: 20px;
+	margin-left: 4px;
 
 	img {
 		float: left;
@@ -44,7 +45,7 @@ $bluebg: #e7f2f7;
 	.hoverable {
 		display: block;
 		margin-right: 6px;
-		padding: 4px 4px 4px 0;
+		padding: 4px;
 		&:hover { background-color: $bluebg; }
 	}
 

--- a/app/views/streams/main_stream.html.haml
+++ b/app/views/streams/main_stream.html.haml
@@ -29,12 +29,12 @@
       = link_to current_user.first_name, local_or_remote_person_path(current_user.person)
 
   %ul#stream_selection
+    %li.hoverable{:data => {:stream => 'stream'}}
+      = link_to t("streams.multi.title"), stream_path, :rel => 'backbone'
     %li.hoverable{:data => {:stream => 'activity'}}
       = link_to t("streams.activity.title"), activity_stream_path, :rel => 'backbone'
     %li.hoverable{:data => {:stream => 'mentions'}}
       = link_to t('streams.mentions.title'), mentioned_stream_path, :rel => 'backbone'
-    %li.hoverable{:data => {:stream => 'stream'}}
-      = link_to t("streams.multi.title"), stream_path, :rel => 'backbone'
     %li.all_aspects
       = render 'aspects/aspect_listings', :stream => @stream
     %li


### PR DESCRIPTION
This PR put the Stream link first in the left sidebar menu. This seems more coherent to me: the stream is the default page, and is first in the header too.
