### PR TITLE
full screen design

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -1835,7 +1835,16 @@ h1.tag
     :font
       :weight bold
 
+.container
+  :width 100%
+#container
+  :margin-top 12px
+.main-container
+  :padding 0 200px
+  
 .rightBar
+  :float right
+  
   .title
     :position relative
     :border

--- a/app/views/layouts/centered_with_header_with_footer.html.haml
+++ b/app/views/layouts/centered_with_header_with_footer.html.haml
@@ -1,5 +1,5 @@
 - content_for :container_content do
-    .span-24.last
+    #container.last
         = yield
 
 = render template: "layouts/with_header_with_footer"

--- a/app/views/streams/main_stream.html.haml
+++ b/app/views/streams/main_stream.html.haml
@@ -41,11 +41,6 @@
       = render 'tags/followed_tags_listings'
 
 
-
-.span-13.append-1
-  #aspect_stream_container.stream_container
-    = render 'aspects/aspect_stream', :stream => @stream
-
 .span-5.rightBar.last
   #selected_aspect_contacts.section
     .title.no_icon
@@ -57,3 +52,8 @@
 
   %a{:id=>"back-to-top", :title=>"#{t('layouts.application.back_to_top')}", :href=>"#"}
     &#8679;
+
+
+.append-1.main-container
+  #aspect_stream_container.stream_container
+    = render 'aspects/aspect_stream', :stream => @stream


### PR DESCRIPTION
This is just an example of how easy it is to modify diaspora design to use all the width of the screen. This is not responsive, and I think that it's not the good way to do it: we probably should port everything to bootstrap first and then build a solid design on sane basis. **But** I have the feeling that if we wait for that, we will not see this done before next summer.

So I create this pull request to hear about opinions. If you think that this way is not too dirty and that we will need to rewrite that anyway when we will port everything to bootstrap, I'm sure I'm able to have something mergeable before the end of the week. Just to let you know :P
