### PR TITLE
Add indication about markdown formatting in the publisher

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -56,6 +56,7 @@ A new feature [has been added](https://github.com/diaspora/diaspora/pull/4602) t
 * Improve the management of the contacts visibility settings in an aspect [#4567](https://github.com/diaspora/diaspora/pull/4567)
 * Add actions on aspects on the contact page [#4570](https://github.com/diaspora/diaspora/pull/4570)
 * Added a statistics route with general pod information, and if enabled in pod settings, total user, half year/monthly active users and local post counts [#4602](https://github.com/diaspora/diaspora/pull/4602)
+* Add indication about markdown formatting in the publisher [#4589](https://github.com/diaspora/diaspora/pull/4589)
 
 # 0.2.0.1
 

--- a/app/assets/stylesheets/publisher.css.scss
+++ b/app/assets/stylesheets/publisher.css.scss
@@ -261,10 +261,9 @@
 }
 
 #publisher.closed {
-  #publisher_textarea_wrapper {
-    #hide_publisher {
-      display: none;
-    }
+  #publisher_textarea_wrapper #hide_publisher,
+  .markdownIndications {
+    display: none;
   }
 }
 
@@ -277,6 +276,8 @@
 }
 
 #publisher-images {
+  padding-left: 5px;
+
   #locator {
     bottom: 1px !important;
     display: inline-block;

--- a/app/views/shared/_publisher.html.haml
+++ b/app/views/shared/_publisher.html.haml
@@ -27,7 +27,7 @@
 
             #publisher-images
               %span.markdownIndications
-                != t('.formatWithMarkdown', link: link_to('markdown', 'https://diasporafoundation.org/formatting'))
+                != t('.formatWithMarkdown', markdown_link: link_to(t('help.markdown'), 'https://diasporafoundation.org/formatting', target: :blank))
               #locator.btn{:title => t('.get_location')}
                 = image_tag 'icons/marker.png', :alt => t('.get_location').titleize, :class => 'publisher_image'
               #file-upload.btn{:title => t('.upload_photos')}

--- a/app/views/shared/_publisher.html.haml
+++ b/app/views/shared/_publisher.html.haml
@@ -26,6 +26,8 @@
             = status.hidden_field :text, :value => h(publisher_hidden_text), :class => 'clear_on_submit'
 
             #publisher-images
+              %span.markdownIndications
+                != t('.formatWithMarkdown', link: link_to('markdown', 'https://diasporafoundation.org/formatting'))
               #locator.btn{:title => t('.get_location')}
                 = image_tag 'icons/marker.png', :alt => t('.get_location').titleize, :class => 'publisher_image'
               #file-upload.btn{:title => t('.upload_photos')}

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -992,6 +992,7 @@ en:
         one: "In %{count} aspect"
         other: "In %{count} aspects"
     publisher:
+      formatWithMarkdown: "You can use %{link} to format your post"
       posting: "Posting..."
       share: "Share"
       preview: "Preview"

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -992,7 +992,7 @@ en:
         one: "In %{count} aspect"
         other: "In %{count} aspects"
     publisher:
-      formatWithMarkdown: "You can use %{link} to format your post"
+      formatWithMarkdown: "You can use %{markdown_link} to format your post"
       posting: "Posting..."
       share: "Share"
       preview: "Preview"

--- a/features/desktop/posts_from_main_page.feature
+++ b/features/desktop/posts_from_main_page.feature
@@ -17,6 +17,14 @@ Feature: posting from the main page
       And I have user with username "alice" in an aspect called "PostingTo"
       And I have user with username "alice" in an aspect called "NotPostingThingsHere"
       And I am on the home page
+      
+    Scenario: expanding the publisher
+      Given ".markdownIndications" is hidden
+      And ".options_and_submit" is hidden
+      When I expand the publisher
+      Then I should see "You can use Markdown to format your post" within "#publisher-images"
+      Then I should see "All Aspects" within ".options_and_submit"
+      Then I should see "Preview" within ".options_and_submit"
 
     Scenario: post a text-only message to all aspects
       Given I expand the publisher

--- a/features/step_definitions/custom_web_steps.rb
+++ b/features/step_definitions/custom_web_steps.rb
@@ -267,3 +267,8 @@ end
 Then /^I should see the Bitcoin address$/ do
   find("#bitcoin_address")['value'].should == "AAAAAA"
 end
+
+Given /^"([^"]*)" is hidden$/ do |selector|
+  page.should have_selector(selector, visible: false)
+  page.should_not have_selector(selector)
+end


### PR DESCRIPTION
This pull request add an indication at the bottom of the publisher to inform the user that he can use markdown to format his post. There is a link to https://diasporafoundation.org/formatting.

![markdown2](https://f.cloud.github.com/assets/930064/1535739/e7acc892-4ca7-11e3-9fee-11c1802dd40f.png)

The indication is hidden when the publisher is closed, so in this case, it looks exactly the same than before this PR.
