### PR TITLE
Add lightbox html to unauthenticated header

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -35,6 +35,7 @@
 * Force comments sort order in mobile spv [#4578](https://github.com/diaspora/diaspora/pull/4578)
 * Fix getting started page for mobile [#4536](https://github.com/diaspora/diaspora/pull/4536)
 * Refactor mobile header, fix [#4579](https://github.com/diaspora/diaspora/issues/4579)
+* Add lightbox to unauthenticated header, fix [#4432](https://github.com/diaspora/diaspora/issues/4432)
 
 ## Features
 * Add oEmbed content to the mobile view [#4343](https://github.com/diaspora/diaspora/pull/4353)

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -11,3 +11,11 @@
         - unless current_page?(controller: :registrations, action: :new)
           %li= link_to t('devise.shared.links.sign_up'), new_user_registration_path, class: 'login'
         %li= link_to t('devise.shared.links.sign_in'), new_user_session_path, class: 'login'
+      #lightbox
+        #lightbox-content
+          %a#lightbox-close-link(href='#')
+            [x]
+            =t('javascripts.header.close')
+          %img#lightbox-image
+          #lightbox-imageset
+      #lightbox-backdrop


### PR DESCRIPTION
This fixes #4432.  The problem was that in the authenticated backbone header view, the lightbox div is there in the html, but it wasn't in the unauthenticated haml header view.  I can also move the unauthenticated view to backbone instead, we just have to move the "Sign up" and "Sign in" translations.  Also not sure about where a test for "there should be a #lightbox div" should go.
