### PR TITLE
Fix "more picture" indication (+n) on mobile by adding a link on the indication

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -35,6 +35,7 @@
 * Force comments sort order in mobile spv [#4578](https://github.com/diaspora/diaspora/pull/4578)
 * Fix getting started page for mobile [#4536](https://github.com/diaspora/diaspora/pull/4536)
 * Refactor mobile header, fix [#4579](https://github.com/diaspora/diaspora/issues/4579)
+* Fix "more picture" indication (+n) on mobile by adding a link on the indication [#4592](https://github.com/diaspora/diaspora/pull/4592)
 
 ## Features
 * Add oEmbed content to the mobile view [#4343](https://github.com/diaspora/diaspora/pull/4353)

--- a/app/views/shared/_photo_area.mobile.haml
+++ b/app/views/shared/_photo_area.mobile.haml
@@ -6,10 +6,11 @@
   - if post.is_a?(StatusMessage)
     -if post.photos.size > 0
       .photo_attachments
-        - if post.photos.size > 1
-          .additional_photo_count
-            = "+ #{post.photos.size-1}"
-        = link_to (image_tag post.photos.first.url(:thumb_large), :class => "stream-photo big-stream-photo"), person_photo_path(post.author, post.photos.first), :class => "stream-photo-link"
+        = link_to person_photo_path(post.author, post.photos.first), class: "stream-photo-link" do
+          - if post.photos.size > 1
+            .additional_photo_count
+              = "+ #{post.photos.size-1}"
+          = image_tag post.photos.first.url(:thumb_large), class: "stream-photo big-stream-photo"
   - elsif post.activity_streams?
     = image_tag post.image_url
 


### PR DESCRIPTION
![1](https://f.cloud.github.com/assets/930064/1556042/8f2d3a0c-4ea6-11e3-867c-6692477540da.png)

This +1 block was the only part of the picture which was not clickable, the opposite of the expected behavior...
