### PR TITLE
Improve notifications and conversations views design on mobile

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@
 * Refactor ConversationsController#create, move more stuff to User model [#4551](https://github.com/diaspora/diaspora/pull/4551)
 * Refactor MessagesController#create, move stuff to User model [#4556](https://github.com/diaspora/diaspora/pull/4556)
 * Reorder the left bar side menu to put the stream first [#4569](https://github.com/diaspora/diaspora/pull/4569)
+* Improve notifications and conversations views design on mobile [#4593](https://github.com/diaspora/diaspora/pull/4593)
 
 ## Bug fixes
 * Highlight down arrow at the user menu on hover [#4441](https://github.com/diaspora/diaspora/pull/4441)

--- a/app/assets/stylesheets/mobile.css.scss
+++ b/app/assets/stylesheets/mobile.css.scss
@@ -674,6 +674,7 @@ select {
 .notifications {
   list-style: none;
   margin: 0px;
+  clear: right;
 }
 
 .notifications_for_day {

--- a/app/assets/stylesheets/mobile.css.scss
+++ b/app/assets/stylesheets/mobile.css.scss
@@ -7,8 +7,7 @@
 
 a {
   color: #2489ce;
-  text: {
-    decoration: none; };
+  text-decoration: none;
 }
 
 body {
@@ -21,9 +20,12 @@ body {
   padding-top: 55px;
 }
 
+h3 {
+  margin-top: 0px;
+}
+
 .message {
-  padding: {
-    left: 2px; };
+  padding-left: 2px;
 }
 
 .stream_element,
@@ -306,7 +308,8 @@ body {
     color: $text-grey; } }
 
 .right {
-  float: right; }
+  float: right;
+}
 
 header {
   position: fixed;
@@ -670,6 +673,11 @@ select {
 
 .notifications {
   list-style: none;
+  margin: 0px;
+}
+
+.notifications_for_day {
+  margin-left: 12px;
 }
 
 .notification_day_header {
@@ -696,10 +704,6 @@ display: inline-block;
     margin: 0 2px;
     position: relative;
     width: 28px;
-}
-
-#conversation_inbox {
-  margin: 10px 0 0 10px;
 }
 
 .message_count {
@@ -786,7 +790,6 @@ form#new_conversation.new_conversation {
   border-bottom: 1px solid $border-dark-grey;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
   border-radius: 5px;
-  margin: 5px 0 5px 15px;
   padding: 5px 10px;
   h4 {
     font-size: 14px;

--- a/app/views/layouts/application.mobile.haml
+++ b/app/views/layouts/application.mobile.haml
@@ -68,11 +68,10 @@
             = link_to(image_tag('icons/compose_mobile2.png', class: 'compose_icon'), new_status_message_path)
 
     #main.container{:role => "main"}
-      .row
-        - if current_page?(:activity_stream)
-          %h3
-            = t('streams.activity.title')
-        = yield
+      - if current_page?(:activity_stream)
+        %h3
+          = t('streams.activity.title')
+      = yield
 
     - if user_signed_in?
       = render :partial =>'shared/footer'

--- a/app/views/notifications/index.mobile.haml
+++ b/app/views/notifications/index.mobile.haml
@@ -4,7 +4,7 @@
 %h3
   = t('.notifications')
 
-%ul.stream.notifications
+%ul.notifications
   - @group_days.each do |day, notes|
     %li
       .notification_day_header

--- a/app/views/notifications/index.mobile.haml
+++ b/app/views/notifications/index.mobile.haml
@@ -1,8 +1,8 @@
-.right
-  = link_to t('.mark_all_as_read'), notifications_read_all_path, :class => 'btn'
-
 %h3
   = t('.notifications')
+
+.right
+  = link_to t('.mark_all_as_read'), notifications_read_all_path, :class => 'btn'
 
 %ul.notifications
   - @group_days.each do |day, notes|

--- a/features/mobile/multiphoto.feature
+++ b/features/mobile/multiphoto.feature
@@ -17,7 +17,7 @@ Feature: viewing photos on the mobile main page
     When I press "Share"
     And I click on selector "img.stream-photo"
     Then I should see a "img" within "#show_content"
-    And I should not see a "#right" within ".row"
+    And I should not see a "#right" within "#main"
 
   Scenario: view multiphoto post
     Given I attach the file "spec/fixtures/button.png" to hidden "file" within "#file-upload-publisher"


### PR DESCRIPTION
Small improvements to the conversation and notification views on mobile

Before:
![conversation-before](https://f.cloud.github.com/assets/930064/1556117/9545a0a2-4eae-11e3-8580-bd8e22e7600b.png)
After: 
![conversation-after](https://f.cloud.github.com/assets/930064/1556116/8c2f2aba-4eae-11e3-85ef-39530352dff8.png)

Before:
![notification-before](https://f.cloud.github.com/assets/930064/1556118/9d733b72-4eae-11e3-9955-3e1d9dcaf8dc.png)
After:
![notification-after](https://f.cloud.github.com/assets/930064/1556120/d226a264-4eae-11e3-9eda-0b85f27a1d29.png)
