### PR TITLE
Allow additional profile fields (previously private profile) to be set public

### DIFF
--- a/app/assets/stylesheets/profile.css.scss
+++ b/app/assets/stylesheets/profile.css.scss
@@ -123,3 +123,12 @@
     }
   }
 }
+
+#update_profile_form {
+  .additional-visibility-icon {
+    cursor: pointer;
+  }
+  #profile_is_public {
+    display: none;
+  }
+}

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -40,6 +40,7 @@ class ProfilesController < ApplicationController
     #checkbox tags wtf
     @profile_attrs[:searchable] ||= false
     @profile_attrs[:nsfw] ||= false
+    @profile_attrs[:is_public] ||= false
 
     if params[:photo_id]
       @profile_attrs[:photo] = Photo.where(:author_id => current_user.person_id, :id => params[:photo_id]).first
@@ -80,6 +81,6 @@ class ProfilesController < ApplicationController
   end
 
   def profile_params
-    params.require(:profile).permit(:first_name, :last_name, :gender, :bio, :location, :searchable, :tag_string, :nsfw, :date => [:year, :month, :day]) || {}
+    params.require(:profile).permit(:first_name, :last_name, :gender, :bio, :location, :searchable, :tag_string, :nsfw, :is_public, :date => [:year, :month, :day]) || {}
   end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -31,7 +31,7 @@ class Person < ActiveRecord::Base
   has_one :profile, :dependent => :destroy
   delegate :last_name, :image_url, :tag_string, :bio, :location,
            :gender, :birthday, :formatted_birthday, :tags, :searchable,
-           to: :profile
+           :is_public, to: :profile
   accepts_nested_attributes_for :profile
 
   before_validation :downcase_diaspora_handle

--- a/app/views/people/_profile_sidebar.html.haml
+++ b/app/views/people/_profile_sidebar.html.haml
@@ -29,33 +29,35 @@
 
       %br 
 
-    -if contact.sharing? || person == current_user.person
-      %ul#profile_information
-      
-        - unless person.bio.blank?
-          %li
-            %h4
-              =t('.bio')
-            %div{ :class => direction_for(person.bio) }
-              = markdownify(person.profile.bio, :oembed => true, :newlines => true)
-        - unless person.profile.location.blank?
-          %li
-            %h4
-              =t('.location')
-            %div{ :class => direction_for(person.location) }
-              = markdownify(person.location, :oembed => true, :newlines => true)
+  - if person.is_public || (user_signed_in? && (contact.sharing? || person == current_user.person))
+    %ul#profile_information
+    
+      - unless person.bio.blank?
+        %li
+          %h4
+            =t('.bio')
+          %div{ :class => direction_for(person.bio) }
+            = markdownify(person.profile.bio, :oembed => true, :newlines => true)
+      - unless person.profile.location.blank?
+        %li
+          %h4
+            =t('.location')
+          %div{ :class => direction_for(person.location) }
+            = markdownify(person.location, :oembed => true, :newlines => true)
 
-        - unless person.gender.blank?
-          %li
-            %h4
-              =t('.gender')
-            = person.gender
+      - unless person.gender.blank?
+        %li
+          %h4
+            =t('.gender')
+          = person.gender
 
-        - unless person.birthday.blank?
-          %li
-            %h4
-              =t('.born')
-            = birthday_format(person.birthday)
+      - unless person.birthday.blank?
+        %li
+          %h4
+            =t('.born')
+          = birthday_format(person.birthday)
+          
+      - if user_signed_in? && (contact.sharing? || person == current_user.person)
         - if @photos.present?
           %li.image_list
             %h4
@@ -66,7 +68,6 @@
               = image_tag(photo.url(:thumb_small))
             %br
               = link_to t('layouts.header.view_all'),  person_photos_path(person)
-  
         - if person == current_user.person
           %li.image_list
             %h4
@@ -88,5 +89,5 @@
                 = person_image_link person, :size => :thumb_small
               %p.see_all= link_to t('layouts.header.view_all'), person_contacts_path(@person)
 
-        %br
-        %br
+      %br
+      %br

--- a/app/views/profiles/_edit.haml
+++ b/app/views/profiles/_edit.haml
@@ -9,10 +9,22 @@
   = render 'profiles/edit_public', :profile => profile, :aspect => aspect, :person => person
 
   %hr
+  :javascript
+    $(document).ready(function () {
+      $('.additional-visibility-icon').click(function() {
+        $('input#profile_is_public').prop('checked', ! $('input#profile_is_public').prop('checked'));
+        $('.additional-visibility-icon').toggle();
+      });
+    });
+  %h3{:class=>"inline"}
+    = t('profiles.edit.additional')
+  = image_tag 'icons/globe.png', class: 'additional-visibility-icon', style: ('display:none;' if ! profile.is_public)
+  = image_tag 'icons/padlock-closed.png', class: 'additional-visibility-icon', style: ('display:none;' if profile.is_public)
+  %span{ :rel => 'facebox', :title => t('profiles.edit.additional_hint') }
+    = image_tag 'icons/monotone_question.png'
+  = check_box_tag 'profile[is_public]', true, profile.is_public
   %br
-  %h3
-    = t('profiles.edit.your_private_profile')
-
+  %br
 
   %h4
     = t('profiles.edit.your_bio')
@@ -40,7 +52,15 @@
 
   %br
   %br
+  
+  %hr
+  %h3{:class=>"inline"}
+    = t('profiles.edit.settings')
+  = image_tag 'icons/padlock-closed.png'
 
+  %br
+  %br
+  
   %h4
     = t('search')
 

--- a/app/views/profiles/_edit_public.haml
+++ b/app/views/profiles/_edit_public.haml
@@ -34,8 +34,11 @@
       });
     });
 
-%h3
-  = t('profiles.edit.your_public_profile')
+%h3{:class=>"inline"}
+  = t('profiles.edit.basic')
+= image_tag 'icons/globe.png'
+%br
+%br
 
 = error_messages_for profile
 

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -855,8 +855,10 @@ en:
 
   profiles:
     edit:
-      your_public_profile: "Your public profile"
-      your_private_profile: "Your private profile"
+      basic: "Basic"
+      additional: "Additional"
+      settings: "Profile settings"
+      additional_hint: "Click the globe or the padlock to set your additional profile data visibility. The globe means it is public (to the internet), the padlock means only people who you share with will see this information."
       your_name: "Your name"
       first_name: "First name"
       last_name: "Last name"

--- a/db/migrate/20131116222339_add_public_to_profiles.rb
+++ b/db/migrate/20131116222339_add_public_to_profiles.rb
@@ -1,0 +1,5 @@
+class AddPublicToProfiles < ActiveRecord::Migration
+  def change
+    add_column :profiles, :is_public, :boolean, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130801063213) do
+ActiveRecord::Schema.define(:version => 20131116222339) do
 
   create_table "account_deletions", :force => true do |t|
     t.string  "diaspora_handle"
@@ -347,6 +347,7 @@ ActiveRecord::Schema.define(:version => 20130801063213) do
     t.string   "location"
     t.string   "full_name",        :limit => 70
     t.boolean  "nsfw",                            :default => false
+    t.boolean  "is_public",                       :default => false
   end
 
   add_index "profiles", ["full_name", "searchable"], :name => "index_profiles_on_full_name_and_searchable"


### PR DESCRIPTION
Change wording of profile sections to Basic and Additional. Add helper icons and rollover text to hint on visibility.

NOTE! Not ready for merge - some work to do on help pages and I haven't even looked at tests yet. Just here for initial review, whether this is even wanted (needed it myself).

See for example change running on my pod, my now public profile: https://iliketoast.net/u/jaywink

In the below screenshots, I realize now it's confusing that the globe and the padlock are not visible at the same time. The way it goes, you click the padlock in the Additional section and it turns into the globe, and if you click the globe, it turns to a padlock. The other two icons (globe for Basic data and padlock for Settings) are not clickable.

I didn't use a toggle slider as Flaburgan suggested since D\* doesn't have any in use yet and I feel visual makeovers should be done in a separate stage.

Edit profile page - Basic (old Public Profile) and Additional (old Private Profile) sections visible, with additional set to public (the globe, by default it is limited = padlock, for new and existing profiles).

![pic](http://i.imgur.com/QEYfjGK.png)

The lower part, didn't have a title before and thus was confusingly mixed with Public Profile - now titled Profile Settings, with padlock to show it's not public data.

![pic](http://i.imgur.com/v4IwyRs.png)

Hint rollover in Additional section - wording is not very good at the moment..

![pic](http://i.imgur.com/PYm7MqY.png)
