### PR TITLE
Fix path ignores in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 #trademark sillyness
 app/views/home/_show.*
-app/assets/images/custom/*
+app/assets/images/custom/
 
 
 # Configuration files
@@ -10,8 +10,8 @@ config/initializers/secret_token.rb
 config/redis.conf
 config/deploy_config.yml
 .bundle
-vendor/bundle/*
-vendor/cache/*
+vendor/bundle/
+vendor/cache/
 config/database.yml
 .rvmrc_custom
 .rvmrc.local
@@ -21,13 +21,13 @@ config/email_offset
 config/mailing_list.csv
 
 # Generated files
-log/*
+log/
 public/stylesheets/*.css
 public/diaspora
 spec/fixtures/*.y*ml
 spec/fixtures/*.fixture.*
-coverage/*
-xml_locales/*
+coverage/
+xml_locales/
 app/assets/images/branding-*.png
 app/assets/images/icons-*.png
 app/assets/images/social_media_logos-*.png
@@ -37,16 +37,16 @@ app/assets/images/social_media_logos-*.png
 doc/
 
 # Uploaded files and local files
-public/uploads/*
-public/assets/*
+public/uploads/
+public/assets/
 public/source.tar*
 public/.well-known
-tmp/**/*
-tmp/*
+tmp/**/
+tmp/
 *.sqlite3
 
 # Temporary files of every sort
-.sass-cache/*
+.sass-cache/
 .DS_Store
 .idea
 .redcar
@@ -65,7 +65,3 @@ dump.rdb
 
 #Rubinius's JIT
 *.rbc
-
-# Ignore precompiled assets
-# Heroku or Capistrano can and should regenerate them on every deploy
-public/assets


### PR DESCRIPTION
So to not ignore files inside the paths, but to ignore the path itself. Otherwise git clean -fd is scary as it says its removing them even if not.

Story: https://iliketoast.net/posts/124739

Also public/assets was duplicated.
