### PR TITLE
4446 webkit search spinner overlaps

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -528,7 +528,7 @@ form p.checkbox_select
 *::-webkit-input-placeholder
   @include placeholder_styles
 
-*:-moz-placeholder
+*::-moz-placeholder
   @include placeholder_styles
 
 .field_with_submit

--- a/app/assets/stylesheets/header.css.scss
+++ b/app/assets/stylesheets/header.css.scss
@@ -214,7 +214,8 @@ body > header {
         }
 
         &::-webkit-input-placeholder { text-shadow: none; }
-        &:-moz-placeholder { text-shadow: none; }
+        &::-moz-placeholder { text-shadow: none; }
+        &.ac_loading::-webkit-search-cancel-button { -webkit-appearance: none; }
       }
     }
   }


### PR DESCRIPTION
This hides the webkit cancel button when the spinner is visible. Also replaced deprecated pseudo class :-moz-placeholder with <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/::-moz-placeholder">::-moz-placeholder</a>.
