### PR TITLE
Change more comments link

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -60,6 +60,7 @@ For more details see https://wiki.diasporafoundation.org/Updating
 * Fix "more picture" indication (+n) on mobile by adding a link on the indication [#4592](https://github.com/diaspora/diaspora/pull/4592)
 * Display errors when photo upload fails [#4509](https://github.com/diaspora/diaspora/issues/4509)
 * Fix posting to Twitter by correctly catching exception [#4627](https://github.com/diaspora/diaspora/issues/4627)
+* Change "Show n more comments"-link, fix [#3119](https://github.com/diaspora/diaspora/issues/3119)
 
 ## Features
 * Add oEmbed content to the mobile view [#4343](https://github.com/diaspora/diaspora/pull/4353)

--- a/app/assets/templates/comment-stream_tpl.jst.hbs
+++ b/app/assets/templates/comment-stream_tpl.jst.hbs
@@ -1,7 +1,7 @@
 {{#unless all_comments_loaded}}
   <div class="show_comments comment {{#unless showExpandCommentsLink}} hidden {{/unless}}">
     <div class="media">
-      <a href="/posts/{{id}}/comments" class="toggle_post_comments">
+      <a href="/posts/{{id}}#comments" class="toggle_post_comments">
         {{t "stream.more_comments" count=moreCommentsCount}}
       </a>
     </div>


### PR DESCRIPTION
Fixes #3119 by changing the "more comments"-link. When following the link in a new tab it will show the SPV.
