### PR TITLE
Instead of redirect on signup form validation, render new

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -64,6 +64,7 @@ For more details see https://wiki.diasporafoundation.org/Updating
 * Change "Show n more comments"-link, fix [#3119](https://github.com/diaspora/diaspora/issues/3119)
 * Specify Firefox version for Travis-CI [#4623](https://github.com/diaspora/diaspora/pull/4623)
 * Remove location when publisher is cleared by user
+* On signup form errors, don't empty previous values by user, fix [#4663](https://github.com/diaspora/diaspora/issues/4663)
 
 ## Features
 * Add oEmbed content to the mobile view [#4343](https://github.com/diaspora/diaspora/pull/4353)

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -6,7 +6,7 @@ class RegistrationsController < Devise::RegistrationsController
   before_filter :check_registrations_open_or_vaild_invite!, :check_valid_invite!
 
   layout ->(c) { request.format == :mobile ? "application" : "with_header" }, :only => [:new]
-  before_filter -> { @css_framework = :bootstrap }, only: [:new]
+  before_filter -> { @css_framework = :bootstrap }, only: [:new, :create]
 
   def create
     @user = User.build(user_params)
@@ -22,7 +22,7 @@ class RegistrationsController < Devise::RegistrationsController
 
       flash[:error] = @user.errors.full_messages.join(" - ")
       Rails.logger.info("event=registration status=failure errors='#{@user.errors.full_messages.join(', ')}'")
-      redirect_to :back
+      render :action => 'new', :layout => 'with_header'
     end
   end
 

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -53,6 +53,8 @@ describe RegistrationsController do
   end
 
   describe "#create" do
+    render_views
+    
     context "with valid parameters" do
       before do
         AppConfig.settings.enable_registrations = true
@@ -107,9 +109,14 @@ describe RegistrationsController do
         flash[:error].should_not be_blank
       end
 
-      it "redirects back" do
+      it "renders new" do
         get :create, @invalid_params
-        response.should be_redirect
+        expect(response).to render_template("registrations/new")
+      end
+      
+      it "keeps invalid params in form" do
+        get :create, @invalid_params
+        expect(response.body).to match /jdoe@example.com/m
       end
     end
   end


### PR DESCRIPTION
Keeps submitted data. Fixes #4663.

However some problems.

1) The URL changes to /users since that is the POST url. This doesn't affect usability of the form as far as I can see (except maybe on an F5..). Is there some way to modify the routing system to take in registrations#create at /users/sign_up? Not sure I understand the Rails routing system especially with the Devise stuff on top.

2) Had to remove the `only: [:new]` from the `before_filter` as otherwise the CSS was not included correctly. Why and is this ok? :P 

Screenshot;
![pic](http://i.imgur.com/GKZdKc1.png)

Ps. Tests will fail I think, will fix once issues cleared up.
