### PR TITLE
Fix: remove location when publisher is cleared by user

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -63,6 +63,7 @@ For more details see https://wiki.diasporafoundation.org/Updating
 * Fix posting to Twitter by correctly catching exception [#4627](https://github.com/diaspora/diaspora/issues/4627)
 * Change "Show n more comments"-link, fix [#3119](https://github.com/diaspora/diaspora/issues/3119)
 * Specify Firefox version for Travis-CI [#4623](https://github.com/diaspora/diaspora/pull/4623)
+* Remove location when publisher is cleared by user
 
 ## Features
 * Add oEmbed content to the mobile view [#4343](https://github.com/diaspora/diaspora/pull/4353)

--- a/app/assets/javascripts/app/views/publisher_view.js
+++ b/app/assets/javascripts/app/views/publisher_view.js
@@ -141,9 +141,6 @@ app.views.Publisher = Backbone.View.extend({
 
     // clear state
     this.clear();
-
-    // clear location
-    this.destroyLocation();
   },
 
   // creates the location
@@ -282,6 +279,9 @@ app.views.Publisher = Backbone.View.extend({
 
     // disable submitting
     this.checkSubmitAvailability();
+
+    // clear location
+    this.destroyLocation();
 
     // force textchange plugin to update lastValue
     this.el_input.data('lastValue', '');

--- a/spec/javascripts/app/views/publisher_view_spec.js
+++ b/spec/javascripts/app/views/publisher_view_spec.js
@@ -105,6 +105,15 @@ describe("app.views.Publisher", function() {
         this.view.clear($.Event());
         expect(this.view.$("input[name='photos[]']").length).toBe(0);
       })
+
+      it("destroy location if exists", function(){
+        setFixtures('<div id="location"></div>');
+        this.view.view_locator = new app.views.Location({el: "#location"});
+
+        expect($("#location").length).toBe(1);
+        this.view.clear($.Event());
+        expect($("#location").length).toBe(0);
+      })
     });
 
     describe("createStatusMessage", function(){


### PR DESCRIPTION
When a post being written and containing a location is cleared (clicking the cross at the top right of the publisher), the location frame is not removed : 
![before](https://f.cloud.github.com/assets/2453133/1846396/a00297f4-75f3-11e3-9420-5fb1a15346e7.png)

This PR automatically removes the location in this case.
