### PR TITLE
bookmarklet publisher more usable

### DIFF
--- a/app/views/status_messages/bookmarklet.html.haml
+++ b/app/views/status_messages/bookmarklet.html.haml
@@ -15,10 +15,13 @@
     standalone: true
   });
 
-  var contents = "#{escape_javascript params[:title]} - #{escape_javascript params[:url]}";
-  var notes    = "#{escape_javascript params[:notes]}";
-  if (notes.length > 0){
-    contents = contents + " - " + notes;
+  var contents = "#{escape_javascript params[:content]}";
+  if(!contents){
+    contents  = "#{escape_javascript params[:title]} - #{escape_javascript params[:url]}";
+    var notes = "#{escape_javascript params[:notes]}";
+    if (notes.length > 0){
+      contents += " - " + notes;
+    }
   }
 
   $("#publisher").bind('ajax:success', function(){


### PR DESCRIPTION
Added another parameter to post without having contents separated by dashes. This makes the publisher more usable by external tools preserving the old parameters to use for the bookmarklet.
