### PR TITLE
Change NSFW explanation on profile settings page

### DIFF
--- a/app/views/profiles/_edit.haml
+++ b/app/views/profiles/_edit.haml
@@ -45,16 +45,19 @@
     = t('search')
 
   %p{:class=>"checkbox_select"}
-    = label_tag 'profile[searchable]', t('profiles.edit.allow_search')
     = check_box_tag 'profile[searchable]', true, profile.searchable
+    = label_tag 'profile[searchable]', t('profiles.edit.allow_search')
   %br
   %br
 
-  %h4= t('nsfw')
-  %p.nsfw_explanation=profile.nsfw? ? t('.you_are_nsfw') : t('.you_are_safe_for_work')
+  %h4
+    = t('nsfw')
+  = t('profiles.edit.nsfw_explanation')
   %p{:class=>"checkbox_select"}
-    = check_box_tag 'profile[nsfw]', true, profile.nsfw?
-    = label_tag 'profile[nsfw]', "nsfw?"
+    = check_box_tag 'profile[nsfw]', true, profile.nsfw
+    = label_tag 'profile[nsfw]', t('profiles.edit.nsfw_check')
+  = t('profiles.edit.nsfw_explanation2')
+  %br
   %br
   %br
 

--- a/app/views/profiles/_edit.haml
+++ b/app/views/profiles/_edit.haml
@@ -54,7 +54,7 @@
     = t('nsfw')
   = t('profiles.edit.nsfw_explanation')
   %p{:class=>"checkbox_select"}
-    = check_box_tag 'profile[nsfw]', true, profile.nsfw
+    = check_box_tag 'profile[nsfw]', true, profile.nsfw?
     = label_tag 'profile[nsfw]', t('profiles.edit.nsfw_check')
   = t('profiles.edit.nsfw_explanation2')
   %br

--- a/app/views/profiles/_edit.mobile.haml
+++ b/app/views/profiles/_edit.mobile.haml
@@ -43,11 +43,14 @@
     = check_box_tag 'profile[searchable]', true, profile.searchable
   %br
 
-  %h4= t('nsfw')
-  %p.nsfw_explanation=profile.nsfw? ? t('.you_are_nsfw') : t('.you_are_safe_for_work')
+  %h4
+    = t('nsfw')
+  = t('profiles.edit.nsfw_explanation')
   %p{:class=>"checkbox_select"}
-    = check_box_tag 'profile[nsfw]', true, profile.nsfw?
-    = label_tag 'profile[nsfw]', "nsfw?"
+    = check_box_tag 'profile[nsfw]', true, profile.nsfw
+    = label_tag 'profile[nsfw]', t('profiles.edit.nsfw_check')
+  = t('profiles.edit.nsfw_explanation2')
+  %br
   %br
 
   .submit_block

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -873,8 +873,9 @@ en:
       update_profile: "Update Profile"
       allow_search: "Allow for people to search for you within Diaspora"
       edit_profile: "Edit profile"
-      you_are_nsfw: "You have marked yourself not safe for work, your content will not show up in people who have opted out of seeing objectionable content's streams."
-      you_are_safe_for_work: "You have marked yourself as safe for work, this means you agree the content you post will agree with the community guidelines."
+      nsfw_explanation: "NSFW (‘not safe for work’) is diaspora*’s self-governing community standard for content which may not be suitable to view while at work. If you plan to share such material frequently, please check this option so that everything you share will be hidden from people’s streams unless they choose to view them."
+      nsfw_explanation2: "If you choose not to select this option, please add the #nsfw tag each time you share such material."
+      nsfw_check: "Mark everything I share as NSFW"
     update:
       updated: "Profile updated"
       failed: "Failed to update profile"

--- a/features/desktop/not_safe_for_work.feature
+++ b/features/desktop/not_safe_for_work.feature
@@ -7,14 +7,15 @@ Scenario: Setting not safe for work
     | pr0n king   | tommy@pr0n.xxx    |
   And I sign in as "tommy@pr0n.xxx"
   When I go to the edit profile page
-  And I should see the "you are safe for work" message
   And I mark myself as not safe for work
   And I submit the form
   Then I should be on the edit profile page
-  And I should see the "you are nsfw" message
-  When I mark myself as safe for work
+  And the "profile[nsfw]" checkbox should be checked
+  When I go to the edit profile page
+  And I mark myself as safe for work
   And I submit the form
-  Then I should see the "you are safe for work" message
+  Then I should be on the edit profile page
+  And the "profile[nsfw]" checkbox should not be checked
 
 Scenario: Toggling nsfw state
   #Nsfw users posts are marked nsfw

--- a/features/step_definitions/message_steps.rb
+++ b/features/step_definitions/message_steps.rb
@@ -5,10 +5,6 @@ Then /^I should see the "(.*)" message$/ do |message|
              I18n.translate('invitation_codes.excited', :name => @alice.name)
            when "welcome to diaspora"
              I18n.translate('users.getting_started.well_hello_there')
-           when 'you are safe for work'
-             I18n.translate('profiles.edit.you_are_safe_for_work')
-           when 'you are nsfw'
-             I18n.translate('profiles.edit.you_are_nsfw')
            when 'post not public'
              I18n.translate('error_messages.post_not_public_or_not_exist')
            else

--- a/features/step_definitions/profile_steps.rb
+++ b/features/step_definitions/profile_steps.rb
@@ -6,16 +6,3 @@ And /^I mark myself as safe for work$/ do
   uncheck('profile[nsfw]')
 end
 
-And /^the "profile[nsfw]" checkbox should be checked$/ do |label, selector|
-  with_scope(selector) do
-    field_checked = find_field(label)['checked']
-	field_checked.should be_true
-  end
-end
-
-And /^the "profile[nsfw]" checkbox should not be checked$/ do |label, selector|
-  with_scope(selector) do
-    field_checked = find_field(label)['checked']
-	field_checked.should be_false
-  end
-end

--- a/features/step_definitions/profile_steps.rb
+++ b/features/step_definitions/profile_steps.rb
@@ -5,3 +5,17 @@ end
 And /^I mark myself as safe for work$/ do
   uncheck('profile[nsfw]')
 end
+
+And /^the "profile[nsfw]" checkbox should be checked$/ do |label, selector|
+  with_scope(selector) do
+    field_checked = find_field(label)['checked']
+	field_checked.should be_true
+  end
+end
+
+And /^the "profile[nsfw]" checkbox should not be checked$/ do |label, selector|
+  with_scope(selector) do
+    field_checked = find_field(label)['checked']
+	field_checked.should be_false
+  end
+end


### PR DESCRIPTION
This PR provides new explanatory text for the NSFW setting, and removes the code which presented different text depending on NSFW setting.

I have made the changes to _edit.haml and _edit.mobile.haml

I have tested both desktop and mobile versions on a local server and everything works - settings page can be updated, and posts are hidden from the stream when NSFW has been selected, and appear again after it's been deselected. However, I would be grateful if someone would check the syntax/coding as this is the first time I've made a PR involving anything more than plain text or HTML changes.
