### PR TITLE
Disabling asset precompile for development environment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,5 +33,5 @@ Diaspora::Application.configure do
   config.assets.compress = false
 
   # Expands the lines which load the assets
-  config.assets.debug = true
+  config.assets.debug = false
 end


### PR DESCRIPTION
 Asset precompile makes page loading slower. So it should be disabled for development environment.  [Reference](http://dennisreimann.de/blog/precompiling-rails-assets-for-development/)
