### PR TITLE
Opengraph link fix (issue #4492)

### DIFF
--- a/app/assets/stylesheets/mobile/mobile.css.scss
+++ b/app/assets/stylesheets/mobile/mobile.css.scss
@@ -1127,23 +1127,25 @@ select#aspect_ids_ {
 
 .opengraph {
   width: 100%;
+  display: block;
+  text-decoration: none;
+  margin: 5px 0px 5px 0px;
+  border-top: solid 1px $border-grey;
+  border-bottom: solid 1px $border-grey;
+  padding: 5px 0px 2px 0px;
+  overflow: hidden;
   a {
-    display: block;
-    text-decoration: none;
     color: #000;
-    margin: 5px 0px 5px 0px;
-    border-top: solid 1px $border-grey;
-    border-bottom: solid 1px $border-grey;
-    padding: 5px 0px 2px 0px;
-    overflow: hidden;
-    img {
-      margin: 0px 3px 3px 0px;
-      float: left;
-      max-width: 80px;
-    }
-    .og-title {
-      margin-bottom: 3px;
-    }
+  }
+  img {
+    margin: 3px 3px 3px 0px;
+    float: left;
+    max-width: 80px;
+    padding-right: 5px;
+  }
+  .og-title {
+    margin-bottom: 3px;
+    font-weight: bold;
   }
 }
 

--- a/app/assets/stylesheets/opengraph.css.scss
+++ b/app/assets/stylesheets/opengraph.css.scss
@@ -1,24 +1,30 @@
-.opengraph {
+.opengraph-container {
   width: 100%;
-
+  display: block;
+  text-decoration: none;
+  font-style: normal;
+  margin: 10px 0px 10px 0px;
+  border-top: solid 1px $border-grey;
+  border-bottom: solid 1px $border-grey;
+  padding: 10px 0px 5px 0px;
+  overflow: hidden;
   a {
-    display: block;
-    text-decoration: none;;
     color: #000;
-    margin: 10px 0px 10px 0px;
-    border-top: solid 1px $border-grey;
-    border-bottom: solid 1px $border-grey;
-    padding: 10px 0px 5px 0px;
-    overflow: hidden;
-
     img {
-      margin: 0px 5px 5px 0px;
+      margin: 5px 5px 5px 0px;
       float: left;
-      max-width: 155px;
+      max-width: 150px;
+      padding-right: 5px;
     }
-
     .og-title {
       margin-bottom: 5px;
+      font-weight: bold;
     }
+  }
+  a:hover {
+    color: $blue;
+  }
+  .og-description {
+    color: $text-grey;
   }
 }

--- a/app/assets/templates/opengraph_tpl.jst.hbs
+++ b/app/assets/templates/opengraph_tpl.jst.hbs
@@ -1,11 +1,12 @@
 {{#unless o_embed_cache}}
   {{#if open_graph_cache}}
-    <a href="{{open_graph_cache.url}}" target="_blank">
-      <div>
-        <img src="{{open_graph_cache.image}}" />
-        <strong>{{open_graph_cache.title}}</strong>
-        <p>{{open_graph_cache.description}}</p>
-      </div>
-    </a>
+    <div class="opengraph-container">
+        <a href="{{open_graph_cache.url}}" target="_blank">
+          <img src="{{open_graph_cache.image}}" />
+          <p class="og-title">{{open_graph_cache.title}}</p>
+        </a>
+          <p class="og-description">{{open_graph_cache.description}}</p>
+    </div>
   {{/if}}
 {{/unless}}
+

--- a/app/assets/templates/opengraph_tpl.jst.hbs
+++ b/app/assets/templates/opengraph_tpl.jst.hbs
@@ -1,11 +1,11 @@
 {{#unless o_embed_cache}}
   {{#if open_graph_cache}}
     <div class="opengraph-container">
-        <a href="{{open_graph_cache.url}}" target="_blank">
-          <img src="{{open_graph_cache.image}}" />
-          <p class="og-title">{{open_graph_cache.title}}</p>
-        </a>
-          <p class="og-description">{{open_graph_cache.description}}</p>
+      <a href="{{open_graph_cache.url}}" target="_blank">
+        <img src="{{open_graph_cache.image}}" />
+        <p class="og-title">{{open_graph_cache.title}}</p>
+      </a>
+      <p class="og-description">{{open_graph_cache.description}}</p>
     </div>
   {{/if}}
 {{/unless}}


### PR DESCRIPTION
Putting this up for testing and code review. It's a WIP.

This PR is for issue #4492, and stops the og:description text from being included in the <a> field and therefore being a link.

However, for reasons I can't quite work out, the og:description still does appear as part of the link in the mobile version. This seems quite useful, because it gives more area for the user to tap on a touch-screen device. However, I'm aware this might be happening because of an error in the coding, so I'd be grateful if a CSS guru such as @Flaburgan would have look at it at some point.

I had to use a different hierarchy of styles in the desktop and mobile CSS. Again, I don't know why, but it works this way, and doesn't work properly if they are given the same hierarchy. Again, if someone would confirm that they are OK as they are, or that need changing, that would be great.

(I don't know why the indentation is a bit wonky in some of the files displayed below - it's fine when viewed in my text editor.)
