### PR TITLE
Drop number of followers from tags page

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Head
 
 ## Refactor
+* Drop number of followers from tags page [#4717](https://github.com/diaspora/diaspora/issues/4717)
 
 ## Bug fixes
 * Improve time agos by updating the plugin [#4280](https://github.com/diaspora/diaspora/issues/4280)

--- a/app/models/acts_as_taggable_on/tag.rb
+++ b/app/models/acts_as_taggable_on/tag.rb
@@ -2,10 +2,6 @@ class ActsAsTaggableOn::Tag
 
   self.include_root_in_json = false
 
-  def followed_count
-   @followed_count ||= TagFollowing.where(:tag_id => self.id).count
-  end
-
   def self.tag_text_regexp
     @@tag_text_regexp ||= "[[:alnum:]]_-"
   end

--- a/app/views/tags/show.haml
+++ b/app/views/tags/show.haml
@@ -29,8 +29,6 @@
     #author_info
       %h2
         = @stream.display_tag_name
-        %small
-          = t('.followed_by_people', count: @stream.tag_follow_count)
 
     - if current_user
       = render 'shared/publisher', :selected_aspects => @stream.aspect_ids, :aspect_ids => @stream.aspect_ids, :for_all_aspects => true, :aspect => @stream.aspect

--- a/lib/stream/tag.rb
+++ b/lib/stream/tag.rb
@@ -16,10 +16,6 @@ class Stream::Tag < Stream::Base
     @tag ||= ActsAsTaggableOn::Tag.named(tag_name).first
   end
 
-  def tag_follow_count
-    @tag_follow_count ||= tag.try(:followed_count).to_i
-  end
-
   def display_tag_name
     @display_tag_name ||= "##{tag_name}"
   end


### PR DESCRIPTION
Decided on [Loomio](https://www.loomio.org/d/eWkzuANF/change-displayed-information-in-tags-view). Will fix #3769
