### PR TITLE
Do not retry sending out posts on SSL errors.  See #4728

### DIFF
--- a/app/workers/http_multi.rb
+++ b/app/workers/http_multi.rb
@@ -7,7 +7,10 @@ module Workers
     sidekiq_options queue: :http
 
     MAX_RETRIES = 3
-
+    ABANDON_ON_CODES=[:peer_failed_verification, # Certificate does not match URL
+                      :ssl_connect_error, # Problem negotiating ssl version or Cert couldn't be verified (often self-signed)
+                      :ssl_cacert, # Expired SSL cert
+                      ]
     def perform(user_id, encoded_object_xml, person_ids, dispatcher_class_as_string, retry_count=0)
       user = User.find(user_id)
       people = Person.where(:id => person_ids)
@@ -16,11 +19,17 @@ module Workers
       hydra = HydraWrapper.new(user, people, encoded_object_xml, dispatcher)
 
       hydra.enqueue_batch
+
+      hydra.keep_for_retry_if do |response|
+        !ABANDON_ON_CODES.include?(response.return_code)
+      end
+
       hydra.run
 
-      unless hydra.failed_people.empty?
+
+      unless hydra.people_to_retry.empty?
         if retry_count < MAX_RETRIES
-          Workers::HttpMulti.perform_in(1.hour, user_id, encoded_object_xml, hydra.failed_people, dispatcher_class_as_string, retry_count + 1)
+          Workers::HttpMulti.perform_in(1.hour, user_id, encoded_object_xml, hydra.people_to_retry, dispatcher_class_as_string, retry_count + 1)
         else
           Rails.logger.info("event=http_multi_abandon sender_id=#{user_id} failed_recipient_ids='[#{person_ids.join(', ')}] '")
         end

--- a/lib/hydra_wrapper.rb
+++ b/lib/hydra_wrapper.rb
@@ -17,16 +17,19 @@ class HydraWrapper
     }
   }
 
-  attr_reader :failed_people, :user, :encoded_object_xml
+  attr_reader :people_to_retry , :user, :encoded_object_xml
   attr_accessor :dispatcher_class, :people
   delegate :run, to: :hydra
 
   def initialize user, people, encoded_object_xml, dispatcher_class
     @user = user
-    @failed_people = []
+    @people_to_retry = []
     @people = people
     @dispatcher_class = dispatcher_class
     @encoded_object_xml = encoded_object_xml
+    @keep_for_retry_proc = Proc.new do |response|
+      true
+    end
   end
 
   # Inserts jobs for all @people
@@ -36,6 +39,14 @@ class HydraWrapper
         insert_job(receive_url, xml, people_for_receive_url)
       end
     end
+  end
+
+  # This method can be used to tell the hydra whether or not to
+  # retry a request that it made which failed.
+  # @yieldparam response [Typhoeus::Response] The response object for the failed request.
+  # @yieldreturn [Boolean] Whether the request whose response was passed to the block should be retried.
+  def keep_for_retry_if &block
+    @keep_for_retry_proc = block
   end
 
   private
@@ -55,7 +66,7 @@ class HydraWrapper
     @people.group_by { |person|
       @dispatcher_class.receive_url_for person
     }
-  end 
+  end
 
   # Prepares and inserts job into the hydra queue
   # @param url [String]
@@ -83,11 +94,14 @@ class HydraWrapper
           event: "http_multi_fail",
           sender_id: @user.id,
           url: response.effective_url,
-          response_code: response.code
+          return_code: response.return_code
         }
-        message[:response_message] = response.return_message if response.code == 0
         Rails.logger.info message.to_a.map { |k,v| "#{k}=#{v}" }.join(' ')
-        @failed_people += people_for_receive_url.map(&:id)
+
+        if @keep_for_retry_proc.call(response)
+          @people_to_retry += people_for_receive_url.map(&:id)
+        end
+
       end
     end
   end


### PR DESCRIPTION
This pull request stops Diaspora from retrying bad SSL cert send jobs pointlessly.  It should clean up the podmin job queues a bit, I think joindiaspora.com's queue is mostly these useless http_multi jobs.  I'm planning on merging it once Travis gives the green light, then pulling it into joindiaspora to see how it affects the memory use/worker bloat issue.
#4728
