### PR TITLE
Fix timeago on mobile devices. Fix missing space

### DIFF
--- a/app/assets/javascripts/mobile.js
+++ b/app/assets/javascripts/mobile.js
@@ -126,10 +126,12 @@ $(document).ready(function(){
             link.addClass('active');
             existingCommentsContainer.show();
             scrollToOffset(parent, commentsContainer());
+            commentsContainer().find('time.timeago').timeago();
           }
         });
       } else {
         existingCommentsContainer.show();
+        existingCommentsContainer.find('time.timeago').timeago();
       }
 
       link.addClass('active');
@@ -141,10 +143,10 @@ $(document).ready(function(){
           parent.append(data);
           link.addClass('active');
           scrollToOffset(parent, commentsContainer());
+          commentsContainer().find('time.timeago').timeago();
         }
       });
     }
-
   });
 
   var scrollToOffset = function(parent, commentsContainer){
@@ -232,6 +234,7 @@ $(document).ready(function(){
       reactionLink.text(reactionLink.text().replace(/(\d+)/, function(match){ return parseInt(match) + 1; }));
       commentCount.text(commentCount.text().replace(/(\d+)/, function(match){ return parseInt(match) + 1; }));
       commentActionLink.addClass("inactive");
+      bottomBar.find('time.timeago').timeago();
     }, 'html');
   });
 

--- a/config/locales/javascript/javascript.en.yml
+++ b/config/locales/javascript/javascript.en.yml
@@ -31,6 +31,7 @@ en:
       months: "%d months"
       year: "about a year"
       years: "%d years"
+      wordSeparator: " "
 
     my_activity: "My Activity"
     my_stream: "Stream"


### PR DESCRIPTION
Fixes timeago for comments on mobile devices. It also adds the missing space for translations.

At the moment the user's chosen language is disregarded for timestamps on mobile devices. Feel free to comment if you know how to fix that.
