### PR TITLE
Make conversations titles consistent (no 'messages') - #4725

### DIFF
--- a/app/assets/javascripts/inbox.js
+++ b/app/assets/javascripts/inbox.js
@@ -34,7 +34,7 @@ $(document).ready(function(){
     history.pushState(null, "", conversation_path);
 
     var conv = $(this).children('.stream_element'),
-        cBadge = $("#message_inbox_badge .badge_count");
+        cBadge = $("#conversations_badge .badge_count");
     if(conv.hasClass('unread') ){
       conv.removeClass('unread');
     }

--- a/app/assets/stylesheets/bootstrap-headerfix.sass
+++ b/app/assets/stylesheets/bootstrap-headerfix.sass
@@ -14,7 +14,7 @@ header
       font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif
       font-size: 13px
 
-  #message_inbox_badge, #notification_badge
+  #conversations_badge, #notification_badge
     background: none
   
 

--- a/app/assets/stylesheets/conversations.css.scss
+++ b/app/assets/stylesheets/conversations.css.scss
@@ -189,7 +189,7 @@
   font-size: 12px;
 }
 
-#new_message_pane {
+#new_conversation_pane {
   ul.as-selections { width: 100% !important; }
   input#contact_ids { box-shadow: none; }
   textarea { width: 98%; }

--- a/app/assets/stylesheets/header.css.scss
+++ b/app/assets/stylesheets/header.css.scss
@@ -95,12 +95,12 @@ body > header {
       }
     }
 
-    #notification_badge, #message_inbox_badge {
+    #notification_badge, #conversations_badge {
       float: left;
       padding: 0px 3px;
     }
 
-    #message_inbox_badge {
+    #conversations_badge {
       padding-top: 3px;
       margin-right: 0px;
       padding-right: 0px;

--- a/app/assets/stylesheets/mobile.css.scss
+++ b/app/assets/stylesheets/mobile.css.scss
@@ -770,7 +770,7 @@ display: inline-block;
   color: #3F8FBA;
 }
 
-form#new_message.new_message input.button.creation{
+form#new_conversation.new_message input.button.creation{
 	float: right;
 	margin: 0 5px 5px;
 }

--- a/app/assets/stylesheets/rtl.css.scss
+++ b/app/assets/stylesheets/rtl.css.scss
@@ -20,7 +20,7 @@ body {
   float: right;
 }
 
-#notification_badge, #message_inbox_badge {
+#notification_badge, #conversations_badge {
   margin: 0 10px 0 -5px;
 }
 
@@ -42,11 +42,11 @@ body {
   margin-left: 3px;
 }
 
-#notification_badge, #message_inbox_badge {
+#notification_badge, #conversations_badge {
   margin: 0 10px 0 -5px;
 }
 
-#notification_badge a, #message_inbox_badge a {
+#notification_badge a, #conversations_badge a {
   right: 0;
 }
 

--- a/app/assets/templates/header_tpl.jst.hbs
+++ b/app/assets/templates/header_tpl.jst.hbs
@@ -30,9 +30,9 @@
       </div>
     </div>
 
-    <div class="badge badge-inverse" id="message_inbox_badge">
+    <div class="badge badge-inverse" id="conversations_badge">
      <div class="icons-mail_grey" >
-        <a href="/conversations" title="{{t "header.messages"}}" class="badge_link" >
+        <a href="/conversations" title="{{t "header.conversations"}}" class="badge_link" >
           <div class="badge_count {{#unless current_user.unread_messages_count}} hidden {{/unless}}">
             {{current_user.unread_messages_count}}
           </div>

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -18,7 +18,7 @@ class MessagesController < ApplicationController
       Rails.logger.info("event=create type=comment user=#{current_user.diaspora_handle} status=success message=#{message.id} chars=#{params[:message][:text].length}")
       Postzord::Dispatcher.build(current_user, message).post
     else
-      flash[:error] = I18n.t('conversations.new_message.fail')
+      flash[:error] = I18n.t('conversations.new_conversation.fail')
     end
     redirect_to conversations_path(:conversation_id => conversation.id)
   end

--- a/app/views/conversations/index.haml
+++ b/app/views/conversations/index.haml
@@ -16,7 +16,7 @@
         #left_pane_header
           %h3
             .pull-right
-              = link_to t('.new_message'), new_conversation_path, :class => 'btn btn-default', :rel => 'facebox'
+              = link_to t('.new_conversation'), new_conversation_path, :class => 'btn btn-default', :rel => 'facebox'
             = t('.inbox')
 
         #conversation_inbox
@@ -38,4 +38,4 @@
             #no_conversation_text
               = t('.no_conversation_selected')
             #no_conversation_controls
-              = link_to t('.create_a_new_message'), new_conversation_path, :rel => 'facebox'
+              = link_to t('.create_a_new_conversation'), new_conversation_path, :rel => 'facebox'

--- a/app/views/conversations/index.haml
+++ b/app/views/conversations/index.haml
@@ -7,7 +7,7 @@
   = javascript_include_tag :inbox
 
 - content_for :page_title do
-  = t('.message_inbox')
+  = t('.conversations_inbox')
 
 .container-fluid.conversations_container
   .row-fluid

--- a/app/views/conversations/index.mobile.haml
+++ b/app/views/conversations/index.mobile.haml
@@ -3,7 +3,7 @@
 -#   the COPYRIGHT file.
 
 .right
-  = link_to t('.new_message'), new_conversation_path, :class => 'btn'
+  = link_to t('.new_conversation'), new_conversation_path, :class => 'btn'
 
 - flash.each do |name, msg|
   %div{:id => "flash_#{name}", :class => "expose"}

--- a/app/views/conversations/new.haml
+++ b/app/views/conversations/new.haml
@@ -26,10 +26,10 @@
     autocompleteInput.focus();
   });
 
-.span6#new_message_pane
+.span6#new_conversation_pane
   .span5#facebox_header
     %h3
-      = t('conversations.index.new_message')
+      = t('conversations.index.new_conversation')
 
   = form_for Conversation.new, html: {class: "new_conversation form_do_not_clear"}, remote: true do |conversation|
 

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -328,9 +328,9 @@ en:
   conversations:
     index:
       conversations_inbox: "Conversations – Inbox"
-      new_message: "New Message"
+      new_conversation: "New conversation"
       no_conversation_selected: "no conversation selected"
-      create_a_new_message: "create a new message"
+      create_a_new_conversation: "start a new conversation"
       no_messages: "no messages"
       inbox: "Inbox"
     conversation:
@@ -354,7 +354,7 @@ en:
       sent: "Message sent"
       fail: "Invalid message"
       no_contact: "Hey, you need to add the contact first!"
-    new_message:
+    new_conversation:
       fail: "Invalid message"
     destroy:
       success: "Conversation successfully removed"

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -327,7 +327,7 @@ en:
 
   conversations:
     index:
-      message_inbox: "Conversations – Inbox"
+      conversations_inbox: "Conversations – Inbox"
       new_message: "New Message"
       no_conversation_selected: "no conversation selected"
       create_a_new_message: "create a new message"

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -327,7 +327,7 @@ en:
 
   conversations:
     index:
-      message_inbox: "Message Inbox"
+      message_inbox: "Conversations – Inbox"
       new_message: "New Message"
       no_conversation_selected: "no conversation selected"
       create_a_new_message: "create a new message"

--- a/config/locales/javascript/javascript.en.yml
+++ b/config/locales/javascript/javascript.en.yml
@@ -148,7 +148,7 @@ en:
       log_out: "Log out"
 
       notifications: "Notifications"
-      messages: "Messages"
+      messages: "Conversations"
 
       search: "Search"
 

--- a/config/locales/javascript/javascript.en.yml
+++ b/config/locales/javascript/javascript.en.yml
@@ -148,7 +148,7 @@ en:
       log_out: "Log out"
 
       notifications: "Notifications"
-      messages: "Conversations"
+      conversations: "Conversations"
 
       search: "Search"
 

--- a/features/desktop/conversations.feature
+++ b/features/desktop/conversations.feature
@@ -1,5 +1,5 @@
 @javascript
-Feature: private messages
+Feature: private conversations
     In order to be talkative
     As a User
     I want to converse with people

--- a/features/mobile/conversations.feature
+++ b/features/mobile/conversations.feature
@@ -1,5 +1,5 @@
 @javascript
-Feature: private messages mobile
+Feature: private conversations mobile
     In order to be talkative
     As a mobile user
     I want to converse with people

--- a/features/step_definitions/conversations_steps.rb
+++ b/features/step_definitions/conversations_steps.rb
@@ -23,7 +23,7 @@ end
 
 Then /^I send a mobile message with subject "([^"]*)" and text "([^"]*)" to "([^"]*)"$/ do |subject, text, person|
   step %(I am on the conversations page)
-  step %(I follow "New Message")
+  step %(I follow "New conversation")
   step %(I fill in "contact_autocomplete" with "#{person}")
   step %(I press the first ".as-result-item" within ".as-results")
   step %(I fill in "conversation_subject" with "#{subject}")

--- a/features/step_definitions/conversations_steps.rb
+++ b/features/step_definitions/conversations_steps.rb
@@ -6,7 +6,7 @@ end
 
 Then /^I send a message with subject "([^"]*)" and text "([^"]*)" to "([^"]*)"$/ do |subject, text, person|
   step %(I am on the conversations page)
-  step %(I follow "New Message")
+  step %(I follow "New conversation")
   step %(I fill in "contact_autocomplete" with "#{person}" in the modal window)
   step %(I press the first ".as-result-item" within ".as-results" in the modal window)
   step %(I fill in "conversation_subject" with "#{subject}" in the modal window)

--- a/spec/javascripts/app/views/header_view_spec.js
+++ b/spec/javascripts/app/views/header_view_spec.js
@@ -24,18 +24,18 @@ describe("app.views.Header", function() {
       })
     })
 
-    context("messages badge", function(){
+    context("conversations badge", function(){
       it("displays a count when the current user has a notification", function(){
         loginAs(_.extend(this.userAttrs, {unread_messages_count : 1}))
         this.view.render();
-        expect(this.view.$("#message_inbox_badge .badge_count").hasClass('hidden')).toBe(false);
-        expect(this.view.$("#message_inbox_badge .badge_count").text()).toContain("1");
+        expect(this.view.$("#conversations_badge .badge_count").hasClass('hidden')).toBe(false);
+        expect(this.view.$("#conversations_badge .badge_count").text()).toContain("1");
       })
 
       it("does not display a count when the current user has a notification", function(){
         loginAs(_.extend(this.userAttrs, {unread_messages_count : 0}))
         this.view.render();
-        expect(this.view.$("#message_inbox_badge .badge_count").hasClass('hidden')).toBe(true);
+        expect(this.view.$("#conversations_badge .badge_count").hasClass('hidden')).toBe(true);
       })
     })
 


### PR DESCRIPTION
Have changed the text for the header bar's conversations icon (message_inbox_badge) and page title of the conversations page (message_inbox).
- The tooltip for the envelope icon in the header now reads 'Conversations'.
- The page title of the conversations page now reads 'Conversations – Inbox'. I thought it was worth keeping the word 'Inbox as a subtitle, because that is in effect what you are seeing.

What I haven't done yet is change the labels themselves, so they still read 'message_inbox_badge' and 'message_inbox'. If you think it would be a good idea to change them now to 'conversations_badge' and 'conversations_inbox' I can do that, but would need to know whether I should change the labels in the various locale files, or whether that is done via WebTranslateIt.
