### PR TITLE
[WIP] Fix hovercard in reshares

### DIFF
--- a/app/assets/templates/reshare_tpl.jst.hbs
+++ b/app/assets/templates/reshare_tpl.jst.hbs
@@ -13,7 +13,7 @@
       {{#with root}}
         <div class="bd">
           <div>
-            <a href="/people/{{author.guid}}" class="author {{{hovercardable this}}}">{{author.name}}</a>
+            <a href="/people/{{author.guid}}" class="author {{{hovercardable author}}}">{{author.name}}</a>
 
             <span class="details grey">
               -

--- a/features/desktop/hovercards.feature
+++ b/features/desktop/hovercards.feature
@@ -22,11 +22,11 @@ Feature: Hovercards
     Then I should not see a hovercard
 
   Scenario: Hovercards on the main stream in reshares
-    When I am on "bob@bob.bob"'s page
-    Then I should see "alice public stuff" within ".reshare"
+    Given I am on "bob@bob.bob"'s page
+    Then I should see "public stuff" within ".stream_element"
     When I hover "Alice" within ".reshare"
     Then I should not see a hovercard
     When I am on "alice@alice.alice"'s page
-    Then I should see "public stuff" within ".reshare"
+    Then I should see "public stuff" within ".stream_element"
     When I hover "Bob Jones" within ".reshare"
     Then I should see a hovercard

--- a/features/desktop/hovercards.feature
+++ b/features/desktop/hovercards.feature
@@ -23,10 +23,10 @@ Feature: Hovercards
 
   Scenario: Hovercards on the main stream in reshares
     Given I am on "bob@bob.bob"'s page
-    Then I should see "public stuff" within ".stream_element"
+    Then I should see "Alice" within ".stream_element"
     When I hover "Alice" within ".reshare"
     Then I should not see a hovercard
     When I am on "alice@alice.alice"'s page
-    Then I should see "public stuff" within ".stream_element"
+    Then I should see "Bob Jones" within ".stream_element"
     When I hover "Bob Jones" within ".reshare"
     Then I should see a hovercard

--- a/features/desktop/hovercards.feature
+++ b/features/desktop/hovercards.feature
@@ -24,9 +24,9 @@ Feature: Hovercards
   Scenario: Hovercards on the main stream in reshares
     When I am on "bob@bob.bob"'s page
     Then I should see "alice public stuff" within ".reshare"
-    When I activate hovercard for "Alice" within ".reshare"
+    When I hover "Alice" within ".reshare"
     Then I should not see a hovercard
     When I am on "alice@alice.alice"'s page
     Then I should see "public stuff" within ".reshare"
-    When I activate hovercard for "Bob Jones" within ".reshare"
+    When I hover "Bob Jones" within ".reshare"
     Then I should see a hovercard

--- a/features/desktop/hovercards.feature
+++ b/features/desktop/hovercards.feature
@@ -8,8 +8,10 @@ Feature: Hovercards
     Given a user named "Bob Jones" with email "bob@bob.bob"
     And "bob@bob.bob" has a public post with text "public stuff"
     And a user named "Alice" with email "alice@alice.alice"
+    And "alice@alice.alice" has a public post with text "alice public stuff"
+    And the post with text "public stuff" is reshared by "alice@alice.alice"
+    And the post with text "alice public stuff" is reshared by "bob@bob.bob"
     And I sign in as "alice@alice.alice"
-
 
   Scenario: Hovercards on the main stream
     Given I am on "bob@bob.bob"'s page
@@ -18,3 +20,13 @@ Feature: Hovercards
     Then I should see a hovercard
     When I deactivate the first hovercard
     Then I should not see a hovercard
+
+  Scenario: Hovercards on the main stream in reshares
+    When I am on "bob@bob.bob"'s page
+    Then I should see "alice public stuff" within ".reshare"
+    When I activate hovercard for "Alice" within ".reshare"
+    Then I should not see a hovercard
+    When I am on "alice@alice.alice"'s page
+    Then I should see "public stuff" within ".reshare"
+    When I activate hovercard for "Bob Jones" within ".reshare"
+    Then I should see a hovercard

--- a/features/step_definitions/hovercard_steps.rb
+++ b/features/step_definitions/hovercard_steps.rb
@@ -1,5 +1,5 @@
 When(/^I activate the first hovercard$/) do
-  page.execute_script("$('.hovercardable').first().trigger('mouseenter');")
+  first('.hovercardable').hover
 end
 
 Then(/^I should see a hovercard$/) do
@@ -16,6 +16,6 @@ end
 
 When (/^I activate hovercard for "([^"]*)" within "([^"]*)"$/) do |name, selector|
   with_scope(selector) do
-    page.execute_script("$('.author').filter(function(index){return $(this).text() === \"#{name}\";}).trigger('mouseenter');")
+    find(".author", text: name).hover
   end
 end

--- a/features/step_definitions/hovercard_steps.rb
+++ b/features/step_definitions/hovercard_steps.rb
@@ -3,7 +3,7 @@ When(/^I activate the first hovercard$/) do
 end
 
 Then(/^I should see a hovercard$/) do
-  page.should have_css '#hovercard'
+  page.should have_css('#hovercard')
 end
 
 When(/^I deactivate the first hovercard$/) do
@@ -11,10 +11,10 @@ When(/^I deactivate the first hovercard$/) do
 end
 
 Then(/^I should not see a hovercard$/) do
-  page.should_not have_css '#hovercard'
+  page.should_not have_css('#hovercard')
 end
 
-When (/^I activate hovercard for "([^"]*)" within "([^"]*)"$/) do |name, selector|
+When (/^I hover "([^"]*)" within "([^"]*)"$/) do |name, selector|
   with_scope(selector) do
     find(".author", text: name).hover
   end

--- a/features/step_definitions/hovercard_steps.rb
+++ b/features/step_definitions/hovercard_steps.rb
@@ -13,3 +13,9 @@ end
 Then(/^I should not see a hovercard$/) do
   page.should_not have_css '#hovercard'
 end
+
+When (/^I activate hovercard for "([^"]*)" within "([^"]*)"$/) do |name, selector|
+  with_scope(selector) do
+    page.execute_script("$('.author').filter(function(index){return $(this).text() === \"#{name}\";}).trigger('mouseenter');")
+  end
+end


### PR DESCRIPTION
This is fix for #4724 issue.

We should pass person object to the `hovecrardable` handlebar's helper. In the current case `this` is the status message, not the status author. So, let's pass `author` instead of `this`.
