### PR TITLE
Update JQuery source to jquery.com

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,7 @@
 * Update image branding to the new decided standard [#4702](https://github.com/diaspora/diaspora/pull/4702)
 * Consistent naming of conversations and messages [#4756](https://github.com/diaspora/diaspora/pull/4756)
 * Improve stream generation time [#4769](https://github.com/diaspora/diaspora/pull/4769)
-
+* Change jQuery CDN to jquery.com from googleapis.com [#4765](https://github.com/diaspora/diaspora/pull/4765)
 
 ## Bug fixes
 * Improve time agos by updating the plugin [#4280](https://github.com/diaspora/diaspora/issues/4280)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -55,7 +55,7 @@ module ApplicationHelper
     buf = []
     if AppConfig.privacy.jquery_cdn?
       version = Jquery::Rails::JQUERY_VERSION
-      buf << [ javascript_include_tag("//ajax.googleapis.com/ajax/libs/jquery/#{version}/jquery.min.js") ]
+      buf << [ javascript_include_tag("//code.jquery.com/jquery-#{version}.min.js") ]
       buf << [ javascript_tag("!window.jQuery && document.write(unescape('#{j javascript_include_tag("jquery")}'));") ]
     else
       buf << [ javascript_include_tag('jquery') ]

--- a/config/diaspora.yml.example
+++ b/config/diaspora.yml.example
@@ -170,7 +170,7 @@ configuration: ## Section
   ## Settings probably affecting the privacy of your users 
   privacy: ## Section
     
-    ## Include jQuery from Google's CDN
+    ## Include jQuery from jquery.com's CDN
     ## This potentially saves you some traffic and speeds up
     ## load time since most clients already have this one cached
     #jquery_cdn: true

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -55,13 +55,13 @@ describe ApplicationHelper do
   end
 
   describe "#jquery_include_tag" do
-    describe "with google cdn" do
+    describe "with jquery cdn" do
       before do
         AppConfig.privacy.jquery_cdn = true
       end
 
-      it 'inclues jquery.js from google cdn' do
-        jquery_include_tag.should match(/googleapis\.com/)
+      it 'inclues jquery.js from jquery cdn' do
+        jquery_include_tag.should match(/jquery\.com/)
       end
 
       it 'falls back to asset pipeline on cdn failure' do
@@ -69,14 +69,14 @@ describe ApplicationHelper do
       end
     end
 
-    describe "without google cdn" do
+    describe "without jquery cdn" do
       before do
         AppConfig.privacy.jquery_cdn = false
       end
 
       it 'includes jquery.js from asset pipeline' do
         jquery_include_tag.should match(/jquery\.js/)
-        jquery_include_tag.should_not match(/googleapis\.com/)
+        jquery_include_tag.should_not match(/jquery\.com/)
       end
     end
 


### PR DESCRIPTION
As a lot of people are concerned about Google being involved in their use of Diaspora, this PR changes the CDN source for JQuery from googleapis.com to jquery.com.

See [Loomio](https://www.loomio.org/d/rkPCY3qJ/change-jquery-library-source) for discussion.
