### PR TITLE
Updating queries for the stream to be faster

### DIFF
--- a/app/models/user/querying.rb
+++ b/app/models/user/querying.rb
@@ -68,10 +68,8 @@ module User::Querying
   end
 
   def construct_public_followings_sql(opts)
-    aspects = Aspect.where(:id => opts[:by_members_of])
-    person_ids = Person.connection.select_values(people_in_aspects(aspects).select("people.id").to_sql)
-
-    query = opts[:klass].where(:author_id => person_ids, :public => true, :pending => false)
+    Rails.logger.debug("[EVIL-QUERY] user.construct_public_followings_sql")
+    query = opts[:klass].where(:author_id => Person.in_aspects(opts[:by_members_of]).select("people.id"), :public => true, :pending => false)
 
     unless(opts[:klass] == Photo)
       query = query.where(:type => opts[:type])

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,7 +27,7 @@ Diaspora::Application.configure do
 
   # Log the query plan for queries taking more than this (works
   # with SQLite, MySQL, and PostgreSQL)
-  config.active_record.auto_explain_threshold_in_seconds = 0.5
+  # config.active_record.auto_explain_threshold_in_seconds = 0.5
 
   # Do not compress assets
   config.assets.compress = false

--- a/lib/evil_query.rb
+++ b/lib/evil_query.rb
@@ -51,20 +51,24 @@ module EvilQuery
     end
 
     def make_relation!
+      Rails.logger.debug("[EVIL-QUERY] make_relation!")
       post_ids = aspects_post_ids! + ids!(followed_tags_posts!) + ids!(mentioned_posts)
       post_ids += ids!(community_spotlight_posts!) if @include_spotlight
       Post.where(:id => post_ids)
     end
 
     def aspects_post_ids!
+      Rails.logger.debug("[EVIL-QUERY] aspect_post_ids!")
       @user.visible_shareable_ids(Post, :limit => 15, :order => "#{@order} DESC", :max_time => @max_time, :all_aspects? => true, :by_members_of => @user.aspect_ids)
     end
 
     def followed_tags_posts!
+      Rails.logger.debug("[EVIL-QUERY] followed_tags_posts!")
       StatusMessage.public_tag_stream(@user.followed_tag_ids)
     end
 
     def mentioned_posts
+      Rails.logger.debug("[EVIL-QUERY] mentioned_posts")
       StatusMessage.where_person_is_mentioned(@user.person)
     end
 


### PR DESCRIPTION
Tested with masses of users, this one change results in a massive performance increase.
- Prior to accepting for merge I'll revert those logs.

I had a user in my dev environment, I gave him 30,000 followers, like poor DiasporaHQ probably has.  His stream was taking quite a while to load. it now takes about 1 second. Both the below messages are from the dev log on my quad core laptop, performed after restarting the server, hitting the stream once to warm up the app, then refreshing once more.  They're taken from the JSON fetch of the stream.

The next place I'll tackle is posting as the user with 30,000.  The things that happen after this tie up the server process for minutes (there's quite a lot of "ID IN [_30,00 IDS GO HERE_]".

```
Started GET "/stream?_=1391948397159" for 127.0.0.1 at 2014-02-09 20:19:57 +0800
Processing by StreamsController#multi as JSON
```

Before:

```
Completed 200 OK in 34196.1ms (Views: 279.6ms | ActiveRecord: 33505.6ms)
```

After:

```
Completed 200 OK in 1361.3ms (Views: 235.7ms | ActiveRecord: 1105.7ms)
```

Queries that do things like "ID IN [array goes here]" are super expensive, the longer that list gets, the longer the query takes.  Sub-selects are slowish too, but nowhere near as bad as that.
