### PR TITLE
Always update last_sign_in_at on new session

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,7 @@
 * You can report a single post by clicking the correct icon in the controler section [#4517](https://github.com/diaspora/diaspora/pull/4517)
 * Add permalinks for comments [#4577](https://github.com/diaspora/diaspora/pull/4577)
 * New menu for the mobile version [#4673](https://github.com/diaspora/diaspora/pull/4673)
+* Always update last_sign_in_at on new user session [#4734](https://github.com/diaspora/diaspora/issues/4734)
 
 # 0.3.0.1
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,7 @@ class ApplicationController < ActionController::Base
   before_filter :mobile_switch
   before_filter :gon_set_current_user
   before_filter :gon_set_preloads
+  before_filter :update_last_sign_in_at
 
   inflection_method :grammatical_gender => :gender
 
@@ -149,6 +150,13 @@ class ApplicationController < ActionController::Base
   def gon_set_preloads
     return unless gon.preloads.nil?
     gon.preloads = {}
+  end
+  
+  def update_last_sign_in_at
+    if user_signed_in? && !session[:logged_signin]
+      sign_in(current_user, :force => true)
+      session[:logged_signin] = true
+    end
   end
 
 end


### PR DESCRIPTION
Trigger update of last_sign_in_at on user session even if user signed in via rememberable strategy, fixes #4734

Basically followed [this SO answer](http://stackoverflow.com/a/12021599/1489738), to get the job done but stay light on the application.
