### PR TITLE
Add handle indication on search page, improve design

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@
 * Change jQuery CDN to jquery.com from googleapis.com [#4765](https://github.com/diaspora/diaspora/pull/4765)
 * Update to jQuery 10
 * Port publisher and bookmarklet to Bootstrap [#4678](https://github.com/diaspora/diaspora/pull/4678)
+* Improve search page, add better indications [#4794](https://github.com/diaspora/diaspora/pull/4794)
 
 ## Bug fixes
 * Improve time agos by updating the plugin [#4280](https://github.com/diaspora/diaspora/issues/4280)

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -488,7 +488,7 @@ input[type="search"]
   :margin
     :bottom 2em
   :padding
-    :bottom 1em
+    :bottom 0.4em
 
   h2
     :display inline
@@ -496,6 +496,11 @@ input[type="search"]
   .right
     :margin
       :top 10px
+      
+  h4
+    :display inline
+    :margin
+      :left 1em
 
 .photo_options
   :color $text-grey

--- a/app/helpers/people_helper.rb
+++ b/app/helpers/people_helper.rb
@@ -9,21 +9,12 @@ module PeopleHelper
     if search_query.blank?
       content_tag(:h2, t('people.index.no_results'))
     else
-      content_tag(:h2, :id => 'search_title') do
-        t('people.index.results_for').html_safe + ' ' +
-        content_tag(:span, search_query, :class => 'term')
+      content_tag(:h2, id: 'search_title') do
+        t('people.index.results_for', search_term: content_tag(:span, search_query, class: 'term')).html_safe + looking_for_tag_link
       end
     end
   end
-
-  def search_or_index
-    if search_query
-      I18n.t 'people.helper.results_for',:params => search_query
-    else
-      I18n.t "people.helper.people_on_pod_are_aware_of"
-    end
-  end
-
+  
   def birthday_format(bday)
     if bday.year == 1000
       I18n.l bday, :format => I18n.t('date.formats.birthday')

--- a/app/views/people/index.html.haml
+++ b/app/views/people/index.html.haml
@@ -9,18 +9,14 @@
   = javascript_include_tag :people
   = javascript_include_tag 'contact-list'
 
-.span-24.last
-  = search_header
-  = looking_for_tag_link
-.span-15
-  %hr
-.clearfix
+#section_header
+  = search_header     
 .span-15.append-1
   #people_stream.stream
     - if @hashes.empty?
       - if @background_query.present?
 
-        / this is gross, and should be extracted!
+        / TODO this is gross, and should be extracted!
         :javascript
           $(document).ready( function() {
             List.startSearchDelay('#{@background_query}')
@@ -41,6 +37,10 @@
 - if AppConfig.settings.invitations.open?
   .span-8.last
     %h4
-      = t('.couldnt_find_them_send_invite')
+      = t('.couldnt_find_them')
+    %p
+      = t('.search_handle')
+    %h4
+      = t('.send_invite')
     = render "shared/invitations"
 

--- a/app/views/people/index.mobile.haml
+++ b/app/views/people/index.mobile.haml
@@ -11,16 +11,12 @@
       = search_field_tag :q, nil, :placeholder => t('find_people'), :class => 'search'
     = submit_tag t('search'), 'data-inline' => 'true', :class => 'btn'
 
-
 - if params[:q].blank?
   %h4
-    =t('.no_results')
+    = t('.no_results')
 - else
   %h4#search_title
-    =t('.results_for')
-    %span.term
-      = params[:q]
-
+    = t('.results_for', search_term: params[:q])
 
   - if @hashes.empty?
     %p

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -752,9 +752,11 @@ en:
       thats_you: "That's you!"
       add_contact: "add contact"
     index:
-      results_for: "search results for"
+      results_for: "Users matching %{search_term}"
       no_results: "Hey! You need to search for something."
-      couldnt_find_them_send_invite: "Couldn't find them?  Send an invite!"
+      couldnt_find_them: "Couldn't find them?"
+      search_handle: "Use their diaspora* ID (username@pod.tld) to be sure to find your friends."
+      send_invite: "Still nothing? Send an invite!"
       no_one_found: "...and no one was found."
       searching: "searching, please be patient..."
       looking_for: "Looking for posts tagged %{tag_link}?"
@@ -791,7 +793,6 @@ en:
       remove_from: "Remove %{name} from %{aspect}?"
     helper:
       results_for: " results for %{params}"
-      people_on_pod_are_aware_of: " people on pod are aware of"
       is_sharing: "%{name} is sharing with you"
       is_not_sharing: "%{name} is not sharing with you"
     aspect_list:
@@ -1042,7 +1043,7 @@ en:
       invite_your_friends: "Invite your friends"
       from_facebook: "From Facebook"
       by_email: "By email"
-      share_this: "Share this link via email, blog, or favorite social network!"
+      share_this: "Share this link via email, blog, or social networks!"
     reshare:
       reshare: "Reshare"
     public_explain:


### PR DESCRIPTION
This comes after discussion on https://github.com/diaspora/diaspora/issues/4773
The search itself needs to be improved, but this already adds an indication to the user: if he doesn't find his friends, he should try to search them using their full handle.

I also changed the design a little bit, displaying the title as elsewhere.

Before
![before](https://f.cloud.github.com/assets/930064/2218357/2fc1574c-9a2d-11e3-9095-233433ca3f33.png)

After
![after](https://f.cloud.github.com/assets/930064/2218388/9f97f472-9a2d-11e3-9a63-f422a51ceb4f.png)

After (with results)
![after-contacts](https://f.cloud.github.com/assets/930064/2218362/36f7f67e-9a2d-11e3-95c3-c4efa20df28e.png)

I'm not sure where to place the text "Looking for posts tagged #thesearch?" when there are results, especially when it's paginated. Any suggestions?
