### PR TITLE
Remove the limit to 8 pictures in the view

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -120,6 +120,7 @@ For more details see https://wiki.diasporafoundation.org/Updating
 * Add indication about markdown formatting in the publisher [#4589](https://github.com/diaspora/diaspora/pull/4589)
 * Add captcha to signup form [#4659](https://github.com/diaspora/diaspora/pull/4659)
 * Update Underscore.js 1.3.1 to 1.5.2, update Backbone.js 0.9.2 to 1.1.0 [#4662](https://github.com/diaspora/diaspora/pull/4662)
+* Display more than 8 pictures on a post [#4796](https://github.com/diaspora/diaspora/pull/4796)
 
 ## Gem updates
 Added:

--- a/app/assets/javascripts/app/views/content_view.js
+++ b/app/assets/javascripts/app/views/content_view.js
@@ -22,7 +22,7 @@ app.views.Content = app.views.Base.extend({
   smallPhotos : function() {
     var photos = this.model.get("photos")
     if(!photos || photos.length < 2) { return }
-    return photos.slice(1,8)
+    return photos
   },
 
 


### PR DESCRIPTION
We allow the user to attach more than 8 pictures to a post, everything is processed correctly after that, so I propose to remove the limit to 8 pictures by post because it's only in the view.

It renders pretty well already, even if the lightbox (is that the correct name?) can be improved (see the second screenshot).

![more-than-8-stream](https://f.cloud.github.com/assets/930064/2218750/7e7255fa-9a35-11e3-99b3-5af72eae4b22.png)

![more-than-8-lightbox](https://f.cloud.github.com/assets/930064/2218729/eefbb2d6-9a34-11e3-884e-ccea192a8d75.png)
