### PR TITLE
Remove auto 'mark as read' in notifications dropdown

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -24,6 +24,7 @@ Read more in [#4249](https://github.com/diaspora/diaspora/pull/4249) and [#4883]
 * Replace .rvmrc by .ruby-version and .ruby-gemset [#4854](https://github.com/diaspora/diaspora/pull/4855)
 * Reorder and reword items on user settings page [#4912](https://github.com/diaspora/diaspora/pull/4912)
 * SPV: Improve padding and interaction counts [#4426](https://github.com/diaspora/diaspora/pull/4426)
+* Remove auto 'mark as read' for notifications [#4810](https://github.com/diaspora/diaspora/pull/4810)
 
 ## Bug fixes
 * Improve time agos by updating the plugin [#4280](https://github.com/diaspora/diaspora/issues/4280)

--- a/app/assets/javascripts/widgets/notifications-badge.js
+++ b/app/assets/javascripts/widgets/notifications-badge.js
@@ -74,13 +74,6 @@
       self.dropdownNotifications.find('.read').each(function(index) {
         Diaspora.page.header.notifications.setUpRead( $(this) );
       });
-      self.dropdownNotifications.find('.unread').each(function(index) {
-        var myItem = $(this);
-        setTimeout(function(){
-          if ( self.dropdownNotifications.is(":visible") )
-            myItem.trigger('click');
-        }, 2000 );
-      });
       self.ajaxLoader.hide();
     };
   };


### PR DESCRIPTION
The behavior is confusing for some users. The notification will be marked as read when you click on it or open the post. You can also click on 'mark all as read'. I don't think that we need an automatic 'mark as read' anymore.
