### PR TITLE
fixed HTML-anchors in markdown in public atom-feed of user

### DIFF
--- a/app/views/users/public.atom.builder
+++ b/app/views/users/public.atom.builder
@@ -33,7 +33,7 @@ atom_feed({'xmlns:thr' => 'http://purl.org/syndication/thread/1.0',
       :id => "#{@user.url}p/#{post.id}" do |entry|
 
       entry.title truncate(post.formatted_message(:plain_text => true), :length => 50)
-      entry.content auto_link(post.formatted_message(:plain_text => true)), :type => 'html'
+      entry.content post.formatted_message(:plain_text => true), :type => 'html'
       entry.tag! 'activity:verb', 'http://activitystrea.ms/schema/1.0/post'
       entry.tag! 'activity:object-type', 'http://activitystrea.ms/schema/1.0/note'
     end


### PR DESCRIPTION
I noticed that there were HTML-style links that were automatically inserted for any url-like string, resulting in invalid markdown in the atom-feed. Fixed that.
