### PR TITLE
atom-feed content changed to html, use better post-title extractor

### DIFF
--- a/app/views/users/public.atom.builder
+++ b/app/views/users/public.atom.builder
@@ -32,8 +32,8 @@ atom_feed({'xmlns:thr' => 'http://purl.org/syndication/thread/1.0',
     feed.entry post, :url => "#{@user.url}p/#{post.id}",
       :id => "#{@user.url}p/#{post.id}" do |entry|
 
-      entry.title truncate(post.formatted_message(:plain_text => true), :length => 50)
-      entry.content auto_link(post.formatted_message(:plain_text => true)), :type => 'html'
+      entry.title post_page_title(post)
+      entry.content markdownify(post), :type => 'html'
       entry.tag! 'activity:verb', 'http://activitystrea.ms/schema/1.0/post'
       entry.tag! 'activity:object-type', 'http://activitystrea.ms/schema/1.0/note'
     end


### PR DESCRIPTION
Atom-Feed is now compatible with feed readers that expect html inside <content>-element.
Additionally it has a proper title, using the same title guessing method as the singlepageview does.
