### PR TITLE
Fix publisher broken after jquery upgrade

### DIFF
--- a/app/views/publisher/_publisher_blueprint.html.haml
+++ b/app/views/publisher/_publisher_blueprint.html.haml
@@ -25,7 +25,7 @@
               = status.text_area :fake_text, :rows => 2, :value => h(publisher_formatted_text), :tabindex => 1, :placeholder => "#{t('contacts.index.start_a_conversation')}..."
             = status.hidden_field :text, :value => h(publisher_hidden_text), :class => 'clear_on_submit'
 
-            #publisher-images
+            %span#publisher-images
               %span.markdownIndications
                 != t('shared.publisher.formatWithMarkdown', markdown_link: link_to(t('help.markdown'), 'https://diasporafoundation.org/formatting', target: :blank))
               #locator.btn{:title => t('shared.publisher.get_location')}


### PR DESCRIPTION
As indicated by @fabianrbz in https://github.com/diaspora/diaspora/issues/4813#issuecomment-37254991 this commit fixes the publisher after jquery update. I don't know if we want to close https://github.com/diaspora/diaspora/issues/4813 or upgrade the plugin though, but this should be merged at least as a temporary fix.
