### PR TITLE
#4851 Add known Pods to statistics.json

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -26,6 +26,7 @@
 * Add permalinks for comments [#4577](https://github.com/diaspora/diaspora/pull/4577)
 * New menu for the mobile version [#4673](https://github.com/diaspora/diaspora/pull/4673)
 * Added comment count to statistic to enable calculations of posts/comments ratios [#4799](https://github.com/diaspora/diaspora/pull/4799)
+* Added a list of known pods to statistics to enable possible compilation of a list of all pods [#4851](https://github.com/diaspora/diaspora/issues/4851)
 
 # 0.3.0.3
 

--- a/app/presenters/statistics_presenter.rb
+++ b/app/presenters/statistics_presenter.rb
@@ -17,9 +17,19 @@ class StatisticsPresenter
     if AppConfig.privacy.statistics.comment_counts?
       result['local_comments'] = self.local_comments
     end
+
+    result['known_pods'] = self.known_pods
     result
   end
-  
+
+  def known_pods
+    podlist = [];
+    Pod.all.each do |pod|
+      podlist << pod.host
+    end
+    return podlist
+  end
+
   def local_posts
     Post.where(:type => "StatusMessage").joins(:author).where("owner_id IS NOT null").count
   end

--- a/app/presenters/statistics_presenter.rb
+++ b/app/presenters/statistics_presenter.rb
@@ -17,8 +17,9 @@ class StatisticsPresenter
     if AppConfig.privacy.statistics.comment_counts?
       result['local_comments'] = self.local_comments
     end
-
-    result['known_pods'] = self.known_pods
+    if AppConfig.privacy.statistics.expose_known_pods?
+      result['known_pods'] = self.known_pods
+    end
     result
   end
 

--- a/config/diaspora.yml.example
+++ b/config/diaspora.yml.example
@@ -201,6 +201,8 @@ configuration: ## Section
       ## Local post total count
       #post_counts: true
       #comment_counts: true
+      ## List of known Pods
+      #expose_known_pods: true
   
   ## General settings
   settings: ## Section


### PR DESCRIPTION
As suggested yesterday (https://github.com/diaspora/diaspora/issues/4851) i added the the possibility to expose the known pods of a pod in the statistics.json
