### PR TITLE
4868 mention inside tags

### DIFF
--- a/lib/assets/javascripts/jquery.mentionsInput.js
+++ b/lib/assets/javascripts/jquery.mentionsInput.js
@@ -6,6 +6,11 @@
  * Using underscore.js
  *
  * License: MIT License - http://www.opensource.org/licenses/mit-license.php
+ * 
+ * Modifcations for Diaspora:
+ *
+ * Prevent replacing the wrong text by marking the  replacement position with a special character
+ * Don't add a space after inserting a mention 
  */
 
 (function ($, _, undefined) {
@@ -69,6 +74,7 @@
     var autocompleteItemCollection = {};
     var inputBuffer = [];
     var currentDataQuery = '';
+    var mentionChar = "\u200B"; // zero width space
 
     settings = $.extend(true, {}, defaultSettings, settings );
 
@@ -114,13 +120,13 @@
 
       _.each(mentionsCollection, function (mention) {
         var textSyntax = settings.templates.mentionItemSyntax(mention);
-        syntaxMessage = syntaxMessage.replace(mention.value, textSyntax);
+        syntaxMessage = syntaxMessage.replace(mentionChar + mention.value, textSyntax);
       });
 
       var mentionText = utils.htmlEncode(syntaxMessage);
 
       _.each(mentionsCollection, function (mention) {
-        var formattedMention = _.extend({}, mention, {value: utils.htmlEncode(mention.value)});
+        var formattedMention = _.extend({}, mention, {value: mentionChar + utils.htmlEncode(mention.value)});
         var textSyntax = settings.templates.mentionItemSyntax(formattedMention);
         var textHighlight = settings.templates.mentionItemHighlight(formattedMention);
 
@@ -170,7 +176,7 @@
       hideAutoComplete();
 
       // Mentions & syntax message
-      var updatedMessageText = start + mention.value + end;
+      var updatedMessageText = start + mentionChar + mention.value + end;
       elmInputBox.val(updatedMessageText);
       updateValues();
 


### PR DESCRIPTION
Fix for: #4868
Example: we have a user with name Olga and I write: "Hello Olga, how are you @olg" , after select username text transform to "Hello Olga, how are you Olga" for mention user script find first "Olga" in my post and add syntax tag, but I need to tag second 'Olga' text, for do this I add zero width character before name of user and mention text where find  "\u200B"+username
Sorry for my very bad English
