### PR TITLE
Add warning to script/server if curl does not support AsyncDNS

### DIFF
--- a/script/server
+++ b/script/server
@@ -125,6 +125,18 @@ application, run:
     bundle exec rake assets:precompile"
 fi
 
+# Check for old curl versions (see https://github.com/diaspora/diaspora/issues/4202)
+if [ `curl -V | grep AsynchDNS | wc -l` -ne 1 ]
+then
+  warning "
+*****************************************************************
+curl does not support async DNS, this can cause Sidekiq to crash!
+Please update curl to version 7.32, see issue
+https://github.com/diaspora/diaspora/issues/4202 for details
+*****************************************************************
+"
+fi
+
 # Start Diaspora
 echo -n "Starting Diaspora in $RAILS_ENV mode on port $port "
 if [ "$embed_sidekiq_worker" = "true" ]


### PR DESCRIPTION
As discussed in #4202, add a warning to script/server if curl doesn't support Async DNS and thus Sidekiq might be unstable.

Should we close 4202 if we add this warning, I can also make sure the install instructions are maybe a little clearer? I guess since upstream is fixed already relating to 4202 and if we warn our users there is no reason to keep that bug open..
