### PR TITLE
Add box shadow and radius to avatars

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@
 * Improve search page, add better indications [#4794](https://github.com/diaspora/diaspora/pull/4794)
 * Port notifications and hovercards to Bootstrap [#4814](https://github.com/diaspora/diaspora/pull/4814)
 * Replace .rvmrc by .ruby-version and .ruby-gemset [#4854](https://github.com/diaspora/diaspora/pull/4855)
+* Add box shadow and radius to avatars [#4887](https://github.com/diaspora/diaspora/pull/4887)
 
 ## Bug fixes
 * Improve time agos by updating the plugin [#4280](https://github.com/diaspora/diaspora/issues/4280)

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -92,9 +92,8 @@ ul > li
   :display none
 
 .avatar
-  :-webkit-box-shadow rgba(0,0,0,0.12) 0px 0px 5px inset
-  :-moz-box-shadow rgba(0,0,0,0.12) 0px 0px 5px inset
-
+  @include box-shadow(0px, 1px, 2px, #666)
+  
   :background
     :color $background-grey
 
@@ -551,7 +550,7 @@ h3 span.current_gs_step
 
   .notification
     @include border-radius(5px)
-    @include box-shadow(0,2px,3px,#333)
+    @include box-shadow(0px, 1px, 2px, #666)
 
     :margin
       :bottom 10px

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -92,7 +92,7 @@ ul > li
   :display none
 
 .avatar
-  @include box-shadow(0px, 1px, 2px, #666)
+  @include box-shadow(inset 0px, 1px, 2px, #666)
   
   :background
     :color $background-grey
@@ -550,7 +550,7 @@ h3 span.current_gs_step
 
   .notification
     @include border-radius(5px)
-    @include box-shadow(0px, 1px, 2px, #666)
+    @include box-shadow(inset 0px, 1px, 2px, #666)
 
     :margin
       :bottom 10px

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -92,7 +92,7 @@ ul > li
   :display none
 
 .avatar
-  @include box-shadow(inset 0px, 1px, 2px, #666)
+  @include box-shadow(0px, 1px, 2px, #666)
   
   :background
     :color $background-grey
@@ -550,7 +550,7 @@ h3 span.current_gs_step
 
   .notification
     @include border-radius(5px)
-    @include box-shadow(inset 0px, 1px, 2px, #666)
+    @include box-shadow(0px, 1px, 2px, #666)
 
     :margin
       :bottom 10px

--- a/app/assets/stylesheets/conversations.css.scss
+++ b/app/assets/stylesheets/conversations.css.scss
@@ -18,6 +18,11 @@
     .avatar{
       width: 50px;
       height: 50px;
+      box-shadow: 0px 1px 2px 0px #666;
+      -webkit-box-shadow: 0px 1px 2px 0px #666;
+      -moz-box-shadow: 0px 1px 2px 0px #666;
+      border-radius: 4px;
+
     }
   }
   .stream .stream_element {
@@ -33,11 +38,7 @@
 }
 
 #conversation_show {
-  .conversation_participants {
-    box-shadow: 0 2px 3px -3px #666;
-    -webkit-box-shadow: 0 2px 3px -3px #666;
-    -moz-box-shadow: 0 2px 3px -3px #666;
-    
+  .conversation_participants {    
     background-color: $background-white;
     margin-bottom: 5px;
     border-bottom: 1px solid $border-grey;
@@ -58,6 +59,10 @@
     .avatar {
       height: 30px;
       width: 30px;
+      box-shadow: 0px 1px 2px 0px #666;
+      -webkit-box-shadow: 0px 1px 2px 0px #666;
+      -moz-box-shadow: 0px 1px 2px 0px #666;
+      border-radius: 3px;
     }
 
     .avatars {
@@ -103,6 +108,10 @@
   .avatar {
     width: 50px;
     height: 50px;
+    box-shadow: 0px 1px 2px 0px #666;
+    -webkit-box-shadow: 0px 1px 2px 0px #666;
+    -moz-box-shadow: 0px 1px 2px 0px #666;
+    border-radius: 4px;
     float: left;
   }
   
@@ -150,6 +159,10 @@
       margin: 0 5px 0 0;
       height: 25px;
       width: 25px;
+      box-shadow: 0px 1px 2px 0px #666;
+      -webkit-box-shadow: 0px 1px 2px 0px #666;
+      -moz-box-shadow: 0px 1px 2px 0px #666;
+      border-radius: 3px;
     }
   }
 

--- a/app/assets/stylesheets/header.css.scss
+++ b/app/assets/stylesheets/header.css.scss
@@ -170,6 +170,11 @@ body > header {
           width: 30px;
           float: left;
           margin-left: -40px;
+          margin-top: 5px;
+          box-shadow: 0px 1px 2px 0px #666;
+          -webkit-box-shadow: 0px 1px 2px 0px #666;
+          -moz-box-shadow: 0px 1px 2px 0px #666;
+          border-radius: 3px;
         }
 
         &.unread {
@@ -290,6 +295,7 @@ body > header {
     left: 7px;
     top: 9px;
     display: block;
+    border-radius: 3px;
   }
 
   .header-nav {

--- a/app/assets/stylesheets/new_styles/_base.scss
+++ b/app/assets/stylesheets/new_styles/_base.scss
@@ -24,11 +24,19 @@ a { color : $link-blue  }
   &.micro {
     height: 20px;
     width: 20px;
+    box-shadow: 0px 1px 2px 0px #666;
+    -webkit-box-shadow: 0px 1px 2px 0px #666;
+    -moz-box-shadow: 0px 1px 2px 0px #666;
+    border-radius: 3px;
   }
 
   &.small {
     height: 35px;
     width: 35px;
+    box-shadow: 0px 1px 2px 0px #666;
+    -webkit-box-shadow: 0px 1px 2px 0px #666;
+    -moz-box-shadow: 0px 1px 2px 0px #666;
+    border-radius: 4px;
   }
 }
 

--- a/app/assets/stylesheets/notifications.css.scss
+++ b/app/assets/stylesheets/notifications.css.scss
@@ -70,6 +70,10 @@
       .avatar {
         width: 35px;
         height: 35px;
+        box-shadow: 0px 1px 2px 0px #666;
+        -webkit-box-shadow: 0px 1px 2px 0px #666;
+        -moz-box-shadow: 0px 1px 2px 0px #666;
+        border-radius: 3px;
       }
 
       .unread-toggle {

--- a/app/assets/stylesheets/profile.css.scss
+++ b/app/assets/stylesheets/profile.css.scss
@@ -3,6 +3,10 @@
   img {
     height: auto;
     width: 200px;
+    @include border-top-left-radius(8px);
+    @include border-top-right-radius(8px);
+    @include border-bottom-left-radius(0px);
+    @include border-bottom-right-radius(0px)
   }
 }
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140308154022) do
+ActiveRecord::Schema.define(:version => 20140422134627) do
 
   create_table "account_deletions", :force => true do |t|
     t.string  "diaspora_handle"
@@ -316,17 +316,6 @@ ActiveRecord::Schema.define(:version => 20140308154022) do
 
   add_index "polls", ["status_message_id"], :name => "index_polls_on_status_message_id"
 
-  create_table "post_reports", :force => true do |t|
-    t.integer  "post_id",                       :null => false
-    t.string   "user_id"
-    t.boolean  "reviewed",   :default => false
-    t.text     "text"
-    t.datetime "created_at",                    :null => false
-    t.datetime "updated_at",                    :null => false
-  end
-
-  add_index "post_reports", ["post_id"], :name => "index_post_reports_on_post_id"
-
   create_table "posts", :force => true do |t|
     t.integer  "author_id",                                              :null => false
     t.boolean  "public",                              :default => false, :null => false
@@ -409,6 +398,18 @@ ActiveRecord::Schema.define(:version => 20140308154022) do
   end
 
   add_index "rails_admin_histories", ["item", "table", "month", "year"], :name => "index_rails_admin_histories"
+
+  create_table "reports", :force => true do |t|
+    t.integer  "item_id",                       :null => false
+    t.string   "item_type",                     :null => false
+    t.boolean  "reviewed",   :default => false
+    t.text     "text"
+    t.datetime "created_at",                    :null => false
+    t.datetime "updated_at",                    :null => false
+    t.integer  "user_id",                       :null => false
+  end
+
+  add_index "reports", ["item_id"], :name => "index_post_reports_on_post_id"
 
   create_table "roles", :force => true do |t|
     t.integer  "person_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140422134627) do
+ActiveRecord::Schema.define(:version => 20140308154022) do
 
   create_table "account_deletions", :force => true do |t|
     t.string  "diaspora_handle"
@@ -316,6 +316,17 @@ ActiveRecord::Schema.define(:version => 20140422134627) do
 
   add_index "polls", ["status_message_id"], :name => "index_polls_on_status_message_id"
 
+  create_table "post_reports", :force => true do |t|
+    t.integer  "post_id",                       :null => false
+    t.string   "user_id"
+    t.boolean  "reviewed",   :default => false
+    t.text     "text"
+    t.datetime "created_at",                    :null => false
+    t.datetime "updated_at",                    :null => false
+  end
+
+  add_index "post_reports", ["post_id"], :name => "index_post_reports_on_post_id"
+
   create_table "posts", :force => true do |t|
     t.integer  "author_id",                                              :null => false
     t.boolean  "public",                              :default => false, :null => false
@@ -398,18 +409,6 @@ ActiveRecord::Schema.define(:version => 20140422134627) do
   end
 
   add_index "rails_admin_histories", ["item", "table", "month", "year"], :name => "index_rails_admin_histories"
-
-  create_table "reports", :force => true do |t|
-    t.integer  "item_id",                       :null => false
-    t.string   "item_type",                     :null => false
-    t.boolean  "reviewed",   :default => false
-    t.text     "text"
-    t.datetime "created_at",                    :null => false
-    t.datetime "updated_at",                    :null => false
-    t.integer  "user_id",                       :null => false
-  end
-
-  add_index "reports", ["item_id"], :name => "index_post_reports_on_post_id"
 
   create_table "roles", :force => true do |t|
     t.integer  "person_id"


### PR DESCRIPTION
I decided to pick up #4296 as it seemed to have been abandoned.

I realise there's quite a lot going on with porting to Bootstrap, and various design changes, so perhaps it's not a good time to merge this. But I wanted to do this work anyway, just as an exercise to help me learn, so here it is.

In #4288 most of us liked rounded corners on avatars, but they didn't fit in with the new profile sidebar in #4374, so that idea was dropped. What I've done on the profile pic on people views is to add a radius of 8px (same as on the bottom of the interaction icons bar) to the top corners only, with no radius on the bottom of the avatar.

See what you think.
