### PR TITLE
Unescape text before add mention, this commit solve #4776

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -33,6 +33,7 @@
 * Don't cut off long tags in stream posts [#4864](https://github.com/diaspora/diaspora/issues/4864)
 * Do not replace earlier appearances of the name while mentioning somebody [#4868](https://github.com/diaspora/diaspora/issues/4868)
 * Catch exceptions when trying to decode an invalid URI [#4874](https://github.com/diaspora/diaspora/issues/4874)
+* Parsing mention witch contain in username special characters [#4919](https://github.com/diaspora/diaspora/pull/4919)
 
 ## Features
 * You can report a single post by clicking the correct icon in the controler section [#4517](https://github.com/diaspora/diaspora/pull/4517)

--- a/spec/lib/diaspora/mentionable_spec.rb
+++ b/spec/lib/diaspora/mentionable_spec.rb
@@ -9,14 +9,14 @@ describe Diaspora::Mentionable do
     @test_txt = <<-STR
 This post contains a lot of mentions
 one @{Alice A; #{@people[0].diaspora_handle}},
-two @{Bob B ; #{@people[1].diaspora_handle}}and finally
-three @{Eve E; #{@people[2].diaspora_handle}}.
+two @{Bob B; #{@people[1].diaspora_handle}} and finally
+three @{"Eve> E; #{@people[2].diaspora_handle}}.
 STR
     @test_txt_plain = <<-STR
 This post contains a lot of mentions
 one Alice A,
 two Bob B and finally
-three Eve E.
+three &quot;Eve&gt; E.
 STR
     @status_msg = FactoryGirl.build(:status_message, text: @test_txt)
   end
@@ -25,6 +25,15 @@ STR
     context 'html output' do
       it 'adds the links to the formatted message' do
         fmt_msg = Diaspora::Mentionable.format(@status_msg.raw_message, @people)
+
+        @people.each do |person|
+          fmt_msg.should include person_link(person, class: 'mention hovercardable')
+        end
+      end
+
+      it 'should work correct when message is escaped html' do
+        raw_msg = @status_msg.raw_message
+        fmt_msg = Diaspora::Mentionable.format(CGI::escapeHTML(raw_msg), @people)
 
         @people.each do |person|
           fmt_msg.should include person_link(person, class: 'mention hovercardable')


### PR DESCRIPTION
[markdownify_helper](https://github.com/diaspora/diaspora/blob/develop/app/helpers/markdownify_helper.rb#L42) send to Diaspora::Mentionable.format method escaped string, for example if username is `@{Eve> E; eve@mail.com}` then escaped string is `@{Eve&gt; E; eve@mail.com}` and regular expression Diaspora::Mentionable::REGEX not work correct because `@{Eve&gt; E; eve@mail.com}` the character `;` is in wrong place
issue: #4919
