### PR TITLE
Switch back from Roboto to Helvetica on bootstrap pages

### DIFF
--- a/app/assets/stylesheets/new_styles/_base.scss
+++ b/app/assets/stylesheets/new_styles/_base.scss
@@ -40,7 +40,6 @@ a { color : $link-blue  }
 }
 
 .author-name {
-  font-family : Roboto;
   color: inherit;
 }
 

--- a/app/assets/stylesheets/new_styles/_typography.scss
+++ b/app/assets/stylesheets/new_styles/_typography.scss
@@ -18,7 +18,7 @@
 }
 
 body, p, h1, h2, h3, h4, h5, h6, textarea, input, * {
-  font-family : Roboto, Helvetica, sans-serif;
+  font-family : "Helvetica Neue", Helvetica, sans-serif;
   font-weight : normal;
 }
 


### PR DESCRIPTION
I searched on loomio and apart in the [discussion about the branding](https://www.loomio.org/d/zsxwVAyP/change-our-branding-to-diaspora-lower-case) (where we discussed about the lower case but never really about the font) I didn't find why we switched from Helvetica to Roboto for the bootstrap pages.

The feeling of inconsistency I have when I compare bootstrap pages and other pages mostly come from that. We can discuss which font we prefer, but during the discussion, I really think that diaspora\* should use one and only one font. As most of the pages are currently not ported to bootstrap, I open this pull request which restores Helvetica as the default font.

There is still some part of the code where Roboto is used, I can change them here too if we want.
