### PR TITLE
Bug 4269: Created_at federation vs ordering issues

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -19,6 +19,9 @@ class Comment < ActiveRecord::Base
   xml_attr :text
   xml_attr :diaspora_handle
 
+  #Don't name it remote_create_at, otherwise it won't work due to some mysterious reasons
+  xml_attr :remote_created
+
   belongs_to :commentable, :touch => true, :polymorphic => true
   alias_attribute :post, :commentable
   belongs_to :author, :class_name => 'Person'
@@ -55,6 +58,14 @@ class Comment < ActiveRecord::Base
 
   def diaspora_handle= nh
     self.author = Webfinger.new(nh).fetch
+  end
+
+  def remote_created
+    Time.zone.parse(self.created_at.to_s).to_i.to_s unless(self.created_at.nil?)
+  end
+
+  def remote_created= date
+    self.created_at = Time.at(date.to_i).utc.to_datetime unless date.blank?
   end
 
   def notification_type(user, person)

--- a/lib/diaspora/relayable.rb
+++ b/lib/diaspora/relayable.rb
@@ -44,6 +44,10 @@ module Diaspora
       true
     end
 
+    def set_created_at
+      self.created_at = Time.now
+    end
+
     # @return [String]
     def parent_guid
       return nil unless parent.present?

--- a/lib/federated/generator.rb
+++ b/lib/federated/generator.rb
@@ -8,6 +8,7 @@ module Federated
     def create!(options={})
       relayable = build(options)
       if relayable.save!
+
         FEDERATION_LOGGER.info("user:#{@user.id} dispatching #{relayable.class}:#{relayable.guid}")
         Postzord::Dispatcher.defer_build_and_post(@user, relayable)
         relayable
@@ -18,6 +19,7 @@ module Federated
       options.merge!(relayable_options)
       relayable = self.class.federated_class.new(options.merge(:author_id => @user.person.id))
       relayable.set_guid
+      relayable.set_created_at
       relayable.initialize_signatures
       relayable
     end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -80,6 +80,10 @@ describe Comment do
       @xml.include?(@commenter.diaspora_handle).should be_true
     end
 
+    it 'serializes the created_at timestamp' do
+      @xml.include?(@comment.remote_created).should be_true
+    end
+
     it 'serializes the post_guid' do
       @xml.should include(@post.guid)
     end
@@ -91,6 +95,10 @@ describe Comment do
 
       it 'marshals the author' do
         @marshalled_comment.author.should == @commenter.person
+      end
+
+      it 'marshals the created_at' do
+        @marshalled_comment.created_at.to_s.should == @comment.created_at.to_s
       end
 
       it 'marshals the post' do


### PR DESCRIPTION
The comments are now shipping with the created_at field. I had to change the generator to set the field, otherwise the signature verification will fail. Do you want to test the ordering issues first with the comments or shall I start implementing the changes also for posts and other relayables?

refs https://github.com/diaspora/diaspora/issues/4269
