### PR TITLE
Fixed validation for post-report

### DIFF
--- a/app/controllers/post_report_controller.rb
+++ b/app/controllers/post_report_controller.rb
@@ -22,11 +22,11 @@ class PostReportController < ApplicationController
   end
 
   def create
-    username = current_user.username
-    unless PostReport.where(post_id: params[:post_id]).exists?(user_id: username)
+    user_id = current_user.id
+    unless PostReport.where(post_id: params[:post_id]).exists?(user_id: user_id)
       post = PostReport.new(
         :post_id => params[:post_id],
-        :user_id => username,
+        :user_id => user_id,
         :text => params[:text])
       result = post.save
       status(( 200 if result ) || ( 422 if !result ))

--- a/app/models/post_report.rb
+++ b/app/models/post_report.rb
@@ -1,11 +1,9 @@
 class PostReport < ActiveRecord::Base
-  validates :user_id, presence: true
-  validates :post_id, presence: true
+  validates :user, presence: true
+  validates :post, presence: true
 
   belongs_to :user
   belongs_to :post
-
-  has_many :post_reports  
 
   after_create :send_report_notification
 

--- a/db/migrate/20131017093025_create_post_reports.rb
+++ b/db/migrate/20131017093025_create_post_reports.rb
@@ -2,7 +2,7 @@ class CreatePostReports < ActiveRecord::Migration
   def change
     create_table :post_reports do |t|
       t.integer :post_id, :null => false
-      t.string :user_id
+      t.integer :user_id
       t.boolean :reviewed, :default => false
       t.text :text
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -318,7 +318,7 @@ ActiveRecord::Schema.define(:version => 20140308154022) do
 
   create_table "post_reports", :force => true do |t|
     t.integer  "post_id",                       :null => false
-    t.string   "user_id"
+    t.integer  "user_id"
     t.boolean  "reviewed",   :default => false
     t.text     "text"
     t.datetime "created_at",                    :null => false

--- a/spec/models/post_report_spec.rb
+++ b/spec/models/post_report_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe PostReport do
+  it 'should validates presence of user' do
+    subject.should have(1).error_on(:user)
+  end
+  it 'should validates presence of post' do
+    subject.should have(1).error_on(:post)
+  end
+end


### PR DESCRIPTION
When send post request to post_report#create with non-existent post_id then this report has been stored on database and cause problems on admin side
