### PR TITLE
Missing transaction in the StatusMessage controller

### DIFF
--- a/app/controllers/status_messages_controller.rb
+++ b/app/controllers/status_messages_controller.rb
@@ -61,34 +61,36 @@ class StatusMessagesController < ApplicationController
 
     @status_message.attach_photos_by_ids(params[:photos])
 
-    if @status_message.save
-      aspects = current_user.aspects_from_ids(destination_aspect_ids)
-      current_user.add_to_streams(@status_message, aspects)
-      receiving_services = Service.titles(services)
+    ActiveRecord::Base.transaction do
+      if @status_message.save
+        aspects = current_user.aspects_from_ids(destination_aspect_ids)
+        current_user.add_to_streams(@status_message, aspects)
+        receiving_services = Service.titles(services)
 
-      current_user.dispatch_post(@status_message, :url => short_post_url(@status_message.guid), :service_types => receiving_services)
+        current_user.dispatch_post(@status_message, :url => short_post_url(@status_message.guid), :service_types => receiving_services)
 
-      #this is done implicitly, somewhere else, but it doesnt work, says max. :'(
-      @status_message.photos.each do |photo|
-        current_user.dispatch_post(photo)
-      end
+        #this is done implicitly, somewhere else, but it doesnt work, says max. :'(
+        @status_message.photos.each do |photo|
+          current_user.dispatch_post(photo)
+        end
 
-      current_user.participate!(@status_message)
+        current_user.participate!(@status_message)
 
-      if coming_from_profile_page? && !own_profile_page? # if this is a post coming from a profile page
-        flash[:notice] = successful_mention_message
-      end
+        if coming_from_profile_page? && !own_profile_page? # if this is a post coming from a profile page
+          flash[:notice] = successful_mention_message
+        end
 
-      respond_to do |format|
-        format.html { redirect_to :back }
-        format.mobile { redirect_to stream_path }
-        format.json { render :json => PostPresenter.new(@status_message, current_user), :status => 201 }
-      end
-    else
-      respond_to do |format|
-        format.html { redirect_to :back }
-        format.mobile { redirect_to stream_path }
-        format.json { render :nothing => true, :status => 403 }
+        respond_to do |format|
+          format.html { redirect_to :back }
+          format.mobile { redirect_to stream_path }
+          format.json { render :json => PostPresenter.new(@status_message, current_user), :status => 201 }
+        end
+      else
+        respond_to do |format|
+          format.html { redirect_to :back }
+          format.mobile { redirect_to stream_path }
+          format.json { render :nothing => true, :status => 403 }
+        end
       end
     end
   end


### PR DESCRIPTION
The status message is created and then the aspect visibilities are created. If the server dies in the middle, the database is left in a inconsistent state. We have to execute this controller in a transaction.

The diff looks a little bigger than it should. Just two lines were added.
