### PR TITLE
Rake task for running outstanding account deletions

### DIFF
--- a/lib/tasks/accounts.rake
+++ b/lib/tasks/accounts.rake
@@ -1,0 +1,15 @@
+namespace :accounts do
+  desc "Run deletions"
+  task :run_deletions => :environment do
+    if ::AccountDeletion.count > 0
+      puts "Running account deletions.."
+      ::AccountDeletion.find_each do |account_delete|
+        account_delete.perform!
+      end
+      puts "OK."
+    end
+
+    puts "No acccount deletions to run."
+  end
+
+end


### PR DESCRIPTION
In addition to #4953 - Adds a rake task `rake accounts:run_deletions` to run oustanding account deletions

Fixes for #4792
