### PR TITLE
Hint that something is happening when user submits status message via publisher

### DIFF
--- a/app/assets/javascripts/app/views/bookmarklet_view.js
+++ b/app/assets/javascripts/app/views/bookmarklet_view.js
@@ -35,6 +35,7 @@ app.views.Bookmarklet = Backbone.View.extend({
   _postSuccess: function(evt) {
     this.$('h4').text(Diaspora.I18n.t('bookmarklet.post_success'));
     app.publisher.close();
+    this.$("#publisher").addClass("hidden");
     _.delay(window.close, 2000);
   },
 

--- a/app/assets/javascripts/app/views/bookmarklet_view.js
+++ b/app/assets/javascripts/app/views/bookmarklet_view.js
@@ -40,6 +40,6 @@ app.views.Bookmarklet = Backbone.View.extend({
   },
 
   _postError: function(evt) {
-    this.$('h4').text(Diaspora.I18n.t('bookmarklet.post_error'));
+    this.$('h4').text(Diaspora.I18n.t('bookmarklet.post_something'));
   }
 });

--- a/app/assets/javascripts/app/views/publisher_view.js
+++ b/app/assets/javascripts/app/views/publisher_view.js
@@ -191,7 +191,6 @@ app.views.Publisher = Backbone.View.extend({
       },
       error: function() {
         if( app.publisher ) app.publisher.trigger('publisher:error');
-        self.setButtonsEnabled(true);
         self.setInputEnabled(true);
         Diaspora.page.flashMessages.render({ 'success':false, 'notice':Diaspora.I18n.t('failed_to_post_message') });
         self.setButtonsEnabled(true);

--- a/app/assets/javascripts/app/views/publisher_view.js
+++ b/app/assets/javascripts/app/views/publisher_view.js
@@ -144,6 +144,8 @@ app.views.Publisher = Backbone.View.extend({
     var serializedForm = $(evt.target).closest("form").serializeObject();
     // disable input while posting, must be after the form is serialized
     this.setInputEnabled(false);
+    this.setButtonsEnabled(false);
+    this.$('#publisher_spinner').removeClass('hidden');
 
     // lulz this code should be killed.
     var statusMessage = new app.models.Post();
@@ -179,6 +181,8 @@ app.views.Publisher = Backbone.View.extend({
       error: function() {
         if( app.publisher ) app.publisher.trigger('publisher:error');
         self.setInputEnabled(true);
+        self.setButtonsEnabled(true);
+        self.$('#publisher_spinner').addClass('hidden');
       }
     });
   },
@@ -346,6 +350,12 @@ app.views.Publisher = Backbone.View.extend({
 
     // enable input
     this.setInputEnabled(true);
+    
+    // enable buttons
+    this.setButtonsEnabled(false);
+    
+    // hide spinner
+    this.$('#publisher_spinner').addClass('hidden');
 
     // clear location
     this.destroyLocation();

--- a/app/assets/javascripts/app/views/publisher_view.js
+++ b/app/assets/javascripts/app/views/publisher_view.js
@@ -183,6 +183,7 @@ app.views.Publisher = Backbone.View.extend({
         self.setInputEnabled(true);
         self.setButtonsEnabled(true);
         self.$('#publisher_spinner').addClass('hidden');
+        Diaspora.page.flashMessages.render({ 'success':false, 'notice':Diaspora.I18n.t('failed_to_post_message') });
       }
     });
   },

--- a/app/assets/stylesheets/publisher.css.scss
+++ b/app/assets/stylesheets/publisher.css.scss
@@ -23,6 +23,10 @@
       margin-top: 10px;
     }
     
+    #publisher_spinner {
+      text-align: center;
+    }
+    
     .options_and_submit {
       #publisher_service_icons {
         .btn-link { text-decoration: none; }

--- a/app/assets/stylesheets/publisher_blueprint.css.scss
+++ b/app/assets/stylesheets/publisher_blueprint.css.scss
@@ -70,6 +70,12 @@
       }
     }
 
+    #publisher_spinner {
+      position: relative;
+      top: 3px;
+      margin-right: 10px;
+    }
+
     #publisher_service_icons {
       position: relative;
       top: 3px;

--- a/app/assets/stylesheets/publisher_blueprint.css.scss
+++ b/app/assets/stylesheets/publisher_blueprint.css.scss
@@ -42,6 +42,15 @@
     width: 483px;
   }
 
+  #publisher_spinner {
+    clear: both;
+    margin-bottom: -2px;
+    min-height: 21px;
+    padding-top: 6px;
+    position: relative;
+    text-align: center;
+  }
+
   .options_and_submit {
     min-height: 21px;
     clear: both;
@@ -68,12 +77,6 @@
       a.question_mark {
         text-decoration: none;
       }
-    }
-
-    #publisher_spinner {
-      position: relative;
-      top: 3px;
-      margin-right: 10px;
     }
 
     #publisher_service_icons {

--- a/app/views/publisher/_publisher_blueprint.html.haml
+++ b/app/views/publisher/_publisher_blueprint.html.haml
@@ -47,10 +47,10 @@
         - for aspect_id in aspect_ids
           = hidden_field_tag 'aspect_ids[]', aspect_id.to_s
 
+      #publisher_spinner{:class => 'hidden'}
+        = image_tag 'ajax-loader.gif'
       .options_and_submit
         .public_toggle
-          %span#publisher_spinner{:class => 'hidden'}
-            = image_tag 'ajax-loader.gif'
           %span#publisher_service_icons
             - if current_user.services
               - for service in current_user.services

--- a/app/views/publisher/_publisher_blueprint.html.haml
+++ b/app/views/publisher/_publisher_blueprint.html.haml
@@ -49,6 +49,8 @@
 
       .options_and_submit
         .public_toggle
+          %span#publisher_spinner{:class => 'hidden'}
+            = image_tag 'ajax-loader.gif'
           %span#publisher_service_icons
             - if current_user.services
               - for service in current_user.services

--- a/app/views/publisher/_publisher_bootstrap.html.haml
+++ b/app/views/publisher/_publisher_bootstrap.html.haml
@@ -53,6 +53,8 @@
         - for aspect_id in aspect_ids
           = hidden_field_tag 'aspect_ids[]', aspect_id.to_s
 
+      .row-fluid#publisher_spinner{:class => 'hidden'}
+        = image_tag 'ajax-loader.gif'
       .row-fluid.options_and_submit
         .public_toggle
           %button.btn.btn-default.pull-left#hide_publisher{:title => t('shared.publisher.discard_post')}
@@ -60,8 +62,6 @@
               =t('cancel')
 
           .btn-toolbar.pull-right
-            %span#publisher_spinner{:class => 'hidden'}
-              = image_tag 'ajax-loader.gif'
             %span#publisher_service_icons
               - if current_user.services
                 - for service in current_user.services

--- a/app/views/publisher/_publisher_bootstrap.html.haml
+++ b/app/views/publisher/_publisher_bootstrap.html.haml
@@ -60,6 +60,8 @@
               =t('cancel')
 
           .btn-toolbar.pull-right
+            %span#publisher_spinner{:class => 'hidden'}
+              = image_tag 'ajax-loader.gif'
             %span#publisher_service_icons
               - if current_user.services
                 - for service in current_user.services

--- a/config/locales/javascript/javascript.en.yml
+++ b/config/locales/javascript/javascript.en.yml
@@ -54,9 +54,9 @@ en:
       add_option: "Add option"
       question: "Question"
     bookmarklet:
+      post_something: "Post to diaspora*"
       post_submit: "Submitting post..."
       post_success: "Posted! Closing popup window..."
-      post_error: "An error occurred, try again later."
     infinite_scroll:
       no_more: "No more posts."
       no_more_contacts: "No more contacts."

--- a/config/locales/javascript/javascript.en.yml
+++ b/config/locales/javascript/javascript.en.yml
@@ -50,6 +50,9 @@ en:
       limited: "Limited - your post will only be seen by people you are sharing with"
       public: "Public - your post will be visible to everyone and found by search engines"
       near_from: "Posted from: <%= location %>"
+      option: "Option <%= nr %>"
+      add_option: "Add option"
+      question: "Question"
     bookmarklet:
       post_submit: "Submitting post..."
       post_success: "Posted! Closing popup window..."
@@ -109,11 +112,6 @@ en:
     notifications:
       mark_read: "Mark read"
       mark_unread: "Mark unread"
-
-    publisher:
-      option: "Option <%= nr %>"
-      add_option: "Add option"
-      question: "Question"
 
     stream:
       hide: "Hide"


### PR DESCRIPTION
Basically, right side of service icons, we use an ajax loader that appears when submitted and disappears after success/error. The button is also disabled, but blueprint doesn't show that - Bootstrap styles it differently. Fixes #4949.

Also added a flash message in case the server reports an error. Otherwise the publisher gave no hint on error, just kept form open and active without saying anything to user.

![pic](http://i.imgur.com/idpe8OD.png)
![pic](http://i.imgur.com/0LX2SmG.png)

Btw, the moving of some strings around in the JS locales was needed since the poll locales for publisher overwrote the earlier defined publisher locales.
