### PR TITLE
[WIP] Get rid of console errors in mobile view

### DIFF
--- a/app/assets/javascripts/app/app.js
+++ b/app/assets/javascripts/app/app.js
@@ -79,9 +79,13 @@ var app = {
   },
 
   setupFacebox: function() {
-    $.facebox.settings.closeImage = app.baseImageUrl()+'facebox/closelabel.png';
-    $.facebox.settings.loadingImage = app.baseImageUrl()+'facebox/loading.gif';
-    $.facebox.settings.opacity = 0.75;
+    try {
+      $.facebox.settings.closeImage = app.baseImageUrl()+'facebox/closelabel.png';
+      $.facebox.settings.loadingImage = app.baseImageUrl()+'facebox/loading.gif';
+      $.facebox.settings.opacity = 0.75;
+    } catch (e) {
+      console.info("Suppressed error: "+e.message);
+    }
   },
 
   setupBackboneLinks: function() {

--- a/app/assets/javascripts/app/helpers/handlebars-partials.js
+++ b/app/assets/javascripts/app/helpers/handlebars-partials.js
@@ -1,4 +1,8 @@
 /* we need to wrap this in a document ready to ensure JST is accessible */
 $(function(){
-  Handlebars.registerPartial('status-message', JST['status-message_tpl'])
+  try {
+    Handlebars.registerPartial('status-message', JST['status-message_tpl']);
+  } catch (e) {
+	console.info("Suppressed error: "+e.message);
+  }
 });

--- a/app/assets/javascripts/app/views.js
+++ b/app/assets/javascripts/app/views.js
@@ -35,15 +35,19 @@ app.views.Base = Backbone.View.extend({
 
   renderTemplate : function(){
     var presenter = _.isFunction(this.presenter) ? this.presenter() : this.presenter
-    this.template = JST[this.templateName+"_tpl"]
-    if(!this.template) {
-      console.log(this.templateName ? ("no template for " + this.templateName) : "no templateName specified")
-    }
+    try {
+      this.template = JST[this.templateName+"_tpl"]
+      if(!this.template) {
+        console.log(this.templateName ? ("no template for " + this.templateName) : "no templateName specified")
+      }
 
-    this.$el
-      .html(this.template(presenter))
-      .attr("data-template", _.last(this.templateName.split("/")));
-    this.postRenderTemplate();
+      this.$el
+        .html(this.template(presenter))
+        .attr("data-template", _.last(this.templateName.split("/")));
+      this.postRenderTemplate();
+    } catch (e) {
+      console.info("Suppressed error: "+e.message);
+    }
   },
 
   postRenderTemplate : $.noop, //hella callbax yo

--- a/app/assets/javascripts/mobile.js
+++ b/app/assets/javascripts/mobile.js
@@ -370,4 +370,8 @@ function createUploader(){
 
    });
 }
-createUploader();
+try {
+  createUploader();
+} catch (e) {
+  console.info("Suppressed error: "+e.message);
+}

--- a/app/assets/javascripts/view.js
+++ b/app/assets/javascripts/view.js
@@ -9,7 +9,11 @@ var View = {
     $("input:submit").addClass("button");
 
     /* label placeholders */
-    $("input, textarea").placeholder();
+    try {
+      $("input, textarea").placeholder();
+    } catch (e) {
+      console.info("Suppressed error: "+e.message);
+    }
 
     /* "Toggling" the search input */
     $(this.search.selector)
@@ -63,7 +67,11 @@ var View = {
 
     $(document.body).click(this.dropdowns.removeFocus);
 
-    $('a[rel*=facebox]').facebox();
+    try {
+      $('a[rel*=facebox]').facebox();
+    } catch (e) {
+      console.info("Suppressed error: "+e.message);
+    }
     $(document).bind('reveal.facebox', function() {
       Diaspora.page.directionDetector.updateBinds();
     });

--- a/app/assets/javascripts/widgets/notifications-badge.js
+++ b/app/assets/javascripts/widgets/notifications-badge.js
@@ -12,16 +12,20 @@
         ajaxLoader: dropdown.find(".ajax_loader")
       });
 
-      if( ! $.browser.msie ) {
-        self.badge.on('click', self.badgeLink, function(evt){
-          evt.preventDefault();
-          evt.stopPropagation();
-          if (self.dropdownShowing()){
-            self.hideDropdown();
-          } else {
-            self.showDropdown();
-          }
-        });
+      try {
+        if( ! $.browser.msie ) {
+          self.badge.on('click', self.badgeLink, function(evt){
+            evt.preventDefault();
+            evt.stopPropagation();
+            if (self.dropdownShowing()){
+              self.hideDropdown();
+            } else {
+              self.showDropdown();
+            }
+          });
+        }
+      } catch (e) {
+        console.info("Suppressed error: "+e.message);
       }
 
       self.documentBody.click(function(evt) {

--- a/app/assets/javascripts/widgets/search.js
+++ b/app/assets/javascripts/widgets/search.js
@@ -22,9 +22,13 @@
         }
       });
 
-      self.searchInput.autocomplete(self.searchFormAction + ".json", $.extend(self.options, {
-        element: self.searchInput
-      }));
+      try {
+        self.searchInput.autocomplete(self.searchFormAction + ".json", $.extend(self.options, {
+          element: self.searchInput
+        }));
+      } catch (e) {
+        console.info("Suppressed error: "+ e.message);
+      }
     });
 
     this.formatItem = function(row) {


### PR DESCRIPTION
This pull is not "ready code" but rather work in progress to get rid of various JS console errors popping up in the mobile view.

I've done a try/catch ignore around the ones I came upon, also images to see the suppress messages produced by them. Images added for /stream and /bookmarklet views.

I was trying to fix the problem with /bookmarklet service icons not working, even though they work in /status_messages/new ok. Any ideas - some code missing due to these errors?

Please feel free to point in the right direction per try/catch here for more proper fixes :)

![pic](http://i.imgur.com/JgoaLlj.png)
![pic](http://i.imgur.com/0UwOfPF.png)
