### PR TITLE
Fix toggling services for mobile bookmarklet

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -56,6 +56,7 @@ Read more in [#4249](https://github.com/diaspora/diaspora/pull/4249) and [#4883]
 * Parsing mention witch contain in username special characters [#4919](https://github.com/diaspora/diaspora/pull/4919)
 * Do not show your own hovercard [#4724](https://github.com/diaspora/diaspora/issues/4724)
 * Hit Nominatim via https [#4967](https://github.com/diaspora/diaspora/issues/4967)
+* Fix services regression in mobile bookmarklet [#4985](https://github.com/diaspora/diaspora/pull/4985)
 
 ## Features
 * You can report a single post or comment by clicking the correct icon in the controler section [#4517](https://github.com/diaspora/diaspora/pull/4517) [#4781](https://github.com/diaspora/diaspora/pull/4781)

--- a/app/views/status_messages/bookmarklet.mobile.haml
+++ b/app/views/status_messages/bookmarklet.mobile.haml
@@ -19,6 +19,3 @@
       $("#status_message_text").val(contents);
     }
   });
-
-- content_for(:head) do
-  = javascript_include_tag :jquery, :mobile


### PR DESCRIPTION
This regression has been introduced at some point when the publisher or bookmarklet was refactored. I didn't bother raising a bug since it was always "I'll fix it soon it's prob some small thing". Indeed it was, though it took me a few hours to find out :D

The guilty part was duplicate inclusion of mobile.js AFAICT -  removing that and also the duplicate jquery fixed the problem. More info here: http://yuji.wordpress.com/2010/02/22/jquery-click-event-fires-twice/

Any chance to include this in the 0.4 release as it's regression? :) Not sure if it's regression since 0.3.x but regression anyhow.
