### PR TITLE
Feature/4923 spv post deletion

### DIFF
--- a/app/assets/javascripts/app/views/single-post-viewer/single_post_actions.js
+++ b/app/assets/javascripts/app/views/single-post-viewer/single_post_actions.js
@@ -3,8 +3,18 @@ app.views.SinglePostActions = app.views.Feedback.extend({
 
   events: function() {
     return _.defaults({
-      "click .focus-comment" : "focusComment"
+      "click .focus-comment" : "focusComment",
+      "click .delete-post" : "deletePost",
+      "click .hide-post" : "hidePost",
+      "click .ignore-user" : "ignoreUser",
     }, app.views.Feedback.prototype.events);
+  },
+
+  presenter: function() {
+    //still need to keep presenter variables from app.views.Feedback.
+    return _.extend(app.views.Feedback.prototype.presenter.apply(this), {
+      authorIsCurrentUser: this.authorIsCurrentUser(),
+    });
   },
 
   renderPluginWidgets : function() {
@@ -16,6 +26,68 @@ app.views.SinglePostActions = app.views.Feedback.extend({
     $('.comment_stream .comment_box').focus();
     $('html,body').animate({scrollTop: $('.comment_stream .comment_box').offset().top - ($('.comment_stream .comment_box').height() + 20)});
     return false;
-  }
+  },
+
+  deletePost: function(evt) {
+    //can't use standard destroyModel here because its callbacks don't make sense
+    //for spv. Creating custom one here.
+    var self = this;
+
+    if(evt) { evt.preventDefault(); }
+    if (confirm(Diaspora.I18n.t("confirm_dialog"))) {
+      this.model.destroy()
+        .done(function() {
+          self.redirectToStream();
+        })
+        .fail(function() {
+          var flash = new Diaspora.Widgets.FlashMessages;
+          flash.render({
+            success: false,
+            notice: Diaspora.I18n.t('failed_to_remove')
+          });
+        });
+    }
+  },
+
+  hidePost: function(evt) {
+    if(evt) { evt.preventDefault(); }
+    if(!confirm(Diaspora.I18n.t('confirm_dialog'))) { return; }
+
+    $.ajax({
+      url : "/share_visibilities/42",
+      type : "PUT",
+      data : {
+        post_id : this.model.id
+      }
+    });
+
+    this.redirectToStream();
+  },
+
+  ignoreUser: function(evt) {
+    if(evt) { evt.preventDefault(); }
+    if(!confirm(Diaspora.I18n.t('ignore_user'))) { return; }
+
+    var personId = this.model.get("author").id;
+    var block = new app.models.Block();
+
+    var self = this;
+
+    block.save({block : {person_id : personId}}, {
+      success : function(){
+        self.redirectToStream();
+      }
+    })
+  },
+
+  redirectToStream : function () {
+    //IE8 does not support window.location.origin so
+    //using window.location.protocol + "//" + window.location.host instead.
+    window.location.href = window.location.protocol + "//" + window.location.host + "/stream";
+  },
+
+  authorIsCurrentUser : function () {
+    return app.currentUser.authenticated() && this.model.get("author").id == app.user().id;
+  },
 
 });

--- a/app/assets/stylesheets/single-post-view.css.scss
+++ b/app/assets/stylesheets/single-post-view.css.scss
@@ -20,6 +20,7 @@
           line-height: 14px;
         }
       }
+
       .avatar.medium {
         max-width: 75px;
       }
@@ -73,9 +74,15 @@
       i.retweet:hover {
         color: #3f8fba;
       }
+      i.cross:hover {
+        color: #424242;
+      }
+      i.mute:hover {
+        color: #424242;
+      }
       time {
         float: right;
-        margin-left: 3px;
+        margin-left: 7px;
       }
       a {
         margin: 0 0 0 6px;

--- a/app/assets/templates/single-post-viewer/single-post-actions_tpl.jst.hbs
+++ b/app/assets/templates/single-post-viewer/single-post-actions_tpl.jst.hbs
@@ -26,5 +26,23 @@
     <a href="#" rel="auth-required" data-type="post" class="post_report" title="{{t "report.name"}}">
       <i class="entypo gray large">&#x21;</i>
     </a>
+
+    {{#if loggedIn}}
+        {{#unless authorIsCurrentUser}}
+            <a href="#" rel="auth-required" class="ignore-user" title="{{t "ignore"}}">
+                <i class="entypo mute gray large"></i>
+            </a>
+        {{/unless}}
+
+        {{#if authorIsCurrentUser}}
+            <a href="#" rel="auth-required" class="delete-post" title="{{t "delete"}}">
+                <i class="entypo cross gray large"></i>
+            </a>
+        {{else}}
+            <a href="#" rel="nofollow" class="hide-post" title="{{t "stream.hide"}}">
+                <i class="entypo cross gray large"></i>
+            </a>
+        {{/if}}
+    {{/if}}
   </div>
 </div>

--- a/spec/javascripts/app/views/single_post_actions_view_spec.js
+++ b/spec/javascripts/app/views/single_post_actions_view_spec.js
@@ -1,0 +1,119 @@
+describe("app.views.SinglePostActions", function() {
+
+	beforeEach(function() {
+		loginAs({name: "bob"});
+
+		this.post = factory.post();
+		this.post.set({author: {
+			id: app.user().id
+		}});
+	});
+
+	context("author signed in", function() {
+		it("displays a delete post button", function(){
+			var view = new app.views.SinglePostActions({model: this.post}).render();
+			expect(view.$(".delete-post")).toExist();
+		});
+
+		it("does not display a hide post button", function() {
+			var view = new app.views.SinglePostActions({model: this.post}).render();
+			expect(view.$(".hide-post")).not.toExist();
+		});
+
+		it("does not display an ignore user button", function() {
+			var view = new app.views.SinglePostActions({model: this.post}).render();
+			expect(view.$(".ignore-post")).not.toExist();
+		});
+
+		it("delete post button calls deletePost in view", function() {
+			var view = new app.views.SinglePostActions({model: this.post});
+
+			//Return false on confirm so redirect doesn't cause jasmine error.
+			//This should be okay seeing as this is testing for deletePost being
+			//called.
+			spyOn(window, "confirm").andReturn(false);
+
+			view = view.render();
+			view.$(".delete-post").click();
+
+			expect(window.confirm).toHaveBeenCalled();
+		});
+	});
+
+	context("author not signed in, but still signed in as other user", function() {
+		beforeEach(function() {
+			logout();
+			loginAs({name: "alice"});
+		});
+
+		it("does not display a delete post button", function() {
+			var view = new app.views.SinglePostActions({model: this.post}).render();
+
+			expect(view.$(".delete-post")).not.toExist();
+		});
+
+		it("displays a hide post button", function() {
+			var view = new app.views.SinglePostActions({model: this.post}).render();
+
+			expect(view.$(".hide-post")).toExist();
+		});
+
+		it("hide post button calls hidePost in view", function() {
+			var view = new app.views.SinglePostActions({model: this.post});
+
+			//Return false on confirm so redirect doesn't cause jasmine error.
+			//This should be okay seeing as this is testing for hidePost being
+			//called.
+			spyOn(window, "confirm").andReturn(false);
+
+			view = view.render();
+			view.$(".hide-post").click();
+
+			expect(window.confirm).toHaveBeenCalled();
+		});
+
+		it("displays ignore user button", function() {
+			var view = new app.views.SinglePostActions({model: this.post}).render();
+
+			expect(view.$(".ignore-user")).toExist();
+		});
+
+		it("ignore user button calls ignoreUser in view", function() {
+			var view = new app.views.SinglePostActions({model: this.post});
+
+			//Return false on confirm so redirect doesn't cause jasmine error.
+			//This should be okay seeing as this is testing for ignoreUser being
+			//called.
+			spyOn(window, "confirm").andReturn(false);
+
+			view = view.render();
+			view.$(".ignore-user").click();
+
+			expect(window.confirm).toHaveBeenCalled();
+		});
+	});
+
+	context("not signed in at all", function() {
+		beforeEach(function() {
+			logout();
+		});
+
+		it("does not display a delete post button", function() {
+			var view = new app.views.SinglePostActions({model: this.post}).render();
+
+			expect(view.$(".delete-post")).not.toExist();
+		});
+
+		it("does not display a hide post button", function() {
+			var view = new app.views.SinglePostActions({model: this.post}).render();
+
+			expect(view.$(".hide-post")).not.toExist();
+		});
+
+		it("does not display an ignore user button", function() {
+			var view = new app.views.SinglePostActions({model: this.post});
+
+			expect(view.$(".ignore-user")).not.toExist();
+		});
+	});
+});


### PR DESCRIPTION
Fixes issue 4923 by adding a 'delete post' button to the SPV if the author is logged in, and both a 'hide post' and 'ignore user' button if the user is not the author. 'Hide post', 'remove post', and 'ignore user' redirect the user to their stream.

'Ignore user' uses a different icon than the one shown on posts in the stream. I couldn't find the icon of an appropriate size, so I used entypo's mute icon.

Added some tests in spec/javascripts/app/views/single_post_actions_view_spec.js for testing the UI elements.

![del-post](https://cloud.githubusercontent.com/assets/1899810/3211319/115176ec-ef10-11e3-929c-94e5c28778b8.png)
![hide-post](https://cloud.githubusercontent.com/assets/1899810/3211320/1152cac4-ef10-11e3-8d9c-8bb29852672d.png)
