### PR TITLE
Load right stream with Show More on mobile

### DIFF
--- a/app/helpers/stream_helper.rb
+++ b/app/helpers/stream_helper.rb
@@ -10,9 +10,12 @@ module StreamHelper
       local_or_remote_person_path(@person, :max_time => time_for_scroll(@stream))
     elsif controller.instance_of?(PostsController)
       public_stream_path(:max_time => time_for_scroll(@stream))
-    elsif controller.instance_of?(StreamsController) 
+    elsif controller.instance_of?(StreamsController)
       if current_page?(:stream)
         stream_path(:max_time => time_for_scroll(@stream))
+      elsif current_page?(:aspects_stream)
+        aspect_ids = (session[:a_ids] || [])
+        aspects_stream_path(:max_time => time_for_scroll(@stream), a_ids: aspect_ids)
       else
         activity_stream_path(:max_time => time_for_scroll(@stream))
       end

--- a/app/helpers/stream_helper.rb
+++ b/app/helpers/stream_helper.rb
@@ -14,8 +14,7 @@ module StreamHelper
       if current_page?(:stream)
         stream_path(:max_time => time_for_scroll(@stream))
       elsif current_page?(:aspects_stream)
-        aspect_ids = (session[:a_ids] || [])
-        aspects_stream_path(:max_time => time_for_scroll(@stream), a_ids: aspect_ids)
+        aspects_stream_path(:max_time => time_for_scroll(@stream), :a_ids => session[:a_ids])
       else
         activity_stream_path(:max_time => time_for_scroll(@stream))
       end

--- a/spec/helpers/stream_helper_spec.rb
+++ b/spec/helpers/stream_helper_spec.rb
@@ -19,13 +19,21 @@ describe StreamHelper do
     end
 
     it 'works for stream page when current page is stream' do
-      helper.stub(:current_page?).and_return(true)
+      helper.stub(:current_page?).and_return(false)
+      helper.should_receive(:current_page?).with(:stream).and_return(true)
       helper.stub(:controller).and_return(build_controller(StreamsController))
       helper.next_page_path.should include stream_path
     end
 
-    it 'works for activity page when current page is not stream' do
-      helper.stub("current_page?").and_return(false)
+    it 'works for aspects page when current page is aspects' do
+      helper.stub(:current_page?).and_return(false)
+      helper.should_receive(:current_page?).with(:aspects_stream).and_return(true)
+      helper.stub(:controller).and_return(build_controller(StreamsController))
+      helper.next_page_path.should include aspects_stream_path
+    end
+
+    it 'works for activity page when current page is not stream or aspects' do
+      helper.stub(:current_page?).and_return(false)
       helper.stub(:controller).and_return(build_controller(StreamsController))
       # binding.pry
       helper.next_page_path.should include activity_stream_path


### PR DESCRIPTION
Fix issue #4999
- Load aspects stream if user is on this stream instead of loading the
  activity stream
