### PR TITLE
Refactor mobile JS loading, no more console errors.

### DIFF
--- a/app/assets/javascripts/diaspora.js
+++ b/app/assets/javascripts/diaspora.js
@@ -78,7 +78,8 @@
       Diaspora.page = new Page();
     }
 
-    if(!$.mobile)//why does this need this?
+    if (typeof MOBILE == "undefined" || !MOBILE)
+	  // don't init BasePage on mobile
       $.extend(Diaspora.page, new Diaspora.BasePage($(document.body)));
     Diaspora.page.publish("page/ready", [$(document.body)])
   };

--- a/app/views/contacts/index.mobile.haml
+++ b/app/views/contacts/index.mobile.haml
@@ -5,8 +5,9 @@
 - content_for :page_title do
   = t('.title')
 
-- content_for :head do
-  = javascript_include_tag :people
+- if ! in_mobile_view?
+  - content_for :head do
+    = javascript_include_tag :people
 
 #section_header
   %h2

--- a/app/views/conversations/new.haml
+++ b/app/views/conversations/new.haml
@@ -2,10 +2,6 @@
 -#   licensed under the Affero General Public License version 3 or later.  See
 -#   the COPYRIGHT file.
 
-- if in_mobile_view?
-  = javascript_include_tag :jquery
-  = javascript_include_tag :mobile
-
 :javascript
   $(document).ready(function () {
     var data = $.parseJSON( "#{escape_javascript(@contacts_json)}" ),

--- a/app/views/layouts/application.mobile.haml
+++ b/app/views/layouts/application.mobile.haml
@@ -42,6 +42,13 @@
 
     - if rtl?
       = stylesheet_link_tag :rtl, :media => 'all'
+      
+    :javascript
+        var MOBILE = true;
+    = jquery_include_tag
+    = include_gon
+    = javascript_include_tag :diaspora, :"helpers/i18n", :mobile
+    = include_chartbeat
 
     = yield(:head)
 
@@ -107,8 +114,3 @@
           %h3
             = t('streams.activity.title')
         = yield
-
-    / javascripts at the bottom
-    = jquery_include_tag
-    = javascript_include_tag :mobile
-    = include_chartbeat

--- a/app/views/publisher/_publisher.mobile.haml
+++ b/app/views/publisher/_publisher.mobile.haml
@@ -2,12 +2,6 @@
 -#   licensed under the Affero General Public License version 3 or later.  See
 -#   the COPYRIGHT file.
 
-- content_for :head do
-  = jquery_include_tag
-  = javascript_include_tag :main
-  = load_javascript_locales
-  = include_gon
-
 = form_for StatusMessage.new, {:data => {:ajax => false}} do |status|
   = status.hidden_field :provider_display_name, :value => 'mobile'
   = status.text_area :text, :placeholder => t('shared.publisher.whats_on_your_mind'), :rows => 4, :autofocus => "autofocus"


### PR DESCRIPTION
So basically currently there are a bunch of console errors in the mobile app due to wrong loading of JS, for example facebox was being initialized which caused the first error.

So I tried to fix things by making sure that the main Diaspora javascript BasePage is not initialized on mobile (there was old code for that but `$.mobile` was never set) and that only JS which is needed is loaded.

Also the JS in the application layout has been moved to the head, since quite many of the HAML templates load JS which requires jQuery. This was causing jQuery and mobile JS to be loaded twice.

This fixed the console errors, but also the mobile bookmarklet.
