### PR TITLE
Set mention notification as read when viewing post

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -85,9 +85,13 @@ class PostsController < ApplicationController
   end
 
   def mark_corresponding_notifications_read
-    Notification.where(recipient_id: current_user.id, target_id: @post.id, unread: true).each do |n|
-      n.unread = false
-      n.save!
+    # For comments, reshares, likes
+    Notification.where(recipient_id: current_user.id, target_type: "Post", target_id: @post.id, unread: true).each do |n|
+      n.set_read_state( true )
     end
+
+    # For mentions
+    mention = @post.mentions.where(person_id: current_user.id).first
+    Notification.where(recipient_id: current_user.id, target_type: "Mention", target_id: mention.id, unread: true).first.try(:set_read_state, true) if mention
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -91,7 +91,7 @@ class PostsController < ApplicationController
     end
 
     # For mentions
-    mention = @post.mentions.where(person_id: current_user.id).first
+    mention = @post.mentions.where(person_id: current_user.person_id).first
     Notification.where(recipient_id: current_user.id, target_type: "Mention", target_id: mention.id, unread: true).first.try(:set_read_state, true) if mention
   end
 end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -50,6 +50,17 @@ describe PostsController do
         }.to change(Notification.where(:unread => true), :count).by(-2)
       end
 
+      it 'marks a corresponding mention notification as read' do
+        status_msg = bob.post(:status_message, {text: "this is a text mentioning @{Mention User ; #{alice.diaspora_handle}} ... have fun testing!", :public => true, :to => 'all'})
+        mention = status_msg.mentions.where(person_id: alice.person.id).first
+        note = FactoryGirl.create(:notification, :recipient => alice, :target_type => "Mention", :target_id => mention.id, :unread => true)
+
+        expect {
+          get :show, :id => status_msg.id
+          note.reload
+        }.to change(Notification.where(:unread => true), :count).by(-1)
+      end
+
       it '404 if the post is missing' do
         expect {
           get :show, :id => 1234567


### PR DESCRIPTION
Fix issue #4940
- If a mention for the current user and the displayed post exists, 
  mark it as read
- Use set_read_state instead of manually setting unread as false
