### PR TITLE
Fix broken bookmarklet if params have encoded linefeeds.

### DIFF
--- a/app/assets/javascripts/app/router.js
+++ b/app/assets/javascripts/app/router.js
@@ -21,9 +21,14 @@ app.Router = Backbone.Router.extend({
     "people/:id/photos": "photos",
 
     "people/:id": "stream",
-    "u/:name": "stream",
-
-    "bookmarklet": "bookmarklet"
+    "u/:name": "stream"
+  },
+  
+  initialize: function() {
+    // To support encoded linefeeds (%0A) we need to specify
+    // our own internal router.route call with the correct regexp.
+    // see: https://github.com/diaspora/diaspora/issues/4994#issuecomment-46431124
+    this.route(/^bookmarklet(?:\?(.*))?/, "bookmarklet");
   },
 
   help: function() {

--- a/spec/javascripts/app/router_spec.js
+++ b/spec/javascripts/app/router_spec.js
@@ -69,4 +69,14 @@ describe('app.Router', function () {
       expect(hideFollowedTags).toHaveBeenCalled();
     });
   });
+
+  describe("bookmarklet", function() {
+    it('routes to bookmarklet even if params have linefeeds', function()  {
+      router = new app.Router();
+      var route = jasmine.createSpy('bookmarklet route');
+      router.on('route:bookmarklet', route);
+      router.navigate("/bookmarklet?\n\nfeefwefwewef\n", {trigger: true});
+      expect(route).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
Closes #4994

See details for fix [here](https://github.com/diaspora/diaspora/issues/4994#issuecomment-46431124) - thanks @Raven24 for finding that. It works perfectly.

I tried to write a failing test but ... I can make a test, [this way](http://stackoverflow.com/a/11849364/1489738) that fails if I navigate to say "bookmarkletio" but runs through with the correct navigate. But it doesn't fail without the fix if I give it a full url with encoded linefeeds.
