### PR TITLE
Set sharing notification as read

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -77,6 +77,8 @@ class PeopleController < ApplicationController
     authenticate_user! if remote_profile_with_no_user_session?
     raise Diaspora::AccountClosed if @person.closed_account?
 
+    mark_corresponding_notifications_read if user_signed_in?
+
     @post_type = :all
     @aspect = :profile
     @stream = Stream::Person.new(current_user, @person, :max_time => max_time)
@@ -200,5 +202,11 @@ class PeopleController < ApplicationController
     end
 
     photos.order('created_at desc')
+  end
+
+  def mark_corresponding_notifications_read
+    Notification.where(recipient_id: current_user.id, target_type: "Person", target_id: @person.id, unread: true).each do |n|
+      n.set_read_state( true )
+    end
   end
 end

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -323,6 +323,15 @@ describe PeopleController do
         get :show, :id => @user.person.to_param
         assigns[:stream].posts.map { |x| x.id }.should include(reshare.id)
       end
+
+      it 'marks a corresponding notifications as read' do
+        note = FactoryGirl.create(:notification, :recipient => @user, :target => @person, :unread => true)
+
+        expect {
+          get :show, :id => @person.to_param
+          note.reload
+        }.to change(Notification.where(:unread => true), :count).by(-1)
+      end
     end
 
     context "when the person is not a contact of the current user" do


### PR DESCRIPTION
Fix issue #4951

If the displayed user (on her profile) started sharing with the
current user, mark the notification as read
