### PR TITLE
A podmin can now disable a spam account from the interface.

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -9,6 +9,12 @@ class AdminsController < ApplicationController
     @users = (@users || User).where(params[:user]) if params[:user].present?
     @users ||= []
   end
+  
+  def remove_spammer
+    user = User.find(params[:user_id])
+    user.close_account!
+    redirect_to root_url, notice:"this account will be deleted in a few moments"
+  end
 
   def admin_inviter
     inviter = InvitationCode.default_inviter_or(current_user)

--- a/app/views/people/_profile_sidebar.html.haml
+++ b/app/views/people/_profile_sidebar.html.haml
@@ -90,3 +90,7 @@
 
         %br
         %br
+          
+
+    - if current_user.admin? && person.owner.present?
+      = link_to 'Disable Account', remove_spammer_path(user_id:person.owner.id), method: :delete, data:{confirm:'Are you sure you want to disable this account?  It will delete all data associated.'}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,6 +128,7 @@ Diaspora::Application.routes.draw do
     get   :admin_inviter
     get   :weekly_user_stats
     get   :correlations
+    delete :remove_spammer
     get   :stats, :as => 'pod_stats'
     get   "add_invites/:invite_code_id" => 'admins#add_invites', :as => 'add_invites'
   end

--- a/spec/controllers/admins_controller_spec.rb
+++ b/spec/controllers/admins_controller_spec.rb
@@ -102,6 +102,17 @@ describe AdminsController do
       end
     end
   end
+  
+  describe '#remove_spammer' do
+    it 'it queues a job to disable the given account' do
+
+      other_user = FactoryGirl.create :user
+      
+      User.stub(:find).and_return(other_user)
+      delete :remove_spammer, user_id: other_user.id
+      other_user.should_receive(:close_account)
+    end
+  end
 
   describe '#stats' do
     before do


### PR DESCRIPTION
With this pull request, an admin of a pod can close an account from the profile page of a user.

See here: http://note.io/V7obPj

This calls User#close_account! under the hood.
