### PR TITLE
remove html from emails, as it is driving me crazy

### DIFF
--- a/app/helpers/notifier_helper.rb
+++ b/app/helpers/notifier_helper.rb
@@ -4,17 +4,19 @@ module NotifierHelper
   # @param opts [Hash] Optional hash.  Accepts :length parameters.
   # @return [String] The truncated and formatted post.
   def post_message(post, opts={})
-    if post.respond_to? :message
-      post.message.plain_text_without_markdown truncate: opts.fetch(:length, 200)
-    else
-      I18n.translate 'notifier.a_post_you_shared'
-    end
+    message = if post.respond_to? :message
+                post.message.plain_text_without_markdown truncate: opts.fetch(:length, 200)
+              else
+                I18n.translate 'notifier.a_post_you_shared'
+              end
+    ActionController::Base.helpers.strip_tags(message)
   end
 
   # @param comment [Comment] The comment to process.
   # @param opts [Hash] Optional hash.  Accepts :length parameters.
   # @return [String] The truncated and formatted comment.
   def comment_message(comment, opts={})
-    comment.message.plain_text_without_markdown truncate: opts.fetch(:length, 600)
+    messsage = comment.message.plain_text_without_markdown truncate: opts.fetch(:length, 600)
+    ActionController::Base.helpers.strip_tags(message)
   end
 end


### PR DESCRIPTION
This removes (to the best of my knowlage) HTML from email bodies, which seem to be getting passed in raw.
