### PR TITLE
Fix description comment of jquery_cdn option

### DIFF
--- a/config/diaspora.yml.example
+++ b/config/diaspora.yml.example
@@ -170,10 +170,12 @@ configuration: ## Section
   ## Settings probably affecting the privacy of your users 
   privacy: ## Section
     
-    ## Include jQuery from jquery.com's CDN
-    ## This potentially saves you some traffic and speeds up
-    ## load time since most clients already have this one cached
-    #jquery_cdn: true
+    ## Don't include jQuery from jquery.com's CDN.
+    ## jQuery is included from jquery.com's CDN by default.
+    ## This feature potentially saves you some traffic and speeds
+    ## up load time since most clients already have this one cached.
+    ## You can disable it, if you want to host jQuery at your pod.
+    #jquery_cdn: false
     
     ## Provide a key to enable tracking by Google Analytics 
     #google_analytics_key:


### PR DESCRIPTION
This option is enabled by default, and old description can mislead podmin. By common sense uncommenting of some example option should change configuration.s option is enabled by default, and old description can mishlead podmin. In common sence uncomment some option should change configuration.
