### PR TITLE
Improve profile page design on mobile

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@ The default for including jQuery from a CDN has changed. If you want to continue
 
 ## Refactor
 * Redesign contacts page [#5153](https://github.com/diaspora/diaspora/pull/5153)
+* Improve profile page design on mobile
 
 ## Bug fixes
 * orca cannot see 'Add Contact' button [#5158](https://github.com/diaspora/diaspora/pull/5158)

--- a/app/assets/stylesheets/mobile/mobile.css.scss
+++ b/app/assets/stylesheets/mobile/mobile.css.scss
@@ -48,9 +48,10 @@ h3 {
   position: relative;
   text-align: left;
   padding: 10px 0;
-  * {
-    max-width: 100%; }
   min-height: 34px;
+  
+  * { max-width: 100%; }
+  
   .avatar {
     @include border-radius(4px);
 
@@ -151,7 +152,8 @@ h3 {
   }
 }
 
-.stream_element, #login_form {
+.stream_element,
+#login_form {
   @include border-radius(5px);
   @include box-shadow(0, 1px, 2px, rgba(0, 0, 0, 0.2));
 
@@ -297,27 +299,42 @@ h3 {
 }
 
 #author_info {
-  height: 100%;
-  position: relative;
+  margin: -10px;
+  margin-bottom: 10px;
+  padding-top: 5px;
+  background-color: #fff;
+  border-bottom: 1px solid #aaa;
   word-wrap: break-word;
 
   img {
-    height: 90px;
-    width: 90px;
-    margin-right: 10px;
+    @include border-radius(4px);
+    
+    height: 70px;
+    width: 70px;
+    margin: 10px;
     float: left;
   }
 
   .content {
-    padding-left: 100px;
-  }
+    padding-left: 90px;
+    
+    h2 {
+      font-size: 20px;
+      line-height: 20px;
+      margin-bottom: 0px;
+    }
 
-  .description {
-    font: {
-      weight: normal;
-      size: small;
-    };
-    color: $text-grey;
+    .description {
+      font: {
+        weight: normal;
+        size: small;
+      };
+      color: $text-grey;
+    }
+  }
+  
+  .bottom_bar {
+    position: static;
   }
 }
 

--- a/app/views/people/_sub_header.html.haml
+++ b/app/views/people/_sub_header.html.haml
@@ -19,7 +19,7 @@
   .description
     - if !person.tag_string.blank? && user_signed_in?
       = Diaspora::Taggable.format_tags(person.profile.tag_string)
-      - if user_signed_in? && person == current_user.person
+      - if person == current_user.person
         %span.hover_edit
           = link_to t('.edit'), edit_profile_path
     - else

--- a/app/views/people/show.mobile.haml
+++ b/app/views/people/show.mobile.haml
@@ -10,6 +10,10 @@
         = @person.name
       %span.description
         = @person.diaspora_handle
+      .clear
+    .bottom_bar
+      - if !@person.tag_string.blank? && user_signed_in?
+        = Diaspora::Taggable.format_tags(@person.profile.tag_string)
 
 .span12.profile_stream
   - if @stream.stream_posts.length > 0


### PR DESCRIPTION
This PR improves the design of the profile user. It was inspired by the design of the hovercard.
**Before**
![before](https://cloud.githubusercontent.com/assets/930064/3648988/6cc3ed8c-110e-11e4-9692-bce51a879fe1.png)

**After**
![after](https://cloud.githubusercontent.com/assets/930064/3648986/6c435f0a-110e-11e4-84e6-7d5e034cb9e1.png)

The space under the diaspora\* ID is here to put the "Add to an aspect" dropdown selector, like on hovercards.

If the username is very long, it goes under. I thought cut it was not a good idea.
![long](https://cloud.githubusercontent.com/assets/930064/3648987/6c7d319e-110e-11e4-99cc-a3f927c26b34.png)
