### PR TITLE
Terms of service and privacy policy feature.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 #trademark sillyness
 app/views/home/_show.*
+app/views/terms/terms.*
 app/assets/images/custom/
 
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -30,6 +30,7 @@
 * Add scrolling thumbnail switcher in the lightbox [#5102](https://github.com/diaspora/diaspora/pull/5102)
 * Add help section about keyboard shortcuts [#5100](https://github.com/diaspora/diaspora/pull/5100)
 * Automatically add poll answers as needed [#5109](https://github.com/diaspora/diaspora/pull/5109)
+* Add Terms of Service as an option for podmins, includes base template [#5104](https://github.com/diaspora/diaspora/pull/5104)
 
 # 0.4.0.1
 

--- a/app/assets/stylesheets/new_styles/_registration.scss
+++ b/app/assets/stylesheets/new_styles/_registration.scss
@@ -42,5 +42,10 @@
     .controls {
       float : right;
     }
+    
+    #terms > a {
+      color: inherit;
+      text-decoration: underline;
+    }
   }
 }

--- a/app/controllers/terms_controller.rb
+++ b/app/controllers/terms_controller.rb
@@ -1,0 +1,20 @@
+#   Copyright (c) 2010-2011, Diaspora Inc.  This file is
+#   licensed under the Affero General Public License version 3 or later.  See
+#   the COPYRIGHT file.
+
+class TermsController < ApplicationController
+
+  respond_to :html, :mobile
+
+  def index
+    @css_framework = :bootstrap
+    partial_dir = Rails.root.join('app', 'views', 'terms')
+    if partial_dir.join('terms.haml').exist? ||
+        partial_dir.join('terms.erb').exist?
+      render :terms
+    else
+      render :default
+    end
+  end
+  
+end

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -68,8 +68,11 @@
               <% end %>
               <%= invite_hidden_tag(invite) %>
             </fieldset>
-
-
+            <% if AppConfig.settings.terms.enable? %>
+              <div id="terms" class="text-center">
+                <%= t('.terms', terms_link: link_to(t('.terms_link'), terms_path, target: "_blank")).html_safe %>
+              </div>
+            <% end %>
             <%= f.submit t('.continue'), :class => "new-btn", :disable_with => t('.submitting') %>
         <% end %>
       </div>

--- a/app/views/registrations/new.mobile.haml
+++ b/app/views/registrations/new.mobile.haml
@@ -44,6 +44,9 @@
                 
             - if AppConfig.settings.captcha.enable?
               = show_simple_captcha(:object => 'user', :code_type => 'numeric')
+            
+            - if AppConfig.settings.terms.enable?
+              = t('registrations.new.terms', terms_link: link_to(t('registrations.new.terms_link'), terms_path, target: "_blank")).html_safe
 
             .controls
               = f.submit t('registrations.new.create_my_account'), :class => 'btn primary', :disable_with => t('registrations.new.submitting')

--- a/app/views/shared/_links.haml
+++ b/app/views/shared/_links.haml
@@ -3,3 +3,5 @@
 %li= link_to t('layouts.application.whats_new'), changelog_url
 %li= link_to(t('layouts.header.code') + " " + pod_version, "#{root_path.chomp('/')}/source.tar.gz", {:title => t('layouts.application.source_package')}) unless request.url.match(/joindiaspora.com/)
 %li= link_to(t('layouts.application.toggle'), toggle_mobile_path)
+- if AppConfig.settings.terms.enable?
+    %li= link_to(t('_terms'), terms_path)

--- a/app/views/terms/default.haml
+++ b/app/views/terms/default.haml
@@ -1,0 +1,318 @@
+-# This is a default template ToS and Privacy Policy for diaspora* pods.
+-# If you want to modify (or completely rewrite) these terms, create a
+-# file called app/views/terms/terms.haml or app/views/terms/terms.erb
+-# Once created, that file will be used automatically instead of this one.
+-#
+-# NOTE! The default terms have not been checked over by a lawyer and
+-# thus are unlikely to provide full legal protection for all situations
+-# for a podmin using them. They are also not specific to all countries
+-# and jurisdictions. If you are unsure, please check with a lawyer.
+-# We provide these for podmins as some basic rules that podmins
+-# can communicate to users easily via the diaspora* server software.
+
+/ These terms of service and privacy policy documents have been forked
+/ from the App.Net ToS repository (https://github.com/appdotnet/terms-of-service).
+/ The terms of use and privacy policy are available to you under the 
+/ CC BY-SA 3.0 Creative Commons license.
+/ If you modify or copy this file, please do not remove this license text.
+
+%div{:class => "container-fluid", :style => "margin-top: 50px;"}
+  %div{:class => "row-fluid"}
+    %div{:class => "span3"}
+      %h3
+        Terms of Service
+      %h4
+        %a{:href => "/terms#privacy"}
+          Privacy Policy
+    %div{:class => "span9", :style => "margin-top: 20px;"}
+      %p
+        Last Updated: 17th August, 2014
+
+      %hr
+
+      %a{:name => "terms"}
+      %h1
+        "#{AppConfig.settings.pod_name}" - Terms of Service
+
+      %p
+        Here are the important things you need to know about accessing and using the "#{AppConfig.settings.pod_name}" (#{AppConfig.environment.url}) website and service (collectively, "Service"). These are our terms of service ("Terms"). Please read them carefully.
+
+      %h2
+        Accepting these Terms
+
+      %p
+        If you access or use the Service, it means you agree to be bound by all of the terms below. So, before you use the Service, please read all of the terms. If you don't agree to all of the terms below, please do not use the Service.
+        - if AppConfig.admins.podmin_email?
+          Also, if a term does not make sense to you, please let us know by e-mailing <a href="mailto:#{AppConfig.admins.podmin_email}">#{AppConfig.admins.podmin_email}</a>.
+          
+      %h2
+        Changes to these Terms
+
+      %p
+        We reserve the right to modify these Terms at any time. For instance, we may need to change these Terms if we come out with a new feature or for some other reason.
+
+      %p
+        Whenever we make changes to these Terms, the changes are effective six (6) weeks after we post such revised Terms to our website (indicated by revising the date at the top of these Terms), or upon your acceptance if we provide a mechanism for your immediate acceptance of the revised Terms (such as a click-through confirmation or acceptance button). It is your responsibility to check the website regularly for changes to these Terms.
+
+      %p
+        If you continue to use the Service after the revised Terms go into effect, then you have accepted the revised Terms.
+
+      %h2
+        Privacy Policy
+
+      %p
+        For information about how we collect and use information about users of the Service, please check out our <a href="/terms#privacy">privacy policy</a>.
+
+      %h2
+        Third-Party Services
+
+      %p
+        From time to time, we may provide you with links to third party websites or services that we do not own or control. Your use of the Service may also include the use of applications that are developed or owned by a third party. Your use of such third party applications, websites, and services is governed by that party’s own terms of service or privacy policies. We encourage you to read the terms and conditions and privacy policy of any third party application, website or service that you visit or use. Note that while "#{AppConfig.settings.pod_name}" itself does not work directly with advertisers, third party applications may contain advertising or marketing materials provided by such third parties.
+
+      %h2
+        Creating Accounts
+
+      %p
+        When you create an account, you may use any name (real, fake or otherwise) for other users to see. However, if you create a "parody" account of a real living person, you must clearly label your account as such. Accounts that are not clearly marked as such and that impersonate other people without permission can be deleted without warning.
+
+      %p
+        When you create an account you also agree to maintain the security of your password and accept all risks of unauthorized access to your account data and any other information you provide to "#{AppConfig.settings.pod_name}".
+
+      %p
+        If you discover or suspect any Service security breaches, please let us know as soon as possible. For security holes in the diaspora* software itself, please contact <a href="mailto:security@diasporafoundation.org">the developers directly</a>.
+
+      %h2
+        Your Content & Conduct
+
+      %p
+        Our Service allows you and other users to post, link and otherwise make available content. You are responsible for the content that you make available to the Service, including its legality, reliability, and appropriateness.
+
+      %p
+        When you post, link or otherwise make available content to the Service, you grant us the right and license to display and distribute your content on or through the Service (including via applications). We may format your content for display throughout the Service, but we will not edit or revise the substance of your content itself. The displaying and distribution of your content happens strictly only according to the visibility rules you have set for the content. We will not modify the visibility of the content you have set.
+
+      %p
+        We cannot be held responsible should a programming or administrative error make your content visible to a larger audience than you had intended.
+
+      %p
+        Aside from our limited right to your content, you retain all of your rights to the content you post, link and otherwise make available on or through the Service.
+
+      %p
+        You can remove the content that you posted by deleting it. Once you delete your content, it will not appear on the Service, but copies of your deleted content may remain in our system or backups for some period of time. Web server access logs might also be stored for some time in the system.
+
+      %p
+        Since diaspora* is a distributed social network, it is possible, depending on the visibility rules set to your content, that your content has been distributed to other diaspora* pods. When you delete your content, we will request those other pods to also delete the content. Our responsibility on the content being deleted from those other pods ends here. If for some reason, some other pod does not delete the content, we cannot be held responsible.
+
+      %p
+        In order to make "#{AppConfig.settings.pod_name}" a great place for all of us, please do not post, link and otherwise make available on or through the Service any of the following:
+
+      %ul
+        %li
+          Content that is libelous, defamatory, bigoted, fraudulent or deceptive;
+        %li
+          Content that is illegal or unlawful, that would otherwise create liability;
+        %li
+          Content that may infringe or violate any patent, trademark, trade secret, copyright, right of privacy, right of publicity or other intellectual or other right of any party;
+        %li
+          Mass or repeated promotions, political campaigning or commercial messages directed at users who do not follow you (SPAM);
+        %li
+          Private information of any third party (e.g., addresses, phone numbers, email addresses, Social Security numbers and credit card numbers); and
+        %li
+          Viruses, corrupted data or other harmful, disruptive or destructive files or code.
+
+      %p
+        Also, you agree that you will not do any of the following in connection with the Service or other users:
+
+      %ul
+        %li
+          Use the Service in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Service or that could damage, disable, overburden or impair the functioning of the Service;
+        %li
+          Impersonate or post on behalf of any person or entity or otherwise misrepresent your affiliation with a person or entity;
+        %li
+          Collect any personal information about other users, or intimidate, threaten, stalk or otherwise harass other users of the Service;
+        - if AppConfig.settings.terms.minimum_age?
+          %li
+            Create an account or post any content if you are not over #{AppConfig.settings.terms.minimum_age} years of age;
+        %li
+          Circumvent or attempt to circumvent any filtering, security measures, rate limits or other features designed to protect the Service, users of the Service, or third parties.
+
+      %h2
+        Source code and materials
+
+      %p
+        This Service runs on a diaspora* social network server. This source code is licensed under an <a href="http://www.gnu.org/licenses/agpl-3.0.html">AGPLv3</a> license which means you are allowed to and even encouraged to take the source code, modify it and use it.
+
+      %p
+        For full details about the diaspora* server <a href="https://github.com/diaspora/diaspora">see here</a>.
+
+      %h2
+        Hyperlinks and Third Party Content
+
+      %p
+        "#{AppConfig.settings.pod_name}" makes no claim or representation regarding, and accepts no responsibility for third party websites accessible by hyperlink from the Service or websites linking to the Service. When you leave the Service, you should be aware that these Terms and our policies no longer govern.
+
+      %p
+        A lot of the content on the Service is from you and others, and we don't review, verify or authenticate it, and it may include inaccuracies or false information. We make no representations, warranties, or guarantees relating to the quality, suitability, truth, accuracy or completeness of any content contained in the Service. You acknowledge sole responsibility for and assume all risk arising from your use of or reliance on any content.
+
+      %h2
+        Unavoidable Legal Stuff
+
+      %p
+        THE SERVICE AND ANY OTHER SERVICE AND CONTENT INCLUDED ON OR OTHERWISE MADE AVAILABLE TO YOU THROUGH THE SERVICE ARE PROVIDED TO YOU ON AN AS IS OR AS AVAILABLE BASIS WITHOUT ANY REPRESENTATIONS OR WARRANTIES OF ANY KIND. WE DISCLAIM ANY AND ALL WARRANTIES AND REPRESENTATIONS (EXPRESS OR IMPLIED, ORAL OR WRITTEN) WITH RESPECT TO THE SERVICE AND CONTENT INCLUDED ON OR OTHERWISE MADE AVAILABLE TO YOU THROUGH THE SERVICE WHETHER ALLEGED TO ARISE BY OPERATION OF LAW, BY REASON OF CUSTOM OR USAGE IN THE TRADE, BY COURSE OF DEALING OR OTHERWISE.
+
+      %p
+        IN NO EVENT WILL "#{AppConfig.settings.pod_name}" BE LIABLE TO YOU OR ANY THIRD PARTY FOR ANY SPECIAL, INDIRECT, INCIDENTAL, EXEMPLARY OR CONSEQUENTIAL DAMAGES OF ANY KIND ARISING OUT OF OR IN CONNECTION WITH THE SERVICE OR ANY OTHER SERVICE AND/OR CONTENT INCLUDED ON OR OTHERWISE MADE AVAILABLE TO YOU THROUGH THE SERVICE, REGARDLESS OF THE FORM OF ACTION, WHETHER IN CONTRACT, TORT, STRICT LIABILITY OR OTHERWISE, EVEN IF WE HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES OR ARE AWARE OF THE POSSIBILITY OF SUCH DAMAGES. THIS SECTION WILL BE GIVEN FULL EFFECT EVEN IF ANY REMEDY SPECIFIED IN THIS AGREEMENT IS DEEMED TO HAVE FAILED OF ITS ESSENTIAL PURPOSE.
+
+      %p
+        You agree to defend, indemnify and hold us harmless from and against any and all costs, damages, liabilities, and expenses (including attorneys' fees, costs, penalties, interest and disbursements) we incur in relation to, arising from, or for the purpose of avoiding, any claim or demand from a third party relating to your use of the Service or the use of the Service by any person using your account, including any claim that your use of the Service violates any applicable law or regulation, or the rights of any third party, and/or your violation of these Terms.
+
+      - if AppConfig.settings.terms.jurisdiction?
+        %h2
+          Governing Law
+
+        %p
+          The validity of these Terms and the rights, obligations, and relations of the parties under these Terms will be construed and determined under and in accordance with the laws of #{AppConfig.settings.terms.jurisdiction}.
+
+        %h2
+          Jurisdiction & Waiver of Representative Actions
+
+        %p
+          You expressly agree that exclusive jurisdiction for any dispute with "#{AppConfig.settings.pod_name}", or in any way relating to your use of the "#{AppConfig.settings.pod_name}" website or Service, resides in the courts of #{AppConfig.settings.terms.jurisdiction} and you further agree and expressly consent to the exercise of personal jurisdiction in the courts of #{AppConfig.settings.terms.jurisdiction} in connection with any such dispute including any claim involving "#{AppConfig.settings.pod_name}". You further agree that you and "#{AppConfig.settings.pod_name}" will not commence against the other a class action, class arbitration or other representative action or proceeding.
+
+      %h2
+        Termination
+
+      %p
+        If you breach any of these Terms, we have the right to suspend or disable your access to or use of the Service.
+
+      %h2
+        Entire Agreement
+
+      %p
+        These Terms constitute the entire agreement between you and "#{AppConfig.settings.pod_name}" regarding the use of the Service, superseding any prior agreements between you and "#{AppConfig.settings.pod_name}" relating to your use of the Service.
+
+      %h2
+        Feedback
+
+      %p
+        We love feedback. Please let us know what you think of the Service, these Terms and, in general, "#{AppConfig.settings.pod_name}". When you provide us with any feedback, comments or suggestions about the Service, these Terms and, in general, "#{AppConfig.settings.pod_name}", you irrevocably assign to us all of your right, title and interest in and to your feedback, comments and suggestions.
+
+      - if AppConfig.admins.podmin_email?
+        %h2
+          Questions & Contact Information
+
+        %p
+          Questions or comments about the Service may be directed to us at the email address <a href="mailto:#{AppConfig.admins.podmin_email}">#{AppConfig.admins.podmin_email}</a>.
+
+      %hr
+
+      %a{:name => "privacy"}
+      %h1
+        "#{AppConfig.settings.pod_name}" - Privacy Policy
+        
+      %p
+        Our privacy policy applies to information we collect when you use or access our website located at #{AppConfig.environment.url} and social networking services, or just interact with us. We may change this privacy policy from time to time. Whenever we make changes to this privacy policy, the changes are effective six (6) weeks after we post the revised privacy policy to our website (as indicated by revising the date at the top of our privacy policy). We encourage you to review our privacy policy whenever you access our services to stay informed about our information practices and the ways you can help protect your privacy.
+
+      %h2
+        Collection of Information
+
+      %h3
+        Information You Provide to Us
+
+      %p
+        We collect information you provide directly to us. For example, we collect information when you create an account, subscribe, participate in any interactive features of our services, fill out a form, request customer support or otherwise communicate with us. The types of information we may collect include your name (real of fake), email address and other contact or identifying information you choose to provide.
+
+      %h3
+        Information We Collect Automatically When You Use the Services
+
+      %p
+        When you access or use our services, we automatically collect information about you, including:
+
+      %dl
+        %dt
+          Log Information
+        %dd
+          We may log information about your use of our services, including the type of browser you use, access times, pages viewed, your IP address and the page you visited before navigating to our services.
+        %dt
+          Device Information
+        %dd
+          We may collect information about the computer you use to access our services, including the hardware model, and operating system and version.
+
+      %h2
+        Use of Information
+
+      %p
+        We do not use your information for serving up ads.
+
+      %p
+        We may use information about you for various purposes, including to:
+
+      %ul
+        %li
+          Provide, maintain and improve our services;
+        %li
+          Send you technical notices, updates, security alerts and support and administrative messages;
+        %li
+          Respond to your comments, questions and requests;
+        %li
+          Communicate with you about "#{AppConfig.settings.pod_name}"-related news and information;
+        %li
+          Monitor and analyze trends, usage and activities in connection with our services; and
+        %li
+          Personalize and improve our services.
+
+      %h2
+        Sharing of Information
+
+      %p
+        Remember, we don't share your information with advertisers.
+
+      %p
+        We may share personal information about you as follows:
+
+      %ul
+        %li
+          If we believe disclosure is reasonably necessary to comply with any applicable law, regulation, legal process or governmental request;
+        %li
+          To enforce applicable user agreements or policies, including our <a href="/terms#terms">terms of service</a>; and to protect "#{AppConfig.settings.pod_name}", our users or the public from harm or illegal activities;
+        %li
+          In connection with any merger, sale of "#{AppConfig.settings.pod_name}" assets, financing or acquisition of all or a portion of our business to another company or individual; and
+        %li
+          If we notify you through our services (or in our privacy policy) that the information you provide will be shared in a particular manner and you provide such information.
+
+      %p
+        We may also share aggregated or anonymized information that does not directly identify you.
+
+      %h2
+        Third Party Analytics
+
+      %p
+        We may allow third parties to provide analytics services. These third parties may use cookies, web beacons and other technologies to collect information about your use of the services and other websites, including your IP address, web browser, pages viewed, time spent on pages, links clicked and conversion information. This information may be used by the Service and third parties to, among other things, analyze and track data, determine the popularity of certain content and other websites and better understand your online activity. Our privacy policy does not apply to, and we are not responsible for, third party cookies, web beacons or other tracking technologies and we encourage you to check the privacy policies of these third parties to learn more about their privacy practices.
+
+      %h2
+        Security
+
+      %p
+        "#{AppConfig.settings.pod_name}" takes reasonable measures to help protect personal information from loss, theft, misuse and unauthorized access, disclosure, alteration and destruction.
+
+      %h2
+        Your Information Choices
+
+      %h3
+        Account Information
+
+      %p
+        You may update, correct or delete information about you at any time by logging into your online account and modifying your personal profile. You may also delete your account at will via the settings page, but note that we may retain certain information as required by law or for legitimate business purposes. We may also retain cached or archived copies of your information for a certain period of time, for example in backup archives.
+
+      %h3
+        Cookies
+
+      %p
+        Most web browsers are set to accept cookies by default. If you prefer, you can usually choose to set your browser to remove or reject browser cookies. Please note that if you choose to remove or reject cookies, this could affect the availability and functionality of our services.
+
+      - if AppConfig.admins.podmin_email?
+        %h2
+          Contact Us
+
+        %p
+          If you have any questions about this privacy policy, please contact us at the email address <a href="mailto:#{AppConfig.admins.podmin_email}">#{AppConfig.admins.podmin_email}</a>.
+

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -89,6 +89,10 @@ defaults:
       captcha_length: 5
       image_style: 'simply_green'
       distortion: 'low'
+    terms:
+      enable: false
+      jurisdiction: false
+      minimum_age: false
   services:
     facebook:
       enable: false

--- a/config/diaspora.yml.example
+++ b/config/diaspora.yml.example
@@ -302,6 +302,34 @@ configuration: ## Section
       ## Sets the level of image distortion used in the captcha.
       ## Available options are: 'low', 'medium', 'high', 'random'
       #distortion: 'low'
+      
+    ## Terms of Service
+    ## Show a default or customized terms of service for users.
+    ## You can create a custom Terms of Service by placing a template
+    ## as app/views/terms/terms.haml or app/views/terms/terms.erb
+    ## The default terms of service that can be extended is
+    ## at app/views/terms/default.haml
+    ## NOTE! The default terms have not been checked over by a lawyer and
+    ## thus are unlikely to provide full legal protection for all situations
+    ## for a podmin using them. They are also not specific to all countries
+    ## and jurisdictions. If you are unsure, please check with a lawyer.
+    ## We provide these for podmins as some basic rules that podmins
+    ## can communicate to users easily via the diaspora* server software.
+    ## Uncomment to enable this feature.
+    terms: ## Section
+      # First enable it by uncommenting
+      #enable: true
+      ## Important! If you enable the terms, you should always
+      ## set a location under which laws any disputes are governed
+      ## under. For example, country or state/country, depending
+      ## on the country in question.
+      ## If this is not set, the whole paragraph about governing
+      ## laws *is not shown* in the terms page.
+      #jurisdiction: ""
+      ## Age limit for signups
+      ## Set a number to activate this setting. This age limit is shown
+      ## in the default ToS document.
+      #minimum_age: false
 
   ## Posting from Diaspora to external services (all are disabled by default)
   services: ## Section

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -46,6 +46,7 @@ en:
   no_results: "No Results Found"
   _contacts: "Contacts"
   welcome: "Welcome!"
+  _terms: "terms"
 
   #for reference translation, the real activerecord english transations are actually
   #in en-US, en-GB, and en-AU yml files
@@ -976,6 +977,8 @@ en:
       password_confirmation: "PASSWORD CONFIRMATION"
       continue: "Continue"
       submitting: "Submitting..."
+      terms: "By creating an account you accept the %{terms_link}."
+      terms_link: "terms of service"
     create:
       success: "You've joined diaspora*!"
     edit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -219,6 +219,11 @@ Diaspora::Application.routes.draw do
 
   #Statistics
   get :statistics, controller: :statistics
+  
+  # Terms
+  if AppConfig.settings.terms.enable?
+    get 'terms' => 'terms#index'
+  end
 
   # Startpage
   root :to => 'home#show'


### PR DESCRIPTION
If enabled, terms of service link will be shown in sign up page.

[Base for discussion on Loomio](https://www.loomio.org/d/ezlIV5rN/add-tos-and-pp-documents-for-podmins-to-use?proposal=k0LZg1M9#comment-128186).

So yeah, if enabled (default false), /terms route will work and contain either the basic template (default.haml) or custom written by podmin (terms.haml). Same templates are used for mobile too - we shouldn't duplicate these I think.

Also I'm sceptical whether there is need to allow somehow creating different language versions. Podmin can write it in whatever language they want or in different languages.

No tests yet, should probably write something for the setting <-> route functionality. Also is this as a feature something we want? Also the base template would need some discussion.

The terms are from [here](https://github.com/jaywink/terms-of-service) - though a little modified in this pull. I'm going to just delete that old repo. I've taken a print out from my local dev box for a little more convenient viewing :) [Check it out here](https://cloud.jasonrobinson.me/public.php?service=files&t=5e0e94be26f0a11b4a810d2bc72c5993).
