### PR TITLE
Change default for jQuery CDN to false

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -41,7 +41,7 @@ defaults:
     embed_sidekiq_worker: false
     sidekiq_workers: 1
   privacy:
-    jquery_cdn: true
+    jquery_cdn: false
     google_analytics_key:
     piwik:
       enable: false

--- a/config/diaspora.yml.example
+++ b/config/diaspora.yml.example
@@ -172,11 +172,11 @@ configuration: ## Section
   ## Settings potentially affecting the privacy of your users 
   privacy: ## Section
     
-    ## Include jQuery from jquery.com's CDN (default=true)
-    ## This can save you some traffic and speeds up load time since most
-    ## clients already have this one cached. Set this to false if you want
-    ## the jQuery library to be loaded from your pod's own resources.
-    #jquery_cdn: true
+    ## Include jQuery from jquery.com's CDN (default=false)
+    ## Enabling this can reduce traffic and speed up load time since most
+    ## clients already have this one cached. When set to false (the default),
+    ## the jQuery library will be loaded from your pod's own resources.
+    #jquery_cdn: false
     
     ## Google Analytics (disabled by default)
     ## Provide a key to enable tracking by Google Analytics 


### PR DESCRIPTION
This changes the default setting for using jQuery.com's CDN from true to false. This is in response to the vote in [this Loomio proposal](https://www.loomio.org/d/zogZmP8d/disable-jquery-cdn-by-default?proposal=gdzIi0Ye).

Note: I think this shouldn't be merged until the next major release is being prepared, so that podmins are more alert to the possibility of defaults being changed. So please set a flag for next-major, and I'll have to rebase when the time comes.

Hope that's OK.
