### PR TITLE
Rake task to send mails to users

### DIFF
--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -3,16 +3,16 @@ class Notifier < ActionMailer::Base
   helper :notifier
   helper :people
 
-  def self.admin(string, recipients, opts = {})
+  def self.admin(string, recipients, opts = {}, subject=nil)
     mails = []
     recipients.each do |rec|
-      mail = single_admin(string, rec, opts.dup)
+      mail = single_admin(string, rec, opts.dup, subject)
       mails << mail
     end
     mails
   end
 
-  def single_admin(string, recipient, opts={})
+  def single_admin(string, recipient, opts={}, subject=nil)
     @receiver = recipient
     @string = string.html_safe
 
@@ -22,12 +22,14 @@ class Notifier < ActionMailer::Base
       }
     end
 
+    unless subject
+      subject = I18n.t('notifier.single_admin.subject')
+    end
+
     default_opts = {:to => @receiver.email,
          :from => AppConfig.mail.sender_address,
-         :subject => I18n.t('notifier.single_admin.subject'),  :host => AppConfig.pod_uri.host}
+         :subject => subject, :host => AppConfig.pod_uri.host}
     default_opts.merge!(opts)
-
-
 
     mail(default_opts) do |format|
       format.text

--- a/lib/tasks/podmin.rake
+++ b/lib/tasks/podmin.rake
@@ -1,17 +1,10 @@
 namespace :podmin do
   
-  desc <<DESC
-  Send an email to users as admin.
-  Parameters
-    users def
-      "all", "active_yearly", "active_monthly" or "active_halfyear"
-    msg_path
-      path to a file that contains the HTML message to send
-DESC
-  task :admin_mail, [:users_def, :msg_path] => :environment do |t, args|
+  desc "Send an email to users as admin"
+  task :admin_mail, [:users_def, :msg_path, :subject] => :environment do |t, args|
     if args[:users_def] == 'all'
       # to all except deleted and deactivated, of course
-      users = User.where(locked_at: nil)
+      users = User.where("locked_at is null and username is not null")
     elsif args[:users_def] == 'active_yearly'
       users = User.yearly_actives
     elsif args[:users_def] == 'active_monthly'
@@ -19,11 +12,17 @@ DESC
     elsif args[:users_def] == 'active_halfyear'
       users = User.halfyear_actives
     end
-    file = File.open(args[:msg_path])
-    msg = file.read
-    file.close
-    mails = Notifier.admin(msg.html_safe, users)
-    mails.each(&:deliver)
+    msg = File.read(args[:msg_path])
+    mails = Notifier.admin(msg.html_safe, users, :subject => args[:subject])
+    count = 0
+    mails.each do |mail|
+      mail.deliver
+      count += 1
+      if count % 100 == 0
+        puts "#{count} out of #{mails.count} delivered"
+      end
+    end
+    puts "#{count} out of #{mails.count} delivered"
   end
   
 end

--- a/lib/tasks/podmin.rake
+++ b/lib/tasks/podmin.rake
@@ -1,0 +1,29 @@
+namespace :podmin do
+  
+  desc <<DESC
+  Send an email to users as admin.
+  Parameters
+    users def
+      "all", "active_yearly", "active_monthly" or "active_halfyear"
+    msg_path
+      path to a file that contains the HTML message to send
+DESC
+  task :admin_mail, [:users_def, :msg_path] => :environment do |t, args|
+    if args[:users_def] == 'all'
+      # to all except deleted and deactivated, of course
+      users = User.where(locked_at: nil)
+    elsif args[:users_def] == 'active_yearly'
+      users = User.yearly_actives
+    elsif args[:users_def] == 'active_monthly'
+      users = User.monthly_actives
+    elsif args[:users_def] == 'active_halfyear'
+      users = User.halfyear_actives
+    end
+    file = File.open(args[:msg_path])
+    msg = file.read
+    file.close
+    mails = Notifier.admin(msg.html_safe, users)
+    mails.each(&:deliver)
+  end
+  
+end

--- a/lib/tasks/podmin.rake
+++ b/lib/tasks/podmin.rake
@@ -16,10 +16,14 @@ namespace :podmin do
     mails = Notifier.admin(msg.html_safe, users, :subject => args[:subject])
     count = 0
     mails.each do |mail|
-      mail.deliver
-      count += 1
-      if count % 100 == 0
-        puts "#{count} out of #{mails.count} delivered"
+      begin
+        mail.deliver
+        count += 1
+        if count % 100 == 0
+          puts "#{count} out of #{mails.count} delivered"
+        end
+      rescue
+        puts $!, $@
       end
     end
     puts "#{count} out of #{mails.count} delivered"


### PR DESCRIPTION
Add rake task `podmin:admin_mail` to send an email to users (via Notifier.admin).

Optional override subject added to input params of Notifier.admin also, can be supplied to rake task.

Would this benefit core? Needed for myself, but can finish for core if wanted. It would be nice to get something like this in the admin panel at some point too.
