### PR TITLE
Service have been added to /statistics.json

### DIFF
--- a/app/presenters/statistics_presenter.rb
+++ b/app/presenters/statistics_presenter.rb
@@ -17,9 +17,15 @@ class StatisticsPresenter
     if AppConfig.privacy.statistics.comment_counts?
       result['local_comments'] = self.local_comments
     end
+
+    AppConfig.services.each do |service, options|
+      result[service] = options ? !!options["enable"] : false
+    
+    end
+
     result
   end
-  
+
   def local_posts
     Post.where(:type => "StatusMessage").joins(:author).where("owner_id IS NOT null").count
   end

--- a/spec/presenters/statistics_presenter_spec.rb
+++ b/spec/presenters/statistics_presenter_spec.rb
@@ -18,28 +18,44 @@ describe StatisticsPresenter do
       AppConfig.privacy.statistics.user_counts = false
       AppConfig.privacy.statistics.post_counts = false
       AppConfig.privacy.statistics.comment_counts = false
-      @presenter.as_json.should == {
-        "name" => AppConfig.settings.pod_name,
-        "version" => AppConfig.version_string,
-        "registrations_open" => AppConfig.settings.enable_registrations
-      }
-    end
-    
-    it 'provides generic pod data and counts in json' do
-      AppConfig.privacy.statistics.user_counts = true
-      AppConfig.privacy.statistics.post_counts = true
-      AppConfig.privacy.statistics.comment_counts = true
-
+      AppConfig.services = {"facebook" => nil}
       @presenter.as_json.should == {
         "name" => AppConfig.settings.pod_name,
         "version" => AppConfig.version_string,
         "registrations_open" => AppConfig.settings.enable_registrations,
-        "total_users" => User.count,
-        "active_users_halfyear" => User.halfyear_actives.count,
-        "active_users_monthly" => User.monthly_actives.count,
-        "local_posts" => @presenter.local_posts,
-        "local_comments" => @presenter.local_comments
+        "facebook" => false
       }
+    end
+    
+    context 'when services are enabled' do
+      before do
+        AppConfig.privacy.statistics.user_counts = true
+        AppConfig.privacy.statistics.post_counts = true
+        AppConfig.privacy.statistics.comment_counts = true
+        AppConfig.services = {
+          "facebook" => {"enable" => true}, 
+          "twitter" => {"enable" => true}, 
+          "wordpress" => {"enable" => false},
+          "tumblr" => {"enable" => false}
+        }
+      end
+
+      it 'provides generic pod data and counts in json' do
+        @presenter.as_json.should == {
+          "name" => AppConfig.settings.pod_name,
+          "version" => AppConfig.version_string,
+          "registrations_open" => AppConfig.settings.enable_registrations,
+          "total_users" => User.count,
+          "active_users_halfyear" => User.halfyear_actives.count,
+          "active_users_monthly" => User.monthly_actives.count,
+          "local_posts" => @presenter.local_posts,
+          "local_comments" => @presenter.local_comments,
+          "facebook" => true,
+          "twitter" => true,
+          "tumblr" => false,
+          "wordpress" => false
+        }
+      end
     end
 
   end


### PR DESCRIPTION
Is it implicit as part of this ticket to include privacy settings for this feature, i.e. should we only display services statistics if that privacy setting has been enabled?
