### PR TITLE
Added Mark all in filter as read feature

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -65,12 +65,21 @@ class NotificationsController < ApplicationController
   end
 
   def read_all
-    Notification.where(:recipient_id => current_user.id).update_all(:unread => false)
+    if params[:type]
+      Notification.where(:recipient_id => current_user.id, :type => Notification.types[params[:type]]).update_all(:unread => false)
+    else
+      Notification.where(:recipient_id => current_user.id).update_all(:unread => false)
+    end
     respond_to do |format|
-      format.html { redirect_to stream_path }
-      format.mobile{ redirect_to stream_path}
-      format.xml { render :xml => {}.to_xml }
-      format.json { render :json => {}.to_json }
+      if current_user.unread_notifications.count > 0
+        format.html { redirect_to notifications_path}
+        format.mobile{ redirect_to notifications_path}
+      else
+        format.html { redirect_to stream_path }
+        format.mobile{ redirect_to stream_path}
+      end
+        format.xml { render :xml => {}.to_xml }
+        format.json { render :json => {}.to_json }
     end
   end
 

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -65,22 +65,22 @@ class NotificationsController < ApplicationController
   end
 
   def read_all
-    if params[:type]
-      Notification.where(:recipient_id => current_user.id, :type => Notification.types[params[:type]]).update_all(:unread => false)
-    else
-      Notification.where(:recipient_id => current_user.id).update_all(:unread => false)
-    end
+    current_type = Notification.types[params[:type]]
+    notifications = Notification.where(:recipient_id => current_user.id)
+    notifications = notifications.where(:type => current_type) if params[:type]
+    notifications.update_all(:unread => false)
     respond_to do |format|
       if current_user.unread_notifications.count > 0
-        format.html { redirect_to notifications_path}
-        format.mobile{ redirect_to notifications_path}
+        format.html { redirect_to notifications_path }
+        format.mobile { redirect_to notifications_path }
       else
         format.html { redirect_to stream_path }
-        format.mobile{ redirect_to stream_path}
+        format.mobile { redirect_to stream_path }
       end
-        format.xml { render :xml => {}.to_xml }
-        format.json { render :json => {}.to_json }
+      format.xml { render :xml => {}.to_xml }
+      format.json { render :json => {}.to_json }
     end
+
   end
 
 end

--- a/app/views/notifications/index.html.haml
+++ b/app/views/notifications/index.html.haml
@@ -37,7 +37,10 @@
               %a.btn.btn-default{ :class => ('active' if params[:show] == 'unread'), :href => '/notifications?show=unread' + (params[:type] ? '&type=' + params[:type] : '') }
                 = t('.show_unread')
             %a.btn.btn-default{:href => read_all_notifications_path(:type => params[:type] ), :class => ('disabled' unless @unread_notification_count > 0)}
-              = t('.mark_all_as_read')
+              -if params[:type]
+                = t('.mark_all_shown_as_read')
+              -else
+                = t('.mark_all_as_read')
       - @group_days.each do |day, notes|
         .day_group.row-fluid
           .date.span2

--- a/app/views/notifications/index.html.haml
+++ b/app/views/notifications/index.html.haml
@@ -36,7 +36,7 @@
                 = t('.show_all')
               %a.btn.btn-default{ :class => ('active' if params[:show] == 'unread'), :href => '/notifications?show=unread' + (params[:type] ? '&type=' + params[:type] : '') }
                 = t('.show_unread')
-            %a.btn.btn-default{:href => notifications_read_all_path, :class => ('disabled' unless @unread_notification_count > 0)}
+            %a.btn.btn-default{:href => read_all_notifications_path(:type => params[:type] ), :class => ('disabled' unless @unread_notification_count > 0)}
               = t('.mark_all_as_read')
       - @group_days.each do |day, notes|
         .day_group.row-fluid

--- a/app/views/notifications/index.mobile.haml
+++ b/app/views/notifications/index.mobile.haml
@@ -2,8 +2,10 @@
   = t('.notifications')
 
 .right
-  = link_to t('.mark_all_as_read'), read_all_notifications_path, :class => 'btn'
-
+  -if params[:type]
+    = link_to t('.mark_all_shown_as_read'), read_all_notifications_path(:type => params[:type] ), :class => 'btn'
+  -else
+    = link_to t('.mark_all_as_read'), read_all_notifications_path, :class => 'btn'
 %ul.notifications
   - @group_days.each do |day, notes|
     %li

--- a/app/views/notifications/index.mobile.haml
+++ b/app/views/notifications/index.mobile.haml
@@ -2,7 +2,7 @@
   = t('.notifications')
 
 .right
-  = link_to t('.mark_all_as_read'), notifications_read_all_path, :class => 'btn'
+  = link_to t('.mark_all_as_read'), read_all_notifications_path, :class => 'btn'
 
 %ul.notifications
   - @group_days.each do |day, notes|

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -708,6 +708,7 @@ en:
     index:
       notifications: "Notifications"
       mark_all_as_read: "Mark all as read"
+      mark_all_shown_as_read: "Mark all shown as read"
       mark_read: "Mark read"
       mark_unread: "Mark unread"
       show_all: "show all"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,9 +79,12 @@ Diaspora::Application.routes.draw do
     delete 'visibility' => 'conversation_visibilities#destroy'
   end
 
-  get 'notifications/read_all' => 'notifications#read_all'
   resources :notifications, :only => [:index, :update] do
+    collection do
+      get :read_all
+    end
   end
+  
 
   resources :tags, :only => [:index]
 


### PR DESCRIPTION
Integrated feature
Added tests
In response to a users request(Issue #5113) i have added a feature that allows users to mark all notifications in the current notfication filter they're on as read without marking all the others read, i have also added tests for this feature in spec/controllers/notifications_controller_spec.rb
