### PR TITLE
Remove ignored peoples posts without refresh (II)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## Refactor
 
 ## Bug fixes
+* Fix which allow to remove ignored users posts without page refresh [#2875](https://github.com/diaspora/diaspora/issues/2875)
 
 ## Features
 

--- a/app/assets/javascripts/app/app.js
+++ b/app/assets/javascripts/app/app.js
@@ -19,7 +19,16 @@ var app = {
   views: {},
   pages: {},
   forms: {},
-  vent: _.extend({}, Backbone.Events),
+
+  // global event broker - use event names in the form of "object:action:data"
+  //   [object]: the class of the acting object
+  //   [action]: infinitive verb naming the performed action
+  //   [data]:   (optional) unique name or ID of the specific instance
+  // e.g. "person:ignore:123"
+  // if your event has to pass more than one datum (singular) - or in case you
+  // need structured data - specify them as arguments to the `#trigger` call
+  // e.g. `app.events.trigger('example:event', {more: 'data'})`
+  events: _.extend({}, Backbone.Events),
 
   user: function(userAttrs) {
     if(userAttrs) { return this._user = new app.models.User(userAttrs) }

--- a/app/assets/javascripts/app/app.js
+++ b/app/assets/javascripts/app/app.js
@@ -19,6 +19,7 @@ var app = {
   views: {},
   pages: {},
   forms: {},
+  vent: _.extend({}, Backbone.Events),
 
   user: function(userAttrs) {
     if(userAttrs) { return this._user = new app.models.User(userAttrs) }

--- a/app/assets/javascripts/app/models/post.js
+++ b/app/assets/javascripts/app/models/post.js
@@ -27,6 +27,14 @@ app.models.Post = Backbone.Model.extend(_.extend({}, app.models.formatDateMixin,
     return this.get("author")
   },
 
+  blockAuthor: function() {
+    var personId = this.get("author").id;
+    var block = new app.models.Block();
+
+    return block.save({block : {person_id : personId}})
+             .done(function(){ app.events.trigger('person:block:'+personId); });
+  },
+
   toggleFavorite : function(options){
     this.set({favorite : !this.get("favorite")})
 

--- a/app/assets/javascripts/app/views/stream_post_views.js
+++ b/app/assets/javascripts/app/views/stream_post_views.js
@@ -27,6 +27,9 @@ app.views.StreamPost = app.views.Post.extend({
   tooltipSelector : ".timeago, .post_scope, .block_user, .delete",
 
   initialize : function(){
+    var personId = this.model.get('author').id;
+    app.vent.on('remove:author:posts:'+personId, this.remove, this);
+
     this.model.on('remove', this.remove, this);
     //subviews
     this.commentStreamView = new app.views.CommentStream({model : this.model});
@@ -77,13 +80,7 @@ app.views.StreamPost = app.views.Post.extend({
 
     block.save({block : {person_id : personId}}, {
       success : function(){
-        if(!app.stream) { return }
-
-        _.each(app.stream.posts.models, function(model){
-          if(model.get("author").id == personId) {
-            app.stream.posts.remove(model);
-          }
-        })
+        app.vent.trigger('remove:author:posts:'+personId);
       }
     })
   },

--- a/app/assets/javascripts/app/views/stream_post_views.js
+++ b/app/assets/javascripts/app/views/stream_post_views.js
@@ -28,7 +28,7 @@ app.views.StreamPost = app.views.Post.extend({
 
   initialize : function(){
     var personId = this.model.get('author').id;
-    app.vent.on('remove:author:posts:'+personId, this.remove, this);
+    app.events.on('person:block:'+personId, this.remove, this);
 
     this.model.on('remove', this.remove, this);
     //subviews
@@ -75,14 +75,13 @@ app.views.StreamPost = app.views.Post.extend({
     if(evt) { evt.preventDefault(); }
     if(!confirm(Diaspora.I18n.t('ignore_user'))) { return }
 
-    var personId = this.model.get("author").id;
-    var block = new app.models.Block();
-
-    block.save({block : {person_id : personId}}, {
-      success : function(){
-        app.vent.trigger('remove:author:posts:'+personId);
-      }
-    })
+    this.model.blockAuthor()
+      .fail(function() {
+        Diaspora.page.flashMessages.render({
+          success: false,
+          notice: Diaspora.I18n.t('ignore_failed')
+        });
+      });
   },
 
   remove : function() {

--- a/config/locales/javascript/javascript.en.yml
+++ b/config/locales/javascript/javascript.en.yml
@@ -16,6 +16,7 @@ en:
         created: "The report was successfully created"
         exists: "The report already exists"
     ignore_user: "Ignore this user?"
+    ignore_failed: "Unable to ignore this user"
     and: "and"
     comma: ","
     edit: "Edit"

--- a/spec/javascripts/app/views/stream_post_spec.js
+++ b/spec/javascripts/app/views/stream_post_spec.js
@@ -21,7 +21,7 @@ describe("app.views.StreamPost", function(){
       it("setup remove:author:posts:#{id} to #remove", function(){
         spyOn(_PostViewClass.prototype, 'remove');
         view = new _PostViewClass({model : this.statusMessage});
-        app.vent.trigger('remove:author:posts:'+authorId);
+        app.events.trigger('person:block:'+authorId);
         expect(_PostViewClass.prototype.remove).toHaveBeenCalled();
       });
     });

--- a/spec/javascripts/app/views/stream_post_spec.js
+++ b/spec/javascripts/app/views/stream_post_spec.js
@@ -1,7 +1,31 @@
 describe("app.views.StreamPost", function(){
   beforeEach(function(){
     this.PostViewClass = app.views.StreamPost
+
+    var posts = $.parseJSON(spec.readFixture("stream_json"));
+    this.collection = new app.collections.Posts(posts);
+    this.statusMessage = this.collection.models[0];
+    this.reshare = this.collection.models[1];
   })
+
+  describe("events", function(){
+    var _PostViewClass = undefined;
+    var author_id = undefined;
+
+    beforeEach(function(){
+      _PostViewClass = this.PostViewClass;
+      authorId = this.statusMessage.get('author').id;
+    });
+
+    describe("remove posts for blocked person", function(){
+      it("setup remove:author:posts:#{id} to #remove", function(){
+        spyOn(_PostViewClass.prototype, 'remove');
+        view = new _PostViewClass({model : this.statusMessage});
+        app.vent.trigger('remove:author:posts:'+authorId);
+        expect(_PostViewClass.prototype.remove).toHaveBeenCalled();
+      });
+    });
+  });
 
   describe("#render", function(){
     var o_embed_cache = {
@@ -32,12 +56,6 @@ describe("app.views.StreamPost", function(){
           other : "<%= count %> Likes"
         }
       }})
-
-      var posts = $.parseJSON(spec.readFixture("stream_json"));
-
-      this.collection = new app.collections.Posts(posts);
-      this.statusMessage = this.collection.models[0];
-      this.reshare = this.collection.models[1];
     })
 
     context("reshare", function(){


### PR DESCRIPTION
this supercedes #5027 
- renamed the variable containing the event broker to `events` - still short and to the point
- introduced a naming scheme for events 
- refactored people blocking into the backbone model
