### PR TITLE
Minor formatting changes to ToS

### DIFF
--- a/app/views/terms/default.haml
+++ b/app/views/terms/default.haml
@@ -32,10 +32,10 @@
 
       %a{:name => "terms"}
       %h1
-        "#{AppConfig.settings.pod_name}" - Terms of Service
+        #{AppConfig.settings.pod_name} - Terms of Service
 
       %p
-        Here are the important things you need to know about accessing and using the "#{AppConfig.settings.pod_name}" (#{AppConfig.environment.url}) website and service (collectively, "Service"). These are our terms of service ("Terms"). Please read them carefully.
+        Here are the important things you need to know about accessing and using the #{AppConfig.settings.pod_name} (#{AppConfig.environment.url}) website and service (collectively, "Service"). These are our terms of service ("Terms"). Please read them carefully.
 
       %h2
         Accepting these Terms
@@ -67,7 +67,7 @@
         Third-Party Services
 
       %p
-        From time to time, we may provide you with links to third party websites or services that we do not own or control. Your use of the Service may also include the use of applications that are developed or owned by a third party. Your use of such third party applications, websites, and services is governed by that party’s own terms of service or privacy policies. We encourage you to read the terms and conditions and privacy policy of any third party application, website or service that you visit or use. Note that while "#{AppConfig.settings.pod_name}" itself does not work directly with advertisers, third party applications may contain advertising or marketing materials provided by such third parties.
+        From time to time, we may provide you with links to third party websites or services that we do not own or control. Your use of the Service may also include the use of applications that are developed or owned by a third party. Your use of such third party applications, websites, and services is governed by that party’s own terms of service or privacy policies. We encourage you to read the terms and conditions and privacy policy of any third party application, website or service that you visit or use. Note that while #{AppConfig.settings.pod_name} itself does not work directly with advertisers, third party applications may contain advertising or marketing materials provided by such third parties.
 
       %h2
         Creating Accounts
@@ -76,7 +76,7 @@
         When you create an account, you may use any name (real, fake or otherwise) for other users to see. However, if you create a "parody" account of a real living person, you must clearly label your account as such. Accounts that are not clearly marked as such and that impersonate other people without permission can be deleted without warning.
 
       %p
-        When you create an account you also agree to maintain the security of your password and accept all risks of unauthorized access to your account data and any other information you provide to "#{AppConfig.settings.pod_name}".
+        When you create an account you also agree to maintain the security of your password and accept all risks of unauthorized access to your account data and any other information you provide to #{AppConfig.settings.pod_name}.
 
       %p
         If you discover or suspect any Service security breaches, please let us know as soon as possible. For security holes in the diaspora* software itself, please contact <a href="mailto:security@diasporafoundation.org">the developers directly</a>.
@@ -103,7 +103,7 @@
         Since diaspora* is a distributed social network, it is possible, depending on the visibility rules set to your content, that your content has been distributed to other diaspora* pods. When you delete your content, we will request those other pods to also delete the content. Our responsibility on the content being deleted from those other pods ends here. If for some reason, some other pod does not delete the content, we cannot be held responsible.
 
       %p
-        In order to make "#{AppConfig.settings.pod_name}" a great place for all of us, please do not post, link and otherwise make available on or through the Service any of the following:
+        In order to make #{AppConfig.settings.pod_name} a great place for all of us, please do not post, link and otherwise make available on or through the Service any of the following:
 
       %ul
         %li
@@ -148,7 +148,7 @@
         Hyperlinks and Third Party Content
 
       %p
-        "#{AppConfig.settings.pod_name}" makes no claim or representation regarding, and accepts no responsibility for third party websites accessible by hyperlink from the Service or websites linking to the Service. When you leave the Service, you should be aware that these Terms and our policies no longer govern.
+        #{AppConfig.settings.pod_name} makes no claim or representation regarding, and accepts no responsibility for third party websites accessible by hyperlink from the Service or websites linking to the Service. When you leave the Service, you should be aware that these Terms and our policies no longer govern.
 
       %p
         A lot of the content on the Service is from you and others, and we don't review, verify or authenticate it, and it may include inaccuracies or false information. We make no representations, warranties, or guarantees relating to the quality, suitability, truth, accuracy or completeness of any content contained in the Service. You acknowledge sole responsibility for and assume all risk arising from your use of or reliance on any content.
@@ -157,10 +157,10 @@
         Unavoidable Legal Stuff
 
       %p
-        THE SERVICE AND ANY OTHER SERVICE AND CONTENT INCLUDED ON OR OTHERWISE MADE AVAILABLE TO YOU THROUGH THE SERVICE ARE PROVIDED TO YOU ON AN AS IS OR AS AVAILABLE BASIS WITHOUT ANY REPRESENTATIONS OR WARRANTIES OF ANY KIND. WE DISCLAIM ANY AND ALL WARRANTIES AND REPRESENTATIONS (EXPRESS OR IMPLIED, ORAL OR WRITTEN) WITH RESPECT TO THE SERVICE AND CONTENT INCLUDED ON OR OTHERWISE MADE AVAILABLE TO YOU THROUGH THE SERVICE WHETHER ALLEGED TO ARISE BY OPERATION OF LAW, BY REASON OF CUSTOM OR USAGE IN THE TRADE, BY COURSE OF DEALING OR OTHERWISE.
+        %strong The Service and any other service and content included on or otherwise made available to you through the Service are provided to you on an as is or as available basis without any representations or warranties of any kind. We disclaim any and all warranties and representations (express or implied, oral or written) with respect to the Service and content included on or otherwise made available to you through the Service whether alleged to arise by operation of law, by reason of custom or usage in the trade, by course of dealing or otherwise.
 
       %p
-        IN NO EVENT WILL "#{AppConfig.settings.pod_name}" BE LIABLE TO YOU OR ANY THIRD PARTY FOR ANY SPECIAL, INDIRECT, INCIDENTAL, EXEMPLARY OR CONSEQUENTIAL DAMAGES OF ANY KIND ARISING OUT OF OR IN CONNECTION WITH THE SERVICE OR ANY OTHER SERVICE AND/OR CONTENT INCLUDED ON OR OTHERWISE MADE AVAILABLE TO YOU THROUGH THE SERVICE, REGARDLESS OF THE FORM OF ACTION, WHETHER IN CONTRACT, TORT, STRICT LIABILITY OR OTHERWISE, EVEN IF WE HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES OR ARE AWARE OF THE POSSIBILITY OF SUCH DAMAGES. THIS SECTION WILL BE GIVEN FULL EFFECT EVEN IF ANY REMEDY SPECIFIED IN THIS AGREEMENT IS DEEMED TO HAVE FAILED OF ITS ESSENTIAL PURPOSE.
+        %strong In no event will #{AppConfig.settings.pod_name} be liable to you or any third party for any special, indirect, incidental, exemplary or consequential damages of any kind arising out of or in connection with the Service or any other service and/or content included on or otherwise made available to you through the Service, regardless of the form of action, whether in contract, tort, strict liability or otherwise, even if we have been advised of the possibility of such damages or are aware of the possibility of such damages. This section will be given full effect even if any remedy specified in this agreement is deemed to have failed of its essential purpose.
 
       %p
         You agree to defend, indemnify and hold us harmless from and against any and all costs, damages, liabilities, and expenses (including attorneys' fees, costs, penalties, interest and disbursements) we incur in relation to, arising from, or for the purpose of avoiding, any claim or demand from a third party relating to your use of the Service or the use of the Service by any person using your account, including any claim that your use of the Service violates any applicable law or regulation, or the rights of any third party, and/or your violation of these Terms.
@@ -176,7 +176,7 @@
           Jurisdiction & Waiver of Representative Actions
 
         %p
-          You expressly agree that exclusive jurisdiction for any dispute with "#{AppConfig.settings.pod_name}", or in any way relating to your use of the "#{AppConfig.settings.pod_name}" website or Service, resides in the courts of #{AppConfig.settings.terms.jurisdiction} and you further agree and expressly consent to the exercise of personal jurisdiction in the courts of #{AppConfig.settings.terms.jurisdiction} in connection with any such dispute including any claim involving "#{AppConfig.settings.pod_name}". You further agree that you and "#{AppConfig.settings.pod_name}" will not commence against the other a class action, class arbitration or other representative action or proceeding.
+          You expressly agree that exclusive jurisdiction for any dispute with #{AppConfig.settings.pod_name}, or in any way relating to your use of the #{AppConfig.settings.pod_name} website or Service, resides in the courts of #{AppConfig.settings.terms.jurisdiction} and you further agree and expressly consent to the exercise of personal jurisdiction in the courts of #{AppConfig.settings.terms.jurisdiction} in connection with any such dispute including any claim involving #{AppConfig.settings.pod_name}. You further agree that you and #{AppConfig.settings.pod_name} will not commence against the other a class action, class arbitration or other representative action or proceeding.
 
       %h2
         Termination
@@ -188,13 +188,13 @@
         Entire Agreement
 
       %p
-        These Terms constitute the entire agreement between you and "#{AppConfig.settings.pod_name}" regarding the use of the Service, superseding any prior agreements between you and "#{AppConfig.settings.pod_name}" relating to your use of the Service.
+        These Terms constitute the entire agreement between you and #{AppConfig.settings.pod_name} regarding the use of the Service, superseding any prior agreements between you and #{AppConfig.settings.pod_name} relating to your use of the Service.
 
       %h2
         Feedback
 
       %p
-        We love feedback. Please let us know what you think of the Service, these Terms and, in general, "#{AppConfig.settings.pod_name}". When you provide us with any feedback, comments or suggestions about the Service, these Terms and, in general, "#{AppConfig.settings.pod_name}", you irrevocably assign to us all of your right, title and interest in and to your feedback, comments and suggestions.
+        We love feedback. Please let us know what you think of the Service, these Terms and, in general, #{AppConfig.settings.pod_name}. When you provide us with any feedback, comments or suggestions about the Service, these Terms and, in general, #{AppConfig.settings.pod_name}, you irrevocably assign to us all of your right, title and interest in and to your feedback, comments and suggestions.
 
       - if AppConfig.admins.podmin_email?
         %h2
@@ -202,12 +202,12 @@
 
         %p
           Questions or comments about the Service may be directed to us at the email address <a href="mailto:#{AppConfig.admins.podmin_email}">#{AppConfig.admins.podmin_email}</a>.
+      %a{:name => "privacy"}
 
       %hr
 
-      %a{:name => "privacy"}
       %h1
-        "#{AppConfig.settings.pod_name}" - Privacy Policy
+        #{AppConfig.settings.pod_name} - Privacy Policy
         
       %p
         Our privacy policy applies to information we collect when you use or access our website located at #{AppConfig.environment.url} and social networking services, or just interact with us. We may change this privacy policy from time to time. Whenever we make changes to this privacy policy, the changes are effective six (6) weeks after we post the revised privacy policy to our website (as indicated by revising the date at the top of our privacy policy). We encourage you to review our privacy policy whenever you access our services to stay informed about our information practices and the ways you can help protect your privacy.
@@ -254,7 +254,7 @@
         %li
           Respond to your comments, questions and requests;
         %li
-          Communicate with you about "#{AppConfig.settings.pod_name}"-related news and information;
+          Communicate with you about #{AppConfig.settings.pod_name}-related news and information;
         %li
           Monitor and analyze trends, usage and activities in connection with our services; and
         %li
@@ -273,9 +273,9 @@
         %li
           If we believe disclosure is reasonably necessary to comply with any applicable law, regulation, legal process or governmental request;
         %li
-          To enforce applicable user agreements or policies, including our <a href="/terms#terms">terms of service</a>; and to protect "#{AppConfig.settings.pod_name}", our users or the public from harm or illegal activities;
+          To enforce applicable user agreements or policies, including our <a href="/terms#terms">terms of service</a>; and to protect #{AppConfig.settings.pod_name}, our users or the public from harm or illegal activities;
         %li
-          In connection with any merger, sale of "#{AppConfig.settings.pod_name}" assets, financing or acquisition of all or a portion of our business to another company or individual; and
+          In connection with any merger, sale of #{AppConfig.settings.pod_name} assets, financing or acquisition of all or a portion of our business to another company or individual; and
         %li
           If we notify you through our services (or in our privacy policy) that the information you provide will be shared in a particular manner and you provide such information.
 
@@ -292,7 +292,7 @@
         Security
 
       %p
-        "#{AppConfig.settings.pod_name}" takes reasonable measures to help protect personal information from loss, theft, misuse and unauthorized access, disclosure, alteration and destruction.
+        #{AppConfig.settings.pod_name} takes reasonable measures to help protect personal information from loss, theft, misuse and unauthorized access, disclosure, alteration and destruction.
 
       %h2
         Your Information Choices

--- a/app/views/terms/default.haml
+++ b/app/views/terms/default.haml
@@ -35,7 +35,7 @@
         #{AppConfig.settings.pod_name} - Terms of Service
 
       %p
-        Here are the important things you need to know about accessing and using the #{AppConfig.settings.pod_name} (#{AppConfig.environment.url}) website and service (collectively, "Service"). These are our terms of service ("Terms"). Please read them carefully.
+        Here are the important things you need to know about accessing and using the <strong>#{AppConfig.settings.pod_name}</strong> (#{AppConfig.environment.url}) website and service (collectively, "Service"). These are our terms of service ("Terms"). Please read them carefully.
 
       %h2
         Accepting these Terms
@@ -67,7 +67,7 @@
         Third-Party Services
 
       %p
-        From time to time, we may provide you with links to third party websites or services that we do not own or control. Your use of the Service may also include the use of applications that are developed or owned by a third party. Your use of such third party applications, websites, and services is governed by that party’s own terms of service or privacy policies. We encourage you to read the terms and conditions and privacy policy of any third party application, website or service that you visit or use. Note that while #{AppConfig.settings.pod_name} itself does not work directly with advertisers, third party applications may contain advertising or marketing materials provided by such third parties.
+        From time to time, we may provide you with links to third party websites or services that we do not own or control. Your use of the Service may also include the use of applications that are developed or owned by a third party. Your use of such third party applications, websites, and services is governed by that party’s own terms of service or privacy policies. We encourage you to read the terms and conditions and privacy policy of any third party application, website or service that you visit or use. Note that while <strong>#{AppConfig.settings.pod_name}</strong> itself does not work directly with advertisers, third party applications may contain advertising or marketing materials provided by such third parties.
 
       %h2
         Creating Accounts
@@ -76,7 +76,7 @@
         When you create an account, you may use any name (real, fake or otherwise) for other users to see. However, if you create a "parody" account of a real living person, you must clearly label your account as such. Accounts that are not clearly marked as such and that impersonate other people without permission can be deleted without warning.
 
       %p
-        When you create an account you also agree to maintain the security of your password and accept all risks of unauthorized access to your account data and any other information you provide to #{AppConfig.settings.pod_name}.
+        When you create an account you also agree to maintain the security of your password and accept all risks of unauthorized access to your account data and any other information you provide to <strong>#{AppConfig.settings.pod_name}</strong>.
 
       %p
         If you discover or suspect any Service security breaches, please let us know as soon as possible. For security holes in the diaspora* software itself, please contact <a href="mailto:security@diasporafoundation.org">the developers directly</a>.
@@ -103,7 +103,7 @@
         Since diaspora* is a distributed social network, it is possible, depending on the visibility rules set to your content, that your content has been distributed to other diaspora* pods. When you delete your content, we will request those other pods to also delete the content. Our responsibility on the content being deleted from those other pods ends here. If for some reason, some other pod does not delete the content, we cannot be held responsible.
 
       %p
-        In order to make #{AppConfig.settings.pod_name} a great place for all of us, please do not post, link and otherwise make available on or through the Service any of the following:
+        In order to make <strong>#{AppConfig.settings.pod_name}</strong> a great place for all of us, please do not post, link and otherwise make available on or through the Service any of the following:
 
       %ul
         %li
@@ -148,7 +148,7 @@
         Hyperlinks and Third Party Content
 
       %p
-        #{AppConfig.settings.pod_name} makes no claim or representation regarding, and accepts no responsibility for third party websites accessible by hyperlink from the Service or websites linking to the Service. When you leave the Service, you should be aware that these Terms and our policies no longer govern.
+        <strong>#{AppConfig.settings.pod_name}</strong> makes no claim or representation regarding, and accepts no responsibility for third party websites accessible by hyperlink from the Service or websites linking to the Service. When you leave the Service, you should be aware that these Terms and our policies no longer govern.
 
       %p
         A lot of the content on the Service is from you and others, and we don't review, verify or authenticate it, and it may include inaccuracies or false information. We make no representations, warranties, or guarantees relating to the quality, suitability, truth, accuracy or completeness of any content contained in the Service. You acknowledge sole responsibility for and assume all risk arising from your use of or reliance on any content.
@@ -160,7 +160,7 @@
         %strong The Service and any other service and content included on or otherwise made available to you through the Service are provided to you on an as is or as available basis without any representations or warranties of any kind. We disclaim any and all warranties and representations (express or implied, oral or written) with respect to the Service and content included on or otherwise made available to you through the Service whether alleged to arise by operation of law, by reason of custom or usage in the trade, by course of dealing or otherwise.
 
       %p
-        %strong In no event will #{AppConfig.settings.pod_name} be liable to you or any third party for any special, indirect, incidental, exemplary or consequential damages of any kind arising out of or in connection with the Service or any other service and/or content included on or otherwise made available to you through the Service, regardless of the form of action, whether in contract, tort, strict liability or otherwise, even if we have been advised of the possibility of such damages or are aware of the possibility of such damages. This section will be given full effect even if any remedy specified in this agreement is deemed to have failed of its essential purpose.
+        %strong In no event will <strong>#{AppConfig.settings.pod_name}</strong> be liable to you or any third party for any special, indirect, incidental, exemplary or consequential damages of any kind arising out of or in connection with the Service or any other service and/or content included on or otherwise made available to you through the Service, regardless of the form of action, whether in contract, tort, strict liability or otherwise, even if we have been advised of the possibility of such damages or are aware of the possibility of such damages. This section will be given full effect even if any remedy specified in this agreement is deemed to have failed of its essential purpose.
 
       %p
         You agree to defend, indemnify and hold us harmless from and against any and all costs, damages, liabilities, and expenses (including attorneys' fees, costs, penalties, interest and disbursements) we incur in relation to, arising from, or for the purpose of avoiding, any claim or demand from a third party relating to your use of the Service or the use of the Service by any person using your account, including any claim that your use of the Service violates any applicable law or regulation, or the rights of any third party, and/or your violation of these Terms.
@@ -176,7 +176,7 @@
           Jurisdiction & Waiver of Representative Actions
 
         %p
-          You expressly agree that exclusive jurisdiction for any dispute with #{AppConfig.settings.pod_name}, or in any way relating to your use of the #{AppConfig.settings.pod_name} website or Service, resides in the courts of #{AppConfig.settings.terms.jurisdiction} and you further agree and expressly consent to the exercise of personal jurisdiction in the courts of #{AppConfig.settings.terms.jurisdiction} in connection with any such dispute including any claim involving #{AppConfig.settings.pod_name}. You further agree that you and #{AppConfig.settings.pod_name} will not commence against the other a class action, class arbitration or other representative action or proceeding.
+          You expressly agree that exclusive jurisdiction for any dispute with <strong>#{AppConfig.settings.pod_name}</strong>, or in any way relating to your use of the <strong>#{AppConfig.settings.pod_name}</strong> website or Service, resides in the courts of #{AppConfig.settings.terms.jurisdiction} and you further agree and expressly consent to the exercise of personal jurisdiction in the courts of #{AppConfig.settings.terms.jurisdiction} in connection with any such dispute including any claim involving <strong>#{AppConfig.settings.pod_name}</strong>. You further agree that you and <strong>#{AppConfig.settings.pod_name}</strong> will not commence against the other a class action, class arbitration or other representative action or proceeding.
 
       %h2
         Termination
@@ -188,13 +188,13 @@
         Entire Agreement
 
       %p
-        These Terms constitute the entire agreement between you and #{AppConfig.settings.pod_name} regarding the use of the Service, superseding any prior agreements between you and #{AppConfig.settings.pod_name} relating to your use of the Service.
+        These Terms constitute the entire agreement between you and <strong>#{AppConfig.settings.pod_name}</strong> regarding the use of the Service, superseding any prior agreements between you and <strong>#{AppConfig.settings.pod_name}</strong> relating to your use of the Service.
 
       %h2
         Feedback
 
       %p
-        We love feedback. Please let us know what you think of the Service, these Terms and, in general, #{AppConfig.settings.pod_name}. When you provide us with any feedback, comments or suggestions about the Service, these Terms and, in general, #{AppConfig.settings.pod_name}, you irrevocably assign to us all of your right, title and interest in and to your feedback, comments and suggestions.
+        We love feedback. Please let us know what you think of the Service, these Terms and, in general, <strong>#{AppConfig.settings.pod_name}</strong>. When you provide us with any feedback, comments or suggestions about the Service, these Terms and, in general, <strong>#{AppConfig.settings.pod_name}</strong>, you irrevocably assign to us all of your right, title and interest in and to your feedback, comments and suggestions.
 
       - if AppConfig.admins.podmin_email?
         %h2
@@ -254,7 +254,7 @@
         %li
           Respond to your comments, questions and requests;
         %li
-          Communicate with you about #{AppConfig.settings.pod_name}-related news and information;
+          Communicate with you about <strong>#{AppConfig.settings.pod_name}</strong>-related news and information;
         %li
           Monitor and analyze trends, usage and activities in connection with our services; and
         %li
@@ -273,9 +273,9 @@
         %li
           If we believe disclosure is reasonably necessary to comply with any applicable law, regulation, legal process or governmental request;
         %li
-          To enforce applicable user agreements or policies, including our <a href="/terms#terms">terms of service</a>; and to protect #{AppConfig.settings.pod_name}, our users or the public from harm or illegal activities;
+          To enforce applicable user agreements or policies, including our <a href="/terms#terms">terms of service</a>; and to protect <strong>#{AppConfig.settings.pod_name}</strong>, our users or the public from harm or illegal activities;
         %li
-          In connection with any merger, sale of #{AppConfig.settings.pod_name} assets, financing or acquisition of all or a portion of our business to another company or individual; and
+          In connection with any merger, sale of <strong>#{AppConfig.settings.pod_name}</strong> assets, financing or acquisition of all or a portion of our business to another company or individual; and
         %li
           If we notify you through our services (or in our privacy policy) that the information you provide will be shared in a particular manner and you provide such information.
 
@@ -292,7 +292,7 @@
         Security
 
       %p
-        #{AppConfig.settings.pod_name} takes reasonable measures to help protect personal information from loss, theft, misuse and unauthorized access, disclosure, alteration and destruction.
+        <strong>#{AppConfig.settings.pod_name}</strong> takes reasonable measures to help protect personal information from loss, theft, misuse and unauthorized access, disclosure, alteration and destruction.
 
       %h2
         Your Information Choices


### PR DESCRIPTION
- Removed quote marks from around pod name (looks a bit ugly)
- Changed full caps (ditto) to bold in legal stuff paras
- Moved privacy anchor up a couple of lines so heading isn't hidden by header bar.

One further suggestion is to put the pod name in bold each time it occurs. 'Terms' and 'Service', when used to mean what they are defined as in this document, are both capitalised, but with many pods being called simply 'diaspora*' (lower case) it doesn't look very distinct. What do you think?

If this is a good idea, could someone tell me how to embolden a portion of text on a line? I don't know how to close a formatting code in haml, and I can't find any decent tutorials online.
