### PR TITLE
Fix for issue 5090

### DIFF
--- a/app/assets/javascripts/app/views/publisher_view.js
+++ b/app/assets/javascripts/app/views/publisher_view.js
@@ -200,10 +200,10 @@ app.views.Publisher = Backbone.View.extend({
         // standalone means single-shot posting (until further notice)
         if( self.standalone ) self.setEnabled(false);
       },
-      error: function() {
+      error: function(model, resp, options) {
         if( app.publisher ) app.publisher.trigger('publisher:error');
         self.setInputEnabled(true);
-        Diaspora.page.flashMessages.render({ 'success':false, 'notice':Diaspora.I18n.t('failed_to_post_message') });
+        Diaspora.page.flashMessages.render({ 'success':false, 'notice':resp.responseText });
         self.setButtonsEnabled(true);
         self.setInputEnabled(true);
       }

--- a/app/controllers/status_messages_controller.rb
+++ b/app/controllers/status_messages_controller.rb
@@ -95,7 +95,7 @@ class StatusMessagesController < ApplicationController
       respond_to do |format|
         format.html { redirect_to :back }
         format.mobile { redirect_to stream_path }
-        format.json { render :text => @status_message.errors.messages[:text].join('. '), :status => 403 }
+        format.json { render :text => @status_message.errors.messages[:text].to_sentence, :status => 403 }
       end
     end
   end

--- a/app/controllers/status_messages_controller.rb
+++ b/app/controllers/status_messages_controller.rb
@@ -95,7 +95,7 @@ class StatusMessagesController < ApplicationController
       respond_to do |format|
         format.html { redirect_to :back }
         format.mobile { redirect_to stream_path }
-        format.json { render :nothing => true, :status => 403 }
+        format.json { render :text => @status_message.errors.messages[:text].join('. '), :status => 403 }
       end
     end
   end

--- a/app/models/status_message.rb
+++ b/app/models/status_message.rb
@@ -10,7 +10,7 @@ class StatusMessage < Post
   acts_as_taggable_on :tags
   extract_tags_from :raw_message
 
-  validates_length_of :text, :maximum => 65535, :message => I18n.t('status_messages.too_long', :count => 65535)
+  validates_length_of :text, :maximum => 65535, :message => proc {|p, v| I18n.t('status_messages.too_long', :count => 65535, :current_length => v[:value].length)}
 
   # don't allow creation of empty status messages
   validate :presence_of_content, on: :create, if: proc { |sm| sm.author.local? }

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -1159,10 +1159,7 @@ en:
       no_message_to_display: "No message to display."
     destroy:
       failure: "Failed to delete post"
-    too_long:
-      zero: "please make your status messages less than %{count} characters"
-      one: "please make your status messages less than %{count} characters"
-      other: "please make your status messages less than %{count} characters"
+    too_long: "Please make your status message fewer than %{count} characters. Right now it is %{current_length} characters"
 
   stream_helper:
     show_comments:


### PR DESCRIPTION
https://github.com/diaspora/diaspora/issues/5090

Changing error message wording and providing more information to user when status message is too long. I can add a test if you'd like, but none existed before. All tests pass. I'm not a huge fan of the controller change (@status_message.errors.messages[:text].join('. ')) as it looks clunky and the model change (adding a proc to the validates message) looks odd, but that seems to be the way to add the current message length.

I think this also will fix https://github.com/diaspora/diaspora/pull/5099 as it appears to be similar if not identical
