### PR TITLE
Fix for issue 5137

### DIFF
--- a/config/locales/javascript/javascript.nl.yml
+++ b/config/locales/javascript/javascript.nl.yml
@@ -165,7 +165,7 @@ nl:
       seconds: "iets minder dan een minuut"
       suffixAgo: "geleden"
       suffixFromNow: "vanaf nu"
-      wordSeparator: ""
+      wordSeparator: " "
       year: "ongeveer een jaar"
       years: "%d jaar"
     videos:


### PR DESCRIPTION
https://github.com/diaspora/diaspora/issues/5137

Assuming the Dutch locale file is supposed to look similar to this (https://github.com/rmm5t/jquery-timeago/blob/master/locales/jquery.timeago.nl.js), then wordSeparator needs to be a space, not an empty string. Tried it out and there is now a space between the time and ago, e.g. "minuten geleden"
