### PR TITLE
Fix for issue 5044

### DIFF
--- a/app/assets/javascripts/app/views/aspect_membership_blueprint_view.js
+++ b/app/assets/javascripts/app/views/aspect_membership_blueprint_view.js
@@ -12,7 +12,8 @@ app.views.AspectMembershipBlueprint = Backbone.View.extend({
     var selector = '.dropdown.aspect_membership .dropdown_list > li';
     $('body')
       .off('click', selector)
-      .on('click', selector, _.bind(this._clickHandler, this));
+      .on('click', selector, _.bind(this._clickHandler, this))
+      .on('keypress', selector, _.bind(this._clickHandler, this));
 
     this.list_item = null;
     this.dropdown  = null;

--- a/app/assets/javascripts/app/views/aspect_membership_view.js
+++ b/app/assets/javascripts/app/views/aspect_membership_view.js
@@ -10,7 +10,8 @@
 app.views.AspectMembership = app.views.AspectsDropdown.extend({
 
   events: {
-    "click ul.aspect_membership.dropdown-menu > li.aspect_selector": "_clickHandler"
+    "click ul.aspect_membership.dropdown-menu > li.aspect_selector": "_clickHandler",
+    "keypress ul.aspect_membership.dropdown-menu > li.aspect_selector": "_clickHandler"
   },
 
   initialize: function() {

--- a/app/assets/javascripts/view.js
+++ b/app/assets/javascripts/view.js
@@ -21,7 +21,8 @@ var View = {
 
     /* Dropdowns */
     $(document)
-      .on('click', this.dropdowns.selector, this.dropdowns.click);
+      .on('click', this.dropdowns.selector, this.dropdowns.click)
+      .on('keypress', this.dropdowns.selector, this.dropdowns.click);
 
     /* Avatars */
     $(this.avatars.selector).error(this.avatars.fallback);

--- a/app/helpers/aspect_global_helper.rb
+++ b/app/helpers/aspect_global_helper.rb
@@ -33,7 +33,7 @@ module AspectGlobalHelper
     klass = am_id.present? ? "selected" : ""
 
     str = <<LISTITEM
-<li data-aspect_id="#{aspect.id}" data-membership_id="#{am_id}" class="#{klass} aspect_selector">
+<li data-aspect_id="#{aspect.id}" data-membership_id="#{am_id}" class="#{klass} aspect_selector" tabindex="0">
   #{aspect.name}
 </li>
 LISTITEM

--- a/app/views/aspect_memberships/_aspect_membership_dropdown.html.haml
+++ b/app/views/aspect_memberships/_aspect_membership_dropdown.html.haml
@@ -1,5 +1,5 @@
 .btn-group.aspect_dropdown.aspect_membership_dropdown
-  %button.btn.btn-small.dropdown-toggle{:class => selected_aspects.size>0 ? "green" : "btn-default", "data-toggle" => "dropdown"}
+  %button.btn.btn-small.dropdown-toggle{:class => selected_aspects.size>0 ? "green" : "btn-default", "data-toggle" => "dropdown", :tabindex => '0'}
     %span.text
       - if selected_aspects.size == all_aspects.size
         = t('all_aspects')
@@ -11,7 +11,7 @@
 
   %ul.dropdown-menu{:class => ["pull-#{hang}", defined?(dropdown_class) && dropdown_class], :unSelectable => 'on', 'data-person_id' => (person.id if defined?(person) && person), 'data-service_uid' => (service_uid if defined?(service_uid)), 'data-person-short-name' => (person.first_name if defined?(person) && person)}
     - for aspect in all_aspects
-      %li.aspect_selector{ :class => ('selected' if aspect_membership_ids[aspect.id].present?), 'data-aspect_id' => aspect.id, 'data-membership_id' => aspect_membership_ids[aspect.id] }
+      %li.aspect_selector{ :class => ('selected' if aspect_membership_ids[aspect.id].present?), 'data-aspect_id' => aspect.id, 'data-membership_id' => aspect_membership_ids[aspect.id], :tabindex => '0' }
         %a
           %span.status_indicator
             %i.icon-ok

--- a/app/views/aspect_memberships/_aspect_membership_dropdown_blueprint.html.haml
+++ b/app/views/aspect_memberships/_aspect_membership_dropdown_blueprint.html.haml
@@ -1,5 +1,5 @@
 .dropdown{:class => ["hang_#{hang}", defined?(dropdown_class) && dropdown_class]}
-  .button.toggle{:class => ("in_aspects" if selected_aspects.size > 0)}
+  .button.toggle{:class => ("in_aspects" if selected_aspects.size > 0), :tabindex => '0'}
     - if selected_aspects.size == all_aspects.size
       = t('all_aspects')
     - elsif selected_aspects.size == 1


### PR DESCRIPTION
https://github.com/diaspora/diaspora/issues/5044

Adding tabindex attributes for add contact dropdown and contents, also binding keypress event to perform same action that click does. For reference, tabindex='0' doesn't mess with the existing tab order.
