### PR TITLE
Fixes issue 4661

### DIFF
--- a/app/assets/javascripts/app/views/hovercard_view.js
+++ b/app/assets/javascripts/app/views/hovercard_view.js
@@ -116,6 +116,11 @@ app.views.Hovercard = Backbone.View.extend({
   _positionHovercard: function() {
     var p = this.$el.parent();
     var p_pos = p.position();
+    if (p_pos.left + $(this.$el).width() > $(window).width()) {
+        // 50 is padding to deal with scrollbar and to provide some space
+        p_pos.left = $(window).width() - $(this.$el).width() - 50;
+    }
+
     var p_height = p.height();
 
     this.$el.css({


### PR DESCRIPTION
https://github.com/diaspora/diaspora/issues/4661

If the right side of the hovercard goes off the screen then pull it to the right. The magic number of 50 is to account for the scroll bar and to give a little padding so the hovercard isn't right against the edge of the screen. Specs pass.
