### PR TITLE
Add sign-up tests for mobile version

### DIFF
--- a/features/desktop/signs_up.feature
+++ b/features/desktop/signs_up.feature
@@ -4,7 +4,7 @@ Feature: new user registration
   Background:
     When I go to the new user registration page
     And I fill in the new user form
-    And I press "Continue"
+    And I submit the form
     Then I should be on the getting started page
     Then I should see the 'getting started' contents
 
@@ -21,7 +21,6 @@ Feature: new user registration
       | profile_first_name | <script>alert(0)// |
     And I focus the "follow_tags" field
     Then I should see a flash message containing "Hey, <script>alert(0)//!"
-
 
   Scenario: new user does not add any tags in setup wizard and cancel the alert
     When I fill in the following:
@@ -46,7 +45,7 @@ Feature: new user registration
     And I wait for the popovers to appear
     And I click close on all the popovers
     And I go to the home page
-    Then I should not see "Welcome to Diaspora"
+    Then I should not see "Welcome to diaspora*"
 
   Scenario: user fills in bogus data - client side validation
     When I log out manually

--- a/features/mobile/activity_stream.feature
+++ b/features/mobile/activity_stream.feature
@@ -7,8 +7,8 @@ Feature: Viewing my activity on the steam mobile page
   Background:
     Given a user with username "alice"
     And "alice@alice.alice" has a public post with text "Hello! i am #newhere"
-    When I sign in as "alice@alice.alice"
-    And I toggle the mobile view
+    When I toggle the mobile view
+    And I sign in as "alice@alice.alice"
 
   Scenario: Show my activity empty
     When I open the drawer

--- a/features/mobile/conversations.feature
+++ b/features/mobile/conversations.feature
@@ -7,9 +7,9 @@ Feature: private conversations mobile
   Background:
     Given a user with username "bob"
     And a user named "Alice Awesome" with email "alice@alice.alice"
-    When I sign in as "bob@bob.bob"
     And a user with username "bob" is connected with "alice_awesome"
-    And I toggle the mobile view
+    When I toggle the mobile view
+    And I sign in as "bob@bob.bob"
 
   Scenario: send and delete a mobile message
     Given I send a mobile message with subject "Greetings" and text "hello, alice!" to "Alice Awesome"

--- a/features/mobile/getting_started.feature
+++ b/features/mobile/getting_started.feature
@@ -1,13 +1,23 @@
 @javascript
 Feature: editing the getting started in the mobile view
 
-  Scenario: editing getting started fields
-    When I go to the new user registration page
+  Background:
+    Given I toggle the mobile view
+    And I am on the login page
+    When I follow "Sign up"
     And I fill in the new user form
-    And I press "Continue"
-    And I visit the mobile getting started page
+    And I submit the form
+    Then I should be on the getting started page
     Then I should see the 'getting started' contents
 
+  Scenario: new user does not add any tags in setup wizard
+    When I fill in the following:
+      | profile_first_name | some name     |
+    And I follow "awesome_button"
+    Then I should be on the stream page
+    And I should not see "awesome_button"
+
+  Scenario: new user adds a profile photo and tags
     When I attach the file "spec/fixtures/bad_urls.txt" to "file" within "#file-upload"
     And I confirm the alert
     And I attach the file "spec/fixtures/button.png" to hidden "file" within "#file-upload"
@@ -17,6 +27,7 @@ Feature: editing the getting started in the mobile view
     And I press the first ".as-result-item" within ".as-results"
     Then I should see "#men" within "ul#as-selections-tags"
 
+  Scenario: new user skips the setup wizard
     When I follow "awesome_button"
     Then I should be on the stream page
     And I should not see "awesome_button"

--- a/features/mobile/multiphoto.feature
+++ b/features/mobile/multiphoto.feature
@@ -7,8 +7,8 @@ Feature: viewing photos on the mobile main page
   Background:
     Given a user with username "bob"
 
-    When I sign in as "bob@bob.bob"
-    And I toggle the mobile view
+    When I toggle the mobile view
+    And I sign in as "bob@bob.bob"
     And I click on selector "#compose_badge"
 
   Scenario: view full size image

--- a/features/mobile/posts_from_main_page.feature
+++ b/features/mobile/posts_from_main_page.feature
@@ -9,7 +9,8 @@ Feature: posting from the mobile main page
         | username   |
         | bob        |
         | alice      |
-      And I visit the mobile home page
+      And I toggle the mobile view
+      And I am on the home page
       And I sign in as "bob@bob.bob"
       And a user with username "bob" is connected with "alice"
       Given I have following aspects:
@@ -19,8 +20,8 @@ Feature: posting from the mobile main page
       And I have user with username "alice" in an aspect called "NotPostingThingsHere"
 
     Scenario: post and delete some text
-      Given I publisher mobile page
-      And I append "I am eating yogurt" to the publisher mobile
+      Given I visit the mobile publisher page
+      And I append "I am eating yogurt" to the mobile publisher
       And I select "Unicorns" from "aspect_ids_"
       And I press "Share"
       When I visit the mobile stream page
@@ -30,7 +31,7 @@ Feature: posting from the mobile main page
       Then I should not see "I am eating yogurt"
 
     Scenario: post a photo without text
-      Given I publisher mobile page
+      Given I visit the mobile publisher page
       When I attach the file "spec/fixtures/button.png" to hidden "file" within "#file-upload-publisher"
       Then I should see an uploaded image within the photo drop zone
       And I should see "button.png completed"
@@ -43,7 +44,7 @@ Feature: posting from the mobile main page
       Then I should see a "img" within ".stream_element div.photo_attachments"
 
     Scenario: back out of posting a photo-only post
-      Given I publisher mobile page
+      Given I visit the mobile publisher page
       When I attach the file "spec/fixtures/bad_urls.txt" to "file" within "#file-upload-publisher"
       And I confirm the alert
       Then I should not see an uploaded image within the photo drop zone
@@ -53,8 +54,8 @@ Feature: posting from the mobile main page
       Then I should not see an uploaded image within the photo drop zone
 
     Scenario: back out of uploading a picture when another has been attached
-      Given I publisher mobile page
-      And I append "I am eating yogurt" to the publisher mobile
+      Given I visit the mobile publisher page
+      And I append "I am eating yogurt" to the mobile publisher
       And I attach the file "spec/fixtures/button.gif" to hidden "file" within "#file-upload-publisher"
       And I attach the file "spec/fixtures/button.png" to hidden "file" within "#file-upload-publisher"
       And I click to delete the first uploaded photo

--- a/features/mobile/reactions.feature
+++ b/features/mobile/reactions.feature
@@ -11,8 +11,8 @@ Feature: reactions mobile post
       | Alice Smith | alice@alice.alice |
     And a user with email "bob@bob.bob" is connected with "alice@alice.alice"
     When "alice@alice.alice" has posted a status message with a photo
-    And I sign in as "bob@bob.bob"
     And I toggle the mobile view
+    And I sign in as "bob@bob.bob"
 
   Scenario: like on a mobile post
     When I should see "0 reactions" within ".show_comments"

--- a/features/mobile/signs_up.feature
+++ b/features/mobile/signs_up.feature
@@ -1,0 +1,34 @@
+@javascript
+Feature: New user registration
+  In order to use Diaspora*
+  As a mobile user
+  I want to register an account
+
+  Background:
+    Given I toggle the mobile view
+    And I am on the login page
+	And I follow "Sign up"
+
+  Scenario: user signs up and goes to getting started
+	When I fill in the new user form
+    And I submit the form
+    Then I should be on the getting started page
+    Then I should see the 'getting started' contents
+
+  Scenario: user fills in bogus data - client side validation
+    When I fill in the following:
+        | user_username        | $%&(/&%$&/=)(/    |
+    And I submit the form
+    Then I should not be able to sign up
+
+    When I fill in the following:
+        | user_username     | valid_user                        |
+        | user_email        | this is not a valid email $%&/()( |
+    And I submit the form
+    Then I should not be able to sign up
+
+    When I fill in the following:
+        | user_email        | valid@email.com        |
+        | user_password     | 1                      |
+    And I submit the form
+    Then I should not be able to sign up

--- a/features/mobile/tags.feature
+++ b/features/mobile/tags.feature
@@ -4,8 +4,8 @@ Feature: Interacting with tags
   Background:
     Given a user with username "alice"
     And "alice@alice.alice" has a public post with text "Hello! i am #newhere"
-    When I sign in as "alice@alice.alice"
-    And I toggle the mobile view
+    When I toggle the mobile view
+    And I sign in as "alice@alice.alice"
 
   Scenario: Searching for a tag
     When I visit the mobile search page

--- a/features/step_definitions/mobile_steps.rb
+++ b/features/step_definitions/mobile_steps.rb
@@ -1,12 +1,20 @@
-When /^I visit the mobile aspects page$/ do
-  visit('/aspects.mobile')
+When /^I toggle the mobile view$/ do
+  visit('/mobile/toggle')
 end
 
 When /^I visit the mobile home page$/ do
   visit('/users/sign_in.mobile')
 end
 
-Given /^I publisher mobile page$/ do
+When /^I visit the mobile registration page$/ do
+  visit('/users/sign_up.mobile')
+end
+
+When /^I visit the mobile getting started page$/ do
+  visit('/getting_started.mobile')
+end
+
+Given /^I visit the mobile publisher page$/ do
   visit('/status_messages/new.mobile')
 end
 
@@ -14,12 +22,8 @@ When /^I visit the mobile stream page$/ do
   visit('/stream.mobile')
 end
 
-When /^I toggle the mobile view$/ do
-  visit('/mobile/toggle')
-end
-
-When /^I visit the mobile getting started page$/ do
-  visit('/getting_started.mobile')
+When /^I visit the mobile aspects page$/ do
+  visit('/aspects.mobile')
 end
 
 When /^I visit the mobile search page$/ do

--- a/features/step_definitions/posts_steps.rb
+++ b/features/step_definitions/posts_steps.rb
@@ -79,7 +79,7 @@ When /^I append "([^"]*)" to the publisher$/ do |text|
   append_to_publisher(text)
 end
 
-When /^I append "([^"]*)" to the publisher mobile$/ do |text|
+When /^I append "([^"]*)" to the mobile publisher$/ do |text|
   append_to_publisher(text, '#status_message_text')
 end
 


### PR DESCRIPTION
Created sign-up tests for the mobile version to address #5168. Amended and added to the getting started tests.

There appear currently to be no alerts or flash messages as part of sign-up or getting-started in the mobile version, so these tests are truncated, and I'm not sure how useful they will be. But they are there, and they pass.

I have also repositioned `I toggle the mobile view` in some other tests so all actions, where possible, are done in the mobile version.

(Also re-arranged the items in `mobile_steps.rb` and made a couple of updates to one desktop test file.)
