### PR TITLE
Fixed Open Graph db insertion

### DIFF
--- a/app/models/open_graph_cache.rb
+++ b/app/models/open_graph_cache.rb
@@ -26,7 +26,7 @@ class OpenGraphCache < ActiveRecord::Base
 
     return if response.blank? || response.type.blank?
 
-    self.title = response.title
+    self.title = response.title.truncate(255)
     self.ob_type = response.type
     self.image = response.images[0]
     self.url = response.url

--- a/db/migrate/20140906192846_fix_open_graph_data.rb
+++ b/db/migrate/20140906192846_fix_open_graph_data.rb
@@ -1,0 +1,10 @@
+class FixOpenGraphData < ActiveRecord::Migration
+  def self.up
+    change_column :open_graph_caches, :url, :text
+    change_column :open_graph_caches, :image, :text
+  end
+  def self.down
+    change_column :open_graph_caches, :url, :string
+    change_column :open_graph_caches, :image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140826165533) do
+ActiveRecord::Schema.define(version: 20140906192846) do
 
   create_table "account_deletions", force: true do |t|
     t.string   "diaspora_handle"
@@ -219,8 +219,8 @@ ActiveRecord::Schema.define(version: 20140826165533) do
   create_table "open_graph_caches", force: true do |t|
     t.string "title"
     t.string "ob_type"
-    t.string "image"
-    t.string "url"
+    t.text "image"
+    t.text "url"
     t.text   "description"
   end
 


### PR DESCRIPTION
in response to issue #5081 i have modified the way open graph data is inserted into the db by truncating the title and changing url and image from string to text to allow for longer urls that exceed 255 characters
