### PR TITLE
[WIP] Global hydra

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -304,12 +304,10 @@ class Person < ActiveRecord::Base
   end
 
   # Update an array of people given a url, and set it as the new destination_url
-  # @param people [Array<People>]
+  # @param people_ids [Array<Integer>]
   # @param url [String]
-  def self.url_batch_update(people, url)
-    people.each do |person|
-      person.update_url(url)
-    end
+  def self.url_batch_update(people_ids, url)
+    where(id: people_ids).update_all(url: sanitize_url(url))
   end
 
   #gross method pulled out from controller, not exactly sure how it should be used.
@@ -317,14 +315,17 @@ class Person < ActiveRecord::Base
     user.contacts.receiving.where(:person_id => self.id).first if user
   end
 
-  # @param person [Person]
   # @param url [String]
   def update_url(url)
+    self.update_attributes(url: self.class.sanitize_url(url))
+  end
+
+  # @param url [String]
+  def self.sanitize_url url
     location = URI.parse(url)
     newuri = "#{location.scheme}://#{location.host}"
     newuri += ":#{location.port}" unless ["80", "443"].include?(location.port.to_s)
     newuri += "/"
-    self.update_attributes(:url => newuri)
   end
 
   def lock_access!

--- a/app/workers/http_multi.rb
+++ b/app/workers/http_multi.rb
@@ -13,7 +13,13 @@ module Workers
                       ]
     def perform(user_id, encoded_object_xml, person_ids, dispatcher_class_as_string, retry_count=0)
       user = User.find(user_id)
-      people = Person.where(:id => person_ids)
+      people = Person.where(:id => person_ids).select(
+        :id,
+        :url,
+        :guid,
+        :diaspora_handle,
+        :serialized_public_key
+      )
 
       dispatcher = dispatcher_class_as_string.constantize
       hydra = HydraWrapper.new(user, people, encoded_object_xml, dispatcher)

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -68,6 +68,7 @@ defaults:
       suggest_email:
     typhoeus_verbose: false
     typhoeus_concurrency: 20
+    typhoeus_connects: 10
     username_blacklist:
       - 'admin'
       - 'administrator'

--- a/config/diaspora.yml.example
+++ b/config/diaspora.yml.example
@@ -71,7 +71,7 @@ configuration: ## Section
 
       ## Number of parallel threads Sidekiq uses (default=5)
       ## If you touch this please set the pool setting in your database.yml to
-      ## a value that's at minimum close to this! You can safely increase it 
+      ## a value that's at minimum close to this! You can safely increase it
       ## to 25 and more on a medium-sized pod. This applies per started Sidekiq
       ## worker, so if you set it to 25 and start two workers you'll process
       ## up to 50 jobs in parallel.
@@ -179,7 +179,7 @@ configuration: ## Section
     #jquery_cdn: false
     
     ## Google Analytics (disabled by default)
-    ## Provide a key to enable tracking by Google Analytics 
+    ## Provide a key to enable tracking by Google Analytics
     #google_analytics_key:
     
     ## Piwik Tracking (disabled by default)
@@ -200,7 +200,7 @@ configuration: ## Section
     ## Statistics
     ## Your pod will report its name, software version and whether
     ## or not registrations are open via /statistics.json.
-    ## Uncomment the options below to enable more statistics. 
+    ## Uncomment the options below to enable more statistics.
     statistics: ## Section
 
       ## Local user total and 6 month active counts
@@ -278,6 +278,11 @@ configuration: ## Section
     ## Be careful, raising this setting will heavily increase the memory usage
     ## of your Sidekiq workers.
     #typhoeus_concurrency: 20
+
+    ## Maximum number of open connections to other pods (default=10)
+    ## Raising this will make delivering posts to other pods faster
+    ## but also increase memory usage.
+    #typhoeus_connects: 10
 
     ## Captcha settings
     captcha: ## Section

--- a/config/initializers/load_libraries.rb
+++ b/config/initializers/load_libraries.rb
@@ -1,6 +1,7 @@
 # Stdlib
 require 'cgi'
 require 'uri'
+require 'singleton'
 
 # Not auto required gems
 require 'builder/xchar'

--- a/spec/lib/hydra_wrapper_spec.rb
+++ b/spec/lib/hydra_wrapper_spec.rb
@@ -6,7 +6,9 @@ require 'spec_helper'
 
 describe HydraWrapper do
   before do
-    @people = ["person", "person2", "person3"]
+    @people = %w[person person2 person3].map.with_index {|name, id|
+      double(id: id, name: name)
+    }
     @wrapper = HydraWrapper.new double, @people, "<encoded_xml>", double
   end
 
@@ -61,7 +63,7 @@ describe HydraWrapper do
       @wrapper.dispatcher_class = double salmon: double(xml_for: "<XML>")
       allow(@wrapper).to receive(:grouped_people).and_return('https://foo.com' => @wrapper.people)
       expect(@wrapper.people).to receive(:first).once
-      expect(@wrapper).to receive(:insert_job).with('https://foo.com', "<XML>", @wrapper.people).once
+      expect(@wrapper).to receive(:insert_job).with('https://foo.com', "<XML>", @wrapper.people.map(&:id)).once
       @wrapper.enqueue_batch
     end
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -491,11 +491,14 @@ describe Person, :type => :model do
     end
 
     describe '.url_batch_update' do
-      it "calls #update_person_url given an array of users and a url" do
-        people = [double.as_null_object, double.as_null_object, double.as_null_object]
-        people.each do |person|
-          expect(person).to receive(:update_url).with(@url)
-        end
+      it "sanitizes and updates the URL" do
+        people = double
+        collection = double
+        url = double
+        expect(Person).to receive(:sanitize_url).with(@url).and_return(url)
+        expect(Person).to receive(:where).with(id: people).and_return(collection)
+        expect(collection).to receive(:update_all).with(url: url)
+
         Person.url_batch_update(people, @url)
       end
     end

--- a/spec/workers/http_multi_spec.rb
+++ b/spec/workers/http_multi_spec.rb
@@ -15,6 +15,7 @@ describe Workers::HttpMulti do
     @people = [FactoryGirl.create(:person), FactoryGirl.create(:person)]
     @post_xml = Base64.encode64 "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAH"
 
+    HydraWrapper::GlobalHydra.instance.reset!
     @hydra = Typhoeus::Hydra.new
     allow(Typhoeus::Hydra).to receive(:new).and_return(@hydra)
     @salmon = Salmon::EncryptedSlap.create_by_user_and_activity bob, Base64.decode64(@post_xml)


### PR DESCRIPTION
Try reducing sidekiq/typhoeus/http_multi memory usage
- Only fetch needed attributes of persons
- Discard person objects as early as possible
- Use only one global hydra instance
- Limit number of cached connections

While being highly experimental, this seems to run stable on my pod for the last two days (in combination with #5209).

Only ever allocating one hydra and limiting the number of connections cached by it drastically reduces and stabilizes memory usage for usage patterns on my pod, I'm stable under 300M RSS now. Though this has the potential to totally wreck outgoing federation performance on different (= higher) load patterns. It may also block Sidekiq workers longer than usual and thus decrease overall Sidekiq throughput. If this goes in, the settings for `sidekiq_concurrency`, `typhoeus_concurrency` and the new `typhoeus_connects` likely need adjusted defaults. Figuring out sensible defaults for these is the hard part of this PR. Reworking the queue priorities in https://github.com/diaspora/diaspora/blob/develop/config/initializers/sidekiq.rb#L20 might also be needed. That said the current defaults are still active on my pod and work good there and I'd still like to target such small instances with the defaults.

Another possible optimization is detecting if one Sidekiq worker is already driving the hydra and not blocking additional ones after they submitted the additional requests. This requires figuring out a reliable way of detecting whether the hydra is already running after the new requests have been queued. That would also requires a complete rework of the retry logic, so I'd like to avoid it if doable.

I'm not sure what more testing could be done from my side since I have no other setups available.
