### PR TITLE
Changelogs for terms and podmin admin mail rake task [ci skip]

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,31 @@ There are also two configuration settings to customize the terms (when using the
 * `settings.terms.jurisdiction` - indicate here in which country or state any legal disputes are handled.
 * `settings.terms.minimum_age` - indicate here if you want to show a minimum required age for creating an account.
 
+## Rake task to email users
+
+There is a new Rake task `podmin:admin_mail` available to allow podmins to easily send news and notices to users. The rake task triggers emails via the normal diaspora mailer mechanism (so they are embedded in the standard template) and takes the following parameters:
+
+1) Users definition
+
+* `all` - all users in the database (except deleted)
+* `active_yearly` - users logged in within the last year
+* `active_monthly` - users logged in within the last month
+* `active_halfyear` - users logged in within the last 6 months
+
+2) Path to message file
+
+* Give here a path to a HTML or plain text file that contains the message.
+
+3) Subject
+
+* A subject for the email
+
+Example shell command (depending on your environment);
+
+`RAILS_ENV=production bundle exec rake podmin:admin_mail['active_monthly','./message.html','Important message from pod']`
+
+Read more about [specifying arguments to Rake tasks](http://stackoverflow.com/a/825832/1489738).
+
 ## Refactor
 * Port help pages to Bootstrap [#5050](https://github.com/diaspora/diaspora/pull/5050)
 * Refactor Notification#notify [#4945](https://github.com/diaspora/diaspora/pull/4945)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,23 @@
 # 0.4.1.0
 
+## New 'Terms of Service' feature and template
+
+This release brings a new ToS feature that allows pods to easily display to users the terms of service they are operating on. This feature is not enabled by default. If you want to enable it, please add under `settings` in `config/diaspora.yml` the following and restart diaspora. If in doubt see `config/diaspora.yml.example`:
+
+    terms:
+      enable: true
+
+When enabled, the footer and sidebar will have a link to terms page, and signup will have a disclaimer indicating that creating an account means the user accepts the terms of use.
+
+While the project itself doesn't restrict what kind of terms pods run on, we realize not all podmins want to spend time writing them from scratch. Thus there is a basic ToS template included that will be used unless a custom one available.
+
+To modify (or completely rewrite) the terms template, create a file called `app/views/terms/terms.haml` or `app/views/terms/terms.erb` and it will automatically replace the default template, which you can find at `app/views/terms/default.haml`.
+
+There are also two configuration settings to customize the terms (when using the default template). These are optional.
+
+* `settings.terms.jurisdiction` - indicate here in which country or state any legal disputes are handled.
+* `settings.terms.minimum_age` - indicate here if you want to show a minimum required age for creating an account.
+
 ## Refactor
 * Port help pages to Bootstrap [#5050](https://github.com/diaspora/diaspora/pull/5050)
 * Refactor Notification#notify [#4945](https://github.com/diaspora/diaspora/pull/4945)


### PR DESCRIPTION
Changelog mentions about terms of service and rake task podmin:admin_mail.

Will add these to wiki too once texts are fine.
