### PR TITLE
Fix services in statistics.json.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -51,6 +51,7 @@ The default for including jQuery from a CDN has changed. If you want to continue
 * Fix deformed getting started popover [#5227](https://github.com/diaspora/diaspora/pull/5227)
 * Use correct locale for invitation subject [#5232](https://github.com/diaspora/diaspora/pull/5232)
 * Initial support for IDN emails
+* Fix services settings reported by statistics.json [#5256](https://github.com/diaspora/diaspora/pull/5256)
 
 ## Features
 * Don't pull jQuery from a CDN by default [#5105](https://github.com/diaspora/diaspora/pull/5105)

--- a/app/presenters/statistics_presenter.rb
+++ b/app/presenters/statistics_presenter.rb
@@ -17,10 +17,8 @@ class StatisticsPresenter
     if AppConfig.privacy.statistics.comment_counts?
       result['local_comments'] = self.local_comments
     end
-
     AppConfig.services.each do |service, options|
-      result[service] = options ? !!options["enable"] : false
-    
+      result[service] = AppConfig["services.#{service}.enable"]
     end
 
     result

--- a/app/presenters/statistics_presenter.rb
+++ b/app/presenters/statistics_presenter.rb
@@ -17,8 +17,8 @@ class StatisticsPresenter
     if AppConfig.privacy.statistics.comment_counts?
       result['local_comments'] = self.local_comments
     end
-    AppConfig.services.each do |service, options|
-      result[service] = AppConfig["services.#{service}.enable"]
+    Configuration::KNOWN_SERVICES.each do |service, options|
+      result[service.to_s] = AppConfig["services.#{service}.enable"]
     end
 
     result
@@ -31,5 +31,5 @@ class StatisticsPresenter
   def local_comments
     Comment.joins(:author).where("owner_id IS NOT null").count
   end
-  
+
 end

--- a/lib/configuration_methods.rb
+++ b/lib/configuration_methods.rb
@@ -1,4 +1,6 @@
 module Configuration
+  KNOWN_SERVICES = [:twitter, :tumblr, :facebook, :wordpress].freeze
+
   module Methods
     def pod_uri
       return @pod_uri unless @pod_uri.nil?
@@ -24,7 +26,7 @@ module Configuration
       return @configured_services unless @configured_services.nil?
 
       @configured_services = []
-      [:twitter, :tumblr, :facebook, :wordpress].each do |service|
+      KNOWN_SERVICES.each do |service|
         @configured_services << service if services.send(service).enable?
       end
 

--- a/spec/presenters/statistics_presenter_spec.rb
+++ b/spec/presenters/statistics_presenter_spec.rb
@@ -18,12 +18,14 @@ describe StatisticsPresenter do
       AppConfig.privacy.statistics.user_counts = false
       AppConfig.privacy.statistics.post_counts = false
       AppConfig.privacy.statistics.comment_counts = false
-      AppConfig.services = {"facebook" => nil}
       expect(@presenter.as_json).to eq({
         "name" => AppConfig.settings.pod_name,
         "version" => AppConfig.version_string,
         "registrations_open" => AppConfig.settings.enable_registrations,
-        "facebook" => false
+        "facebook" => true,
+        "twitter" => false,
+        "tumblr" => false,
+        "wordpress" => false,
       })
     end
     

--- a/spec/presenters/statistics_presenter_spec.rb
+++ b/spec/presenters/statistics_presenter_spec.rb
@@ -13,11 +13,17 @@ describe StatisticsPresenter do
   end
 
   describe '#statistics contents' do
-
-    it 'provides generic pod data in json' do
+    before do
       AppConfig.privacy.statistics.user_counts = false
       AppConfig.privacy.statistics.post_counts = false
       AppConfig.privacy.statistics.comment_counts = false
+    end
+
+    after do
+      AppConfig.privacy = nil
+    end
+
+    it 'provides generic pod data in json' do
       expect(@presenter.as_json).to eq({
         "name" => AppConfig.settings.pod_name,
         "version" => AppConfig.version_string,
@@ -28,18 +34,23 @@ describe StatisticsPresenter do
         "wordpress" => false,
       })
     end
-    
+
     context 'when services are enabled' do
       before do
         AppConfig.privacy.statistics.user_counts = true
         AppConfig.privacy.statistics.post_counts = true
         AppConfig.privacy.statistics.comment_counts = true
         AppConfig.services = {
-          "facebook" => {"enable" => true}, 
-          "twitter" => {"enable" => true}, 
+          "facebook" => {"enable" => true},
+          "twitter" => {"enable" => true},
           "wordpress" => {"enable" => false},
           "tumblr" => {"enable" => false}
         }
+      end
+
+      after do
+        AppConfig.services = nil
+        AppConfig.privacy = nil
       end
 
       it 'provides generic pod data and counts in json' do


### PR DESCRIPTION
Currently there is a bug in configurate that reports incorrectly the services settings if they are set as ENV variables, instead of diaspora.yml settings.
This commit works around that issue by changing the way the setting is fetched.
