### PR TITLE
SPV: Resharer's avatar links to reshare

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -42,7 +42,7 @@ The default for including jQuery from a CDN has changed. If you want to continue
 * Display new conversation form on conversations/index [#5178](https://github.com/diaspora/diaspora/pull/5178)
 * Port profile page to Backbone [#5180](https://github.com/diaspora/diaspora/pull/5180)
 * Pull punycode.js from rails-assets.org [#5263](https://github.com/diaspora/diaspora/pull/5263)
-
+* SPV resharer list: link to reshares instead of resharers [#5277](https://github.com/diaspora/diaspora/pull/5277)
 
 ## Bug fixes
 * orca cannot see 'Add Contact' button [#5158](https://github.com/diaspora/diaspora/pull/5158)

--- a/app/assets/templates/single-post-viewer/single-post-interactions_tpl.jst.hbs
+++ b/app/assets/templates/single-post-viewer/single-post-interactions_tpl.jst.hbs
@@ -6,9 +6,9 @@
     </span>
     <span>
       {{#each reshares}}
-        {{#linkToPerson author}}
-          {{{personImage this 'small' 'micro'}}}
-        {{/linkToPerson}}
+        <a href="{{{urlTo 'post' id}}}">
+          {{{personImage author 'small' 'micro'}}}
+        </a>
       {{/each}}
     </span>
   </div>


### PR DESCRIPTION
In the SPV the resharer's avatar now link to the reshare instead of the author's profile.
