### PR TITLE
Hidden overflow for long names on tag pages

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -42,7 +42,7 @@ The default for including jQuery from a CDN has changed. If you want to continue
 * Display new conversation form on conversations/index [#5178](https://github.com/diaspora/diaspora/pull/5178)
 * Port profile page to Backbone [#5180](https://github.com/diaspora/diaspora/pull/5180)
 * Pull punycode.js from rails-assets.org [#5263](https://github.com/diaspora/diaspora/pull/5263)
-
+* Hidden overflow for long names on tag pages [#5279](https://github.com/diaspora/diaspora/pull/5279)
 
 ## Bug fixes
 * orca cannot see 'Add Contact' button [#5158](https://github.com/diaspora/diaspora/pull/5158)

--- a/app/assets/stylesheets/tag.css.scss
+++ b/app/assets/stylesheets/tag.css.scss
@@ -22,5 +22,15 @@ h1.tag {
 }
 
 #tags_show {
-  .span3 { border-right: 1px solid $border-grey; }
+  .span3 {
+    border-right: 1px solid $border-grey;
+    .side_stream #people_stream {
+      .name { display: block; }
+      .name, .diaspora_handle, .tags {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
+  }
 }


### PR DESCRIPTION
small screens:
![](https://cloud.githubusercontent.com/assets/3798614/4515550/b7a3073a-4bc3-11e4-869e-74e0109a8bcd.png)
wide screens:
![](https://cloud.githubusercontent.com/assets/3798614/4515548/a733bc8c-4bc3-11e4-9f43-ba0f0bb45833.png)

Fixes #3926, closes #3975.
