### PR TITLE
Added classes onto the body tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,7 +119,7 @@ gem 'omniauth-wordpress','0.2.1'
 
 # Tags
 
-gem 'acts-as-taggable-on', '3.4.1'
+gem 'acts-as-taggable-on', '3.4.2'
 
 # URIs and HTTP
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
-    acts-as-taggable-on (3.4.1)
+    acts-as-taggable-on (3.4.2)
       activerecord (>= 3.2, < 5)
     acts_as_api (0.4.2)
       activemodel (>= 3.0.0)
@@ -63,6 +63,10 @@ GEM
     bootstrap-sass (2.3.2.2)
       sass (~> 3.2)
     builder (3.2.2)
+    byebug (3.5.1)
+      columnize (~> 0.8)
+      debugger-linecache (~> 1.2)
+      slop (~> 3.6)
     capybara (2.4.1)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -87,13 +91,14 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.8.0)
+    columnize (0.8.9)
     compass (0.12.7)
       chunky_png (~> 1.2)
       fssm (>= 0.2.7)
       sass (~> 3.2.19)
     compass-rails (2.0.0)
       compass (>= 0.12.2)
-    configurate (0.1.0)
+    configurate (0.2.0)
     connection_pool (2.0.0)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
@@ -110,6 +115,7 @@ GEM
       nokogiri (~> 1.5)
       rails (>= 3, < 5)
     database_cleaner (1.3.0)
+    debugger-linecache (1.2.0)
     devise (3.3.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -266,7 +272,7 @@ GEM
     mini_magick (3.8.1)
       subexec (~> 0.2.1)
     mini_portile (0.5.3)
-    minitest (5.4.1)
+    minitest (5.4.2)
     mobile-fu (1.3.1)
       rack-mobile-detect
       rails
@@ -317,6 +323,9 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-byebug (2.0.0)
+      byebug (~> 3.4)
+      pry (~> 0.10)
     pry-debundle (0.8)
       pry
     rack (1.5.2)
@@ -350,6 +359,7 @@ GEM
     rails-assets-jquery (1.11.1)
     rails-assets-perfect-scrollbar (0.4.11)
       rails-assets-jquery (>= 1.10)
+    rails-assets-punycode (1.3.1)
     rails-i18n (4.0.3)
       i18n (~> 0.6)
       railties (~> 4.0)
@@ -504,7 +514,7 @@ DEPENDENCIES
   actionpack-action_caching
   actionpack-page_caching
   activerecord-import (= 0.5.0)
-  acts-as-taggable-on (= 3.4.1)
+  acts-as-taggable-on (= 3.4.2)
   acts_as_api (= 0.4.2)
   addressable (= 2.3.6)
   asset_sync (= 1.1.0)
@@ -513,7 +523,7 @@ DEPENDENCIES
   capybara (= 2.4.1)
   carrierwave (= 0.10.0)
   compass-rails (= 2.0.0)
-  configurate (= 0.1.0)
+  configurate (= 0.2.0)
   cucumber-rails (= 1.4.1)
   database_cleaner (= 1.3.0)
   devise (= 3.3.0)
@@ -554,6 +564,7 @@ DEPENDENCIES
   omniauth-wordpress (= 0.2.1)
   opengraph_parser (= 0.2.3)
   pry
+  pry-byebug
   pry-debundle
   rack-cors (= 0.2.9)
   rack-google-analytics (= 1.2.0)
@@ -564,6 +575,7 @@ DEPENDENCIES
   rails (= 4.1.6)
   rails-assets-jquery (= 1.11.1)
   rails-assets-perfect-scrollbar (= 0.4.11)
+  rails-assets-punycode (= 1.3.1)
   rails-i18n (= 4.0.3)
   rails-timeago (= 2.11.0)
   rails_admin (= 0.6.3)


### PR DESCRIPTION
This makes it easier to identify pages when styling. For example, if you want the home page `<body>` to have a background-image, but not the rest of the site, just target the `.page-home.action-show` class.
