### PR TITLE
Added classes to the body for easier page specific styling.

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -52,7 +52,7 @@
 
     = include_gon(:camel_case => true)
 
-  %body
+  %body{ :class => "page-#{controller_name} action-#{action_name}" }
     = flash_messages
 
     = yield :before_content


### PR DESCRIPTION
This makes it easier to identify pages when styling. For example, if you want the home page `<body>` to have a background-image, but not the rest of the site, just target the `.page-home.action-show` class.
