### PR TITLE
Add a small margin to reshares in bootstrap streams

### DIFF
--- a/app/assets/stylesheets/stream_element.css.scss
+++ b/app/assets/stylesheets/stream_element.css.scss
@@ -75,9 +75,11 @@
     }
   }
 
-  .reshare > .media {
+  .reshare {    
     border-left: 2px solid $border-grey;
-    .avatar {
+    margin-top: 3px;
+  
+    & > .media .avatar {
       height: 30px;
       width: 30px;
     }


### PR DESCRIPTION
I just moved the border to be on the .reshare, to avoid it to be collapsed next to the content (user photo).

**Before**
![before](https://cloud.githubusercontent.com/assets/930064/4530648/b4acfa0c-4d82-11e4-89c1-90e10f90d0b5.png)

**After**
![after](https://cloud.githubusercontent.com/assets/930064/4530647/b4a24f76-4d82-11e4-8bc7-d5ad8d3b457e.png)
