### PR TITLE
pre-fill tag page form with the tag #4234

### DIFF
--- a/app/assets/javascripts/app/views/publisher_view.js
+++ b/app/assets/javascripts/app/views/publisher_view.js
@@ -50,6 +50,9 @@ app.views.Publisher = Backbone.View.extend({
     if( this.el_hiddenInput.val() == "" ) {
       this.el_hiddenInput.val( this.el_input.val() );
     }
+    if( this.el_input.val() == "" ) {
+      this.el_input.val( this.el_hiddenInput.val() );
+    }
 
     // hide close and preview buttons, in case publisher is standalone
     // (e.g. bookmarklet, mentions popup)

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -1219,7 +1219,7 @@ en:
     tags:
       title: "Posts tagged: %{tags}"
       contacts_title: "People who dig this tag"
-      tag_prefill_text: "The thing about %{tag_name} is... "
+      tag_prefill_text: "%{tag_name} "
 
     public:
       title: "Public Activity"


### PR DESCRIPTION
https://github.com/diaspora/diaspora/issues/4234
i checked the codes. It's already implemented and generated HTML's text area is OK. But javascript seems to behave not good over it.
