### PR TITLE
Most recent new users show on Weekly User Stats admin page

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -41,7 +41,7 @@ class AdminsController < Admin::AdminController
       @created_users_by_week[week] << u.username
     end
 
-    @selected_week = params[:week] || @created_users_by_week.keys.first
+    @selected_week = params[:week] || @created_users_by_week.keys.last
     @counter = @created_users_by_week[@selected_week].count
   end
 

--- a/app/views/admins/weekly_user_stats.haml
+++ b/app/views/admins/weekly_user_stats.haml
@@ -7,7 +7,7 @@
 
 %div.pull-right
   = form_tag('/admins/weekly_user_stats', method: 'get', class: 'form-inline') do
-    = select_tag(:week, options_for_select(@created_users_by_week.keys), selected: @selected_week)
+    = select_tag(:week, options_for_select(@created_users_by_week.keys.reverse), selected: @selected_week)
     = submit_tag t('admins.stats.go'), class: 'btn btn-primary'
 
 = t('.amount_of', count: @counter)


### PR DESCRIPTION
Updated Weekly User Stats admin page to show data for the most recent week including reversing the order of the weeks in the drop down to show the most recent. 
