### PR TITLE
Using character (&times;) instead of asset for publisher close button

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -232,11 +232,15 @@ ul.as-selections
       :width 14px
 
   .delete
+    :color #000
     :display inline-block
+    :font-size 1.3em
+    :font-weight bold
+    :line-height 0.9em
+    :padding-left 3px
+    :position relative
+    :top -2px
 
-    .icons-deletelabel
-      :height 14px
-      :width 14px
 
   a:hover
     :text-decoration none

--- a/app/assets/stylesheets/conversations.css.scss
+++ b/app/assets/stylesheets/conversations.css.scss
@@ -131,14 +131,12 @@
     line-height: 0px;
 
     a.close_conversation {
+      color: #000;
       display: block;
-      margin-top: 10px;
       float: right;
-
-      .icons-deletelabel {
-        height: 14px;
-        width: 14px;
-      }
+      font-size: 1.2em;
+      font-weight: bold;
+      margin-top: 2px;
     }
 
     .avatar {

--- a/app/assets/stylesheets/new_styles/_interactions.scss
+++ b/app/assets/stylesheets/new_styles/_interactions.scss
@@ -10,11 +10,14 @@
       }
     }
     .delete {
+      color: #000;
       display: inline-block;
-      .icons-deletelabel {
-        height: 14px;
-        width: 14px;
-      }
+      font-size: 1.2em;
+      font-weight: bold;
+      margin-right: 2px;
+      margin-top: -4px;
+      position: relative;
+
     }
     & > a:hover {
       text-decoration: none;

--- a/app/assets/stylesheets/popover.css.scss
+++ b/app/assets/stylesheets/popover.css.scss
@@ -2,13 +2,16 @@
   .close {
     @include opacity(0);
     @include transition(opacity, 0.2s);
-    position: relative;
-    top: 1px;
-    right: -5px;
+    color: #000;
     float: right;
-    .icons-deletelabel {
-      height: 14px;
-      width: 14px;
+    font-size: 1.2em;
+    font-weight: bold;
+    position: relative;
+    right: -5px;
+    top: -2px;
+
+    &:hover {
+      text-decoration: none;
     }
 
     img { margin-top: 10px; }

--- a/app/assets/stylesheets/publisher_blueprint.css.scss
+++ b/app/assets/stylesheets/publisher_blueprint.css.scss
@@ -244,15 +244,23 @@
       }
 
       .x {
+        color: #fff;
+        cursor: pointer;
         display: none;
-        z-index: 2;
-        position: absolute;
-        top: -3px;
-        right: -1px;
-        font-size: small;
+        font-size: 1.2em;
         font-weight: bold;
+        position: absolute;
+        opacity: 0.7;
+        right: -1px;
+        top: -7.5px;
+        z-index: 2;
+
         &:before {
-          content: 'X';
+          content: '\00d7';
+        }
+
+        &:hover {
+          opacity: 1;
         }
       }
 
@@ -384,13 +392,16 @@
       vertical-align: bottom;
     }
     .remove-answer {
-      width: 14px;
-      height: 14px;
-      @include opacity(0.4);
+      color: #000;
       cursor: pointer;
-      vertical-align: top;
-      margin-top: 7px;
       display: none;
+      font-size: 1.2em;
+      font-weight: bold;
+      height: 14px;
+      margin-left: 3px;
+      @include opacity(0.4);
+      vertical-align: top;
+      width: 11px;
 
       &:hover {
         @include opacity(1);

--- a/app/assets/stylesheets/publisher_blueprint.css.scss
+++ b/app/assets/stylesheets/publisher_blueprint.css.scss
@@ -164,19 +164,18 @@
 #publisher_textarea_wrapper {
   #hide_publisher {
     @include opacity(0.3);
-    z-index: 5;
+    color: #000;
+    font-size: 1.2em;
+    font-weight: bold;
+    margin-top: 2px;
     padding: 3px;
     position: absolute;
-    right: 6px;
-    margin-top: 9px;
-
-    .icons-deletelabel {
-      height: 14px;
-      width: 14px;
-    }
+    right: 8px;
+    z-index: 5;
 
     &:hover {
       @include opacity(1);
+      text-decoration: none;
     }
   }
   

--- a/app/assets/templates/comment_tpl.jst.hbs
+++ b/app/assets/templates/comment_tpl.jst.hbs
@@ -9,9 +9,7 @@
     <div class="controls">
     {{#if loggedIn}}
       {{#if canRemove}}
-        <a href="#" class="delete comment_delete" title="{{t "delete"}}">
-          <div alt="Deletelabel" class="icons-deletelabel" />
-        <a/>
+        <a href="#" class="delete comment_delete" title="{{t "delete"}}">&times;<a/>
       {{else}}
         <a href="#" data-type="comment" class="comment_report" title="{{t "report.name"}}">
           <div class="icons-report"/>

--- a/app/assets/templates/poll_creator_tpl.jst.hbs
+++ b/app/assets/templates/poll_creator_tpl.jst.hbs
@@ -7,13 +7,13 @@
   <div class="poll-answer control-group">
     <div class="controls">
       <input type="text" name="poll_answers[]" placeholder="{{t 'publisher.option' }}">
-      <div class="remove-answer icons-deletelabel"></div>
+      <div class="remove-answer">&times;</div>
     </div>
   </div>
   <div class="poll-answer control-group">
     <div class="controls">
       <input type="text" name="poll_answers[]" placeholder="{{t 'publisher.option' }}">
-      <div class="remove-answer icons-deletelabel"></div>
+      <div class="remove-answer">&times;</div>
     </div>
   </div>
 </div>

--- a/app/assets/templates/stream-element_tpl.jst.hbs
+++ b/app/assets/templates/stream-element_tpl.jst.hbs
@@ -16,13 +16,9 @@
           <a href="#" rel="nofollow" class="block_user" title="{{t "ignore"}}">
             <div class="icons-ignoreuser control_icon"></div>
           </a>
-          <a href="#" rel="nofollow" class="delete hide_post" title="{{t "stream.hide"}}">
-            <div class="icons-deletelabel delete control_icon"/>
-          </a>
+          <a href="#" rel="nofollow" class="delete hide_post control_icon" title="{{t "stream.hide"}}">&times;</a>
         {{else}}
-          <a href="#" rel="nofollow" class="delete remove_post" title="{{t "delete"}}">
-            <div class="icons-deletelabel delete control_icon"/>
-          </a>
+          <a href="#" rel="nofollow" class="delete remove_post control_icon" title="{{t "delete"}}">&times;</a>
         {{/unless}}
       </div>
     {{/if}}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -46,7 +46,7 @@ module ApplicationHelper
   end
 
   def popover_with_close_html(without_close_html)
-    without_close_html + link_to(content_tag(:div, nil, :class => 'icons-deletelabel'), "#", :class => 'close')
+    without_close_html + link_to('&times;'.html_safe, "#", :class => 'close')
   end
 
   # Require jQuery from CDN if possible, falling back to vendored copy, and require

--- a/app/views/conversations/_show.haml
+++ b/app/views/conversations/_show.haml
@@ -3,7 +3,7 @@
 -#   the COPYRIGHT file.
 
 .conversation_participants
-  = link_to(content_tag(:div, nil, :class => 'icons-deletelabel'),
+  = link_to('&times'.html_safe,
             conversation_visibility_path(conversation),
             :method => 'delete',
             :data => { :confirm => "#{t('.delete')}?" },

--- a/app/views/publisher/_publisher_blueprint.html.haml
+++ b/app/views/publisher/_publisher_blueprint.html.haml
@@ -15,7 +15,7 @@
       %div
         %params
           #publisher_textarea_wrapper
-            = link_to(content_tag(:div, nil, :class => 'icons-deletelabel'), "#", :id => "hide_publisher", :title => t('shared.publisher.discard_post'))
+            = link_to('&times;'.html_safe, "#", :id => "hide_publisher", :title => t('shared.publisher.discard_post'))
             %ul#photodropzone
             - if current_user.getting_started?
               = status.text_area :fake_text, :rows => 2, :value => h(publisher_formatted_text), :tabindex => 1, :placeholder => "#{t('contacts.index.start_a_conversation')}...",


### PR DESCRIPTION
Using a character instead of an image asset for the close button on the publisher. The character matches the screen resolution and looks better! 

**Before**
![screen shot 2014-10-10 at 8 04 45 pm](https://cloud.githubusercontent.com/assets/1065321/4601237/9875bb98-50f3-11e4-8bcd-713a3d7e4240.png)

**After**
![screen shot 2014-10-10 at 8 05 38 pm](https://cloud.githubusercontent.com/assets/1065321/4601238/988b61a0-50f3-11e4-9d8e-a3458a44e824.png)

For those of us using high resolution screens our eyes will thanks us!
