### PR TITLE
Add a link to a reported comment in the admin panel

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -67,6 +67,7 @@ The keys will still be available in the root level within the 0.5 release. The o
 * Increased the number of notifications shown in drop down bar to 15 [#5129](https://github.com/diaspora/diaspora/pull/5129)
 * Increase possible captcha length [#5169](https://github.com/diaspora/diaspora/pull/5169)
 * Display visibility icon in publisher aspects dropdown [#4982](https://github.com/diaspora/diaspora/pull/4982)
+* Add a link to the reported comment in the admin panel [#5337](https://github.com/diaspora/diaspora/pull/5337)
 
 # 0.4.1.1
 

--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -9,7 +9,7 @@ module ReportHelper
     elsif type == 'comment' && !(comment = Comment.find_by_id(id)).nil?
       # comment_message is not html_safe. To prevent
       # cross-site-scripting we have to escape html
-      raw t('report.comment_label', data: h(comment_message(comment)))
+      raw t('report.comment_label', data: link_to(h(comment_message(comment)), post_path(comment.post.id, anchor: comment.guid)))
     else
       raw t('report.not_found')
     end

--- a/spec/helpers/report_helper_spec.rb
+++ b/spec/helpers/report_helper_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe ReportHelper, :type => :helper do
+  before do
+    @comment = FactoryGirl.create(:comment)
+    @post = @comment.post
+  end
+
+  describe "#report_content" do
+    it "contains a link to the post" do
+      expect(helper.report_content(@post, 'post')).to include %Q(href="#{post_path(@post)}")
+    end
+    it "contains an anchor to the comment" do 
+      expect(helper.report_content(@comment, 'comment')).to include %Q(href="#{post_path(@post, anchor: @comment.guid)}")
+    end
+  end
+end


### PR DESCRIPTION
Fix "There is no link to the reported comment in the admin interface" from https://github.com/diaspora/diaspora/issues/4711
