### PR TITLE
bump sidekiq to 3.2.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'simple_captcha2', '0.3.2', :require => 'simple_captcha'
 
 # Background processing
 
-gem 'sidekiq', '3.2.5'
+gem 'sidekiq', '3.2.6'
 gem 'sinatra', '1.3.3'
 
 # Scheduled processing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -488,7 +488,7 @@ GEM
       multi_json (~> 1.0)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
-    sidekiq (3.2.5)
+    sidekiq (3.2.6)
       celluloid (= 0.15.2)
       connection_pool (>= 2.0.0)
       json
@@ -651,7 +651,7 @@ DEPENDENCIES
   ruby-oembed (= 0.8.11)
   sass-rails (= 4.0.4)
   selenium-webdriver (= 2.44.0)
-  sidekiq (= 3.2.5)
+  sidekiq (= 3.2.6)
   sidetiq (= 0.6.3)
   simple_captcha2 (= 0.3.2)
   sinatra (= 1.3.3)


### PR DESCRIPTION
From upstream changelog,

```
Deprecate delay extension for ActionMailer 4.2+ . [seuros, #1933]
Poll interval tuning now accounts for dead processes [epchris, #1984]
Add non-production environment to Web UI page titles [JacobEvelyn, #2004]
```

Debian already have 3.2.6 and I'd like to keep both versions in sync.
