### PR TITLE
Fix for "more" link on mobile view

### DIFF
--- a/app/assets/stylesheets/mobile/mobile.css.scss
+++ b/app/assets/stylesheets/mobile/mobile.css.scss
@@ -192,7 +192,7 @@ h3 {
   }
 }
 
-.more-link {
+.more-link, .no-more-posts {
   -webkit-box-shadow: inset 0 1px 5px #777, 0 1px 1px rgba(0,0,0,0.4);
   display: block;
   text-align: center;
@@ -204,10 +204,12 @@ h3 {
     color: rgba(220,220,220,0.8);
   }
 
-  h1 {
+  h1, h2 {
     color: $text-grey;
     padding: 20px;
-    text-shadow: 0 2px 0 #fff; } }
+    text-shadow: 0 2px 0 #fff;
+  }
+}
 
 .info {
   color: #ccc;

--- a/app/views/people/show.mobile.haml
+++ b/app/views/people/show.mobile.haml
@@ -22,10 +22,7 @@
     - else
       #main_stream.stream
         = render 'shared/stream', :posts => @stream.stream_posts
-        #pagination
-          %a.more-link.paginate{:href => next_page_path}
-            %h1
-              = t("more")
+        = render 'shared/stream_more_button'
   - else
     #main_stream
       .dull
@@ -33,4 +30,3 @@
         = t('.ignoring', :name => @person.first_name)
       - elsif user_signed_in? && (current_user.person != @person)
         = t('.has_not_shared_with_you_yet', :name => @person.first_name)
-

--- a/app/views/shared/_stream_more_button.mobile.haml
+++ b/app/views/shared/_stream_more_button.mobile.haml
@@ -3,8 +3,13 @@
     %a.more-link.paginate{:href => next_page_path}
       %h1
         = t("more")
--else
+-elsif params[:max_time].present?
   #pagination
     %div.no-more-posts
       %h2
         = t("stream_helper.no_more_posts")
+-else
+  #pagination
+    %div.no-more-posts
+      %h2
+        = t("stream_helper.no_posts_yet")

--- a/app/views/shared/_stream_more_button.mobile.haml
+++ b/app/views/shared/_stream_more_button.mobile.haml
@@ -1,0 +1,10 @@
+-if @stream.stream_posts.length == 15
+  #pagination
+    %a.more-link.paginate{:href => next_page_path}
+      %h1
+        = t("more")
+-else
+  #pagination
+    %div.no-more-posts
+      %h2
+        = t("stream_helper.no_more_posts")

--- a/app/views/streams/main_stream.mobile.haml
+++ b/app/views/streams/main_stream.mobile.haml
@@ -10,8 +10,4 @@
 
 #main_stream.stream
   = render 'shared/stream', :posts => @stream.stream_posts
-  -if @stream.stream_posts.length > 0
-    #pagination
-      %a.more-link.paginate{:href => next_page_path}
-        %h1
-          = t("more")
+  = render 'shared/stream_more_button'

--- a/app/views/tags/show.mobile.haml
+++ b/app/views/tags/show.mobile.haml
@@ -7,9 +7,5 @@
 
 #main_stream.stream
   = render 'shared/stream', :posts => @stream.stream_posts
-  -if @stream.stream_posts.length > 0
-    #pagination
-      %a.more-link.paginate{:href => next_page_path}
-        %h1
-          = t("more")
+  = render 'shared/stream_more_button'
 

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -1189,6 +1189,7 @@ en:
       other: "Show %{count} more comments"
     hide_comments: "Hide all comments"
     no_more_posts: "You have reached the end of the stream."
+    no_posts_yet: "There are no posts yet."
 
   tags:
     show:

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -1188,6 +1188,7 @@ en:
       one: "Show one more comment"
       other: "Show %{count} more comments"
     hide_comments: "Hide all comments"
+    no_more_posts: "You have reached the end of the stream."
 
   tags:
     show:

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -2,6 +2,10 @@ require 'rubygems'
 
 prefork = proc do
   ENV["RAILS_ENV"] ||= "test"
+
+   # Have all rests run with english browser locale
+  ENV['LANG'] = 'C'
+
   require 'cucumber/rails'
 
   require 'capybara/rails'


### PR DESCRIPTION
Changes in "more"-button for mobile view.
Previously the "more"-button was displayed if there were any posts displayed on the page.

Now the "more"-button is only shown if the current page is full (=15 posts), so there is a good chance there might be more posts available.

Also I added a message to mark the end of posts available for the stream.
This will serve two purposes:
- If you have a stream with exactly 15 \* x posts in it, your second to last page will have a "more"-button and the next page will be empty. Now there will be a message informing you why its empty, signaling the user that diaspora is not broken and it's the right result for the users action.
- If the user expects the more-button at the end of a page, but the page has < 15 posts, the "no more posts" message is displayed to signal that there is no "more"-button for a reason.

This will fix #5003.
