### PR TITLE
fixed margins and fonts in headerbar. fixed bootstrap2 placeholder error

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -66,6 +66,10 @@ body {
   };
 }
 
+header {
+  line-height: 20px;
+}
+
 a {
   color: $blue;
   text: {

--- a/app/assets/stylesheets/bootstrap-fix.css.scss
+++ b/app/assets/stylesheets/bootstrap-fix.css.scss
@@ -1,0 +1,11 @@
+// A temporary fix for broken classes in bootstrap 2.
+// Can probably be removed when migration of bootstrap 3 is done.
+
+input::-moz-placeholder,
+textarea::-moz-placeholder {
+  color: #999999;
+}
+input::-ms-input-placeholder,
+textarea::-ms-input-placeholder {
+  color: #999999;
+}

--- a/app/assets/stylesheets/header.css.scss
+++ b/app/assets/stylesheets/header.css.scss
@@ -233,6 +233,7 @@ body > header {
         border: 1px solid #222;
         font-size: 13px;
         padding: 4px;
+        margin-top: 1px;
 
         &:hover { background-color: #555; }
 
@@ -345,7 +346,7 @@ body > header {
     float: left;
     height: 100%;
     margin-right: 5px;
-    margin-top: 3px;
+    margin-top: 2px;
 
     a {
       padding: 0 10px;

--- a/app/assets/stylesheets/new-templates.css.scss
+++ b/app/assets/stylesheets/new-templates.css.scss
@@ -1,3 +1,5 @@
+@import 'bootstrap-fix';
+
 @import 'perfect-scrollbar';
 
 @import "colors";


### PR DESCRIPTION
I adjusted the items in header-bar on pages using bootstap so it looks as smooth as in blueprint.

Also I fixed an error in bootstrap2 by introducing bootstrap-fix.css.scss which contains the styles for placeholders. These were written with a defective selector in bootstrap2, so they had no effect, causing the global search field to have dark text.

Fix for #4721.
