### PR TITLE
Revert "bump simple_oauth"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -500,7 +500,7 @@ GEM
       sidekiq (>= 3.0.0)
     simple_captcha2 (0.3.2)
       rails (>= 4.1)
-    simple_oauth (0.3.0)
+    simple_oauth (0.2.0)
     sinatra (1.3.3)
       rack (~> 1.3, >= 1.3.6)
       rack-protection (~> 1.2)


### PR DESCRIPTION
This reverts commit 13cb07fed746a61cbe1f9aa4f4d584d2054ff3ab.

Fixes simple_oauth regression that breaks Twitter posting, see issue #5411
