### PR TITLE
Add minitest to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -154,6 +154,13 @@ gem 'rails-timeago',           '2.11.0'
 # https://github.com/rubyzip/rubyzip#important-note
 gem 'zip-zip'
 
+# Prevent occasions where minitest is not bundled in
+# packaged versions of ruby. See following issues/prs:
+# https://github.com/gitlabhq/gitlabhq/issues/3826
+# https://github.com/gitlabhq/gitlabhq/pull/3852
+# https://github.com/discourse/discourse/pull/238
+gem 'minitest'
+
 
 # Windows and OSX have an execjs compatible runtime built-in, Linux users should
 # install Node.js or use 'therubyracer'.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -642,6 +642,7 @@ DEPENDENCIES
   markerb (= 1.0.2)
   messagebus_ruby_api (= 1.0.3)
   mini_magick (= 4.0.1)
+  minitest
   mobile-fu (= 1.3.1)
   mysql2 (= 0.3.17)
   nokogiri (= 1.6.4.1)


### PR DESCRIPTION
In order to use the system Fedora/EPEL ruby we need to install minitest in production. There is an old issue which this PR fixes it: #3783.

Long story short is that the packaged ruby in Fedora/RHEL/CentOS doesn't ship with minitest, it is packaged as a separate library.

This was the case with GitLab and Discourse where both now include minitest in Gemfile.

https://github.com/gitlabhq/gitlabhq/issues/3826
https://github.com/gitlabhq/gitlabhq/pull/3852
https://github.com/discourse/discourse/pull/238

We use system ruby on CentOS7 and the modified Gemfile at https://librenet.gr without any issues so far.
