### PR TITLE
Two columns main stream

### DIFF
--- a/app/views/streams/main_stream.html.haml
+++ b/app/views/streams/main_stream.html.haml
@@ -42,20 +42,18 @@
     %li
       = render 'tags/followed_tags_listings'
 
-
-
-.span-13.append-1
-  #aspect_stream_container.stream_container
-    = render 'aspects/aspect_stream', :stream => @stream
-
-.span-5.rightBar.last
+  %h5.stream_title
+    = @stream.title
   #selected_aspect_contacts.section
-    .title.no_icon
-      %h5.stream_title
-        = @stream.title
     .content
+  
+  %br
 
   = render 'shared/right_sections'
+
+.span-19.last
+  #aspect_stream_container.stream_container
+    = render 'aspects/aspect_stream', :stream => @stream
 
   %a{:id=>"back-to-top", :title=>"#{t('layouts.application.back_to_top')}", :href=>"#"}
     &#8679;


### PR DESCRIPTION
I believe that using two columns layout in main stream page would be a better use of the screen.

Currently in used in [diasp.org pod](https://diasp.org/).
