### PR TITLE
A temporary fix for mention modal #5329

### DIFF
--- a/app/assets/stylesheets/bootstrap-fix.css.scss
+++ b/app/assets/stylesheets/bootstrap-fix.css.scss
@@ -9,3 +9,15 @@ input::-ms-input-placeholder,
 textarea::-ms-input-placeholder {
   color: #999999;
 }
+
+// A temporary fix for mention modal #5329
+
+#new_status_message_pane .modal {
+  position: absolute;
+  max-height: none;
+}
+
+#new_status_message_pane .modal-body{
+  overflow-y: visible;
+  max-height: none;
+}


### PR DESCRIPTION
Results : 

![modal_mention](https://cloud.githubusercontent.com/assets/6507951/5229554/8fce6ce6-7719-11e4-9088-5815a4414df7.png)
![modal_mention2](https://cloud.githubusercontent.com/assets/6507951/5229556/92582e8e-7719-11e4-94b3-5d50c35fdcf4.png)

I wanted to add 

```
#new_status_message_pane .modal {
  padding-bottom: 35px; /* or something else */
}
```

But I wasn't sure (little bit ugly).
