### PR TITLE
Only remove photos from view when destroyed on server

### DIFF
--- a/app/assets/javascripts/app/views.js
+++ b/app/assets/javascripts/app/views.js
@@ -121,11 +121,13 @@ app.views.Base = Backbone.View.extend({
     var url = this.model.urlRoot + '/' + this.model.id;
 
     if (confirm(Diaspora.I18n.t("confirm_dialog"))) {
+      this.$el.addClass('deleting');
       this.model.destroy({ url: url })
         .done(function() {
           self.remove();
         })
         .fail(function() {
+          self.$el.removeClass('deleting');
           var flash = new Diaspora.Widgets.FlashMessages;
           flash.render({
             success: false,

--- a/app/assets/javascripts/app/views/photo_view.js
+++ b/app/assets/javascripts/app/views/photo_view.js
@@ -14,7 +14,6 @@ app.views.Photo = app.views.Base.extend({
 
   initialize : function() {
     $(this.el).attr("id", this.model.get("guid"));
-    this.model.bind('remove', this.remove, this);
     return this;
   },
 

--- a/app/assets/stylesheets/stream_element.css.scss
+++ b/app/assets/stylesheets/stream_element.css.scss
@@ -6,6 +6,10 @@
   & > .media {
     margin: 0px;
   }
+  &.deleting {
+    > .media { opacity: 0.3; }
+    .controls { display: none !important; }
+  }
 }
 
 #main_stream .stream_element {

--- a/features/desktop/profile_photos.feature
+++ b/features/desktop/profile_photos.feature
@@ -31,5 +31,6 @@ Feature: show photos
       When I am on "robert@grimm.grimm"'s photos page
       And I delete a photo
       And I confirm the alert
-      And I am on "robert@grimm.grimm"'s page
+      Then I should not see ".deleting" within ".stream"
+      When I am on "robert@grimm.grimm"'s page
       Then I should not see "Photos" within "#profile_horizontal_bar"


### PR DESCRIPTION
When clicking the remove button the photo becomes transparent and is removed from the photo stream once it got destroyed on the server. We should do the same for posts but solving that isn't that easy because the easy solution (removing `this.model.on('remove', this.remove, this);`) would break post preview and hiding posts. I'll open a new issue and won't fix it in this PR.

This PR should also improve the deleting photo spec.
