### PR TITLE
Content shouldn't exceed the profile sidebar

### DIFF
--- a/app/assets/stylesheets/profile.css.scss
+++ b/app/assets/stylesheets/profile.css.scss
@@ -112,6 +112,8 @@
     ul#profile_information {
       margin: 0;
       list-style: none;
+      overflow-x: hidden;
+      word-wrap: break-word;
       > li {
           margin-bottom: 2em;
         h4 { font-weight: bold; }


### PR DESCRIPTION
Fixes #5346. (The second half because the first half is a duplicate)

Before:
![](https://cloud.githubusercontent.com/assets/3798614/5256386/23744ba4-79c8-11e4-8ca9-8f469de0d152.png)

After:
![](https://cloud.githubusercontent.com/assets/3798614/5256389/2e8d53fa-79c8-11e4-827f-737ea58b7c1c.png)
