### PR TITLE
Add currency setting to paypal donation and allow unhosted button setting

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -50,6 +50,11 @@ It is now possible to enable an automatic proxying of external assets, for examp
 
 This is disabled by default since it requires the installation of additional packages and might cause some traffic. Check the [wiki page](https://wiki.diasporafoundation.org/Installation/Camo) for more information and detailed installation instructions.
 
+## Paypal unhosted button and currency
+Podmins can now set the currency for donations, and use an unhosted button if they can't use
+a hosted one. Note: you need to **copy the new settings from diaspora.yml.example to your
+diaspora.yml file**. The existing settings from 0.4.x and before will not work any more.
+
 ## Refactor
 * Redesign contacts page [#5153](https://github.com/diaspora/diaspora/pull/5153)
 * Improve profile page design on mobile [#5084](https://github.com/diaspora/diaspora/pull/5084)
@@ -129,7 +134,7 @@ This is disabled by default since it requires the installation of additional pac
 * Make the source code URL configurable [#5410](https://github.com/diaspora/diaspora/pull/5410)
 * Prefill publisher on the tag pages [#5442](https://github.com/diaspora/diaspora/pull/5442)
 * Allows users to export their data in JSON format from their user settings page [#5354](https://github.com/diaspora/diaspora/pull/5354)
-
+* Allow to set unhosted button and currency for paypal donation [#5452](https://github.com/diaspora/diaspora/pull/5452)
 
 # 0.4.1.2
 

--- a/app/views/shared/_donatepod.html.haml
+++ b/app/views/shared/_donatepod.html.haml
@@ -1,16 +1,15 @@
-- if AppConfig.settings.paypal_hosted_button_id.present?
+- if AppConfig.settings.paypal_donations.enable?
   PayPal:
-  %form{:action => "https://www.paypal.com/cgi-bin/webscr", :method => "post"}
-    %input{:name => "cmd", :type => "hidden", :value => "_s-xclick"}
-    %input{:name => "hosted_button_id", :type => "hidden", :value => AppConfig.settings.paypal_hosted_button_id}
-    %input{:name => "on0", :type => "hidden", :value => "Type"}
-    %input{:name => "modify", :type => "hidden", :value => "2"}
-    %select{:name => "os0"}
-      %option{:value => "Mocha"} Mocha : $3.00USD
-      %option{:value => "Americano"} Americano : $5.00USD
-      %option{:value => "Box o' Joe"} Box o' Joe : $20.00USD
-    %input{:name => "currency_code", :type => "hidden", :value => "USD"}
-    %input{:name => "submit", :type => "submit", :value => t('aspects.index.donate')}
+  %form{action: "https://www.paypal.com/cgi-bin/webscr", method: "post", target: "_blank"}
+    %input{name: "cmd", type: "hidden", value: "_s-xclick"}
+    - if AppConfig.settings.paypal_donations.paypal_hosted_button_id.present?
+      %input{name: "hosted_button_id", type: "hidden", value: AppConfig.settings.paypal_donations.paypal_hosted_button_id}
+    -if AppConfig.settings.paypal_donations.paypal_unhosted_button_encrypted.present?
+      %input{name: "encrypted", type: "hidden", value: AppConfig.settings.paypal_donations.paypal_unhosted_button_encrypted}
+    %input{name: "currency_code", type: "hidden", value: AppConfig.settings.paypal_donations.currency}
+    %input{name: "submit", type: "submit", value: t('aspects.index.donate')}
+    
 - if AppConfig.bitcoin_donation_address
   Bitcoin:
-  %input{:type => "text", :id => "bitcoin_address", :value => AppConfig.bitcoin_donation_address, :readonly => true}
+  %input{type: "text", id: "bitcoin_address", value: AppConfig.bitcoin_donation_address, readonly: true}
+

--- a/app/views/shared/_right_sections.html.haml
+++ b/app/views/shared/_right_sections.html.haml
@@ -68,7 +68,7 @@
   .content
     != t('bookmarklet.explanation', :link => link_to(t('bookmarklet.post_something'), bookmarklet_url))
 
-- if AppConfig.settings.paypal_hosted_button_id.present? || AppConfig.bitcoin_donation_address
+- if AppConfig.settings.paypal_donations.enable? || AppConfig.bitcoin_donation_address
   .section
     .title
       .icons-coffee

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -95,7 +95,11 @@ defaults:
     invitations:
       open: true
       count: 25
-    paypal_hosted_button_id:
+    paypal_donations:
+      enable: false
+      currency: USD
+      paypal_hosted_button_id:
+      paypal_unhosted_button_encrypted:
     bitcoin_address:
     community_spotlight:
       enable: false

--- a/config/diaspora.yml.example
+++ b/config/diaspora.yml.example
@@ -399,11 +399,22 @@ configuration: ## Section
       ## invitations on your pod.
       #count: 25
 
-    ## Paypal donations
-    ## You can provide the ID of a hosted Paypal button here to allow your users
-    ## to send donations to help run their pod. If you leave this out your users
-    ## will see a button to donate to the Diaspora Foundation instead :)
-    #paypal_hosted_button_id: "change_me"
+    ## Paypal donations (disabled by default)
+    ## You can set details for a Paypal button here to allow donations
+    ## towards running the pod.
+    ## First, enable the function, then set the currency in which you
+    ## wish to receive donations, and **either** a hosted button id
+    ## **or** an encrypted key for an unhosted button.
+    paypal_donations: ## Section
+      #enable: false
+    
+      ## Currency used (USD, EUR...)
+      #currency: USD
+    
+      ## hosted Paypal button id
+      #paypal_hosted_button_id: "change_me"
+      ## OR encrypted key of unhosted button
+      #paypal_unhosted_button_encrypted: "-----BEGIN PKCS7-----" 
 
     ## Bitcoin donations
     ## You can provide a bitcoin address here to allow your users to provide


### PR DESCRIPTION
I didn't find the way to set up easily an "hosted button" on paypal, all I found was the unhosted one, so I modified diaspora\* to allow both type of button.
