### PR TITLE
Add followed tags to the mobile menu

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -129,7 +129,7 @@ This is disabled by default since it requires the installation of additional pac
 * Make the source code URL configurable [#5410](https://github.com/diaspora/diaspora/pull/5410)
 * Prefill publisher on the tag pages [#5442](https://github.com/diaspora/diaspora/pull/5442)
 * Allows users to export their data in JSON format from their user settings page [#5354](https://github.com/diaspora/diaspora/pull/5354)
-
+* Add followed tags in the mobile menu [#5468](https://github.com/diaspora/diaspora/pull/5468)
 
 # 0.4.1.2
 

--- a/app/assets/javascripts/mobile.js
+++ b/app/assets/javascripts/mobile.js
@@ -40,6 +40,12 @@ $(document).ready(function(){
     $("#all_aspects + li").toggleClass('hide');
   });
 
+  /* Show / hide followed tags in the drawer */
+  $('#followed_tags').bind("tap click", function(evt){
+    evt.preventDefault();
+    $("#followed_tags + li").toggleClass('hide');
+  });
+
   /* Heart toggle */
   $(".like_action", ".stream").bind("tap click", function(evt){
     evt.preventDefault();

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -1,17 +1,16 @@
 module TagsHelper
   def looking_for_tag_link
-    return if search_query.include?('@') || normalized_tag_name.blank?
+    return if search_query.include?('@') || normalize_tag_name(search_query).blank?
     content_tag('small') do
-      t('people.index.looking_for', :tag_link => tag_link).html_safe
+      t('people.index.looking_for', tag_link: tag_link(search_query)).html_safe
     end
   end
 
-  def normalized_tag_name
-    ActsAsTaggableOn::Tag.normalize(search_query)
+  def normalize_tag_name(tag)
+    ActsAsTaggableOn::Tag.normalize(tag.to_s)
   end
 
-  def tag_link
-    tag = normalized_tag_name
-    link_to("##{tag}", tag_path(:name => tag))
+  def tag_link(tag)
+    link_to("##{tag}", tag_path(name: normalize_tag_name(tag)))
   end
 end

--- a/app/views/layouts/application.mobile.haml
+++ b/app/views/layouts/application.mobile.haml
@@ -91,6 +91,13 @@
                   - current_user.aspects.each do |aspect|
                     %li
                       = link_to aspect.name, aspects_stream_path(a_ids: [aspect.id])
+              %li#followed_tags
+                = link_to t('streams.followed_tag.title'), "#"
+              %li.no_border.hide
+                %ul
+                  - current_user.followed_tags.each do |tag|
+                    %li
+                      = tag_link(tag)
               %li
                 = link_to user_profile_path(current_user.username) do
                   = t('layouts.header.profile')

--- a/features/mobile/drawer.feature
+++ b/features/mobile/drawer.feature
@@ -1,0 +1,87 @@
+@javascript
+Feature: Naviguate between pages using the header menu and the drawer
+  As a user
+  I want to be able naviguate between the pages of the mobile version
+
+  Background:
+    Given following users exist:
+      | username     | email             |
+      | Bob Jones    | bob@bob.bob       |
+      | Alice Smith  | alice@alice.alice |
+      
+    And I sign in as "alice@alice.alice"
+    And a user with email "bob@bob.bob" is connected with "alice@alice.alice"
+    And I search for "#boss"
+    And I press "Follow #boss"
+    And I toggle the mobile view
+    
+  Scenario: naviguate to the stream page
+    When I open the drawer
+    And I follow "My Activity"
+    And I click on selector "#header_title"
+    Then I should see "There are no posts yet." within "#main_stream"
+    
+  Scenario: naviguate to the notification page
+    When I click on selector "#notification_badge"
+    Then I should see "Notifications" within "#main"
+    
+  Scenario: naviguate to the conversation page
+    When I click on selector "#conversations_badge"
+    Then I should see "Inbox" within "#main"
+    
+  Scenario: naviguate to the publisher page
+    When I click on selector "#compose_badge"
+    Then I should see "All Aspects" within "#new_status_message"
+    
+  Scenario: search a user
+    When I open the drawer
+    And I search for "Bob"
+    Then I should see "Users matching Bob" within "#search_title"
+    
+  Scenario: search for a tag
+    When I open the drawer
+    And I search for "#bob"
+    Then I should see "#bob" within "#main > h1"
+    
+  Scenario: naviguate to my activity page
+    When I open the drawer
+    And I follow "My Activity"
+    Then I should see "My Activity" within "#main"
+    
+  Scenario: naviguate to my mentions page
+    Given Alice has a post mentioning Bob
+    And I sign in as "bob@bob.bob"    
+    When I open the drawer
+    And I follow "@Mentions"
+    Then I should see "Bob Jones" within ".stream_element"
+    
+  Scenario: naviguate to my aspects page
+    Given "bob@bob.bob" has a public post with text "bob's text"
+    When I open the drawer
+    And I follow "My Aspects"
+    Then I should see "Besties" within "#all_aspects + li > ul"
+    And I follow "Besties"
+    Then I should see "bob's text" within "#main_stream"
+    
+  Scenario: naviguate to the followed tags page
+    Given "bob@bob.bob" has a public post with text "bob is da #boss"
+    When I open the drawer
+    And I follow "#Followed Tags"
+    Then I should see "#boss" within "#followed_tags + li > ul"
+    And I follow "#boss"
+    Then I should see "bob is da #boss" within "#main_stream"
+    
+  Scenario: naviguate to my profile page
+    When I open the drawer
+    And I follow "Profile"
+    Then I should see "Alice" within "#author_info"
+    
+  Scenario: naviguate to my mentions page
+    When I open the drawer
+    And I follow "Contacts"
+    Then I should see "Contacts" within "#main"
+    
+  Scenario: naviguate to my mentions page
+    When I open the drawer
+    And I follow "Settings"
+    Then I should see "Settings" within "#main"

--- a/features/step_definitions/custom_web_steps.rb
+++ b/features/step_definitions/custom_web_steps.rb
@@ -175,7 +175,7 @@ end
 When /^I search for "([^\"]*)"$/ do |search_term|
   fill_in "q", :with => search_term
   find_field("q").native.send_key(:enter)
-  find("#tags_show .span3")
+  have_content(search_term)
 end
 
 Then /^the "([^"]*)" field(?: within "([^"]*)")? should be filled with "([^"]*)"$/ do |field, selector, value|

--- a/spec/helpers/tags_helper_spec.rb
+++ b/spec/helpers/tags_helper_spec.rb
@@ -14,7 +14,7 @@ describe TagsHelper, :type => :helper do
 
     it 'returns a link to the tag otherwise' do
       allow(helper).to receive(:search_query).and_return('foo')
-      expect(helper.looking_for_tag_link).to include(helper.tag_link)
+      expect(helper.looking_for_tag_link).to include(helper.tag_link('foo'))
     end
   end
 end


### PR DESCRIPTION
I had two bad reviews on the mozilla marketplace because the mobile version doesn't allow to access followed tags, so here we go :)
