### PR TITLE
Refactor mobile javascript to get rid of console errors.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -116,6 +116,7 @@ diaspora.yml file**. The existing settings from 0.4.x and before will not work a
 * Replace %{third_party_tools} by the appropriate hyperlink in tags FAQ [#5509](https://github.com/diaspora/diaspora/pull/5509)
 * Repair downloading the profile image from Facebook [#5493](https://github.com/diaspora/diaspora/pull/5493)
 * Fix localization of post and comment timestamps on mobile [#5482](https://github.com/diaspora/diaspora/issues/5482)
+* Fix mobile JS loading to quieten errors. Fixes also service buttons on mobile bookmarklet.
 
 ## Features
 * Don't pull jQuery from a CDN by default [#5105](https://github.com/diaspora/diaspora/pull/5105)

--- a/app/assets/javascripts/jasmine-load-all.js
+++ b/app/assets/javascripts/jasmine-load-all.js
@@ -4,7 +4,7 @@
 //= require main
 //= require home
 //= require inbox
-//= require mobile
+//= require mobile/mobile
 //= require profile
 //= require contact-list
 //= require sinon

--- a/app/assets/javascripts/mobile/mobile.js
+++ b/app/assets/javascripts/mobile/mobile.js
@@ -15,6 +15,7 @@
 //= require diaspora
 //= require helpers/i18n
 //= require widgets/timeago
+//= require mobile/mobile_file_uploader
 
 $(document).ready(function(){
 
@@ -302,86 +303,5 @@ $(document).ready(function(){
 
 });
 
-function createUploader(){
-
-   var aspectIds = gon.preloads.aspect_ids;
-
-   var uploader = new qq.FileUploaderBasic({
-       element: document.getElementById('file-upload-publisher'),
-       params: {'photo' : {'pending' : 'true', 'aspect_ids' : aspectIds},},
-       allowedExtensions: ['jpg', 'jpeg', 'png', 'gif', 'tiff'],
-       action: "/photos",
-       debug: true,
-       button: document.getElementById('file-upload-publisher'),
-       sizeLimit: 4194304,
-
-       onProgress: function(id, fileName, loaded, total){
-        var progress = Math.round(loaded / total * 100 );
-         $('#fileInfo-publisher').text(fileName + ' ' + progress + '%');
-       },
-
-       messages: {
-          typeError: Diaspora.I18n.t("photo_uploader.invalid_ext"),
-          sizeError: Diaspora.I18n.t("photo_uploader.new_photo.size_error"),
-          emptyError: Diaspora.I18n.t("photo_uploader.new_photo.empty")
-       },
-
-       onSubmit: function(id, fileName){
-        $('#file-upload-publisher').addClass("loading");
-        $('#publisher_textarea_wrapper').addClass("with_attachments");
-        $('#photodropzone').append(
-          "<li class='publisher_photo loading' style='position:relative;'>" +
-            "<img alt='Ajax-loader2' src='"+ImagePaths.get('ajax-loader2.gif')+"' />" +
-          "</li>"
-          );
-       },
-
-       onComplete: function(id, fileName, responseJSON) {
-        $('#fileInfo-publisher').text(Diaspora.I18n.t("photo_uploader.completed", {'file': fileName}));
-        var id = responseJSON.data.photo.id,
-            url = responseJSON.data.photo.unprocessed_image.url,
-            currentPlaceholder = $('li.loading').first();
-
-        $('#publisher_textarea_wrapper').addClass("with_attachments");
-        $('#new_status_message').append("<input type='hidden' value='" + id + "' name='photos[]' />");
-
-        // replace image placeholders
-        var img = currentPlaceholder.find('img');
-        img.attr('src', url);
-        img.attr('data-id', id);
-        currentPlaceholder.removeClass('loading');
-        currentPlaceholder.append("<div class='x'>X</div>" +
-            "<div class='circle'></div>");
-        ////
-
-        var publisher = $('#publisher'),
-            textarea = publisher.find('textarea');
-
-        publisher.find("input[type='submit']").removeAttr('disabled');
-
-        $('.x').bind('click', function(){
-          var photo = $(this).closest('.publisher_photo');
-          photo.addClass("dim");
-          $.ajax({url: "/photos/" + photo.children('img').attr('data-id'),
-                  dataType: 'json',
-                  type: 'DELETE',
-                  success: function() {
-                            photo.fadeOut(400, function(){
-                              photo.remove();
-                              if ( $('.publisher_photo').length == 0){
-                                $('#publisher_textarea_wrapper').removeClass("with_attachments");
-                              }
-                            });
-                          }
-                  });
-        });
-       },
-
-       onAllComplete: function(completed_files){
-       }
-
-   });
-}
-createUploader();
 // @license-end
 

--- a/app/assets/javascripts/mobile/mobile_file_uploader.js
+++ b/app/assets/javascripts/mobile/mobile_file_uploader.js
@@ -1,0 +1,85 @@
+// @license magnet:?xt=urn:btih:0b31508aeb0634b347b8270c7bee4d411b5d4109&dn=agpl-3.0.txt AGPL-v3-or-Later
+//= require js_image_paths
+
+function createUploader(){
+
+   var aspectIds = gon.preloads.aspect_ids;
+
+   var uploader = new qq.FileUploaderBasic({
+       element: document.getElementById('file-upload-publisher'),
+       params: {'photo' : {'pending' : 'true', 'aspect_ids' : aspectIds},},
+       allowedExtensions: ['jpg', 'jpeg', 'png', 'gif', 'tiff'],
+       action: "/photos",
+       debug: true,
+       button: document.getElementById('file-upload-publisher'),
+       sizeLimit: 4194304,
+
+       onProgress: function(id, fileName, loaded, total){
+        var progress = Math.round(loaded / total * 100 );
+         $('#fileInfo-publisher').text(fileName + ' ' + progress + '%');
+       },
+
+       messages: {
+          typeError: Diaspora.I18n.t("photo_uploader.invalid_ext"),
+          sizeError: Diaspora.I18n.t("photo_uploader.new_photo.size_error"),
+          emptyError: Diaspora.I18n.t("photo_uploader.new_photo.empty")
+       },
+
+       onSubmit: function(id, fileName){
+        $('#file-upload-publisher').addClass("loading");
+        $('#publisher_textarea_wrapper').addClass("with_attachments");
+        $('#photodropzone').append(
+          "<li class='publisher_photo loading' style='position:relative;'>" +
+            "<img alt='Ajax-loader2' src='"+ImagePaths.get('ajax-loader2.gif')+"' />" +
+          "</li>"
+          );
+       },
+
+       onComplete: function(id, fileName, responseJSON) {
+        $('#fileInfo-publisher').text(Diaspora.I18n.t("photo_uploader.completed", {'file': fileName}));
+        var id = responseJSON.data.photo.id,
+            url = responseJSON.data.photo.unprocessed_image.url,
+            currentPlaceholder = $('li.loading').first();
+
+        $('#publisher_textarea_wrapper').addClass("with_attachments");
+        $('#new_status_message').append("<input type='hidden' value='" + id + "' name='photos[]' />");
+
+        // replace image placeholders
+        var img = currentPlaceholder.find('img');
+        img.attr('src', url);
+        img.attr('data-id', id);
+        currentPlaceholder.removeClass('loading');
+        currentPlaceholder.append("<div class='x'>X</div>" +
+            "<div class='circle'></div>");
+        ////
+
+        var publisher = $('#publisher'),
+            textarea = publisher.find('textarea');
+
+        publisher.find("input[type='submit']").removeAttr('disabled');
+
+        $('.x').bind('click', function(){
+          var photo = $(this).closest('.publisher_photo');
+          photo.addClass("dim");
+          $.ajax({url: "/photos/" + photo.children('img').attr('data-id'),
+                  dataType: 'json',
+                  type: 'DELETE',
+                  success: function() {
+                            photo.fadeOut(400, function(){
+                              photo.remove();
+                              if ( $('.publisher_photo').length == 0){
+                                $('#publisher_textarea_wrapper').removeClass("with_attachments");
+                              }
+                            });
+                          }
+                  });
+        });
+       },
+
+       onAllComplete: function(completed_files){
+       }
+
+   });
+}
+createUploader();
+// @license-end

--- a/app/views/conversations/new.mobile.haml
+++ b/app/views/conversations/new.mobile.haml
@@ -3,7 +3,6 @@
 -#   the COPYRIGHT file.
 
 = javascript_include_tag :jquery
-= javascript_include_tag :mobile
 
 :javascript
   $(document).ready(function () {

--- a/app/views/layouts/application.mobile.haml
+++ b/app/views/layouts/application.mobile.haml
@@ -119,6 +119,6 @@
 
     / javascripts at the bottom
     = jquery_include_tag
-    = javascript_include_tag :mobile
+    = javascript_include_tag "mobile/mobile"
     = load_javascript_locales
     = include_chartbeat

--- a/app/views/publisher/_publisher.mobile.haml
+++ b/app/views/publisher/_publisher.mobile.haml
@@ -2,12 +2,6 @@
 -#   licensed under the Affero General Public License version 3 or later.  See
 -#   the COPYRIGHT file.
 
-- content_for :head do
-  = jquery_include_tag
-  = javascript_include_tag :main
-  = load_javascript_locales
-  = include_gon
-
 = form_for StatusMessage.new, {:data => {:ajax => false}} do |status|
   = status.hidden_field :provider_display_name, :value => 'mobile'
   = status.text_area :text, :placeholder => t('shared.publisher.whats_on_your_mind'), :rows => 4, :autofocus => "autofocus"

--- a/app/views/status_messages/bookmarklet.mobile.haml
+++ b/app/views/status_messages/bookmarklet.mobile.haml
@@ -21,4 +21,4 @@
   });
 
 - content_for(:head) do
-  = javascript_include_tag :jquery, :mobile
+  = javascript_include_tag :jquery

--- a/config/application.rb
+++ b/config/application.rb
@@ -61,7 +61,7 @@ module Diaspora
       mailchimp.js
       main.js
       jsxc.js
-      mobile.js
+      mobile/mobile.js
       profile.js
       people.js
       profile.js


### PR DESCRIPTION
Fixes also mobile bookmarklet services.

Basically:
- Went through the whole mobile app checking for console errors
- Extracted mobile file uploader to own file, since it's only needed in status message creation
- Made sure "main" JS does not need to be loaded in status message creation by including I18n JS directly, instead of having to rely on the rest of the JS to run
- Removed unnecessary duplicate loading of mobile.js on a few pages

I would have liked to move the inline JS to JS files and maybe reorganize a bit better so includes could be used- but I think that should be another PR. This fixes actual bugs, ie bookmarklet service icons have not been working for a long time.
