### PR TITLE
Ajust conversarion visibility deletion test to properly change user

### DIFF
--- a/spec/controllers/conversation_visibilities_controller_spec.rb
+++ b/spec/controllers/conversation_visibilities_controller_spec.rb
@@ -26,8 +26,12 @@ describe ConversationVisibilitiesController, :type => :controller do
     end
 
     it 'does not let a user destroy a visibility that is not theirs' do
+      sign_out :user
+      
       user2 = eve
       sign_in :user, user2
+      
+      expect(@controller.current_user.id).to eq(eve.id)
 
       expect {
         delete :destroy, :conversation_id => @conversation.id


### PR DESCRIPTION
Controller visibility test that test if a foreign user can't delete visibility does not properly change user before try to delete record.

Currently, that test only check if current user can delete same record twice.
