### PR TITLE
Changed delete conversation button tooltip

### DIFF
--- a/app/controllers/conversation_visibilities_controller.rb
+++ b/app/controllers/conversation_visibilities_controller.rb
@@ -10,8 +10,13 @@ class ConversationVisibilitiesController < ApplicationController
     @vis = ConversationVisibility.where(:person_id => current_user.person.id,
                                         :conversation_id => params[:conversation_id]).first
     if @vis
+      participants = @vis.conversation.participants.count
       if @vis.destroy
-        flash[:notice] = I18n.t('conversations.destroy.success')
+        if participants == 1
+          flash[:notice] = I18n.t('conversations.destroy.delete_success')
+        else
+          flash[:notice] = I18n.t('conversations.destroy.hide_success')
+        end
       end
     end
     redirect_to conversations_path

--- a/app/views/conversations/_show.haml
+++ b/app/views/conversations/_show.haml
@@ -3,13 +3,21 @@
 -#   the COPYRIGHT file.
 
 .conversation_participants
-  = link_to(content_tag(:div, nil, :class => 'icons-deletelabel'),
-            conversation_visibility_path(conversation),
-            :method => 'delete',
-            :data => { :confirm => "#{t('.delete')}?" },
-            :title => t('.delete'),
-            :class => 'close_conversation')
-
+  - if conversation.participants.count > 1
+    = link_to(content_tag(:div, nil, :class => 'icons-deletelabel'),
+              conversation_visibility_path(conversation),
+              :method => 'delete',
+              :data => { :confirm => "#{t('.hide')}?" },
+              :title => t('.hide'),
+              :class => 'close_conversation')
+  - else
+    = link_to(content_tag(:div, nil, :class => 'icons-deletelabel'),
+              conversation_visibility_path(conversation),
+              :method => 'delete',
+              :data => { :confirm => "#{t('.delete')}?" },
+              :title => t('.delete'),
+              :class => 'close_conversation')
+              
   %h3{ :class => direction_for(conversation.subject) }
     = conversation.subject
 

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -358,7 +358,8 @@ en:
     show:
       reply: "reply"
       replying: "Replying..."
-      delete: "delete and block conversation"
+      hide: "hide and mute conversation"
+      delete: "delete conversation"
     new:
       to: "to"
       subject: "subject"
@@ -377,8 +378,8 @@ en:
     new_conversation:
       fail: "Invalid message"
     destroy:
-      success: "Conversation successfully removed"
-
+      delete_success: "Conversation successfully deleted"
+      hide_success: "Conversation successfully hidden"
   date:
     formats:
       fullmonth_day: "%B %d"

--- a/spec/controllers/conversation_visibilities_controller_spec.rb
+++ b/spec/controllers/conversation_visibilities_controller_spec.rb
@@ -33,5 +33,18 @@ describe ConversationVisibilitiesController, :type => :controller do
         delete :destroy, :conversation_id => @conversation.id
       }.not_to change(ConversationVisibility, :count)
     end
+    
+    it 'returns "hidden"' do
+      get :destroy, :conversation_id => @conversation.id
+      expect(flash.notice).to include("hidden")
+    end
+    
+    it 'returns "deleted" when last participant' do
+      get :destroy, :conversation_id => @conversation.id
+      sign_out :user
+      sign_in :user, bob
+      get :destroy, :conversation_id => @conversation.id
+      expect(flash.notice).to include("deleted")
+    end
   end
 end


### PR DESCRIPTION
Delete conversation button currently says 'delete and block conversation'.

When I click that button I expect to delete or block that conversation from DB so that neither me or any participant can see it or reply.

Currently, signed in user is deleted from visibility table, so he is not longer part of the conversation.

"Leave conversation" is an appropriate text to describe button behavior.

Some localization files are update as well.
