### PR TITLE
Destroy conversation when all participants leave it

### DIFF
--- a/app/models/conversation_visibility.rb
+++ b/app/models/conversation_visibility.rb
@@ -3,4 +3,14 @@ class ConversationVisibility < ActiveRecord::Base
   belongs_to :conversation
   belongs_to :person
 
+  after_destroy :check_orphan_conversation
+
+  private
+  
+  def check_orphan_conversation
+    conversation = Conversation.find_by_id(self.conversation.id)
+    if conversation
+      conversation.destroy if conversation.participants.count == 0
+    end
+  end
 end

--- a/db/migrate/20141216213423_purge_orphan_conversations.rb
+++ b/db/migrate/20141216213423_purge_orphan_conversations.rb
@@ -1,0 +1,9 @@
+class PurgeOrphanConversations < ActiveRecord::Migration
+  def up
+    Conversation.joins("LEFT JOIN conversation_visibilities ON conversation_visibilities.conversation_id = conversations.id").group('conversations.id').having("COUNT(conversation_visibilities.id) = 0").delete_all
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141209041241) do
+ActiveRecord::Schema.define(version: 20141216213423) do
 
   create_table "account_deletions", force: true do |t|
     t.string   "diaspora_handle"

--- a/spec/models/conversation_visibilities_spec.rb
+++ b/spec/models/conversation_visibilities_spec.rb
@@ -1,0 +1,28 @@
+#   Copyright (c) 2010-2011, Diaspora Inc.  This file is
+#   licensed under the Affero General Public License version 3 or later.  See
+#   the COPYRIGHT file.
+
+require 'spec_helper'
+
+describe ConversationVisibility, :type => :model do
+  before do
+    @user1 = alice
+    @participant_ids = [@user1.contacts.first.person.id, @user1.person.id]
+
+    @create_hash = {
+      :author => @user1.person,
+      :participant_ids => @participant_ids,
+      :subject => "cool stuff",
+      :messages_attributes => [ {:author => @user1.person, :text => 'hey'} ]
+    }
+    @conversation = Conversation.create(@create_hash)
+  end
+
+  it 'destroy conversation when no participant' do
+    @conversation.conversation_visibilities.each do |visibility|
+      visibility.destroy
+    end
+      
+    expect(Conversation).not_to exist(@conversation.id)
+  end
+end


### PR DESCRIPTION
When all participants of a conversation leave it, conversation remains in db.

Due to private issues, when nobody is seeing it, it should be destroyed.

Test is long but I think it accurately ensures expected behavior.
