### PR TITLE
Fixed growing number on events on hovercard dropdown container

### DIFF
--- a/app/assets/javascripts/app/views/hovercard_view.js
+++ b/app/assets/javascripts/app/views/hovercard_view.js
@@ -70,7 +70,7 @@ app.views.Hovercard = app.views.Base.extend({
       this.$el.hide();
     }
 
-    this.dropdown_container.empty();
+    this.dropdown_container.unbind().empty();
     return false;
   },
 


### PR DESCRIPTION
I think Bug #5313 was caused by the frontend. Prior to this patch events were stacking on the dropdown container with each time the hovercard was displayed.

I added an unbind to remove events from the container when the hovercard is dismissed, preventing multiple calls to the server on click / keyboard.
