### PR TITLE
Set refresh_search async searchresults load to use bootstrap

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -7,7 +7,7 @@ class PeopleController < ApplicationController
   before_action :find_person, only: [:show, :stream, :hovercard]
 
   layout ->(c){ request.format == :mobile ? "application" : "with_header_with_footer" }
-  use_bootstrap_for :index, :show, :contacts
+  use_bootstrap_for :index, :show, :contacts, :refresh_search
 
   respond_to :html, :except => [:tag_index]
   respond_to :json, :only => [:index, :show]


### PR DESCRIPTION
If you search a person by it's full qualifier and async results are used (person not known on the local pod) there is a delay of 10s until the results are asynchroniously loaded. The results ajax-code returns the blueprint-version of `_aspect_membership_dropdown`, but the calling page is rendered with bootstrap.

I added the refresh_search to the list of methods which will use bootstrap for rendering.

This solves #5240 .
