### PR TITLE
Remove limited content from email notifications

### DIFF
--- a/app/helpers/notifier_helper.rb
+++ b/app/helpers/notifier_helper.rb
@@ -4,7 +4,9 @@ module NotifierHelper
   # @param opts [Hash] Optional hash.  Accepts :length parameters.
   # @return [String] The truncated and formatted post.
   def post_message(post, opts={})
-    if post.respond_to? :message
+    if !post.public?
+      I18n.translate 'notifier.a_private_message'
+    elsif post.respond_to? :message
       post.message.plain_text_without_markdown truncate: opts.fetch(:length, 200)
     else
       I18n.translate 'notifier.a_post_you_shared'
@@ -15,6 +17,10 @@ module NotifierHelper
   # @param opts [Hash] Optional hash.  Accepts :length parameters.
   # @return [String] The truncated and formatted comment.
   def comment_message(comment, opts={})
-    comment.message.plain_text_without_markdown truncate: opts.fetch(:length, 600)
+    if comment.post.public?
+      comment.message.plain_text_without_markdown truncate: opts.fetch(:length, 600)
+    else
+      I18n.translate 'notifier.a_limited_post_comment'
+    end
   end
 end

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -731,6 +731,8 @@ en:
 
   notifier:
     a_post_you_shared: "a post."
+    a_private_message: "There's a new private message in diaspora* for you to check out."
+    a_limited_post_comment: "There's a new comment on a limited post in diaspora* for you to check out."
     email_sent_by_diaspora: "This email was sent by %{pod_name}. If you'd like to stop getting emails like this,"
     click_here: "click here"
     hello: "Hello %{name}!"

--- a/spec/helpers/notifier_helper_spec.rb
+++ b/spec/helpers/notifier_helper_spec.rb
@@ -8,12 +8,14 @@ describe NotifierHelper, :type => :helper do
   describe '#post_message' do
     before do
       # post for truncate test
-      @post = FactoryGirl.create(:status_message, text: "hi dude! "*10)
+      @post = FactoryGirl.create(:status_message, text: "hi dude! "*10, public: true)
       @truncated_post = "hi dude! hi dude! hi dude! hi dude! hi dude! hi dude! hi dude! hi dude! hi du..."
       # post for markdown test
       @markdown_post = FactoryGirl.create(:status_message,
-        text: "[link](http://diasporafoundation.org) **bold text** *other text*")
+        text: "[link](http://diasporafoundation.org) **bold text** *other text*", public: true)
       @striped_markdown_post = "link (http://diasporafoundation.org) bold text other text"
+      
+      @limited_post = FactoryGirl.create(:status_message, text: "This is top secret post. Shhhhhhhh!!!", public: false)
     end
 
     it 'truncates in the post' do
@@ -25,6 +27,10 @@ describe NotifierHelper, :type => :helper do
       opts = {:length => @markdown_post.text.length}
       expect(post_message(@markdown_post, opts)).to eq(@striped_markdown_post)
     end
+
+    it 'hides the private content' do
+      expect(post_message(@limited_post)).not_to include("secret post")
+    end
   end
 
   describe '#comment_message' do
@@ -32,11 +38,19 @@ describe NotifierHelper, :type => :helper do
       # comment for truncate test
       @comment = FactoryGirl.create(:comment)
       @comment.text = "hi dude! "*10
+      @comment.post.public = true
       @truncated_comment = "hi dude! hi dude! hi dude! hi dude! hi dude! hi dude! hi dude! hi dude! hi d..."
+
       # comment for markdown test
       @markdown_comment = FactoryGirl.create(:comment)
+      @markdown_comment.post.public = true
       @markdown_comment.text = "[link](http://diasporafoundation.org) **bold text** *other text*"
       @striped_markdown_comment = "link (http://diasporafoundation.org) bold text other text"
+      
+      # comment for limited post
+      @limited_comment = FactoryGirl.create(:comment)
+      @limited_comment.post.public = false
+      @limited_comment.text = "This is top secret comment. Shhhhhhhh!!!"
     end
 
     it 'truncates in the comment' do
@@ -47,6 +61,10 @@ describe NotifierHelper, :type => :helper do
     it 'strip markdown in the comment' do
       opts = {:length => @markdown_comment.text.length}
       expect(comment_message(@markdown_comment, opts)).to eq(@striped_markdown_comment)
+    end
+    
+    it 'hides the private content' do
+      expect(comment_message(@limited_comment)).not_to include("secret comment")
     end
   end
 end


### PR DESCRIPTION
This is my solution to pull request #4508 that solves issue #4342 and #4266 

I have doubts in messages 'notifier.a_private_message' and 'notifier.a_limited_post_comment' due to I'm not a native English speaker.

I also updated 'spec/mailers/notifier_spec.rb' file 'cause now if post is public or not changes email text, but I don't know if this file requires new tests for private mails. What do you think?
