### PR TITLE
Full sized images for lightbox

### DIFF
--- a/app/assets/javascripts/widgets/lightbox.js
+++ b/app/assets/javascripts/widgets/lightbox.js
@@ -115,7 +115,7 @@ jQuery.fn.center = (function() {
         imageUrl = selectedImage.attr("data-full-photo"),
         images = selectedImage.parents(self.options.imageParent).find(self.options.imageSelector),
         imageThumb;
-
+      
       if( $.browser.msie ) {
         /* No fancy schmancy lightbox for IE, because it doesn't work in IE */
         window.open(imageUrl);
@@ -159,7 +159,10 @@ jQuery.fn.center = (function() {
     this.selectImage = function(imageThumb) {
       $(".selected", self.imageset).removeClass("selected");
       imageThumb.addClass("selected");
-      self.image.attr("src", imageThumb.attr("data-full-photo"));
+      
+      bigimagesource = imageThumb.attr("data-full-photo");
+      bigimagesource = bigimagesource.replace("scaled_full_", "");			// We want the original version of the image file, so remove "scaled_full_" from filename
+      self.image.attr("src", bigimagesource);
 
       self.scrollToThumbnail(imageThumb);
 

--- a/app/assets/stylesheets/lightbox.css.scss
+++ b/app/assets/stylesheets/lightbox.css.scss
@@ -31,11 +31,18 @@
     display: block;
     margin-bottom: 120px;
     background: white;
+    max-width:100%;
   }
 
   #lightbox-content{
     text-align: left;
     display: inline-block;
+    margin-left:auto;
+    margin-right:auto;
+    max-width:100%;
+    padding-left:20px;
+    padding-right:20px;
+    box-sizing:border-box;
   }
 
   #lightbox-links{

--- a/app/assets/stylesheets/lightbox.css.scss
+++ b/app/assets/stylesheets/lightbox.css.scss
@@ -102,7 +102,7 @@
   left: 0;
   bottom: 0;
   text-align: center;
-  background-color: rgba(0,0,0,0.4);
+  background-color: rgba(0,0,0,0.8);
   padding: 5px 0;
   white-space: nowrap;
   overflow: hidden;

--- a/app/uploaders/processed_image.rb
+++ b/app/uploaders/processed_image.rb
@@ -30,7 +30,7 @@ class ProcessedImage < CarrierWave::Uploader::Base
     process :strip
   end
   version :scaled_full do
-    process :resize_to_limit => [1400,nil]
+    process :resize_to_limit => [700,nil]
     process :strip
   end
 

--- a/app/uploaders/processed_image.rb
+++ b/app/uploaders/processed_image.rb
@@ -30,7 +30,7 @@ class ProcessedImage < CarrierWave::Uploader::Base
     process :strip
   end
   version :scaled_full do
-    process :resize_to_limit => [700,nil]
+    process :resize_to_limit => [1400,nil]
     process :strip
   end
 


### PR DESCRIPTION
With the modified code, the lightbox will show the original image file instead of a smaller version. We store the original image on our servers but only use scaled-down versions? That looks strange to me, so i decided to let the lightbox show a hight resolution version of every image.

If an image is too big for the screen, it will be scaled down dynamically by CSS.

Corresponding post on loom.io: https://www.loomio.org/d/95wh18Lt/high-resolution-full-sized-images-for-lightbox
