### PR TITLE
Add sidekiq-failures gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'simple_captcha2', '0.3.2', :require => 'simple_captcha'
 # Background processing
 
 gem 'sidekiq', '3.3.0'
+gem 'sidekiq-failures'
 gem 'sinatra', '1.4.5'
 
 # Scheduled processing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -529,6 +529,8 @@ GEM
       json
       redis (>= 3.0.6)
       redis-namespace (>= 1.3.1)
+    sidekiq-failures (0.4.3)
+      sidekiq (>= 2.16.0)
     sidetiq (0.6.3)
       celluloid (>= 0.14.1)
       ice_cube (= 0.11.1)
@@ -694,6 +696,7 @@ DEPENDENCIES
   sass-rails (= 4.0.4)
   selenium-webdriver (= 2.44.0)
   sidekiq (= 3.3.0)
+  sidekiq-failures
   sidetiq (= 0.6.3)
   simple_captcha2 (= 0.3.2)
   sinatra (= 1.4.5)


### PR DESCRIPTION
It has been discussed in #3993. The ability to manually restart failed jobs has been implemented.

As for memory consumption, we could configure it so that it only tracks failures if the job exhausts all its retries ([see readme](https://github.com/mhfs/sidekiq-failures#exhausted)).

We've been using it in out pod for about 2 months and hadn't noticed any glitches so far: 1GB ram, ~300 users, ~170.000 failed jobs so far.
