### PR TITLE
Properly translate "Show getting started hints" to Dutch

### DIFF
--- a/config/locales/diaspora/nl.yml
+++ b/config/locales/diaspora/nl.yml
@@ -1283,7 +1283,7 @@ nl:
       receive_email_notifications: "Ontvang e-mail notificaties wanneer:"
       reshared: "iemand jouw bericht doorgeeft"
       show_community_spotlight: "Laat Community Spotlight zien in Stream"
-      show_getting_started: "Maak Beginnen opnieuw mogelijk"
+      show_getting_started: "Geef tips voor het eerste gebruik"
       someone_reported: "iemand zond een melding in"
       started_sharing: "iemand met je begint te delen"
       stream_preferences: "Stream voorkeuren"


### PR DESCRIPTION
@petervdv mentioned the issue. Here is a fix. The old translation doesn't make much sense.
