### PR TITLE
Convert MySQL fields to 4 byte unicode 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -32,6 +32,10 @@ series and run our comprehensive test suite against it.
 ## Change in defaults.yml
 The default for including jQuery from a CDN has changed. If you want to continue to include it from a CDN, please explicitly set the `jquery_cdn` setting to `true` in diaspora.yml.
 
+## Change in database.yml
+For MySQL databases, replace `charset: utf8` with `encoding: utf8mb4`. This is enables full UTF8 support (4bytes characters), including standard emoji characters. See `database.yml.example` for reference.
+Also, do not forget to remove `collation: utf8_bin`. It will choose a compatible one automatically.
+
 ## Experimental chat feature
 This release adds experimental integration with XMPP for real-time chat. Please see  [our wiki](https://wiki.diasporafoundation.org/Vines) for further informations.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -33,7 +33,7 @@ series and run our comprehensive test suite against it.
 The default for including jQuery from a CDN has changed. If you want to continue to include it from a CDN, please explicitly set the `jquery_cdn` setting to `true` in diaspora.yml.
 
 ## Change in database.yml
-For MySQL databases, replace `charset: utf8` with `encoding: utf8mb4`. This is enables full UTF8 support (4bytes characters), including standard emoji characters. See `database.yml.example` for reference.
+For MySQL databases, replace `charset: utf8` with `encoding: utf8mb4` in the file `config/database.yml`. This is enables full UTF8 support (4bytes characters), including standard emoji characters. See `database.yml.example` for reference.
 Also, do not forget to remove `collation: utf8_bin`. It will choose a compatible one automatically.
 
 ## Experimental chat feature

--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -5,8 +5,7 @@ mysql: &mysql
   username: "root"
   password: ""
 #  socket: /tmp/mysql.sock
-  charset: utf8mb4
-  collation: utf8_bin
+  encoding: utf8mb4
 
 postgres: &postgres
   adapter: postgresql

--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -5,7 +5,7 @@ mysql: &mysql
   username: "root"
   password: ""
 #  socket: /tmp/mysql.sock
-  charset: utf8
+  charset: utf8mb4
   collation: utf8_bin
 
 postgres: &postgres
@@ -25,7 +25,7 @@ common: &common
 
   # Should match environment.sidekiq.concurrency
   #pool: 25
-  
+
 ##################################################
 #### CONFIGURE ABOVE #############################
 ##################################################

--- a/db/migrate/0000_create_schema.rb
+++ b/db/migrate/0000_create_schema.rb
@@ -199,7 +199,7 @@ class CreateSchema < ActiveRecord::Migration
     t.text   "data",                 :null => false
   end
 
-  add_index "o_embed_caches", ["url"], :name => "index_o_embed_caches_on_url", :length => {"url"=>255}
+  add_index "o_embed_caches", ["url"], :name => "index_o_embed_caches_on_url", :length => {"url"=> 191}, using: :btree
 
   create_table "participations", :force => true do |t|
     t.string   "guid"
@@ -227,7 +227,7 @@ class CreateSchema < ActiveRecord::Migration
     t.integer  "fetch_status",          :default => 0
   end
 
-  add_index "people", ["diaspora_handle"], :name => "index_people_on_diaspora_handle", :unique => true
+  add_index "people", ["diaspora_handle"], :name => "index_people_on_diaspora_handle", :unique => true, :length => {"diaspora_handle" => 191}
   add_index "people", ["guid"], :name => "index_people_on_guid", :unique => true
   add_index "people", ["owner_id"], :name => "index_people_on_owner_id", :unique => true
 
@@ -265,7 +265,7 @@ class CreateSchema < ActiveRecord::Migration
     t.integer  "author_id",                                              :null => false
     t.boolean  "public",                              :default => false, :null => false
     t.string   "diaspora_handle"
-    t.string   "guid",                                                   :null => false
+    t.string   "guid"
     t.boolean  "pending",                             :default => false, :null => false
     t.string   "type",                  :limit => 40,                    :null => false
     t.text     "text"
@@ -337,7 +337,7 @@ class CreateSchema < ActiveRecord::Migration
     t.datetime "updated_at",              :null => false
   end
 
-  add_index "rails_admin_histories", ["item", "table", "month", "year"], :name => "index_rails_admin_histories"
+  add_index "rails_admin_histories", ["item", "table", "month", "year"], :name => "index_rails_admin_histories", :length => {"table" => 180}
 
   create_table "roles", :force => true do |t|
     t.integer  "person_id"
@@ -404,7 +404,7 @@ class CreateSchema < ActiveRecord::Migration
     t.string "name"
   end
 
-  add_index "tags", ["name"], :name => "index_tags_on_name", :unique => true
+  add_index "tags", ["name"], :name => "index_tags_on_name", :unique => true, :length => {"name" => 191}
 
   create_table "user_preferences", :force => true do |t|
     t.string   "email_type"
@@ -449,7 +449,7 @@ class CreateSchema < ActiveRecord::Migration
   end
 
   add_index "users", ["authentication_token"], :name => "index_users_on_authentication_token", :unique => true
-  add_index "users", ["email"], :name => "index_users_on_email"
+  add_index "users", ["email"], :name => "index_users_on_email", length: {"email" => "191"}
   add_index "users", ["invitation_service", "invitation_identifier"], :name => "index_users_on_invitation_service_and_invitation_identifier", :unique => true
   add_index "users", ["invitation_token"], :name => "index_users_on_invitation_token"
   add_index "users", ["username"], :name => "index_users_on_username", :unique => true

--- a/db/migrate/0000_create_schema.rb
+++ b/db/migrate/0000_create_schema.rb
@@ -24,8 +24,8 @@ class CreateSchema < ActiveRecord::Migration
   end
 
   add_index "aspect_visibilities", ["aspect_id"], :name => "index_aspect_visibilities_on_aspect_id"
-  add_index "aspect_visibilities", ["shareable_id", "shareable_type", "aspect_id"], :name => "shareable_and_aspect_id"
-  add_index "aspect_visibilities", ["shareable_id", "shareable_type"], :name => "index_aspect_visibilities_on_shareable_id_and_shareable_type"
+  add_index 'aspect_visibilities', ["shareable_id", "shareable_type", "aspect_id"], :name => 'shareable_and_aspect_id', length: {"shareable_type"=>189}, :using => :btree
+  add_index 'aspect_visibilities', ["shareable_id", "shareable_type"], :name => 'index_aspect_visibilities_on_shareable_id_and_shareable_type', length: {"shareable_type"=>190}, :using => :btree
 
   create_table "aspects", :force => true do |t|
     t.string   "name",                               :null => false
@@ -59,7 +59,7 @@ class CreateSchema < ActiveRecord::Migration
 
   add_index "comments", ["author_id"], :name => "index_comments_on_person_id"
   add_index "comments", ["commentable_id", "commentable_type"], :name => "index_comments_on_commentable_id_and_commentable_type"
-  add_index "comments", ["guid"], :name => "index_comments_on_guid", :unique => true
+  add_index 'comments', ["guid"], :name => 'index_comments_on_guid', length: {"guid"=>191}, :using => :btree, :unique => true
 
   create_table "contacts", :force => true do |t|
     t.integer  "user_id",                       :null => false
@@ -133,7 +133,7 @@ class CreateSchema < ActiveRecord::Migration
   end
 
   add_index "likes", ["author_id"], :name => "likes_author_id_fk"
-  add_index "likes", ["guid"], :name => "index_likes_on_guid", :unique => true
+  add_index 'likes', ["guid"], :name => 'index_likes_on_guid', length: {"guid"=>191}, :using => :btree, :unique => true
   add_index "likes", ["target_id", "author_id", "target_type"], :name => "index_likes_on_target_id_and_author_id_and_target_type", :unique => true
   add_index "likes", ["target_id"], :name => "index_likes_on_post_id"
 
@@ -192,7 +192,7 @@ class CreateSchema < ActiveRecord::Migration
 
   add_index "notifications", ["recipient_id"], :name => "index_notifications_on_recipient_id"
   add_index "notifications", ["target_id"], :name => "index_notifications_on_target_id"
-  add_index "notifications", ["target_type", "target_id"], :name => "index_notifications_on_target_type_and_target_id"
+  add_index 'notifications', ["target_type", "target_id"], name: 'index_notifications_on_target_type_and_target_id', length: {"target_type"=>190}, using: :btree
 
   create_table "o_embed_caches", :force => true do |t|
     t.string "url",  :limit => 1024, :null => false
@@ -212,7 +212,7 @@ class CreateSchema < ActiveRecord::Migration
     t.datetime "updated_at",                            :null => false
   end
 
-  add_index "participations", ["guid"], :name => "index_participations_on_guid"
+  add_index 'participations', ["guid"], :name => 'index_participations_on_guid', length: {"guid"=>191}, :using => :btree
   add_index "participations", ["target_id", "target_type", "author_id"], :name => "index_participations_on_target_id_and_target_type_and_author_id"
 
   create_table "people", :force => true do |t|
@@ -228,7 +228,7 @@ class CreateSchema < ActiveRecord::Migration
   end
 
   add_index "people", ["diaspora_handle"], :name => "index_people_on_diaspora_handle", :unique => true, :length => {"diaspora_handle" => 191}
-  add_index "people", ["guid"], :name => "index_people_on_guid", :unique => true
+  add_index 'people', ["guid"], :name => 'index_people_on_guid', length: {"guid"=>191}, :using => :btree, :unique => true
   add_index "people", ["owner_id"], :name => "index_people_on_owner_id", :unique => true
 
   create_table "photos", :force => true do |t|
@@ -252,7 +252,7 @@ class CreateSchema < ActiveRecord::Migration
     t.integer  "width"
   end
 
-  add_index "photos", ["status_message_guid"], :name => "index_photos_on_status_message_guid"
+  add_index 'photos', ["status_message_guid"], :name => 'index_photos_on_status_message_guid', length: {"status_message_guid"=>191}, :using => :btree
 
   create_table "pods", :force => true do |t|
     t.string   "host"
@@ -265,7 +265,7 @@ class CreateSchema < ActiveRecord::Migration
     t.integer  "author_id",                                              :null => false
     t.boolean  "public",                              :default => false, :null => false
     t.string   "diaspora_handle"
-    t.string   "guid"
+    t.string   "guid",                                                   :null => false
     t.boolean  "pending",                             :default => false, :null => false
     t.string   "type",                  :limit => 40,                    :null => false
     t.text     "text"
@@ -294,13 +294,13 @@ class CreateSchema < ActiveRecord::Migration
     t.boolean  "favorite",                            :default => false
   end
 
-  add_index "posts", ["author_id", "root_guid"], :name => "index_posts_on_author_id_and_root_guid", :unique => true
+  add_index 'posts', ["author_id", "root_guid"], :name => 'index_posts_on_author_id_and_root_guid', length: {"root_guid"=>30}, :using => :btree, :unique => true
   add_index "posts", ["author_id"], :name => "index_posts_on_person_id"
-  add_index "posts", ["guid"], :name => "index_posts_on_guid", :unique => true
+  add_index 'posts', ["guid"], :name => 'index_posts_on_guid', length: {"guid"=>191}, :using => :btree, :unique => true
   add_index "posts", ["id", "type", "created_at"], :name => "index_posts_on_id_and_type_and_created_at"
-  add_index "posts", ["root_guid"], :name => "index_posts_on_root_guid"
-  add_index "posts", ["status_message_guid", "pending"], :name => "index_posts_on_status_message_guid_and_pending"
-  add_index "posts", ["status_message_guid"], :name => "index_posts_on_status_message_guid"
+  add_index 'posts', ["root_guid"], :name => 'index_posts_on_root_guid', length: {"root_guid"=>30}
+  add_index 'posts', ["status_message_guid", "pending"], :name => 'index_posts_on_status_message_guid_and_pending', length: {"status_message_guid"=>190}, :using => :btree
+  add_index 'posts', ["status_message_guid"], :name => 'index_posts_on_status_message_guid', length: {"status_message_guid"=>191}, :using => :btree
   add_index "posts", ["type", "pending", "id"], :name => "index_posts_on_type_and_pending_and_id"
 
   create_table "profiles", :force => true do |t|
@@ -337,7 +337,7 @@ class CreateSchema < ActiveRecord::Migration
     t.datetime "updated_at",              :null => false
   end
 
-  add_index "rails_admin_histories", ["item", "table", "month", "year"], :name => "index_rails_admin_histories", :length => {"table" => 180}
+  add_index "rails_admin_histories", ["item", "table", "month", "year"], :name => "index_rails_admin_histories", :length => {"table" => 188}
 
   create_table "roles", :force => true do |t|
     t.integer  "person_id"
@@ -357,7 +357,7 @@ class CreateSchema < ActiveRecord::Migration
     t.datetime "updated_at",                   :null => false
   end
 
-  add_index "services", ["type", "uid"], :name => "index_services_on_type_and_uid"
+  add_index 'services', ["type", "uid"], :name => 'index_services_on_type_and_uid', length: {"type"=>64, "uid"=>127}, :using => :btree
   add_index "services", ["user_id"], :name => "index_services_on_user_id"
 
   create_table "share_visibilities", :force => true do |t|
@@ -397,7 +397,7 @@ class CreateSchema < ActiveRecord::Migration
 
   add_index "taggings", ["created_at"], :name => "index_taggings_on_created_at"
   add_index "taggings", ["tag_id"], :name => "index_taggings_on_tag_id"
-  add_index "taggings", ["taggable_id", "taggable_type", "context"], :name => "index_taggings_on_taggable_id_and_taggable_type_and_context"
+  add_index 'taggings', ["taggable_id", "taggable_type", "context"], :name => 'index_taggings_on_taggable_id_and_taggable_type_and_context', length: {"taggable_type"=>95, "context"=>95}, :using => :btree
   add_index "taggings", ["taggable_id", "taggable_type", "tag_id"], :name => "index_taggings_uniquely", :unique => true
 
   create_table "tags", :force => true do |t|
@@ -450,9 +450,9 @@ class CreateSchema < ActiveRecord::Migration
 
   add_index "users", ["authentication_token"], :name => "index_users_on_authentication_token", :unique => true
   add_index "users", ["email"], :name => "index_users_on_email", length: {"email" => "191"}
-  add_index "users", ["invitation_service", "invitation_identifier"], :name => "index_users_on_invitation_service_and_invitation_identifier", :unique => true
+  add_index 'users', ["invitation_service", "invitation_identifier"], :name => 'index_users_on_invitation_service_and_invitation_identifier', length: {"invitation_service"=>64, "invitation_identifier"=>127}, :using => :btree, :unique => true
   add_index "users", ["invitation_token"], :name => "index_users_on_invitation_token"
-  add_index "users", ["username"], :name => "index_users_on_username", :unique => true
+  add_index 'users', ["username"], :name => 'index_users_on_username', length: {"username"=>191}, :using => :btree, :unique => true
 
   add_foreign_key "aspect_memberships", "aspects", name: "aspect_memberships_aspect_id_fk", dependent: :delete
   add_foreign_key "aspect_memberships", "contacts", name: "aspect_memberships_contact_id_fk", dependent: :delete

--- a/db/migrate/20130429073928_add_tweet_id_to_post.rb
+++ b/db/migrate/20130429073928_add_tweet_id_to_post.rb
@@ -1,6 +1,6 @@
 class AddTweetIdToPost < ActiveRecord::Migration
   def change
-  	add_column :posts, :tweet_id, :string, limit: 64
-  	add_index :posts, :tweet_id
+  	add_column :posts, :tweet_id, :string
+  	add_index :posts, ['tweet_id'], :length => { "tweet_id" => 191 }
   end
 end

--- a/db/migrate/20130429073928_add_tweet_id_to_post.rb
+++ b/db/migrate/20130429073928_add_tweet_id_to_post.rb
@@ -1,6 +1,6 @@
 class AddTweetIdToPost < ActiveRecord::Migration
   def change
-  	add_column :posts, :tweet_id, :string
+  	add_column :posts, :tweet_id, :string, limit: 64
   	add_index :posts, :tweet_id
   end
 end

--- a/db/migrate/20130613203350_remove_limit_from_root_guid_in_posts.rb
+++ b/db/migrate/20130613203350_remove_limit_from_root_guid_in_posts.rb
@@ -1,9 +1,13 @@
 class RemoveLimitFromRootGuidInPosts < ActiveRecord::Migration
   def up
-    change_column :posts, :root_guid, :string, limit: 64
+    remove_index 'posts', :name => 'index_posts_on_root_guid'
+    remove_index 'posts', :name => 'index_posts_on_author_id_and_root_guid'
+    change_column :posts, :root_guid, :string
+    add_index 'posts', ["root_guid"], :name => 'index_posts_on_root_guid', length: {"root_guid"=>191}
+    add_index 'posts', ["author_id", "root_guid"], :name => 'index_posts_on_author_id_and_root_guid', length: {"root_guid"=>190}, :using => :btree, :unique => true
   end
 
   def down
-    change_column :posts, :root_guid, :string, limit: 64
+    change_column :posts, :root_guid, :string, limit: 30
   end
 end

--- a/db/migrate/20130613203350_remove_limit_from_root_guid_in_posts.rb
+++ b/db/migrate/20130613203350_remove_limit_from_root_guid_in_posts.rb
@@ -1,9 +1,9 @@
 class RemoveLimitFromRootGuidInPosts < ActiveRecord::Migration
   def up
-    change_column :posts, :root_guid, :string
+    change_column :posts, :root_guid, :string, limit: 64
   end
 
   def down
-    change_column :posts, :root_guid, :string, limit: 30
+    change_column :posts, :root_guid, :string, limit: 64
   end
 end

--- a/db/migrate/20140801101230_create_chat_contacts.rb
+++ b/db/migrate/20140801101230_create_chat_contacts.rb
@@ -3,12 +3,12 @@ class CreateChatContacts < ActiveRecord::Migration
     create_table :chat_contacts do |t|
       t.integer :user_id,                  null: false
       ## JID <= 3071 bytes http://tools.ietf.org/html/rfc6122
-      t.string :jid,          limit: 3071, null: false
-      t.string :name,         limit: 255,  null: true
-      t.string :ask,          limit: 128,  null: true
-      t.string :subscription, limit: 128,  null: false
+      t.string :jid,                      null: false
+      t.string :name,         limit: 255, null: true
+      t.string :ask,          limit: 128, null: true
+      t.string :subscription, limit: 128, null: false
     end
-    add_index :chat_contacts, [:user_id, :jid], unique: true, length: {"jid": 100}
+    add_index :chat_contacts, [:user_id, :jid], unique: true, :length => {:jid => 190}
   end
 
   def down

--- a/db/migrate/20140801101230_create_chat_contacts.rb
+++ b/db/migrate/20140801101230_create_chat_contacts.rb
@@ -1,13 +1,14 @@
 class CreateChatContacts < ActiveRecord::Migration
   def up
     create_table :chat_contacts do |t|
-      t.integer :user_id, null: false
-      t.string :jid, null: false
-      t.string :name, limit: 255, null: true
-      t.string :ask, limit: 128, null: true
-      t.string :subscription, limit: 128, null: false
+      t.integer :user_id,                  null: false
+      ## JID <= 3071 bytes http://tools.ietf.org/html/rfc6122
+      t.string :jid,          limit: 3071, null: false
+      t.string :name,         limit: 255,  null: true
+      t.string :ask,          limit: 128,  null: true
+      t.string :subscription, limit: 128,  null: false
     end
-    add_index :chat_contacts, [:user_id, :jid], unique: true
+    add_index :chat_contacts, [:user_id, :jid], unique: true, length: {"jid": 100}
   end
 
   def down

--- a/db/migrate/20140801101352_create_chat_fragments.rb
+++ b/db/migrate/20140801101352_create_chat_fragments.rb
@@ -6,7 +6,7 @@ class CreateChatFragments < ActiveRecord::Migration
       t.string :namespace, limit: 256, null: false
       t.text :xml, null: false
     end
-    # That'll wont work due UTF-8 and the limit of 767 bytes
+    # That won't work due UTF-8 and the limit of 767 bytes
     #add_index :chat_fragments, [:user_id, :root, :namespace], unique: true
     add_index :chat_fragments, [:user_id], unique: true
   end

--- a/db/migrate/20150106050733_set_mysql_to_unicode_mb4.rb
+++ b/db/migrate/20150106050733_set_mysql_to_unicode_mb4.rb
@@ -1,43 +1,112 @@
 class SetMysqlToUnicodeMb4 < ActiveRecord::Migration
   # Converts the tables and strings columns to utf8mb4, which is the true, full
   # unicode support in MySQl
-  UTF8_PAIRS = {}
-  tables = ActiveRecord::Base.connection.tables
 
-  tables.each do |table|
-    ActiveRecord::Base.connection.columns(table).each do |column|
-      # build a hash with all the columns that contain text
-      if (column.type == :string) || (column.type == :text)
-        UTF8_PAIRS[table] = { :name => column.name, :type => column.sql_type }
+  def self.up
+    # shorten indexes regardless of the RDBMS provider - for consitency
+    shorten_indexes
+    change_encoding('utf8mb4') if AppConfig.mysql?
+  end
+
+  def self.down
+    change_encoding('utf8') if AppConfig.mysql?
+  end
+
+  def change_encoding(encoding)
+    execute "ALTER DATABASE `#{ActiveRecord::Base.connection.current_database}` CHARACTER SET #{encoding};"
+
+    tables.each do |table|
+      execute "ALTER TABLE `#{table}` CHARACTER SET = #{encoding}"
+    end
+
+    character_columns.each do |table, columns|
+      columns.each do |column|
+        execute "ALTER TABLE `#{table}` CHANGE `#{column.name}` `#{column.name}` #{column.sql_type} CHARACTER SET #{encoding} #{column.null ? 'NULL' : 'NOT NULL'} #{"DEFAULT '#{column.default}'" if column.has_default?};"
       end
     end
   end
 
-  def self.up
-    # these will only affect tables on InnoDB, and only on rows with the dynamic
-    # format
-    execute "SET global innodb_file_format = BARRACUDA;"
-    execute "SET global innodb_large_prefix = 1;"
-    execute "SET global innodb_file_per_table = 1;"
-    change_encoding('utf8mb4', 'ENGINE=InnoDB ROW_FORMAT=DYNAMIC') if AppConfig.mysql?
+  def character_columns
+    # build a hash with all the columns that contain characters
+    @character_columns ||= tables.map {|table|
+      col = columns(table)
+        .select {|column| column.type == :string || column.type == :text }
+      next if col.empty?
+      [table, col]
+    }.compact.to_h
   end
 
-  def self.down
-    # let MySQL pick the default engine
-    change_encoding('utf8', '') if AppConfig.mysql?
-  end
+  def shorten_indexes
+    remove_index 'aspect_visibilities', :name => 'shareable_and_aspect_id'
+    add_index 'aspect_visibilities', ["shareable_id", "shareable_type", "aspect_id"], :name => 'shareable_and_aspect_id', length: {"shareable_type"=>189}, :using => :btree
 
-  def change_encoding(encoding, engine)
-    execute "ALTER DATABASE `#{ActiveRecord::Base.connection.current_database}` CHARACTER SET #{encoding};"
+    remove_index 'aspect_visibilities', :name => 'index_aspect_visibilities_on_shareable_id_and_shareable_type'
+    add_index 'aspect_visibilities', ["shareable_id", "shareable_type"], :name => 'index_aspect_visibilities_on_shareable_id_and_shareable_type', length: {"shareable_type"=>190}, :using => :btree
 
-    tables.each do |table|
-      execute "ALTER TABLE `#{table}` CHARACTER SET = #{encoding} #{engine};"
-    end
+    remove_index 'chat_contacts', :name => 'index_chat_contacts_on_user_id_and_jid'
+    add_index 'chat_contacts', ["user_id", "jid"], :name => 'index_chat_contacts_on_user_id_and_jid', length: {"jid"=>190}, :using => :btree, :unique => true
 
-    UTF8_PAIRS.each do |table, column|
-      name = column[:name]
-      type = column[:type]
-      execute "ALTER TABLE `#{table}` CHANGE `#{name}` `#{name}` #{type}  CHARACTER SET #{encoding} NULL;"
-    end
+    remove_index 'comments', :name => 'index_comments_on_guid'
+    add_index 'comments', ["guid"], :name => 'index_comments_on_guid', length: {"guid"=>191}, :using => :btree, :unique => true
+
+    remove_index 'likes', :name => 'index_likes_on_guid'
+    add_index 'likes', ["guid"], :name => 'index_likes_on_guid', length: {"guid"=>191}, :using => :btree, :unique => true
+
+    remove_index 'o_embed_caches', :name => 'index_o_embed_caches_on_url'
+    add_index 'o_embed_caches', ["url"], :name => 'index_o_embed_caches_on_url', length: {"url"=>191}, :using => :btree
+
+    remove_index 'participations', :name => 'index_participations_on_guid'
+    add_index 'participations', ["guid"], :name => 'index_participations_on_guid', length: {"guid"=>191}, :using => :btree
+
+    remove_index 'people', :name => 'index_people_on_diaspora_handle'
+    add_index "people", ["diaspora_handle"], :name => "index_people_on_diaspora_handle", :unique => true, :length => {"diaspora_handle" => 191}
+
+    remove_index 'people', :name => 'index_people_on_guid'
+    add_index 'people', ["guid"], :name => 'index_people_on_guid', length: {"guid"=>191}, :using => :btree, :unique => true
+
+    remove_index 'photos', :name => 'index_photos_on_status_message_guid'
+    add_index 'photos', ["status_message_guid"], :name => 'index_photos_on_status_message_guid', length: {"status_message_guid"=>191}, :using => :btree
+
+    remove_index 'posts', :name => 'index_posts_on_guid'
+    add_index 'posts', ["guid"], :name => 'index_posts_on_guid', length: {"guid"=>191}, :using => :btree, :unique => true
+
+    remove_index 'posts', :name => 'index_posts_on_status_message_guid_and_pending'
+    add_index 'posts', ["status_message_guid", "pending"], :name => 'index_posts_on_status_message_guid_and_pending', length: {"status_message_guid"=>190}, :using => :btree
+
+    remove_index 'posts', :name => 'index_posts_on_status_message_guid'
+    add_index 'posts', ["status_message_guid"], :name => 'index_posts_on_status_message_guid', length: {"status_message_guid"=>191}, :using => :btree
+
+    remove_index 'posts', :name => 'index_posts_on_author_id_and_root_guid'
+    add_index 'posts', ["author_id", "root_guid"], :name => 'index_posts_on_author_id_and_root_guid', length: {"root_guid"=>190}, :using => :btree, :unique => true
+
+    remove_index 'posts', :name => 'index_posts_on_root_guid'
+    add_index 'posts', ["root_guid"], :name => 'index_posts_on_root_guid', length: {"root_guid"=>191}
+
+    remove_index 'rails_admin_histories', :name => 'index_rails_admin_histories'
+    add_index 'rails_admin_histories', ["item", "table", "month", "year"], :name => 'index_rails_admin_histories', length: {"table"=>188}, :using => :btree
+
+    remove_index 'schema_migrations', :name => 'unique_schema_migrations'
+    add_index 'schema_migrations', ["version"], :name => 'unique_schema_migrations', length: {"version"=>191}, :using => :btree
+
+    remove_index 'services', :name => 'index_services_on_type_and_uid'
+    add_index 'services', ["type", "uid"], :name => 'index_services_on_type_and_uid', length: {"type"=>64, "uid"=>127}, :using => :btree
+
+    remove_index 'taggings', :name => 'index_taggings_on_taggable_id_and_taggable_type_and_context'
+    add_index 'taggings', ["taggable_id", "taggable_type", "context"], :name => 'index_taggings_on_taggable_id_and_taggable_type_and_context', length: {"taggable_type"=>95, "context"=>95}, :using => :btree
+
+    remove_index 'tags', :name => 'index_tags_on_name'
+    add_index 'tags', ["name"], :name => 'index_tags_on_name', length: {"name"=>191}, :using => :btree, :unique => true
+
+    remove_index 'users', :name => 'index_users_on_invitation_service_and_invitation_identifier'
+    add_index 'users', ["invitation_service", "invitation_identifier"], :name => 'index_users_on_invitation_service_and_invitation_identifier', length: {"invitation_service"=>64, "invitation_identifier"=>127}, :using => :btree, :unique => true
+
+    remove_index 'users', :name => 'index_users_on_username'
+    add_index 'users', ["username"], :name => 'index_users_on_username', length: {"username"=>191}, :using => :btree, :unique => true
+
+    remove_index 'users', :name => 'index_users_on_email'
+    add_index 'users', ["email"], :name => 'index_users_on_email', length: {"email"=>191}, :using => :btree
+
+    remove_index 'notifications', :name => 'index_notifications_on_target_type_and_target_id'
+    add_index 'notifications', ["target_type", "target_id"], name: 'index_notifications_on_target_type_and_target_id', length: {"target_type"=>190}, using: :btree
   end
 end

--- a/db/migrate/20150106050733_set_mysql_to_unicode_mb4.rb
+++ b/db/migrate/20150106050733_set_mysql_to_unicode_mb4.rb
@@ -1,0 +1,38 @@
+class SetMysqlToUnicodeMb4 < ActiveRecord::Migration
+
+  UTF8_PAIRS = {
+    'comments': 'text',
+    'messages': 'text',
+    'poll_answers': 'answer',
+    'polls': 'question',
+    'posts': 'text',
+  }
+
+  def self.up
+    if ENV['DB'] == 'mysql'
+      execute "ALTER DATABASE `#{ActiveRecord::Base.connection.current_database}` CHARACTER SET utf8mb4;"
+
+      ActiveRecord::Base.connection.tables.each do |table|
+        execute "ALTER TABLE `#{table}` CHARACTER SET = utf8mb4;"
+      end
+
+      UTF8_PAIRS.each do |table, col|
+        execute "ALTER TABLE `#{table}` CHANGE `#{col}` `#{col}` TEXT  CHARACTER SET utf8mb4  NULL;"
+      end
+    end
+  end
+
+  def self.down
+    if ENV['DB'] == 'mysql'
+      execute "ALTER DATABASE `#{ActiveRecord::Base.connection.current_database}` CHARACTER SET utf8;"
+
+      ActiveRecord::Base.connection.tables.each do |table|
+        execute "ALTER TABLE `#{table}` CHARACTER SET = utf8;"
+      end
+
+      UTF8_PAIRS.each do |table, col|
+        execute "ALTER TABLE `#{table}` CHANGE `#{col}` `#{col}` TEXT  CHARACTER SET utf8  NULL;"
+      end
+    end
+  end
+end

--- a/db/migrate/20150106050733_set_mysql_to_unicode_mb4.rb
+++ b/db/migrate/20150106050733_set_mysql_to_unicode_mb4.rb
@@ -1,40 +1,43 @@
 class SetMysqlToUnicodeMb4 < ActiveRecord::Migration
-
+  # Converts the tables and strings columns to utf8mb4, which is the true, full
+  # unicode support in MySQl
   UTF8_PAIRS = {}
   tables = ActiveRecord::Base.connection.tables
 
   tables.each do |table|
     ActiveRecord::Base.connection.columns(table).each do |column|
       # build a hash with all the columns that contain text
-      UTF8_PAIRS[table] = column.name if (column.type == :string) || (column.type == :text)
+      if (column.type == :string) || (column.type == :text)
+        UTF8_PAIRS[table] = { :name => column.name, :type => column.sql_type }
+      end
     end
   end
 
   def self.up
-    if AppConfig.mysql?
-      execute "ALTER DATABASE `#{ActiveRecord::Base.connection.current_database}` CHARACTER SET utf8mb4;"
-
-      tables.each do |table|
-        execute "ALTER TABLE `#{table}` CHARACTER SET = utf8mb4;"
-      end
-
-      UTF8_PAIRS.each do |table, col|
-        execute "ALTER TABLE `#{table}` CHANGE `#{col}` `#{col}` TEXT  CHARACTER SET utf8mb4  NULL;"
-      end
-    end
+    # these will only affect tables on InnoDB, and only on rows with the dynamic
+    # format
+    execute "SET global innodb_file_format = BARRACUDA;"
+    execute "SET global innodb_large_prefix = 1;"
+    execute "SET global innodb_file_per_table = 1;"
+    change_encoding('utf8mb4', 'ENGINE=InnoDB ROW_FORMAT=DYNAMIC') if AppConfig.mysql?
   end
 
   def self.down
-    if AppConfig.mysql?
-      execute "ALTER DATABASE `#{ActiveRecord::Base.connection.current_database}` CHARACTER SET utf8;"
+    # let MySQL pick the default engine
+    change_encoding('utf8', '') if AppConfig.mysql?
+  end
 
-      tables.each do |table|
-        execute "ALTER TABLE `#{table}` CHARACTER SET = utf8;"
-      end
+  def change_encoding(encoding, engine)
+    execute "ALTER DATABASE `#{ActiveRecord::Base.connection.current_database}` CHARACTER SET #{encoding};"
 
-      UTF8_PAIRS.each do |table, col|
-        execute "ALTER TABLE `#{table}` CHANGE `#{col}` `#{col}` TEXT  CHARACTER SET utf8  NULL;"
-      end
+    tables.each do |table|
+      execute "ALTER TABLE `#{table}` CHARACTER SET = #{encoding} #{engine};"
+    end
+
+    UTF8_PAIRS.each do |table, column|
+      name = column[:name]
+      type = column[:type]
+      execute "ALTER TABLE `#{table}` CHANGE `#{name}` `#{name}` #{type}  CHARACTER SET #{encoding} NULL;"
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150106050733) do
+ActiveRecord::Schema.define(version: 20150106050734) do
 
   create_table "account_deletions", force: true do |t|
     t.string   "diaspora_handle"
@@ -66,7 +66,6 @@ ActiveRecord::Schema.define(version: 20150106050733) do
     t.string  "name"
     t.string  "ask",          limit: 128
     t.string  "subscription", limit: 128, null: false
-    t.text    "groups"
   end
 
   add_index "chat_contacts", ["user_id", "jid"], name: "index_chat_contacts_on_user_id_and_jid", unique: true, using: :btree
@@ -242,7 +241,7 @@ ActiveRecord::Schema.define(version: 20150106050733) do
     t.text   "data",              null: false
   end
 
-  add_index "o_embed_caches", ["url"], name: "index_o_embed_caches_on_url", using: :btree
+  add_index "o_embed_caches", ["url"], name: "index_o_embed_caches_on_url", length: {"url"=>255}, using: :btree
 
   create_table "open_graph_caches", force: true do |t|
     t.string "title"
@@ -430,11 +429,11 @@ ActiveRecord::Schema.define(version: 20150106050733) do
 
   create_table "reports", force: true do |t|
     t.integer  "item_id",                    null: false
+    t.string   "item_type",                  null: false
     t.boolean  "reviewed",   default: false
     t.text     "text"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "item_type",                  null: false
     t.integer  "user_id",                    null: false
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141230214830) do
+ActiveRecord::Schema.define(version: 20150106050733) do
 
   create_table "account_deletions", force: true do |t|
     t.string   "diaspora_handle"
@@ -66,6 +66,7 @@ ActiveRecord::Schema.define(version: 20141230214830) do
     t.string  "name"
     t.string  "ask",          limit: 128
     t.string  "subscription", limit: 128, null: false
+    t.text    "groups"
   end
 
   add_index "chat_contacts", ["user_id", "jid"], name: "index_chat_contacts_on_user_id_and_jid", unique: true, using: :btree
@@ -241,7 +242,7 @@ ActiveRecord::Schema.define(version: 20141230214830) do
     t.text   "data",              null: false
   end
 
-  add_index "o_embed_caches", ["url"], name: "index_o_embed_caches_on_url", length: {"url"=>255}, using: :btree
+  add_index "o_embed_caches", ["url"], name: "index_o_embed_caches_on_url", using: :btree
 
   create_table "open_graph_caches", force: true do |t|
     t.string "title"
@@ -429,11 +430,11 @@ ActiveRecord::Schema.define(version: 20141230214830) do
 
   create_table "reports", force: true do |t|
     t.integer  "item_id",                    null: false
-    t.string   "item_type",                  null: false
     t.boolean  "reviewed",   default: false
     t.text     "text"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "item_type",                  null: false
     t.integer  "user_id",                    null: false
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,7 +14,7 @@
 ActiveRecord::Schema.define(version: 20150106050733) do
 
   create_table "account_deletions", force: true do |t|
-    t.text     "diaspora_handle"
+    t.string   "diaspora_handle"
     t.integer  "person_id"
     t.datetime "completed_at"
   end
@@ -31,19 +31,19 @@ ActiveRecord::Schema.define(version: 20150106050733) do
   add_index "aspect_memberships", ["contact_id"], name: "index_aspect_memberships_on_contact_id", using: :btree
 
   create_table "aspect_visibilities", force: true do |t|
-    t.integer  "shareable_id",   null: false
-    t.integer  "aspect_id",      null: false
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
-    t.string   "shareable_type"
+    t.integer  "shareable_id",                    null: false
+    t.integer  "aspect_id",                       null: false
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
+    t.string   "shareable_type", default: "Post", null: false
   end
 
   add_index "aspect_visibilities", ["aspect_id"], name: "index_aspect_visibilities_on_aspect_id", using: :btree
-  add_index "aspect_visibilities", ["shareable_id", "shareable_type", "aspect_id"], name: "shareable_and_aspect_id", using: :btree
-  add_index "aspect_visibilities", ["shareable_id", "shareable_type"], name: "index_aspect_visibilities_on_shareable_id_and_shareable_type", using: :btree
+  add_index "aspect_visibilities", ["shareable_id", "shareable_type", "aspect_id"], name: "shareable_and_aspect_id", length: {"shareable_id"=>nil, "shareable_type"=>189, "aspect_id"=>nil}, using: :btree
+  add_index "aspect_visibilities", ["shareable_id", "shareable_type"], name: "index_aspect_visibilities_on_shareable_id_and_shareable_type", length: {"shareable_id"=>nil, "shareable_type"=>190}, using: :btree
 
   create_table "aspects", force: true do |t|
-    t.string   "name"
+    t.string   "name",                             null: false
     t.integer  "user_id",                          null: false
     t.datetime "created_at",                       null: false
     t.datetime "updated_at",                       null: false
@@ -65,16 +65,16 @@ ActiveRecord::Schema.define(version: 20150106050733) do
     t.string  "jid",                      null: false
     t.string  "name"
     t.string  "ask",          limit: 128
-    t.string  "subscription", limit: 128
+    t.string  "subscription", limit: 128, null: false
   end
 
-  add_index "chat_contacts", ["user_id", "jid"], name: "index_chat_contacts_on_user_id_and_jid", unique: true, using: :btree
+  add_index "chat_contacts", ["user_id", "jid"], name: "index_chat_contacts_on_user_id_and_jid", unique: true, length: {"user_id"=>nil, "jid"=>190}, using: :btree
 
   create_table "chat_fragments", force: true do |t|
     t.integer "user_id",               null: false
     t.string  "root",      limit: 256, null: false
     t.string  "namespace", limit: 256, null: false
-    t.text    "xml"
+    t.text    "xml",                   null: false
   end
 
   add_index "chat_fragments", ["user_id"], name: "index_chat_fragments_on_user_id", unique: true, using: :btree
@@ -82,26 +82,26 @@ ActiveRecord::Schema.define(version: 20150106050733) do
   create_table "chat_offline_messages", force: true do |t|
     t.string   "from",       null: false
     t.string   "to",         null: false
-    t.text     "message"
+    t.text     "message",    null: false
     t.datetime "created_at", null: false
   end
 
   create_table "comments", force: true do |t|
-    t.text     "text",                                           null: false
-    t.integer  "commentable_id",                                 null: false
-    t.integer  "author_id",                                      null: false
-    t.string   "guid",                                           null: false
+    t.text     "text",                                                null: false
+    t.integer  "commentable_id",                                      null: false
+    t.integer  "author_id",                                           null: false
+    t.string   "guid",                                                null: false
     t.text     "author_signature"
     t.text     "parent_author_signature"
-    t.datetime "created_at",                                     null: false
-    t.datetime "updated_at",                                     null: false
-    t.integer  "likes_count",                        default: 0, null: false
-    t.string   "commentable_type",        limit: 60
+    t.datetime "created_at",                                          null: false
+    t.datetime "updated_at",                                          null: false
+    t.integer  "likes_count",                        default: 0,      null: false
+    t.string   "commentable_type",        limit: 60, default: "Post", null: false
   end
 
   add_index "comments", ["author_id"], name: "index_comments_on_person_id", using: :btree
   add_index "comments", ["commentable_id", "commentable_type"], name: "index_comments_on_commentable_id_and_commentable_type", using: :btree
-  add_index "comments", ["guid"], name: "index_comments_on_guid", unique: true, using: :btree
+  add_index "comments", ["guid"], name: "index_comments_on_guid", unique: true, length: {"guid"=>191}, using: :btree
 
   create_table "contacts", force: true do |t|
     t.integer  "user_id",                    null: false
@@ -129,7 +129,7 @@ ActiveRecord::Schema.define(version: 20150106050733) do
 
   create_table "conversations", force: true do |t|
     t.string   "subject"
-    t.string   "guid"
+    t.string   "guid",       null: false
     t.integer  "author_id",  null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -155,7 +155,7 @@ ActiveRecord::Schema.define(version: 20150106050733) do
     t.string   "service"
     t.string   "identifier"
     t.boolean  "admin",        default: false
-    t.string   "language"
+    t.string   "language",     default: "en"
   end
 
   add_index "invitations", ["aspect_id"], name: "index_invitations_on_aspect_id", using: :btree
@@ -171,11 +171,11 @@ ActiveRecord::Schema.define(version: 20150106050733) do
     t.text     "parent_author_signature"
     t.datetime "created_at",                                        null: false
     t.datetime "updated_at",                                        null: false
-    t.string   "target_type",             limit: 60
+    t.string   "target_type",             limit: 60,                null: false
   end
 
   add_index "likes", ["author_id"], name: "likes_author_id_fk", using: :btree
-  add_index "likes", ["guid"], name: "index_likes_on_guid", unique: true, using: :btree
+  add_index "likes", ["guid"], name: "index_likes_on_guid", unique: true, length: {"guid"=>191}, using: :btree
   add_index "likes", ["target_id", "author_id", "target_type"], name: "index_likes_on_target_id_and_author_id_and_target_type", unique: true, using: :btree
   add_index "likes", ["target_id"], name: "index_likes_on_post_id", using: :btree
 
@@ -234,14 +234,14 @@ ActiveRecord::Schema.define(version: 20150106050733) do
 
   add_index "notifications", ["recipient_id"], name: "index_notifications_on_recipient_id", using: :btree
   add_index "notifications", ["target_id"], name: "index_notifications_on_target_id", using: :btree
-  add_index "notifications", ["target_type", "target_id"], name: "index_notifications_on_target_type_and_target_id", using: :btree
+  add_index "notifications", ["target_type", "target_id"], name: "index_notifications_on_target_type_and_target_id", length: {"target_type"=>190, "target_id"=>nil}, using: :btree
 
   create_table "o_embed_caches", force: true do |t|
     t.string "url",  limit: 1024, null: false
-    t.text   "data"
+    t.text   "data",              null: false
   end
 
-  add_index "o_embed_caches", ["url"], name: "index_o_embed_caches_on_url", length: {"url"=>255}, using: :btree
+  add_index "o_embed_caches", ["url"], name: "index_o_embed_caches_on_url", length: {"url"=>191}, using: :btree
 
   create_table "open_graph_caches", force: true do |t|
     t.string "title"
@@ -262,14 +262,14 @@ ActiveRecord::Schema.define(version: 20150106050733) do
     t.datetime "updated_at",                         null: false
   end
 
-  add_index "participations", ["guid"], name: "index_participations_on_guid", using: :btree
+  add_index "participations", ["guid"], name: "index_participations_on_guid", length: {"guid"=>191}, using: :btree
   add_index "participations", ["target_id", "target_type", "author_id"], name: "index_participations_on_target_id_and_target_type_and_author_id", using: :btree
 
   create_table "people", force: true do |t|
     t.string   "guid",                                  null: false
     t.text     "url",                                   null: false
     t.string   "diaspora_handle",                       null: false
-    t.text     "serialized_public_key"
+    t.text     "serialized_public_key",                 null: false
     t.integer  "owner_id"
     t.datetime "created_at",                            null: false
     t.datetime "updated_at",                            null: false
@@ -277,8 +277,8 @@ ActiveRecord::Schema.define(version: 20150106050733) do
     t.integer  "fetch_status",          default: 0
   end
 
-  add_index "people", ["diaspora_handle"], name: "index_people_on_diaspora_handle", unique: true, using: :btree
-  add_index "people", ["guid"], name: "index_people_on_guid", unique: true, using: :btree
+  add_index "people", ["diaspora_handle"], name: "index_people_on_diaspora_handle", unique: true, length: {"diaspora_handle"=>191}, using: :btree
+  add_index "people", ["guid"], name: "index_people_on_guid", unique: true, length: {"guid"=>191}, using: :btree
   add_index "people", ["owner_id"], name: "index_people_on_owner_id", unique: true, using: :btree
 
   create_table "photos", force: true do |t|
@@ -302,7 +302,7 @@ ActiveRecord::Schema.define(version: 20150106050733) do
     t.integer  "width"
   end
 
-  add_index "photos", ["status_message_guid"], name: "index_photos_on_status_message_guid", using: :btree
+  add_index "photos", ["status_message_guid"], name: "index_photos_on_status_message_guid", length: {"status_message_guid"=>191}, using: :btree
 
   create_table "pods", force: true do |t|
     t.string   "host"
@@ -381,14 +381,14 @@ ActiveRecord::Schema.define(version: 20150106050733) do
     t.text     "tumblr_ids"
   end
 
-  add_index "posts", ["author_id", "root_guid"], name: "index_posts_on_author_id_and_root_guid", unique: true, using: :btree
+  add_index "posts", ["author_id", "root_guid"], name: "index_posts_on_author_id_and_root_guid", unique: true, length: {"author_id"=>nil, "root_guid"=>190}, using: :btree
   add_index "posts", ["author_id"], name: "index_posts_on_person_id", using: :btree
-  add_index "posts", ["guid"], name: "index_posts_on_guid", unique: true, using: :btree
+  add_index "posts", ["guid"], name: "index_posts_on_guid", unique: true, length: {"guid"=>191}, using: :btree
   add_index "posts", ["id", "type", "created_at"], name: "index_posts_on_id_and_type_and_created_at", using: :btree
-  add_index "posts", ["root_guid"], name: "index_posts_on_root_guid", using: :btree
-  add_index "posts", ["status_message_guid", "pending"], name: "index_posts_on_status_message_guid_and_pending", using: :btree
-  add_index "posts", ["status_message_guid"], name: "index_posts_on_status_message_guid", using: :btree
-  add_index "posts", ["tweet_id"], name: "index_posts_on_tweet_id", using: :btree
+  add_index "posts", ["root_guid"], name: "index_posts_on_root_guid", length: {"root_guid"=>191}, using: :btree
+  add_index "posts", ["status_message_guid", "pending"], name: "index_posts_on_status_message_guid_and_pending", length: {"status_message_guid"=>190, "pending"=>nil}, using: :btree
+  add_index "posts", ["status_message_guid"], name: "index_posts_on_status_message_guid", length: {"status_message_guid"=>191}, using: :btree
+  add_index "posts", ["tweet_id"], name: "index_posts_on_tweet_id", length: {"tweet_id"=>191}, using: :btree
   add_index "posts", ["type", "pending", "id"], name: "index_posts_on_type_and_pending_and_id", using: :btree
 
   create_table "profiles", force: true do |t|
@@ -425,7 +425,7 @@ ActiveRecord::Schema.define(version: 20150106050733) do
     t.datetime "updated_at",           null: false
   end
 
-  add_index "rails_admin_histories", ["item", "table", "month", "year"], name: "index_rails_admin_histories", using: :btree
+  add_index "rails_admin_histories", ["item", "table", "month", "year"], name: "index_rails_admin_histories", length: {"item"=>nil, "table"=>188, "month"=>nil, "year"=>nil}, using: :btree
 
   create_table "reports", force: true do |t|
     t.integer  "item_id",                    null: false
@@ -457,16 +457,16 @@ ActiveRecord::Schema.define(version: 20150106050733) do
     t.datetime "updated_at",                null: false
   end
 
-  add_index "services", ["type", "uid"], name: "index_services_on_type_and_uid", using: :btree
+  add_index "services", ["type", "uid"], name: "index_services_on_type_and_uid", length: {"type"=>64, "uid"=>nil}, using: :btree
   add_index "services", ["user_id"], name: "index_services_on_user_id", using: :btree
 
   create_table "share_visibilities", force: true do |t|
-    t.integer  "shareable_id",                              null: false
-    t.datetime "created_at",                                null: false
-    t.datetime "updated_at",                                null: false
-    t.boolean  "hidden",                    default: false, null: false
-    t.integer  "contact_id",                                null: false
-    t.string   "shareable_type", limit: 60
+    t.integer  "shareable_id",                               null: false
+    t.datetime "created_at",                                 null: false
+    t.datetime "updated_at",                                 null: false
+    t.boolean  "hidden",                    default: false,  null: false
+    t.integer  "contact_id",                                 null: false
+    t.string   "shareable_type", limit: 60, default: "Post", null: false
   end
 
   add_index "share_visibilities", ["contact_id"], name: "index_post_visibilities_on_contact_id", using: :btree
@@ -506,7 +506,7 @@ ActiveRecord::Schema.define(version: 20150106050733) do
 
   add_index "taggings", ["created_at"], name: "index_taggings_on_created_at", using: :btree
   add_index "taggings", ["tag_id"], name: "index_taggings_on_tag_id", using: :btree
-  add_index "taggings", ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context", using: :btree
+  add_index "taggings", ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context", length: {"taggable_id"=>nil, "taggable_type"=>95, "context"=>95}, using: :btree
   add_index "taggings", ["taggable_id", "taggable_type", "tag_id"], name: "index_taggings_uniquely", unique: true, using: :btree
 
   create_table "tags", force: true do |t|
@@ -514,7 +514,7 @@ ActiveRecord::Schema.define(version: 20150106050733) do
     t.integer "taggings_count", default: 0
   end
 
-  add_index "tags", ["name"], name: "index_tags_on_name", unique: true, using: :btree
+  add_index "tags", ["name"], name: "index_tags_on_name", unique: true, length: {"name"=>191}, using: :btree
 
   create_table "user_preferences", force: true do |t|
     t.string   "email_type"
@@ -558,17 +558,17 @@ ActiveRecord::Schema.define(version: 20150106050733) do
     t.datetime "reset_password_sent_at"
     t.datetime "last_seen"
     t.datetime "remove_after"
-    t.boolean  "strip_exif",                                     default: true
     t.string   "export"
     t.datetime "exported_at"
     t.boolean  "exporting",                                      default: false
+    t.boolean  "strip_exif",                                     default: true
   end
 
   add_index "users", ["authentication_token"], name: "index_users_on_authentication_token", unique: true, using: :btree
-  add_index "users", ["email"], name: "index_users_on_email", using: :btree
-  add_index "users", ["invitation_service", "invitation_identifier"], name: "index_users_on_invitation_service_and_invitation_identifier", unique: true, using: :btree
+  add_index "users", ["email"], name: "index_users_on_email", length: {"email"=>191}, using: :btree
+  add_index "users", ["invitation_service", "invitation_identifier"], name: "index_users_on_invitation_service_and_invitation_identifier", unique: true, length: {"invitation_service"=>64, "invitation_identifier"=>nil}, using: :btree
   add_index "users", ["invitation_token"], name: "index_users_on_invitation_token", using: :btree
-  add_index "users", ["username"], name: "index_users_on_username", unique: true, using: :btree
+  add_index "users", ["username"], name: "index_users_on_username", unique: true, length: {"username"=>191}, using: :btree
 
   add_foreign_key "aspect_memberships", "aspects", name: "aspect_memberships_aspect_id_fk", dependent: :delete
   add_foreign_key "aspect_memberships", "contacts", name: "aspect_memberships_contact_id_fk", dependent: :delete

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150106050734) do
+ActiveRecord::Schema.define(version: 20150106050733) do
 
   create_table "account_deletions", force: true do |t|
-    t.string   "diaspora_handle"
+    t.text     "diaspora_handle"
     t.integer  "person_id"
     t.datetime "completed_at"
   end
@@ -31,11 +31,11 @@ ActiveRecord::Schema.define(version: 20150106050734) do
   add_index "aspect_memberships", ["contact_id"], name: "index_aspect_memberships_on_contact_id", using: :btree
 
   create_table "aspect_visibilities", force: true do |t|
-    t.integer  "shareable_id",                    null: false
-    t.integer  "aspect_id",                       null: false
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
-    t.string   "shareable_type", default: "Post", null: false
+    t.integer  "shareable_id",   null: false
+    t.integer  "aspect_id",      null: false
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+    t.string   "shareable_type"
   end
 
   add_index "aspect_visibilities", ["aspect_id"], name: "index_aspect_visibilities_on_aspect_id", using: :btree
@@ -43,7 +43,7 @@ ActiveRecord::Schema.define(version: 20150106050734) do
   add_index "aspect_visibilities", ["shareable_id", "shareable_type"], name: "index_aspect_visibilities_on_shareable_id_and_shareable_type", using: :btree
 
   create_table "aspects", force: true do |t|
-    t.string   "name",                             null: false
+    t.string   "name"
     t.integer  "user_id",                          null: false
     t.datetime "created_at",                       null: false
     t.datetime "updated_at",                       null: false
@@ -65,7 +65,7 @@ ActiveRecord::Schema.define(version: 20150106050734) do
     t.string  "jid",                      null: false
     t.string  "name"
     t.string  "ask",          limit: 128
-    t.string  "subscription", limit: 128, null: false
+    t.string  "subscription", limit: 128
   end
 
   add_index "chat_contacts", ["user_id", "jid"], name: "index_chat_contacts_on_user_id_and_jid", unique: true, using: :btree
@@ -74,7 +74,7 @@ ActiveRecord::Schema.define(version: 20150106050734) do
     t.integer "user_id",               null: false
     t.string  "root",      limit: 256, null: false
     t.string  "namespace", limit: 256, null: false
-    t.text    "xml",                   null: false
+    t.text    "xml"
   end
 
   add_index "chat_fragments", ["user_id"], name: "index_chat_fragments_on_user_id", unique: true, using: :btree
@@ -82,21 +82,21 @@ ActiveRecord::Schema.define(version: 20150106050734) do
   create_table "chat_offline_messages", force: true do |t|
     t.string   "from",       null: false
     t.string   "to",         null: false
-    t.text     "message",    null: false
+    t.text     "message"
     t.datetime "created_at", null: false
   end
 
   create_table "comments", force: true do |t|
-    t.text     "text",                                                null: false
-    t.integer  "commentable_id",                                      null: false
-    t.integer  "author_id",                                           null: false
-    t.string   "guid",                                                null: false
+    t.text     "text",                                           null: false
+    t.integer  "commentable_id",                                 null: false
+    t.integer  "author_id",                                      null: false
+    t.string   "guid",                                           null: false
     t.text     "author_signature"
     t.text     "parent_author_signature"
-    t.datetime "created_at",                                          null: false
-    t.datetime "updated_at",                                          null: false
-    t.integer  "likes_count",                        default: 0,      null: false
-    t.string   "commentable_type",        limit: 60, default: "Post", null: false
+    t.datetime "created_at",                                     null: false
+    t.datetime "updated_at",                                     null: false
+    t.integer  "likes_count",                        default: 0, null: false
+    t.string   "commentable_type",        limit: 60
   end
 
   add_index "comments", ["author_id"], name: "index_comments_on_person_id", using: :btree
@@ -129,7 +129,7 @@ ActiveRecord::Schema.define(version: 20150106050734) do
 
   create_table "conversations", force: true do |t|
     t.string   "subject"
-    t.string   "guid",       null: false
+    t.string   "guid"
     t.integer  "author_id",  null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -155,7 +155,7 @@ ActiveRecord::Schema.define(version: 20150106050734) do
     t.string   "service"
     t.string   "identifier"
     t.boolean  "admin",        default: false
-    t.string   "language",     default: "en"
+    t.string   "language"
   end
 
   add_index "invitations", ["aspect_id"], name: "index_invitations_on_aspect_id", using: :btree
@@ -171,7 +171,7 @@ ActiveRecord::Schema.define(version: 20150106050734) do
     t.text     "parent_author_signature"
     t.datetime "created_at",                                        null: false
     t.datetime "updated_at",                                        null: false
-    t.string   "target_type",             limit: 60,                null: false
+    t.string   "target_type",             limit: 60
   end
 
   add_index "likes", ["author_id"], name: "likes_author_id_fk", using: :btree
@@ -238,7 +238,7 @@ ActiveRecord::Schema.define(version: 20150106050734) do
 
   create_table "o_embed_caches", force: true do |t|
     t.string "url",  limit: 1024, null: false
-    t.text   "data",              null: false
+    t.text   "data"
   end
 
   add_index "o_embed_caches", ["url"], name: "index_o_embed_caches_on_url", length: {"url"=>255}, using: :btree
@@ -269,7 +269,7 @@ ActiveRecord::Schema.define(version: 20150106050734) do
     t.string   "guid",                                  null: false
     t.text     "url",                                   null: false
     t.string   "diaspora_handle",                       null: false
-    t.text     "serialized_public_key",                 null: false
+    t.text     "serialized_public_key"
     t.integer  "owner_id"
     t.datetime "created_at",                            null: false
     t.datetime "updated_at",                            null: false
@@ -461,12 +461,12 @@ ActiveRecord::Schema.define(version: 20150106050734) do
   add_index "services", ["user_id"], name: "index_services_on_user_id", using: :btree
 
   create_table "share_visibilities", force: true do |t|
-    t.integer  "shareable_id",                               null: false
-    t.datetime "created_at",                                 null: false
-    t.datetime "updated_at",                                 null: false
-    t.boolean  "hidden",                    default: false,  null: false
-    t.integer  "contact_id",                                 null: false
-    t.string   "shareable_type", limit: 60, default: "Post", null: false
+    t.integer  "shareable_id",                              null: false
+    t.datetime "created_at",                                null: false
+    t.datetime "updated_at",                                null: false
+    t.boolean  "hidden",                    default: false, null: false
+    t.integer  "contact_id",                                null: false
+    t.string   "shareable_type", limit: 60
   end
 
   add_index "share_visibilities", ["contact_id"], name: "index_post_visibilities_on_contact_id", using: :btree

--- a/lib/configuration_methods.rb
+++ b/lib/configuration_methods.rb
@@ -119,8 +119,11 @@ module Configuration
     end
 
     def postgres?
-      defined?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter) &&
-      ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
+      ActiveRecord::Base.connection.adapter_name == "PostgreSQL"
+    end
+
+    def mysql?
+      ActiveRecord::Base.connection.adapter_name == "Mysql2"
     end
 
     def bitcoin_donation_address


### PR DESCRIPTION
This will make Diaspora\* running on postgres and on mysql behave consistently: in the postgres version, you can use 4-byte UTF8, or full UTF8. In MySQL `utf8` == the 3 byte subset of UTF8, while `utf8mb4` is the true, full UTF8 encoding.
