### PR TITLE
Remove CSS vendor prefixes and switch to autoprefixer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem 'rack-cors', '0.2.9', :require => 'rack/cors'
 gem 'bootstrap-sass', '2.3.2.2'
 gem 'compass-rails',  '2.0.0'
 gem 'sass-rails',     '4.0.4'
-gem 'autoprefixer-rails'
+gem 'autoprefixer-rails', '4.0.2.1'
 
 # Database
 

--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem 'rack-cors', '0.2.9', :require => 'rack/cors'
 gem 'bootstrap-sass', '2.3.2.2'
 gem 'compass-rails',  '2.0.0'
 gem 'sass-rails',     '4.0.4'
+gem 'autoprefixer-rails'
 
 # Database
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -615,7 +615,7 @@ DEPENDENCIES
   acts_as_api (= 0.4.2)
   addressable (= 2.3.6)
   asset_sync (= 1.1.0)
-  autoprefixer-rails
+  autoprefixer-rails (= 4.0.2.1)
   backbone-on-rails (= 1.1.2)
   bootstrap-sass (= 2.3.2.2)
   capybara (= 2.4.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,8 @@ GEM
       activemodel
       fog (>= 1.8.0)
       unf
+    autoprefixer-rails (4.0.2.1)
+      execjs
     backbone-on-rails (1.1.2.0)
       actionmailer
       actionpack
@@ -159,7 +161,7 @@ GEM
     erubis (2.7.0)
     ethon (0.7.1)
       ffi (>= 1.3.0)
-    eventmachine (1.0.3)
+    eventmachine (1.0.4)
     excon (0.41.0)
     execjs (2.2.2)
     factory_girl (4.5.0)
@@ -613,6 +615,7 @@ DEPENDENCIES
   acts_as_api (= 0.4.2)
   addressable (= 2.3.6)
   asset_sync (= 1.1.0)
+  autoprefixer-rails
   backbone-on-rails (= 1.1.2)
   bootstrap-sass (= 2.3.2.2)
   capybara (= 2.4.4)

--- a/app/assets/stylesheets/_flash_messages.scss
+++ b/app/assets/stylesheets/_flash_messages.scss
@@ -18,8 +18,7 @@
   }
 
   .message {
-    @include border-radius(6px);
-    @include box-shadow(0, 1px, 4px, rgba(0,0,0,0.8));
+    box-shadow: 0 1px 4px rgba(0,0,0,0.8);
 
     display : inline-block;
     padding: 10px 12px;
@@ -29,6 +28,7 @@
     color : #fff;
     background-color : rgba(0,0,0,0.8);
     border : 1px solid rgba(255,255,255,0.7);
+    border-radius: 6px;
 
     font-weight: bold;
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;

--- a/app/assets/stylesheets/_mixins.css.scss
+++ b/app/assets/stylesheets/_mixins.css.scss
@@ -8,15 +8,6 @@ $easing: linear;
 $default-border-radius: 3px;
 
 /* Style includes */
-@mixin border-radius($tl:$default-border-radius, $tr:$tl, $br:$tl, $bl:$tl){
-  -moz-border-radius: $tl $tr $br $bl;
-  -webkit-border-radius: $tl $tr $br $bl;
-  border-radius: $tl $tr $br $bl;
-}
-
-@mixin dropdown-shadow{
-  @include box-shadow(0,0px,13px,rgba(20,20,20,0.5))
-}
 
 @mixin button-gradient($color){
   @include linear-gradient(lighten($color,20%), $color);
@@ -30,65 +21,34 @@ $default-border-radius: 3px;
   @include linear-gradient(lighten($color,20%), darken($color,15%));
 }
 
-/* Browser compatability */
-@mixin box-shadow($left, $top, $blur, $color:#000){
-  -webkit-box-shadow: $left $top $blur $color;
-  -moz-box-shadow: $left $top $blur $color;
-  box-shadow: $left $top $blur $color;
-}
 
 @mixin linear-gradient($from, $to, $start:0%, $end:100%){
-  background-image: mix($from,$to);
+  background: mix($from,$to);
 
   filter: progid:DXImageTransform.Microsoft.gradient(GradientType=0, startColorstr=$from, endColorstr=$to);
   -ms-filter: "progid:DXImageTransform.Microsoft.gradient (GradientType=0, startColorstr=#{$from}, endColorstr=#{$to})";
 
-  background-image: -webkit-gradient(linear, 0% $start, 0% $end, from($from), to($to));
+  background-image: gradient(linear, 0% $start, 0% $end, from($from), to($to));
   background-image: -moz-linear-gradient(top, $from $start, $to $end);
-  background-image: -o-linear-gradient(top, $from $start, $to $end);
+  background-image: linear-gradient(top, $from $start, $to $end);
 }
 
 @mixin horizontal-linear-gradient($from, $to, $start:0%, $end:100%){
   background-image: mix($from,$to);
-
-  background-image: -moz-linear-gradient(left, $from $start, $to $end);
-  background-image: -o-linear-gradient(left, $from $start, $to $end);
-  background-image: -webkit-linear-gradient(left, $from $start, $to $end);
-  background-image: -ms-linear-gradient(left, $from $start, $to $end);
-  background-image: -khtml-linear-gradient(left, $from $start, $to $end);
+  background-image: linear-gradient(left, $from $start, $to $end);
 }
 
-@mixin opacity($val){
-  filter: alpha(opacity= $val* 100);
-  -moz-opacity: $val;
-  -khtml-opacity: $val;
-  opacity: $val;
-}
-
-@mixin user-select($val){
-  -webkit-user-select: $val;
-  -moz-user-select: $val;
-}
 
 @mixin transition($type, $speed:$speed, $easing:$easing){
-  -webkit-transition : $type $speed $easing;
-     -moz-transition : $type $speed $easing;
-       -o-transition : $type $speed $easing;
-          transition : $type $speed $easing;
+    transition : $type $speed $easing;
 }
 
 @mixin animate($name, $speed:$speed, $occurances:"") {
-  -webkit-animation : $name $speed $occurances;
-     -moz-animation : $name $speed $occurances;
-      -ms-animation : $name $speed $occurances;
-       -o-animation : $name $speed $occurances;
+    animation : $name $speed $occurances;
 }
 
 @mixin animation($name, $speed:0.2s, $easing:ease-in-out) {
-  -webkit-animation: $name $speed $easing;
-  -moz-animation: $name $speed $easing;
-  -ms-animation: $name $speed $easing;
-  -o-animation: $name $speed $easing;
+  animation: $name $speed $easing;
 }
 
 @mixin video-overlay(){
@@ -104,8 +64,8 @@ $default-border-radius: 3px;
       size : 60px 60px;
     }
 
-    @include border-radius(70px, 10px, 10px, 70px);
-    @include box-shadow(0, 0, 32px, rgba(255,255,255,.5));
+    border-radius: 70px 10px 10px 70px;
+    box-shadow: 0 0 32px rgba(255,255,255,.5);
 
     position : absolute;
     top : 50%;
@@ -126,7 +86,7 @@ $default-border-radius: 3px;
     }
 
     & > div > div {
-      @include opacity(1.0);
+      opacity: 1;
       overflow: hidden;
       text-shadow: -1px -1px 0 #000, 0 0 7px #111;
       color: #F0F0F0;
@@ -143,7 +103,7 @@ $default-border-radius: 3px;
       font-size: .94em;
       line-height: 1.3em;
       white-space: nowrap;
-      @include opacity(.9);
+      opacity: 0.9;
 
       a {
         color: lighten($blue, 25%);

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -34,7 +34,6 @@
 
 .media, .bd {
   overflow: hidden;
-  _overflow: visible;
   zoom: 1;
 }
 
@@ -124,8 +123,7 @@ ul > li {
 }
 
 .avatar {
-  -webkit-box-shadow: rgba(0, 0, 0, 0.12) 0px 0px 5px inset;
-  -moz-box-shadow: rgba(0, 0, 0, 0.12) 0px 0px 5px inset;
+  box-shadow: rgba(0, 0, 0, 0.12) 0px 0px 5px inset;
   background: {
     color: $background-grey;
   };
@@ -416,7 +414,7 @@ ul.as-selections {
 
 input:not([type='submit']):not([type='reset']):not([type='hidden']):not(.as-input),
 textarea {
-  @include border-radius(2px);
+  border-radius: 2px;
   background-color: white;
   color: black;
   margin-top: 1px;
@@ -470,11 +468,7 @@ form p.checkbox_select {
 }
 
 /* those can't be combined, see: http://stackoverflow.com/questions/2610497 */
-*::-webkit-input-placeholder {
-  @include placeholder_styles;
-}
-
-*::-moz-placeholder {
+*::input-placeholder {
   @include placeholder_styles;
 }
 
@@ -486,7 +480,7 @@ form p.checkbox_select {
 }
 
 .dim {
-  @include opacity(0.3);
+  opacity: 0.3;
 }
 
 img.thumb_small {
@@ -604,8 +598,7 @@ h2,h3,h4 {
 }
 
 input[type="search"] {
-  -webkit-appearance: textfield;
-  -moz-appearance: textfield;
+  appearance: textfield;
 }
 
 #photo_edit_options {
@@ -657,7 +650,7 @@ input[type="search"] {
 }
 
 .floating {
-  @include box-shadow(0, 1px, 3px, #333333);
+  box-shadow: 0 1px 3px #333333;
   position: relative;
   padding: 12px;
   margin: {
@@ -682,7 +675,7 @@ input[type="search"] {
 
 #user_photo_uploader {
   .avatar {
-    @include border-radius(5px);
+    border-radius: 5px;
     height: 100px;
     width: 100px;
   }
@@ -748,8 +741,6 @@ ul#request_result {
     };
     width: 300px;
     border-radius: 5px 0 0 5px;
-    -webkit-border-radius: 5px 0 0 5px;
-    -moz-border-radius: 5px 0 0 5px;
     position: relative;
     display: inline;
     padding: 12px;
@@ -764,8 +755,6 @@ ul#request_result {
     background: {
       color: $blue;
     };
-    -webkit-border-radius: 0 5px 5px 0;
-    -moz-border-radius: 0 5px 5px 0;
     border-radius: 0 5px 5px 0;
     border: 1px solid #cccccc;
     padding: 12px;
@@ -802,7 +791,7 @@ ul#request_result {
   };
   text-shadow: 0 1px 3px #999999;
   p {
-    @include box-shadow(0, 1px, 3px, #cccccc);
+    box-shadow: 0 1px 3px #cccccc;
     padding: 12px;
     background: {
       color: white;
@@ -988,7 +977,7 @@ ul#press_logos {
 
 .share_with {
   .add_aspect {
-    @include border-radius(5px);
+    border-radius: 5px;
     margin: {
       top: 0.5em;
     };
@@ -1053,7 +1042,7 @@ ul#press_logos {
 }
 
 #contact_visibility_padlock:hover {
-  @include opacity(0.7);
+  opacity: 0.7;
 }
 
 .side_stream {
@@ -1174,7 +1163,7 @@ ul#requested-scopes {
   line-height: 16px;
   text-align: center;
   float: right;
-  @include border-radius(4px);
+  border-radius: 4px;
   margin-top: 1px;
   color: $text-grey;
   background: {
@@ -1233,8 +1222,6 @@ ul.left_nav {
   a.tag_selector,
   a.element_selector {
     &:active {
-      cursor: -webkit-grabbing;
-      cursor: -moz-grabbing;
       cursor: grabbing;
     }
   }
@@ -1250,7 +1237,7 @@ ul.left_nav {
   li.aspect_element,
   a.element_selector {
     &:hover {
-      @include border-radius(2px);
+      border-radius: 2px;
       background: {
         color: lighten($blue, 45%);
       };
@@ -1263,12 +1250,12 @@ ul.left_nav {
     margin-right: 10px;
     margin-top: 4px;
     @include transition(opacity);
-    @include opacity(0.3);
+    opacity: 0.3;
     position: absolute;
     display: none;
     padding: 0 5px;
     &:hover {
-      @include opacity(1);
+      opacity: 1;
     }
   }
   .edit {
@@ -1278,11 +1265,11 @@ ul.left_nav {
     height: 12px;
     margin-top: 6px;
     @include transition(opacity);
-    @include opacity(0.3);
+    opacity: 0.3;
     float: right;
     display: none;
     &:hover {
-      @include opacity(1);
+      opacity: 1;
     }
   }
   ul.sub_nav {
@@ -1356,7 +1343,7 @@ ul.left_nav {
       li.unfollow:hover,
       li.sub_nav_item:hover,
       li.hover {
-        @include border-radius(2px);
+        border-radius: 2px;
         background: {
           color: lighten($blue, 45%);
         };
@@ -1425,8 +1412,8 @@ a.toggle_selector {
 }
 
 .user_card {
-  @include border-radius(3px);
-  @include box-shadow(0, 1px, 5px, #cccccc);
+  border-radius: 3px;
+  box-shadow: 0 1px 5px #cccccc;
   padding: 10px {
     bottom: 30px;
   };
@@ -1536,7 +1523,7 @@ a.toggle_selector {
 }
 
 #grey_header {
-  @include box-shadow(0, 1px, 1px, #eeeeee);
+  box-shadow: 0 1px 1px #eeeeee;
   background: {
     color: #fafafa;
   };
@@ -1565,7 +1552,7 @@ a.toggle_selector {
 .field_with_errors {
   position: relative;
   input {
-    @include box-shadow(0, 0, 8px, lighten(#dd0000, 30%));
+    box-shadow: 0 0 8px lighten(#dd0000, 30%);
     border: 1px solid #dd0000 !important;
   }
 }
@@ -1580,7 +1567,7 @@ a.toggle_selector {
 }
 
 .new_user_form fieldset, .accept_invitation_form fieldset {
-  @include border-radius(3px);
+  border-radius: 3px;
   background: {
     color: white;
     color: rgba(255, 255, 255, 0.95);
@@ -1604,8 +1591,6 @@ a.toggle_selector {
 
 .nostrap,
 .nostrap:focus {
-  -webkit-box-shadow: none;
-  -moz-box-shadow: none;
   box-shadow: none;
 }
 
@@ -1656,8 +1641,7 @@ a.toggle_selector {
 }
 
 #welcome-to-diaspora {
-  -webkit-box-shadow: inset 0 -2px 10px rgba(0, 0, 0, 0.35);
-  -moz-box-shadow: inset 0 -2px 10px rgba(0, 0, 0, 0.35);
+  box-shadow: inset 0 -2px 10px rgba(0, 0, 0, 0.35);
   position: absolute;
   width: 100%;
   left: 0;
@@ -1674,10 +1658,10 @@ a.toggle_selector {
   background: orange;
   &:hover {
     #gs-skip-x {
-      @include opacity(0.4);
+      opacity: 0.4;
       @include transition(opacity, 0.25s);
       &:hover {
-        @include opacity(1);
+        opacity: 1;
       }
     }
   }
@@ -1689,7 +1673,7 @@ a.toggle_selector {
 }
 
 #gs-skip-x {
-  @include opacity(0);
+  opacity: 0;
   @include transition(opacity, 0.25s);
   img {
     position: relative;
@@ -1730,7 +1714,7 @@ a.toggle_selector {
 }
 
 .nsfw-shield {
-  @include border-radius(3px);
+  border-radius: 3px;
   background-color: $background-grey;
   width: 90%;
   padding: 5px 10px;
@@ -1813,8 +1797,6 @@ a.toggle_selector {
     z-index: 5;
   }
   a#hide_location:hover {
-    @include opacity(0);
-    -khtml-opacity: 1;
     opacity: 1;
     cursor: pointer;
   }

--- a/app/assets/stylesheets/autocomplete.css.scss
+++ b/app/assets/stylesheets/autocomplete.css.scss
@@ -6,12 +6,7 @@
   min-width: 300px !important;
   width: 100%;
 
-  -webkit-border-radius: 3px;
-  -moz-border-radius: 3px;
   border-radius: 3px;
-
-  -webkit-box-shadow: 0 1px 3px #999;
-  -moz-box-shadow: 0 1px 3px #999;
   box-shadow: 0 1px 3px #999;
 }
 

--- a/app/assets/stylesheets/bootstrap-fix.css.scss
+++ b/app/assets/stylesheets/bootstrap-fix.css.scss
@@ -1,12 +1,12 @@
 // A temporary fix for broken classes in bootstrap 2.
 // Can probably be removed when migration of bootstrap 3 is done.
 
-input::-moz-placeholder,
-textarea::-moz-placeholder {
+input::placeholder,
+textarea::placeholder {
   color: #999999;
 }
-input::-ms-input-placeholder,
-textarea::-ms-input-placeholder {
+input::input-placeholder,
+textarea::input-placeholder {
   color: #999999;
 }
 

--- a/app/assets/stylesheets/bootstrap-headerfix.scss
+++ b/app/assets/stylesheets/bootstrap-headerfix.scss
@@ -22,7 +22,7 @@ header {
     background: none;
   }
   #notification_badge.active {
-    @include border-radius(0);
+    border-radius: 0;
   }
   #global_search {
     form {

--- a/app/assets/stylesheets/conversations.css.scss
+++ b/app/assets/stylesheets/conversations.css.scss
@@ -67,7 +67,7 @@
     }
 
     .participants_count {
-      @include opacity(0.5);
+      opacity: 0.5;
       &:before { content: '+'; }
       float: left;
       background-color: #fff;
@@ -121,8 +121,6 @@
 #conversation_show {
   .conversation_participants {
     box-shadow: 0 2px 3px -3px #666;
-    -webkit-box-shadow: 0 2px 3px -3px #666;
-    -moz-box-shadow: 0 2px 3px -3px #666;
 
     background-color: $background-white;
     margin-bottom: 5px;

--- a/app/assets/stylesheets/error_pages.css.scss
+++ b/app/assets/stylesheets/error_pages.css.scss
@@ -11,7 +11,7 @@
   color: #ddd;
 }
 .transparent {
-  @include opacity(0.8);
+  opacity: 0.8;
 }
 #content {
   font-family: Roboto, Helvetica, Arial, sans-serif;

--- a/app/assets/stylesheets/footer.css.scss
+++ b/app/assets/stylesheets/footer.css.scss
@@ -31,7 +31,7 @@ footer {
       &.separator {
         margin-left: -.35em;
         margin-right: .65em;
-        @include opacity(.6);
+        opacity: 0.6;
       }
 
       &:last-child {

--- a/app/assets/stylesheets/header.css.scss
+++ b/app/assets/stylesheets/header.css.scss
@@ -4,7 +4,7 @@
 }
 
 body > header {
-  @include box-shadow(0,1px,3px,rgba(0,0,0,0.9));
+  box-shadow: 0 1px 3px rgba(0,0,0,0.9);
   background: image-url('header-bg.png') rgb(40,35,35);
   z-index: 1001;
   padding: 6px 0;
@@ -68,7 +68,7 @@ body > header {
       font-size: smaller;
 
       .badge_count {
-        @include border-radius(2px);
+        border-radius: 2px;
         z-index: 3;
         position: absolute;
         top: -4px;
@@ -118,10 +118,9 @@ body > header {
     }
 
     #notification_dropdown {
-      @include dropdown-shadow;
-
       background: white;
       border: solid $border-dark-grey 1px;
+      box-shadow: 0 0px 13px rgba(20,20,20,0.5);
       left: 300px;
       width: 380px;
       display: none;
@@ -225,8 +224,8 @@ body > header {
       right: 0;
 
       input {
-        @include box-shadow(0, 1px, 1px, #444);
-        @include border-radius(15px);
+        box-shadow: 0 1px 1px #444;
+        border-radius: 15px;
         @include transition(width);
         width: 100px;
         background-color: #444;
@@ -248,8 +247,8 @@ body > header {
           width: 200px;
         }
 
-        &::-webkit-input-placeholder { text-shadow: none; }
-        &::-moz-placeholder { text-shadow: none; }
+        &::input-placeholder { text-shadow: none; }
+        &::placeholder { text-shadow: none; }
         &.ac_loading::-webkit-search-cancel-button { -webkit-appearance: none; }
       }
     }
@@ -286,7 +285,7 @@ body > header {
     }
 
     &.active {
-      @include dropdown-shadow;
+      box-shadow: 0 0px 13px rgba(20,20,20,0.5);
       background-color: rgb(34,30,30);
       visibility: visible;
 
@@ -384,8 +383,8 @@ body > header {
         color: $blue;
 
         &.login {
-          @include border-radius(5px);
-          @include box-shadow(0, 1px, 1px, #666);
+          border-radius: 5px;
+          box-shadow: 0 1px 1px #666;
           padding: 5px 8px;
           background-color: #000;
           border-top: 1px solid #000;

--- a/app/assets/stylesheets/help.css.scss
+++ b/app/assets/stylesheets/help.css.scss
@@ -57,38 +57,38 @@ ul#help_nav {
     text-align: left;
   }
   ul > li {
-    list-style-type: disc !important; 
+    list-style-type: disc !important;
   }
-  
+
   text-align: justify;
 
   .question {
     background-color: rgb(242, 242, 242);
     margin-bottom: 10px;
-    @include border-radius(4px);
+    border-radius: 4px;
     a.toggle {
-      text-decoration: none; 
+      text-decoration: none;
       color: black;
     }
-    h4 { 
+    h4 {
       text-align: left;
       font-weight: 700;
       margin: 0px;
-      padding: 10px 20px;    
+      padding: 10px 20px;
     }
-    
+
     &.collapsed {
-      border: 2px solid rgb(242, 242, 242); 
+      border: 2px solid rgb(242, 242, 242);
     }
-    
-    &.opened { 
+
+    &.opened {
       border: 2px solid rgb(142, 222, 61);
       h4 {
         background-color: rgb(142, 222, 61);
       }
     }
     .answer {
-      @include border-radius(0px, 0px, 4px, 4px);
+      border-radius: 0px 0px 4px 4px;
       background-color: white;
       padding: 10px 20px;
     }

--- a/app/assets/stylesheets/hovercard.css.scss
+++ b/app/assets/stylesheets/hovercard.css.scss
@@ -2,8 +2,8 @@
 @import "_mixins.css.scss";
 
 #hovercard {
-  @include border-radius(2px);
-  @include box-shadow(0, 0, 5px, #666666);
+  border-radius: 2px;
+  box-shadow: 0 0 5px #666666;
 
   position: relative;
   display: inline-block;

--- a/app/assets/stylesheets/lightbox.css.scss
+++ b/app/assets/stylesheets/lightbox.css.scss
@@ -26,7 +26,7 @@
   }
 
   #lightbox-image{
-    @include box-shadow(0, 10px, 20px, black);
+    box-shadow: 0 10px 20px black;
     top: 0;
     display: block;
     margin-bottom: 120px;
@@ -74,8 +74,6 @@
 }
 
 #lightbox-backdrop{
-  -moz-box-shadow:inset 0 0 50px #000000;
-  -webkit-box-shadow:inset 0 0 50px #000000;
   box-shadow:inset 0 0 50px #000000;
 
   z-index: 1002;
@@ -128,8 +126,8 @@
   padding-right: 50px;
 
   img{
-    @include transition(opacity, 0.2s);
-    @include opacity(0.2);
+    transition: opacity 0.2s;
+    opacity: 0.2;
     height: 70px;
     width: 70px;
     margin-right: 5px;
@@ -141,7 +139,7 @@
     }
 
     &.selected{
-      @include opacity(1);
+      opacity: 1;
     }
   }
 }

--- a/app/assets/stylesheets/mentions.css.scss
+++ b/app/assets/stylesheets/mentions.css.scss
@@ -2,7 +2,7 @@
 @import '_mixins.css.scss';
 
 .mentions-input-box {
-  @include border-radius(3px);
+  border-radius: 3px;
 
   background: #fff;
   position: relative;
@@ -37,7 +37,7 @@
       margin: 0;
       padding: 0;
 
-      @include border-radius(0px, 0px, 5px, 5px);
+      border-radius: 0px 0px 5px 5px;
 
       li {
         color: #444;
@@ -54,7 +54,7 @@
         white-space: nowrap;
 
         &:hover, &.active { background: $background-grey; }
-        &:last-child { @include border-radius(0px, 0px, 5px, 5px); }
+        &:last-child { border-radius: 0px 0px 5px 5px; }
 
         img, div.icon {
           float: left;

--- a/app/assets/stylesheets/mobile/header.css.scss
+++ b/app/assets/stylesheets/mobile/header.css.scss
@@ -6,7 +6,7 @@ header {
   top: 0px;
   z-index: 10;
   background: image-url('header-bg-long.jpg') rgb(40,35,35);
-  @include box-shadow(0, 1px, 2px, #333);
+  box-shadow: 0 1px 2px #333;
   border-bottom: 1px solid #222;
 }
 
@@ -40,7 +40,7 @@ header {
     }
 
     .badge_count {
-      @include border-radius(2px);
+      border-radius: 2px;
       z-index: 3;
       position: absolute;
       top: 3px;
@@ -62,12 +62,7 @@ header {
   width: 100%;
   left: 100%;
   background-color: #444;
-
-          box-shadow: -2px 0px 2px 1px #333;
-       -o-box-shadow: -2px 0px 2px 1px #333;
-      -ms-box-shadow: -2px 0px 2px 1px #333;
-     -moz-box-shadow: -2px 0px 2px 1px #333;
-  -webkit-box-shadow: -2px 0px 2px 1px #333;
+  box-shadow: -2px 0px 2px 1px #333;
 
   header {
     position: static;
@@ -83,8 +78,8 @@ header {
         right: 22%;
 
         input {
-          @include box-shadow(0, 1px, 1px, #444);
-          @include border-radius(15px);
+          box-shadow: 0 1px 1px #444;
+          border-radius: 15px;
           width: 100%;
           margin-top: 7px;
           background-color: #444;
@@ -103,8 +98,7 @@ header {
             background-color: white;
           }
 
-          &::-webkit-input-placeholder { text-shadow: none; }
-          &:-moz-placeholder { text-shadow: none; }
+          &:placeholder { text-shadow: none; }
         }
       }
     }
@@ -171,8 +165,4 @@ header {
 /* This class is added when the user open the drawer */
 #app.draw > * {
           transform: translateX(-80%);
-       -o-transform: translateX(-80%);
-      -ms-transform: translateX(-80%);
-     -moz-transform: translateX(-80%);
-  -webkit-transform: translateX(-80%);
 }

--- a/app/assets/stylesheets/mobile/mobile.css.scss
+++ b/app/assets/stylesheets/mobile/mobile.css.scss
@@ -49,11 +49,11 @@ h3 {
   text-align: left;
   padding: 10px 0;
   min-height: 34px;
-  
+
   * { max-width: 100%; }
-  
+
   .avatar {
-    @include border-radius(4px);
+    border-radius: 4px;
 
     float: left;
     height: 35px;
@@ -154,8 +154,8 @@ h3 {
 
 .stream_element,
 #login_form {
-  @include border-radius(5px);
-  @include box-shadow(0, 1px, 2px, rgba(0, 0, 0, 0.2));
+  border-radius: 5px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
 
   background-color: #fff;
   margin-bottom: 10px;
@@ -180,7 +180,7 @@ h3 {
   padding: 0;
   margin: 0;
   img {
-    @include border-radius(3px);
+    border-radius: 3px;
     margin: 0;
     padding: 0; } }
 
@@ -193,7 +193,7 @@ h3 {
 }
 
 .more-link, .no-more-posts {
-  -webkit-box-shadow: inset 0 1px 5px #777, 0 1px 1px rgba(0,0,0,0.4);
+  box-shadow: inset 0 1px 5px #777, 0 1px 1px rgba(0,0,0,0.4);
   display: block;
   text-align: center;
   padding: 0 10px;
@@ -309,8 +309,8 @@ h3 {
   word-wrap: break-word;
 
   img {
-    @include border-radius(4px);
-    
+    border-radius: 4px;
+
     height: 70px;
     width: 70px;
     margin: 10px;
@@ -319,7 +319,7 @@ h3 {
 
   .content {
     padding-left: 90px;
-    
+
     h2 {
       font-size: 20px;
       line-height: 20px;
@@ -334,7 +334,7 @@ h3 {
       color: $text-grey;
     }
   }
-  
+
   .bottom_bar {
     position: static;
   }
@@ -350,7 +350,7 @@ h3 {
 }
 
 .bottom_bar {
-  @include border-radius(0, 0, 5px, 5px);
+  border-radius: 0 0 5px 5px;
   z-index: 3;
   display: block;
   position: relative;
@@ -437,14 +437,14 @@ h3 {
   float: right; }
 
 .stream_element .photo_attachments {
-  @include border-radius(3px, 3px, 0, 0);
+  border-radius: 3px 3px 0 0;
 
   border: {
     bottom: 1px solid #ccc;
   }
 
   img.big-stream-photo {
-    @include border-radius(3px, 3px, 0, 0);
+    border-radius: 3px 3px 0 0;
     width: 100%;
   }
   a {
@@ -453,7 +453,7 @@ h3 {
 }
 
 .photo_area {
-  @include border-radius(3px);
+  border-radius: 3px;
   text-align: center; }
 
 .image_link {
@@ -507,7 +507,7 @@ h3 {
       cursor: pointer;
 
       &.dim {
-        @include opacity(0.6);
+        opacity: 0.6;
       }
     }
   }
@@ -517,8 +517,8 @@ h3 {
   }
 
   textarea {
-    @include border-radius(0);
-    @include box-shadow(0, 2px, 3px, #999);
+    border-radius: 0;
+    box-shadow: 0 2px 3px #999;
     border: none;
     border-bottom: 1px solid $border-dark-grey;
     width: 96%;
@@ -562,7 +562,7 @@ select {
 }
 
 .additional_photo_count {
-  @include opacity(0.5);
+  opacity: 0.5;
 
   position: absolute;
   padding: 3px 8px;
@@ -761,24 +761,17 @@ textarea#conversation_text {
   vertical-align: middle;
   cursor: pointer;
   background-color: #f5f5f5;
-  background-image: -moz-linear-gradient(top, #ffffff, #e6e6e6);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ffffff), to(#e6e6e6));
-  background-image: -webkit-linear-gradient(top, #ffffff, #e6e6e6);
-  background-image: -o-linear-gradient(top, #ffffff, #e6e6e6);
+  background-image: gradient(linear, 0 0, 0 100%, from(#ffffff), to(#e6e6e6));
   background-image: linear-gradient(to bottom, #ffffff, #e6e6e6);
   background-repeat: repeat-x;
   border: 1px solid #cccccc;
   border-color: #e6e6e6 #e6e6e6 #bfbfbf;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
   border-bottom-color: #b3b3b3;
-  -webkit-border-radius: 4px;
-     -moz-border-radius: 4px;
-          border-radius: 4px;
+  border-radius: 4px;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffffff', endColorstr='#ffe6e6e6', GradientType=0);
   filter: progid:DXImageTransform.Microsoft.gradient(enabled=false);
-  -webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
-     -moz-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
-          box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
 }
 
 .button.creation:hover,
@@ -801,10 +794,7 @@ textarea#conversation_text {
   color: #333333;
   text-decoration: none;
   background-position: 0 -15px;
-  -webkit-transition: background-position 0.1s linear;
-     -moz-transition: background-position 0.1s linear;
-       -o-transition: background-position 0.1s linear;
-          transition: background-position 0.1s linear;
+  transition: background-position 0.1s linear;
 }
 
 .button.creation:focus {
@@ -910,8 +900,8 @@ form p.checkbox_select {
   position: relative;
 
   img {
-    @include border-radius(5px);
-    @include box-shadow(0,1px,2px,#666);
+    border-radius: 5px;
+    box-shadow: 0 1px 2px #666;
 
     position: absolute;
     left: 0;
@@ -921,7 +911,7 @@ form p.checkbox_select {
     &.avatar {
       @include transition(opacity, 0.5s);
       &.loading {
-        @include opacity(0.3);
+        opacity: 0.3;
       }
     }
   }
@@ -929,9 +919,9 @@ form p.checkbox_select {
 }
 
 #file-upload.button {
-  @include border-radius(3px);
   @include button-gradient($light-grey);
-  @include box-shadow(0,1px,1px,#cfcfcf);
+  border-radius: 3px;
+  box-shadow: 0 1px 1px #cfcfcf;
   @include transition(border);
 
   display: inline-block;
@@ -987,8 +977,6 @@ select#user_language, #user_auto_follow_back_aspect_id, #aspect_ids_ {
   line-height: 18px;
   color: inherit;
   background-color: $background-grey;
-    -webkit-border-radius: 6px;
-    -moz-border-radius: 6px;
   border-radius: 10px;
 }
 
@@ -1021,19 +1009,19 @@ select#aspect_ids_ {
   cursor: pointer;
 
   &:hover img {
-      @include opacity(0.4);
+      opacity: 0.4;
   }
 }
 
 #publisher_textarea_wrapper {
-  @include border-radius(2px);
+  border-radius: 2px;
   margin: 12px 0px;
   background: #fff;
   position: relative;
   padding-right: 10px;
 
   #hide_publisher  {
-    @include opacity(0.3);
+    opacity: 0.3;
     z-index: 5;
     padding: 3px;
     position: absolute;
@@ -1041,7 +1029,7 @@ select#aspect_ids_ {
     top: 0;
 
     &:hover {
-      @include opacity(1);
+      opacity: 1;
     }
   }
 
@@ -1081,7 +1069,7 @@ select#aspect_ids_ {
       }
 
       .circle {
-        @include border-radius(20px);
+        border-radius: 20px;
         z-index: 1;
         position: absolute;
         right: -7px;

--- a/app/assets/stylesheets/new_styles/_animations.scss
+++ b/app/assets/stylesheets/new_styles/_animations.scss
@@ -1,78 +1,21 @@
-@-webkit-keyframes opacity-pulse {
-	0%   { @include opacity(0.3); }
-	65%  { @include opacity(0.9); }
-	100% { @include opacity(0.3); }
-}
-@-moz-keyframes opacity-pulse {
-	0%   { @include opacity(0.3); }
-	65%  { @include opacity(0.9); }
-	100% { @include opacity(0.3); }
-}
-@-ms-keyframes opacity-pulse {
-	0%   { @include opacity(0.3); }
-	65%  { @include opacity(0.9); }
-	100% { @include opacity(0.3); }
-}
-@-o-keyframes opacity-pulse {
-	0%   { @include opacity(0.3); }
-	65%  { @include opacity(0.9); }
-	100% { @include opacity(0.3); }
+@keyframes opacity-pulse {
+	0%   { opacity: 0.3; }
+	65%  { opacity: 0.9; }
+	100% { opacity: 0.3; }
 }
 
-@-webkit-keyframes ease-over {
-	0%   { @include opacity(0); -webkit-transform : scale(1.3); }
-	100% { @include opacity(1); -webkit-transform : scale(1); }
-}
-@-moz-keyframes ease-over {
-	0%   { @include opacity(0); -moz-transform : scale(1.3); }
-	100% { @include opacity(1); -moz-transform : scale(1); }
-}
-@-ms-keyframes ease-over {
-	0%   { @include opacity(0); -ms-transform : scale(1.3); }
-	100% { @include opacity(1); -ms-transform : scale(1); }
-}
-@-o-keyframes ease-over {
-	0%   { @include opacity(0); -o-transform : scale(1.3); }
-	100% { @include opacity(1); -o-transform : scale(1); }
+@keyframes ease-over {
+	0%   { opacity: 0; transform : scale(1.3); }
+	100% { opacity: 1; transform : scale(1); }
 }
 
-@-webkit-keyframes ease-out {
-	0%     { @include opacity(1); -webkit-transform : scale(1); }
-	100%   { @include opacity(0); -webkit-transform : scale(1.3); }
-}
-@-moz-keyframes ease-out {
-	0%     { @include opacity(1); -moz-transform : scale(1); }
-	100%   { @include opacity(0); -moz-transform : scale(1.3); }
-}
-@-ms-keyframes ease-out {
-	0%     { @include opacity(1); -ms-transform : scale(1); }
-	100%   { @include opacity(0); -ms-transform : scale(1.3); }
-}
-@-o-keyframes ease-out {
-	0%     { @include opacity(1); -o-transform : scale(1); }
-	100%   { @include opacity(0); -o-transform : scale(1.3); }
+@keyframes ease-out {
+	0%     { opacity: 1; transform : scale(1); }
+	100%   { opacity: 0; transform : scale(1.3); }
 }
 
 /* flash message animations - header height is about 40px */
-@-webkit-keyframes expose {
-        0%   { top : -100px; }
-        15%  { top : 34px; }
-        85%  { top : 34px; }
-        100% { top : -100px; }
-}
-@-moz-keyframes expose {
-        0%   { top : -100px; }
-        15%  { top : 34px; }
-        85%  { top : 34px; }
-        100% { top : -100px; }
-}
-@-ms-keyframes expose {
-        0%   { top : -100px; }
-        15%  { top : 34px; }
-        85%  { top : 34px; }
-        100% { top : -100px; }
-}
-@-o-keyframes expose {
+@keyframes expose {
         0%   { top : -100px; }
         15%  { top : 34px; }
         85%  { top : 34px; }

--- a/app/assets/stylesheets/new_styles/_base.scss
+++ b/app/assets/stylesheets/new_styles/_base.scss
@@ -62,12 +62,12 @@ $bring-dark-accent-forward-color: #DDD;
 
   & > a {
     @include transition(opacity);
-    @include opacity(0.4);
+    opacity: 0.4;
 
     margin-left : 5px;
 
     &:hover {
-      @include opacity(0.75);
+      opacity: 0.75;
       text-decoration : none;
     }
   }
@@ -80,9 +80,7 @@ $bring-dark-accent-forward-color: #DDD;
   padding : 15px;
   z-index : 30;
 
-  -webkit-box-shadow : inset 0 -10px 10px -8px rgba(0,0,0,0.8);
-  -moz-box-shadow : inset 0 -10px 10px -8px rgba(0,0,0,0.8);
-
+  box-shadow : inset 0 -10px 10px -8px rgba(0,0,0,0.8);
   border-bottom : 1px solid #333;
 
   color : #fff;
@@ -93,7 +91,7 @@ $bring-dark-accent-forward-color: #DDD;
   }
 
   h1 {
-    @include opacity(0.4);
+    opacity: 0.4;
   }
 }
 

--- a/app/assets/stylesheets/new_styles/_buttons.css.scss
+++ b/app/assets/stylesheets/new_styles/_buttons.css.scss
@@ -33,8 +33,8 @@
 // TODO remove this when everything has been ported to Bootstrap
 .button.creation {
     $button-border-color: #aaa;
-    @include border-radius(3px);
-    @include box-shadow(0,1px,1px,#cfcfcf);
+    border-radius: 3px;
+    box-shadow: 0 1px 1px #cfcfcf;
     @include transition(border);
     @include button-gradient($creation-blue);
     font: {

--- a/app/assets/stylesheets/new_styles/_forms.scss
+++ b/app/assets/stylesheets/new_styles/_forms.scss
@@ -16,9 +16,6 @@ form.block-form {
     &:invalid,
     &:invalid:required,
     &:invalid:required:focus {
-      -webkit-box-shadow : none;
-      -moz-box-shadow : none;
-      box-shadow : none;
       box-shadow : none;
 
       border : none;
@@ -27,28 +24,21 @@ form.block-form {
   }
 
   fieldset {
-    @include border-radius(5px);
-
-    -webkit-box-shadow : inset 0 1px 1px rgba(0,0,0,0.2), 0 1px 2px rgba(255,255,255,0.7);
-
+    box-shadow : inset 0 1px 1px rgba(0,0,0,0.2), 0 1px 2px rgba(255,255,255,0.7);
     margin-bottom : 1em;
-
     background-color : #fff;
-
     border : 1px solid $border-dark-grey;
+    border-radius: 5px;
 
     input[type=text],
     input[type=email],
     input[type=password] {
-      @include box-shadow(0,0,0,0);
-      @include border-radius(0);
-
-      background : transparent;
-
-      padding : 10px;
-
-      margin-bottom : 0;
+      box-shadow: 0 0 0 0;
+      border-radius: 0;
       border : none;
+      background : transparent;
+      padding : 10px;
+      margin-bottom : 0;
     }
 
   /* mainly bootstrap overrides */
@@ -87,14 +77,13 @@ form.block-form {
 }
 
 textarea, input[type=text], input[type=password], input[type=search] {
-  &:focus, 
+  &:focus,
   &:invalid,
   &:invalid:focus,
   &:invalid:required,
   &:invalid:required:focus {
     border: 1px solid $border-dark-grey;
     outline: none;
-    -webkit-box-shadow: none;
     box-shadow: none;
     color : $text-dark-grey;
   }
@@ -103,12 +92,12 @@ textarea, input[type=text], input[type=password], input[type=search] {
 /* buttons to be extracted? */
 .new-btn {
   @include transition(box-shadow);
-  @include border-radius(5px);
   @include linear-gradient(#fff, rgb(233,233,233));
-  @include box-shadow(0, 1px, 2px, rgba(0,0,0,0));
 
+  box-shadow: 0 1px 2px rgba(0,0,0,0);
   background-color : rgb(233,233,233);
   color : $text-grey;
+  border-radius: 5px;
   border : 1px solid $border-dark-grey;
 
   //font-family : Roboto-Bold;
@@ -116,7 +105,7 @@ textarea, input[type=text], input[type=password], input[type=search] {
   text-shadow : 0 1px 2px #eee;
 
   &:hover {
-    @include box-shadow(0, 1px, 2px, rgba(0,0,0,0.3));
+    box-shadow: 0 1px 2px rgba(0,0,0,0.3);
   }
 
   &:active {

--- a/app/assets/stylesheets/new_styles/_interactions.scss
+++ b/app/assets/stylesheets/new_styles/_interactions.scss
@@ -22,11 +22,11 @@
   }
 
   .stream_element, .comment, .photo, .stream_element:hover .comment {
-    .controls > a { @include opacity(0); }
+    .controls > a { opacity: 0; }
 
     &:hover .controls {
-      & > a { @include opacity(0.3); }
-      & > a:hover { @include opacity(1); }
+      & > a { opacity: 0.3; }
+      & > a:hover { opacity: 1; }
     }
   }
 }

--- a/app/assets/stylesheets/new_styles/_landing.scss
+++ b/app/assets/stylesheets/new_styles/_landing.scss
@@ -25,7 +25,7 @@
 
       input[type='submit'] {
         @include transition(background);
-        @include box-shadow(0,0,0,0);
+        box-shadow: 0 0 0 0;
 
         font-size:1.2em;
         background : #99CC00;
@@ -38,7 +38,7 @@
         }
 
         &:active {
-          @include box-shadow(0,0,0,0);
+          box-shadow: 0 0 0 0;
           background : darken(rgb(255, 77, 54), 2%);
         }
       }
@@ -92,7 +92,7 @@
     }
 
     .login-button {
-      @include border-radius(3px);
+      border-radius: 3px;
       border:1px solid #666;
       background:#111;
 

--- a/app/assets/stylesheets/new_styles/_login.scss
+++ b/app/assets/stylesheets/new_styles/_login.scss
@@ -68,11 +68,11 @@
     }
     input[type=text] {
       margin-bottom: -24px;
-      @include border-radius(5px, 5px, 0, 0);
+      border-radius: 5px 5px 0 0;
     }
     input[type=password] {
       margin-bottom: -23px;
-      @include border-radius(0, 0, 5px, 5px);
+      border-radius: 0 0 5px 5px;
     }
     #forgot_password_link {
       margin-top: 20px;

--- a/app/assets/stylesheets/new_styles/_new_mixins.scss
+++ b/app/assets/stylesheets/new_styles/_new_mixins.scss
@@ -5,16 +5,6 @@ $night-text-color : #999;
 
 /* mixins */
 @mixin center($orient:vertical) {
-  display: -webkit-box;
-  -webkit-box-orient: $orient;
-  -webkit-box-pack: center;
-  -webkit-box-align: center;
-
-  display: -moz-box;
-  -moz-box-orient: $orient;
-  -moz-box-pack: center;
-  -moz-box-align: center;
-
   display: box;
   box-orient: $orient;
   box-pack: center;
@@ -28,14 +18,11 @@ $night-text-color : #999;
 
 @mixin background-cover() {
   background: no-repeat center center fixed;
-  -webkit-background-size: cover;
-  -moz-background-size: cover;
-  -o-background-size: cover;
   background-size: cover;
 }
 
 @mixin info-container-base() {
-  @include box-shadow(0, 6px, 20px, #000);
+  box-shadow: 0 6px 20px #000;
   @include dark-hatched-bg();
 
   border-top: 1px solid #555;
@@ -44,7 +31,7 @@ $night-text-color : #999;
 
 @mixin info-container() {
   @include info-container-base();
-  @include border-radius(3px, 0px);
+  border-radius: 3px 0px;
   @include pane-width();
 
   display: inline-block;
@@ -65,11 +52,11 @@ $night-text-color : #999;
 }
 
 @mixin photo-shadow() {
-  @include box-shadow(0, 3px, 15px, rgba(0,0,0,0.7));
+  box-shadow: 0 3px 15px rgba(0,0,0,0.7);
 }
 
 @mixin media-text() {
-  font-size: 2em; 
+  font-size: 2em;
   line-height: 1.2em;
   padding-bottom: 0;
   margin-bottom: 0;

--- a/app/assets/stylesheets/new_styles/_poll.scss
+++ b/app/assets/stylesheets/new_styles/_poll.scss
@@ -21,7 +21,7 @@
 
   .progress {
     background-image: none;
-    @include box-shadow(0, 0, 0);
+    box-shadow: 0 0 0;
     margin-bottom: 5px;
     height: 10px !important;
 

--- a/app/assets/stylesheets/new_styles/_spinner.scss
+++ b/app/assets/stylesheets/new_styles/_spinner.scss
@@ -1,21 +1,11 @@
-@-webkit-keyframes fade-in {
+@keyframes fade-in {
   0%   { opacity: 0; }
   100% { opacity: 1; }
 }
 
-@-webkit-keyframes spin {
+@keyframes spin {
   0%   { -webkit-transform: rotate(0deg); }
   100% { -webkit-transform: rotate(360deg); }
-}
-
-@-moz-keyframes fade-in {
-  0%   { opacity: 0; }
-  100% { opacity: 1; }
-}
-
-@-moz-keyframes spin {
-  0%   { -moz-transform: rotate(0deg); }
-  100% { -moz-transform: rotate(360deg); }
 }
 
 #paginate, #infscr-loading {
@@ -28,16 +18,12 @@
 }
 
 .loaded {
-  -webkit-animation: fade-in 0.16s linear;
-  -moz-animation: fade-in 0.16s linear;
+  animation: fade-in 0.16s linear;
 }
 
 .loader {
-  -webkit-mask-image: image-url('static-loader.png');
-  -webkit-animation: spin 1s infinite ease-in-out,
-  fade-in 0.2s ease-in;
-  -moz-animation: spin 1s infinite ease-in-out,
-  fade-in 0.2s ease-in;
+  mask-image: image-url('static-loader.png');
+  animation: spin 1s infinite ease-in-out, fade-in 0.2s ease-in;
 
   background-image : image-url("static-loader.png");
 

--- a/app/assets/stylesheets/photo.css.scss
+++ b/app/assets/stylesheets/photo.css.scss
@@ -2,17 +2,17 @@
   .controls:first-child {
     .control_icon {
       @include transition(opacity);
-      @include opacity(0);
+      opacity: 0;
     }
   }
 
   &:hover {
     .controls:first-child {
       .control_icon {
-        @include opacity(0.3);
+        opacity: 0.3;
       }
       .control_icon:hover {
-        @include opacity(1);
+        opacity: 1;
       }
     }
   }

--- a/app/assets/stylesheets/poll.css.scss
+++ b/app/assets/stylesheets/poll.css.scss
@@ -22,7 +22,7 @@
   .progress {
     overflow: hidden;
     background-color: #f6f6f6;
-    @include border-radius(4px);
+    border-radius: 4px;
 
     .bar {
       height: 100%;

--- a/app/assets/stylesheets/popover.css.scss
+++ b/app/assets/stylesheets/popover.css.scss
@@ -1,6 +1,6 @@
 .popover {
   .close {
-    @include opacity(0);
+    opacity: 0;
     @include transition(opacity, 0.2s);
     position: relative;
     top: 1px;
@@ -16,9 +16,9 @@
 
   &:hover {
     .close {
-      @include opacity(0.5);
+      opacity: 0.5;
 
-      &:hover { @include opacity(1); }
+      &:hover { opacity: 1; }
     }
   }
 }

--- a/app/assets/stylesheets/publisher.css.scss
+++ b/app/assets/stylesheets/publisher.css.scss
@@ -1,7 +1,7 @@
 #publisher {
   z-index: 1;
   color: $text-grey;
-  
+
   &.closed {
     #button_container,
     #location_container,
@@ -10,23 +10,23 @@
     .options_and_submit {
       display: none !important;
     }
-    
+
     #publisher_textarea_wrapper { border: 1px solid $border-grey !important; }
   }
-  
+
   .mentions-autocomplete-list ul { width: 100% !important; }
-  
+
   form {
     margin: 0;
     #fileInfo { display: none !important; }
     #hide_publisher {
       margin-top: 10px;
     }
-    
+
     #publisher_spinner {
       text-align: center;
     }
-    
+
     .options_and_submit {
       #publisher_service_icons {
         .btn-link { text-decoration: none; }
@@ -36,7 +36,7 @@
           padding-left: 5px;
           padding-right: 5px;
         }
-        .dim { @include opacity(0.3); }
+        .dim { opacity: 0.3; }
         .social_media_logos-wordpress-16x16 {
           display: inline-block;
           height: 16px;
@@ -44,7 +44,7 @@
         }
       }
     }
-    
+
     #publisher_textarea_wrapper {
       background-color: white;
       border-radius: 3px;
@@ -67,7 +67,7 @@
       &.active textarea {
         min-height: 70px;
       }
-      
+
       .help-block {
         font-size: 13px;
         line-height: 30px;
@@ -76,13 +76,13 @@
         color: lighten($text-grey,20%);
         a { color: lighten($blue,20%); }
       }
-     
+
       .mentions-input-box .mentions {
         line-height: 20px !important;
       }
 
       &.with_attachments .row-fluid#photodropzone_container {
-        border-top: 1px dashed $border-grey; 
+        border-top: 1px dashed $border-grey;
       }
 
       .row-fluid#poll_creator_container {
@@ -90,8 +90,6 @@
         border-top: 1px dashed $border-grey;
         padding:4px 6px 4px 6px;
         box-sizing: border-box;
-        -moz-box-sizing: border-box;
-        -webkit-box-sizing: border-box;
         .remove-answer.entypo.cross {
           display: none;
           color: lighten($black,75%);
@@ -107,12 +105,12 @@
         height: 30px;
         #hide_location { display: none !important; }
         border-top: 1px dashed $border-grey;
-        input[type='text'] { 
+        input[type='text'] {
           margin-bottom: 0;
           color: $text-grey;
         }
       }
-      &.active .row-fluid#button_container { 
+      &.active .row-fluid#button_container {
         border-top: 1px solid $border-grey;
       }
 
@@ -127,13 +125,13 @@
           overflow: hidden;
           line-height: 80px;
           vertical-align: middle;
-            
+
           img {
             vertical-align: middle;
             width: 80px;
           }
 
-          .x { 
+          .x {
             display: none;
             width: 50px;
             height: 50px;
@@ -146,11 +144,11 @@
             font-style: bold;
             position: absolute;
             z-index: 2;
-            @include opacity(0.85);
+            opacity: 0.85;
             cursor: pointer;
             top: 15px;
             left: 15px;
-            
+
             &:before {
               content: '\2716';
               font-family: 'entypo';
@@ -160,17 +158,17 @@
           &:hover .x {
             display: inline-block;
           }
-          
-          .progress { 
+
+          .progress {
             width: 100%;
             height: 20px;
             margin: 30px 0;
           }
-          
+
           .ajax-loader { display: none; }
         }
       }
-      
+
       #upload_error {
         color: white;
         font-style: bold;
@@ -178,7 +176,7 @@
         background-color: $red;
         text-align: center;
       }
-      
+
       #publisher-images {
         margin-right: 5px;
         #file-upload,
@@ -188,13 +186,13 @@
           text-decoration: none !important;
           font-size: 16px;
           padding: 4px 5px;
-          i { 
+          i {
             color: $text-grey;
           }
           &:hover{
             i { color: black; }
           }
-          input[type='file'] { 
+          input[type='file'] {
             cursor: pointer;
             &::-webkit-file-upload-button {
               cursor: pointer;
@@ -227,7 +225,7 @@
       .exceeded {
         color: red;
       }
-    } 
+    }
   }
 
   .aspect_dropdown {

--- a/app/assets/stylesheets/publisher_blueprint.css.scss
+++ b/app/assets/stylesheets/publisher_blueprint.css.scss
@@ -140,7 +140,7 @@
     }
 
     img {
-      @include opacity(0.4);
+      opacity: 0.4;
       vertical-align: bottom;
     }
 
@@ -149,7 +149,7 @@
       cursor: pointer;
 
       img {
-        @include opacity(0.8);
+        opacity: 0.8;
       }
     }
 
@@ -158,19 +158,19 @@
       text-shadow: 0 1px 0 #fafafa;
 
       img {
-        @include opacity(1);
+        opacity: 1;
       }
     }
 
     &.loading {
-      @include opacity(0.5);
+      opacity: 0.5;
     }
   }
 }
 
 #publisher_textarea_wrapper {
   #hide_publisher {
-    @include opacity(0.3);
+    opacity: 0.3;
     z-index: 5;
     padding: 3px;
     position: absolute;
@@ -183,7 +183,7 @@
     }
 
     &:hover {
-      @include opacity(1);
+      opacity: 1;
     }
   }
 
@@ -193,7 +193,7 @@
     left: 5px;
   }
 
-  @include border-radius(2px);
+  border-radius: 2px;
 
   border: 1px solid #ccc;
   background: #fff;
@@ -231,7 +231,7 @@
         max-height: 55px;
       }
       .circle {
-        @include border-radius(20px);
+        border-radius: 20px;
 
         display: none;
         z-index: 1;
@@ -310,13 +310,13 @@
     cursor: pointer;
     img {
       padding-top: 2px;
-      @include opacity(0.4);
+      opacity: 0.4;
     }
     &:hover {
       color: $text-dark-grey;
       cursor: pointer;
       img {
-        @include opacity(0.8);
+        opacity: 0.8;
       }
     }
   }
@@ -328,13 +328,13 @@
     position: absolute !important;
     right: 55px;
     i {
-      @include opacity(0.4);
+      opacity: 0.4;
     }
     &:hover {
       color: $text-dark-grey;
       cursor: pointer;
       i {
-        @include opacity(1);
+        opacity: 1;
       }
     }
   }
@@ -349,7 +349,7 @@
   border: 1px solid $border-dark-grey;
   padding: 5px;
   margin-top: 5px;
-  @include border-radius(2px);
+  border-radius: 2px;
   display: none;
 
   &.active {
@@ -388,13 +388,13 @@
       vertical-align: bottom;
     }
     .remove-answer {
-      @include opacity(0.4);
+      opacity: 0.4;
       cursor: pointer;
       display: none;
       line-height: 27px;
 
       &:hover {
-        @include opacity(1);
+        opacity: 1;
       }
       &.active {
         display: inline-block;

--- a/app/assets/stylesheets/sidebar.css.scss
+++ b/app/assets/stylesheets/sidebar.css.scss
@@ -187,7 +187,7 @@
 
       #invite_code {
         width: 100%;
-        @include box-sizing(border-box);
+        box-sizing: border-box;
       }
     }
   }

--- a/app/assets/stylesheets/single-post-view.css.scss
+++ b/app/assets/stylesheets/single-post-view.css.scss
@@ -15,8 +15,8 @@
         font-size: 12px;
         .post-time a { color: $text-grey; }
         .post_scope { margin-right: 5px; }
-        .status-message-location { 
-          padding-top: 2px; 
+        .status-message-location {
+          padding-top: 2px;
           line-height: 14px;
         }
       }
@@ -29,8 +29,8 @@
     }
     .row-fluid.reshare {
       border-top: 1px solid lighten($border-grey,5%);
-      padding-top: 10px; 
-      margin-top: 10px; 
+      padding-top: 10px;
+      margin-top: 10px;
     }
     #reshare-info {
       line-height: 15px;
@@ -85,7 +85,7 @@
       }
     }
   }
-  
+
   #body {
     margin-left: 20px;
     padding-top: 20px;
@@ -98,8 +98,8 @@
       padding-bottom: 10px;
       text-align: center;
       img {
-        &.big_stream_photo { 
-          display: block; 
+        &.big_stream_photo {
+          display: block;
           max-width: 90%;
         }
         &.thumb_small {
@@ -133,7 +133,7 @@
   left: -1px;
   margin-left: 0;
   padding-left: 15px;
-  
+
   .comments .comment {
     border-top: none;
     border-bottom: solid 1px #cccccc;
@@ -157,7 +157,7 @@
     padding-bottom: 10px;
     background-color: $background-grey;
     text-align: center;
-    @include border-radius(4px);
+    border-radius: 4px;
     margin-bottom: 30px;
   }
 

--- a/app/assets/stylesheets/stream_element.css.scss
+++ b/app/assets/stylesheets/stream_element.css.scss
@@ -85,10 +85,10 @@
     }
   }
 
-  .reshare {    
+  .reshare {
     border-left: 2px solid $border-grey;
     margin-top: 3px;
-  
+
     & > .media .avatar {
       height: 30px;
       width: 30px;
@@ -119,7 +119,7 @@
       text-shadow: 0 0 7px #FFF;
       cursor: pointer;
       border-bottom: 2px solid $border-grey;
-      @include border-radius(0, 0, 3px, 3px);
+      border-radius: 0 0 3px 3px;
       @include linear-gradient(rgba(255,255,255,0) , #EEE, 0%, 95%);
       background-color: transparent;
     }

--- a/app/assets/stylesheets/stream_element_blueprint.css.scss
+++ b/app/assets/stylesheets/stream_element_blueprint.css.scss
@@ -74,17 +74,17 @@
   .controls:first-child {
     .control_icon {
       @include transition(opacity);
-      @include opacity(0);
+      opacity: 0;
     }
   }
 
   &:hover {
     .controls:first-child {
       .control_icon {
-        @include opacity(0.3);
+        opacity: 0.3;
       }
       .control_icon:hover {
-        @include opacity(1);
+        opacity: 1;
       }
     }
   }
@@ -140,16 +140,16 @@
     .controls {
       .comment_delete, .comment_report {
         @include transition(opacity);
-        @include opacity(0);
+        opacity: 0;
       }
     }
     &:hover {
       .controls {
         .comment_delete, .comment_report {
-          @include opacity(0.3);
+          opacity: 0.3;
         }
         .comment_delete:hover, .comment_report:hover {
-          @include opacity(1);
+          opacity: 1;
         }
       }
     }
@@ -266,7 +266,7 @@ form.new_comment {
       text-shadow: 0 0 7px #FFF;
       cursor: pointer;
       border-bottom: 2px solid $border-grey;
-      @include border-radius(0, 0, 3px, 3px);
+      border-radius: 0 0 3px 3px;
       @include linear-gradient(rgba(255,255,255,0) , #EEE, 0%, 95%);
       background-color: transparent;
     }

--- a/app/assets/stylesheets/ui.css.scss
+++ b/app/assets/stylesheets/ui.css.scss
@@ -11,9 +11,8 @@ $button-border-color: #aaa;
 }
 
 .button {
-  @include border-radius(3px);
   @include button-gradient($light-grey);
-  @include box-shadow(0,1px,1px,#cfcfcf);
+  box-shadow: 0 1px 1px #cfcfcf;
   @include transition(border);
 
   display: inline;
@@ -30,6 +29,7 @@ $button-border-color: #aaa;
   min-height: 10px;
 
   border: 1px solid $button-border-color;
+  border-radius: 3px;
 
   cursor: pointer;
   white-space: nowrap;
@@ -112,8 +112,7 @@ input.button {
   }
 
   .wrapper {
-    @include box-shadow(0, 2px, 5px, #666);
-    //@include opacity(0)
+    box-shadow: 0 2px 5px #666;
     @include transition(opacity);
 
     display: none;
@@ -187,14 +186,14 @@ input.button {
 
   &.hang_right {
     .wrapper {
-      @include border-radius(3px, 0, 3px, 3px);
+      border-radius: 3px 0 3px 3px;
       right: 3px;
     }
   }
 
   &.hang_left {
     .wrapper {
-      @include border-radius(0, 3px, 3px, 3px);
+      border-radius: 0 3px 3px 3px;
       left: 0px;
     }
   }
@@ -205,12 +204,11 @@ input.button {
 
   &.active {
     .wrapper {
-      //@include opacity(1)
       display: block;
     }
 
     .button {
-      @include border-radius(3px, 3px, 0, 0);
+      border-radius: 3px 3px 0 0;
       border: 1px solid #444;
     }
 

--- a/app/assets/stylesheets/vendor/autoSuggest.css.erb
+++ b/app/assets/stylesheets/vendor/autoSuggest.css.erb
@@ -7,8 +7,6 @@ ul.as-selections {
 	overflow: auto;
 	background-color: #fff;
 	border-radius: 3px;
-	-webkit-border-radius: 3px;
-	-moz-border-radius: 3px;
 	/* 1% padding (all sides) + 98% width = 100% */
 	padding: 1%;
 	width: 98%;
@@ -29,18 +27,14 @@ ul.as-selections li.as-selection-item {
 	font-size: 13px;
 	text-shadow: 0 1px 1px #fff;
 	background-color: #ddeefe;
-	background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, from(#ddeefe), to(#bfe0f1));
+	background-image: gradient(linear, 0% 0%, 0% 100%, from(#ddeefe), to(#bfe0f1));
 	border: 1px solid #acc3ec;
 	padding: 0;
   padding-top: 6px;
   padding-bottom: 6px;
   padding-left: 6px;
 	border-radius: 5px;
-	-webkit-border-radius: 5px;
-	-moz-border-radius: 5px;
 	box-shadow: 0 1px 1px #e4edf2;
-	-webkit-box-shadow: 0 1px 1px #e4edf2;
-	-moz-box-shadow: 0 1px 1px #e4edf2;
   line-height: 10px;
   margin-top: -1px;
   margin-bottom: 10px;
@@ -60,18 +54,16 @@ ul.as-selections li.as-selection-item a.as-close {
 	font-size: 14px;
 	font-weight: bold;
 	text-shadow: 0 1px 1px #fff;
-	-webkit-transition: color .1s ease-in;
+	transition: color .1s ease-in;
 }
 
 ul.as-selections li.as-selection-item.blur {
 	color: #666666;
 	background-color: #f4f4f4;
-	background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, from(#f4f4f4), to(#d5d5d5));
+	background-image: gradient(linear, 0% 0%, 0% 100%, from(#f4f4f4), to(#d5d5d5));
 	border-color: #bbb;
 	border-top-color: #ccc;
 	box-shadow: 0 1px 1px #e9e9e9;
-	-webkit-box-shadow: 0 1px 1px #e9e9e9;
-	-moz-box-shadow: 0 1px 1px #e9e9e9;
 }
 
 ul.as-selections li.as-selection-item.blur a.as-close {
@@ -81,7 +73,7 @@ ul.as-selections li.as-selection-item.blur a.as-close {
 ul.as-selections li:hover.as-selection-item {
 	color: #2b3840;
 	background-color: #bbd4f1;
-	background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, from(#bbd4f1), to(#a3c2e5));
+	background-image: gradient(linear, 0% 0%, 0% 100%, from(#bbd4f1), to(#a3c2e5));
 	border-color: #6da0e0;
 	border-top-color: #8bb7ed;
 }
@@ -135,11 +127,7 @@ ul.as-list {
 	background-color: rgba(255,255,255,0.95);
 	z-index: 2;
 	box-shadow: 0 2px 12px #222;
-	-webkit-box-shadow: 0 2px 12px #222;
-	-moz-box-shadow: 0 2px 12px #222;
 	border-radius: 5px;
-	-webkit-border-radius: 5px;
-	-moz-border-radius: 5px;
 }
 
 li.as-result-item, li.as-message {
@@ -150,8 +138,6 @@ li.as-result-item, li.as-message {
 	border-bottom: 1px solid #ddd;
 	cursor: pointer;
 	border-radius: 3px;
-	-webkit-border-radius: 3px;
-	-moz-border-radius: 3px;
 }
 
 li:first-child.as-result-item {
@@ -165,7 +151,7 @@ li.as-message {
 
 li.as-result-item.active {
 	background-color: #3668d9;
-	background-image: -webkit-gradient(linear, 0% 0%, 0% 64%, from(rgb(110, 129, 245)), to(rgb(62, 82, 242)));
+	background-image: gradient(linear, 0% 0%, 0% 64%, from(rgb(110, 129, 245)), to(rgb(62, 82, 242)));
 	border-color: #3342e8;
 	color: #fff;
 	text-shadow: 0 1px 2px #122042;

--- a/app/assets/stylesheets/vendor/facebox.css
+++ b/app/assets/stylesheets/vendor/facebox.css
@@ -9,11 +9,7 @@
 #facebox .popup{
   position:relative;
   border:1px solid #999;
-  -webkit-border-radius:2px;
-  -moz-border-radius:2px;
   border-radius:2px;
-  -webkit-box-shadow:0 0 10px rgba(0,0,0,0.8), 0 2px 200px rgba(255,255,255,0.2);
-  -moz-box-shadow:0 0 10px rgba(0,0,0,0.8), 0 2px 200px rgba(255,255,255,0.2);;
   box-shadow:0 0 10px rgba(0,0,0,0.8), 0 2px 200px rgba(255,255,255,0.2);;
 }
 
@@ -22,8 +18,6 @@
   width: 370px;
   padding: 20px;
   background: #fff;
-  -webkit-border-radius:2px;
-  -moz-border-radius:2px;
   border-radius:2px;
 }
 

--- a/app/assets/stylesheets/vendor/fileuploader.css
+++ b/app/assets/stylesheets/vendor/fileuploader.css
@@ -1,29 +1,74 @@
-.qq-uploader { position:relative; width: 100%;}
+.qq-uploader {
+    position:relative;
+    width: 100%;
+}
 
 .qq-upload-button {
     display:block; /* or inline-block */
-    width: 105px; padding: 7px 0; text-align:center;    
-    background:#333; border-bottom:1px solid #999;color:#fff;
+    width: 105px;
+    padding: 7px 0;
+    text-align:center;
+    background:#333;
+    border-bottom:1px solid #999;
+    color:#fff;
 }
 
 .qq-upload-drop-area {
-    position:absolute; top:0; left:0; width:100%; height:100%; min-height: 70px; z-index:2;
-    background:#ccc; text-align:center; 
+    position:absolute;
+    top:0; left:0;
+    width:100%;
+    height:100%;
+    min-height: 70px;
+    z-index:2;
+    background:#ccc;
+    text-align:center;
 }
-.qq-upload-drop-area span {
-    display:block; position:absolute; top: 50%; width:100%; margin-top:-8px; font-size:16px;
-}
-.qq-upload-drop-area-active {background:#FF7171;}
 
-.qq-upload-list {margin:15px 35px; padding:0; list-style:disc;}
-.qq-upload-list li { margin:0; padding:0; line-height:15px; font-size:12px;}
+.qq-upload-drop-area span {
+    display:block;
+    position:absolute;
+    top: 50%;
+    width:100%;
+    margin-top:-8px;
+    font-size:16px;
+}
+
+.qq-upload-drop-area-active {
+    background:#FF7171;
+}
+
+.qq-upload-list {
+    margin:15px 35px;
+    padding:0;
+    list-style:disc;
+}
+
+.qq-upload-list li {
+    margin:0;
+    padding:0;
+    line-height:15px;
+    font-size:12px;
+}
+
 .qq-upload-file, .qq-upload-spinner, .qq-upload-size, .qq-upload-cancel, .qq-upload-failed-text {
     margin-right: 7px;
 }
 
-.qq-upload-file {}
-.qq-upload-spinner {display:inline-block; background: url("loading.gif"); width:15px; height:15px; vertical-align:text-bottom;}
-.qq-upload-size,.qq-upload-cancel {font-size:11px;}
+.qq-upload-spinner {
+    display:inline-block;
+    background: url("loading.gif");
+    width:15px;
+    height:15px;
+    vertical-align:text-bottom;
+}
 
-.qq-upload-failed-text {display:none;}
-.qq-upload-fail .qq-upload-failed-text {display:inline;}
+.qq-upload-size,.qq-upload-cancel {
+    font-size:11px;
+}
+
+.qq-upload-failed-text {
+    display:none;
+}
+.qq-upload-fail .qq-upload-failed-text {
+    display:inline;
+}

--- a/config/autoprefixer.yml
+++ b/config/autoprefixer.yml
@@ -1,0 +1,3 @@
+browsers:
+  - "last 2 version"
+  - "> 1%"


### PR DESCRIPTION
In some cases the prefixes were really old (border-radius, opacity).
Now you only have to write standard compliant CSS, and the prefixes for latest 2 versions will be added automatically. 
