### PR TITLE
Add missing export_user queue to sidekiq config

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -14,5 +14,6 @@
   - receive
   - receive_salmon
   - http
+  - export_user
   - maintenance
   - default


### PR DESCRIPTION
Introduced in #5499
