### PR TITLE
Make PurgeOrphanConversations migration safer

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -10,7 +10,7 @@ class Conversation < ActiveRecord::Base
 
   has_many :conversation_visibilities, :dependent => :destroy
   has_many :participants, :class_name => 'Person', :through => :conversation_visibilities, :source => :person
-  has_many :messages, -> { order('created_at ASC') }
+  has_many :messages, -> { order('created_at ASC') }, :dependent => :destroy
 
   belongs_to :author, :class_name => 'Person'
 
@@ -20,7 +20,7 @@ class Conversation < ActiveRecord::Base
   def max_participants
     errors.add(:max_participants, "too many participants") if participants.count > 20
   end
-  
+
   def local_recipients
     recipients.each do |recipient|
       if recipient.local?

--- a/db/migrate/20141216213423_purge_orphan_conversations.rb
+++ b/db/migrate/20141216213423_purge_orphan_conversations.rb
@@ -1,6 +1,14 @@
 class PurgeOrphanConversations < ActiveRecord::Migration
+  disable_ddl_transaction!
+
   def up
-    Conversation.joins("LEFT JOIN conversation_visibilities ON conversation_visibilities.conversation_id = conversations.id").group('conversations.id').having("COUNT(conversation_visibilities.id) = 0").delete_all
+    Conversation.joins("LEFT JOIN conversation_visibilities ON conversation_visibilities.conversation_id = conversations.id").group('conversations.id').having("COUNT(conversation_visibilities.id) = 0").each do |conversation|
+      begin
+        conversation.delete
+      rescue
+        puts "PurgeOrphanConversations: Failed to delete orphan conversation #{conversation.id}"
+      end
+    end
   end
 
   def down

--- a/db/migrate/20150124211314_safer_migration.rb
+++ b/db/migrate/20150124211314_safer_migration.rb
@@ -1,0 +1,9 @@
+class SaferMigration < ActiveRecord::Migration
+  def up
+    Conversation.joins("LEFT JOIN conversation_visibilities ON conversation_visibilities.conversation_id = conversations.id").group('conversations.id').having("COUNT(conversation_visibilities.id) = 0").destroy_all
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
This migration crashed when I updated iliketoast.net

In order to make 0.5 upgrades for the 100+ pods safer, I'd propose adding some safety by using rescue to catch deletion problems. In my situation, it was one conversation that failed with:

```
PG::ForeignKeyViolation: ERROR:  update or delete on table "conversations" violates foreign key constraint "messages_conversation_id_fkey" on table "messages"
DETAIL:  Key (id)=(36) is still referenced from table "messages".
: DELETE FROM "conversations" WHERE "conversations"."id" IN (SELECT "conversations"."id" FROM "conversations" LEFT JOIN conversation_visibilities ON conversation_visibilities.conversation_id = conversations.id GROUP BY conversations.id HAVING COUNT(conversation_visibilities.id) = 0)/home/diaspora/.rvm/gems/ruby-2.1.5/gems/activerecord-4.1.8/lib/active_record/connection_adapters/postgresql_adapter.rb:822:in `async_exec'
```
