### PR TITLE
Add emoji support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem 'autoprefixer-rails', '4.0.2.1'
 
 # Database
 
-ENV['DB'] ||= 'mysql'
+ENV['DB'] ||= 'postgres'
 
 gem 'mysql2', '0.3.17' if ENV['DB'] == 'all' || ENV['DB'] == 'mysql'
 gem 'pg',     '0.17.1' if ENV['DB'] == 'all' || ENV['DB'] == 'postgres'
@@ -96,6 +96,7 @@ gem 'rails-assets-markdown-it-sanitizer',               '0.2.0'
 gem 'rails-assets-markdown-it--markdown-it-for-inline', '0.1.0'
 gem 'rails-assets-markdown-it-sub',                     '0.1.0'
 gem 'rails-assets-markdown-it-sup',                     '0.1.0'
+gem 'rails-assets-twemoji',                             '1.1.1'
 
 # jQuery plugins
 

--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem 'autoprefixer-rails', '4.0.2.1'
 
 # Database
 
-ENV['DB'] ||= 'postgres'
+ENV['DB'] ||= 'mysql'
 
 gem 'mysql2', '0.3.17' if ENV['DB'] == 'all' || ENV['DB'] == 'mysql'
 gem 'pg',     '0.17.1' if ENV['DB'] == 'all' || ENV['DB'] == 'postgres'
@@ -96,7 +96,8 @@ gem 'rails-assets-markdown-it-sanitizer',               '0.2.0'
 gem 'rails-assets-markdown-it--markdown-it-for-inline', '0.1.0'
 gem 'rails-assets-markdown-it-sub',                     '0.1.0'
 gem 'rails-assets-markdown-it-sup',                     '0.1.0'
-gem 'rails-assets-twemoji',                             '1.1.1'
+gem 'rails-assets-markdown-it-emoji',                   '0.1.3'
+gem 'rails-assets-twemoji',                             '1.2.0'
 
 # jQuery plugins
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -338,7 +338,6 @@ GEM
     multi_test (0.1.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
-    mysql2 (0.3.17)
     nested_form (0.3.2)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -380,6 +379,7 @@ GEM
       nokogiri
       rbvmomi
     orm_adapter (0.5.0)
+    pg (0.17.1)
     phantomjs (1.9.7.1)
     pry (0.10.1)
       coderay (~> 1.1.0)
@@ -448,6 +448,7 @@ GEM
     rails-assets-perfect-scrollbar (0.5.7)
       rails-assets-jquery (>= 1.10)
     rails-assets-punycode (1.3.2)
+    rails-assets-twemoji (1.1.1)
     rails-i18n (4.0.3)
       i18n (~> 0.6)
       railties (~> 4.0)
@@ -664,7 +665,6 @@ DEPENDENCIES
   mini_magick (= 4.0.1)
   minitest
   mobile-fu (= 1.3.1)
-  mysql2 (= 0.3.17)
   nokogiri (= 1.6.4.1)
   omniauth (= 1.2.2)
   omniauth-facebook (= 1.6.0)
@@ -672,6 +672,7 @@ DEPENDENCIES
   omniauth-twitter (= 1.0.1)
   omniauth-wordpress (= 0.2.1)
   open_graph_reader (= 0.4.0)
+  pg (= 0.17.1)
   pry
   pry-byebug
   pry-debundle
@@ -697,6 +698,7 @@ DEPENDENCIES
   rails-assets-markdown-it-sup (= 0.1.0)
   rails-assets-perfect-scrollbar (= 0.5.7)
   rails-assets-punycode (= 1.3.2)
+  rails-assets-twemoji (= 1.1.1)
   rails-i18n (= 4.0.3)
   rails-timeago (= 2.11.0)
   rails_admin (= 0.6.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -338,6 +338,7 @@ GEM
     multi_test (0.1.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
+    mysql2 (0.3.17)
     nested_form (0.3.2)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -379,7 +380,6 @@ GEM
       nokogiri
       rbvmomi
     orm_adapter (0.5.0)
-    pg (0.17.1)
     phantomjs (1.9.7.1)
     pry (0.10.1)
       coderay (~> 1.1.0)
@@ -441,6 +441,7 @@ GEM
     rails-assets-markdown-it--markdown-it-for-inline (0.1.0)
     rails-assets-markdown-it (3.0.3)
     rails-assets-markdown-it-diaspora-mention (0.1.2)
+    rails-assets-markdown-it-emoji (0.1.3)
     rails-assets-markdown-it-hashtag (0.2.3)
     rails-assets-markdown-it-sanitizer (0.2.0)
     rails-assets-markdown-it-sub (0.1.0)
@@ -448,7 +449,7 @@ GEM
     rails-assets-perfect-scrollbar (0.5.7)
       rails-assets-jquery (>= 1.10)
     rails-assets-punycode (1.3.2)
-    rails-assets-twemoji (1.1.1)
+    rails-assets-twemoji (1.2.0)
     rails-i18n (4.0.3)
       i18n (~> 0.6)
       railties (~> 4.0)
@@ -665,6 +666,7 @@ DEPENDENCIES
   mini_magick (= 4.0.1)
   minitest
   mobile-fu (= 1.3.1)
+  mysql2 (= 0.3.17)
   nokogiri (= 1.6.4.1)
   omniauth (= 1.2.2)
   omniauth-facebook (= 1.6.0)
@@ -672,7 +674,6 @@ DEPENDENCIES
   omniauth-twitter (= 1.0.1)
   omniauth-wordpress (= 0.2.1)
   open_graph_reader (= 0.4.0)
-  pg (= 0.17.1)
   pry
   pry-byebug
   pry-debundle
@@ -692,13 +693,14 @@ DEPENDENCIES
   rails-assets-markdown-it (= 3.0.3)
   rails-assets-markdown-it--markdown-it-for-inline (= 0.1.0)
   rails-assets-markdown-it-diaspora-mention (= 0.1.2)
+  rails-assets-markdown-it-emoji (= 0.1.3)
   rails-assets-markdown-it-hashtag (= 0.2.3)
   rails-assets-markdown-it-sanitizer (= 0.2.0)
   rails-assets-markdown-it-sub (= 0.1.0)
   rails-assets-markdown-it-sup (= 0.1.0)
   rails-assets-perfect-scrollbar (= 0.5.7)
   rails-assets-punycode (= 1.3.2)
-  rails-assets-twemoji (= 1.1.1)
+  rails-assets-twemoji (= 1.2.0)
   rails-i18n (= 4.0.3)
   rails-timeago (= 2.11.0)
   rails_admin (= 0.6.5)

--- a/app/assets/javascripts/app/helpers/text_formatter.js
+++ b/app/assets/javascripts/app/helpers/text_formatter.js
@@ -59,14 +59,16 @@
     });
 
     var mentionPlugin = window.markdownitDiasporaMention;
-    md.use(mentionPlugin, mentions);
-
     var subPlugin = window.markdownitSub;
-    md.use(subPlugin);
     var supPlugin = window.markdownitSup;
-    md.use(supPlugin);
     var sanitizerPlugin = window.markdownitSanitizer;
-    md.use(sanitizerPlugin);
+    var emojiPlugin = window.markdownitEmoji;
+
+    md.use(mentionPlugin, mentions)
+      .use(sanitizerPlugin)
+      .use(supPlugin)
+      .use(subPlugin)
+      .use(emojiPlugin);
 
     // TODO this is a temporary fix
     // remove it as soon as markdown-it fixes its autolinking feature
@@ -75,6 +77,11 @@
 
     // Bootstrap table markup
     md.renderer.rules.table_open = function () { return '<table class="table table-striped">\n'; };
+
+    // use twemoji library for emojis
+    md.renderer.rules.emoji = function (token, idx) {
+      return twemoji.parse (token[idx].to, { base: '/assets/twemoji/' });
+    };
 
     return md.render(text);
   };

--- a/app/assets/javascripts/app/models/post/interactions.js
+++ b/app/assets/javascripts/app/models/post/interactions.js
@@ -82,6 +82,9 @@ app.models.Post.Interactions = Backbone.Model.extend({
 
   comment : function (text) {
     var self = this;
+    console.log(text);
+    text = twemoji.parse(text, {base: "/assets/twemoji/" });
+    console.log(text);
 
     this.comments.make(text).fail(function () {
       flash = new Diaspora.Widgets.FlashMessages;

--- a/app/assets/javascripts/app/models/post/interactions.js
+++ b/app/assets/javascripts/app/models/post/interactions.js
@@ -82,9 +82,6 @@ app.models.Post.Interactions = Backbone.Model.extend({
 
   comment : function (text) {
     var self = this;
-    console.log(text);
-    text = twemoji.parse(text, {base: "/assets/twemoji/" });
-    console.log(text);
 
     this.comments.make(text).fail(function () {
       flash = new Diaspora.Widgets.FlashMessages;

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -48,3 +48,4 @@
 //= require bootstrap-dropdown
 //= require bootstrap-modal
 //= require osmlocator
+//= require twemoji/twemoji

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -32,6 +32,7 @@
 //= require markdown-it-sanitizer
 //= require markdown-it-sub
 //= require markdown-it-sup
+//= require markdown-it-emoji
 //= require punycode
 //= require parse_url
 //= require clear-form

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1801,3 +1801,11 @@ a.toggle_selector {
     cursor: pointer;
   }
 }
+
+img.emoji {
+   height: 1em;
+   width: 1em;
+   margin: 0 .05em 0 .1em;
+   vertical-align: -0.1em;
+}
+

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1807,5 +1807,6 @@ img.emoji {
    width: 1em;
    margin: 0 .05em 0 .1em;
    vertical-align: -0.1em;
+   filter: grayscale(50%);
 }
 


### PR DESCRIPTION
This will convert common stuff like :) or :P into emojis. By default it uses the images from the local assets - they are really small, around 0.61 KB / emoji.

The technical burden will be small for d*, as I used a plugin for markdown-it.
