### PR TITLE
Fix bad email formatting

### DIFF
--- a/app/mailers/export_mailer.rb
+++ b/app/mailers/export_mailer.rb
@@ -4,7 +4,7 @@ class ExportMailer < ActionMailer::Base
   def export_complete_for(user)
     @user = user
 
-    mail(to: @user.email, subject: I18n.t('notifier.export_email.subject')) do |format|
+    mail(to: @user.email, subject: I18n.t('notifier.export_email.subject', name: @user.name)) do |format|
       format.html { render 'users/export_email' }
       format.text { render 'users/export_email' }
     end.deliver
@@ -13,7 +13,7 @@ class ExportMailer < ActionMailer::Base
   def export_failure_for(user)
     @user = user
 
-    mail(to: @user.email, subject: I18n.t('notifier.export_failure_email.subject')) do |format|
+    mail(to: @user.email, subject: I18n.t('notifier.export_failure_email.subject', name: @user.name)) do |format|
       format.html { render 'users/export_failure_email' }
       format.text { render 'users/export_failure_email' }
     end.deliver

--- a/app/views/users/export_email.markerb
+++ b/app/views/users/export_email.markerb
@@ -1,1 +1,1 @@
-<%= t('notifier.export_email.body', url: @user.export.url, username: @user.username) %>
+<%= t('notifier.export_email.body', url: download_profile_user_url, name: @user.first_name) %>

--- a/app/views/users/export_failure_email.markerb
+++ b/app/views/users/export_failure_email.markerb
@@ -1,1 +1,1 @@
-<%= t('notifier.export_failure_email.body', username: @user.username) %>
+<%= t('notifier.export_failure_email.body', name: @user.first_name) %>

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -782,19 +782,19 @@ en:
 
           [1]: %{url}
     export_email:
-      subject: "Your personal data is ready for download, %{username}"
+      subject: "Your personal data is ready for download, %{name}"
       body: |-
-        Hello %{username}
+        Hello %{name},
 
-        Your data has been processed and is ready for download by following [this link][%{url}].
+        Your data has been processed and is ready for download by following [this link](%{url}).
 
         Cheers,
 
         The diaspora* email robot!
     export_failure_email:
-      subject: "We're sorry, there was an issue with your data, %{username}"
+      subject: "We're sorry, there was an issue with your data, %{name}"
       body: |-
-        Hello %{username}
+        Hello %{name}
 
         We''ve encountered an issue while processing your personal data for download.
         Please try again!


### PR DESCRIPTION
For #5567

Here's a sample updated email:
----==_mimepart_54bdd0e23b7cb_2012770981868097
Content-Type: text/html;
 charset=UTF-8
Content-Transfer-Encoding: 7bit

<p>Hello James,</p>


<p>Your data has been processed and is ready for download by following <a href="http://localhost:3000/user/download_profile">this link</a>.</p>


<p>Cheers,</p>


<p>The diaspora* email robot!</p>


----==_mimepart_54bdd0e23b7cb_2012770981868097--
