### PR TITLE
fix #5568 - overflow json exporter

### DIFF
--- a/app/assets/stylesheets/new_styles/_base.scss
+++ b/app/assets/stylesheets/new_styles/_base.scss
@@ -164,7 +164,7 @@ $bring-dark-accent-forward-color: #DDD;
 /* general purpose classes */
 
 .small-horizontal-spacer {
-  height: 20px;
+  min-height: 20px;
 }
 
 .big-horizontal-spacer {


### PR DESCRIPTION
Screenshots : 
Before
![screenshot](https://cloud.githubusercontent.com/assets/1436309/5788876/27197498-9e51-11e4-92f9-34e951f1156b.png)

After 
![5568_overflow](https://cloud.githubusercontent.com/assets/6507951/5840610/26697a4a-a197-11e4-8a5a-59c00b2542e9.png)
