### PR TITLE
Added environment-variable to specify Firefox version for testing

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -15,6 +15,12 @@ require 'capybara/session'
 # Ensure we know the appservers port
 Capybara.server_port = 9887
 
+# Use a version of Firefox defined by environment variable, if set
+Capybara.register_driver :selenium do |app|
+  require 'selenium/webdriver'
+  Selenium::WebDriver::Firefox::Binary.path = ENV['FIREFOX_BINARY_PATH'] || Selenium::WebDriver::Firefox::Binary.path
+  Capybara::Selenium::Driver.new(app, :browser => :firefox)
+end
 
 # Capybara defaults to XPath selectors rather than Webrat's default of CSS3. In
 # order to ease the transition to Capybara we set the default here. If you'd


### PR DESCRIPTION
Implemented this workaround [1] , so we can still use Firefox 34 for testing (since Selenium Driver is currently broken for Firefox 35).

To use, define environment-variable `FIREFOX_BINARY_PATH` pointing to the firefox executable which should be used.

1: http://blog.pixarea.com/2013/02/locking-the-firefox-version-when-testing-rails-with-capybara-and-selenium
