### PR TITLE
Standardise capitalisation throughout UI

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -91,6 +91,7 @@ diaspora.yml file**. The existing settings from 0.4.x and before will not work a
 * Replace a modifier-rescue with a specific rescue [#5491](https://github.com/diaspora/diaspora/pull/5491)
 * Port contacts page to backbone [#5473](https://github.com/diaspora/diaspora/pull/5473)
 * Replace CSS vendor prefixes automatically [#5532](https://github.com/diaspora/diaspora/pull/5532)
+* Use sentence case consistently throughout UI [#5588](https://github.com/diaspora/diaspora/pull/5588)
 
 ## Bug fixes
 * orca cannot see 'Add Contact' button [#5158](https://github.com/diaspora/diaspora/pull/5158)

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -10,11 +10,11 @@ en:
   profile: "Profile"
   account: "Account"
   privacy: "Privacy"
-  privacy_policy: "Privacy Policy"
-  terms_and_conditions: "Terms and Conditions"
+  privacy_policy: "Privacy policy"
+  terms_and_conditions: "Terms and conditions"
   _services: "Services"
   _applications: "Applications"
-  _photos: "photos"
+  _photos: "Photos"
   _help: "Help"
   ok: "OK"
   cancel: "Cancel"
@@ -29,7 +29,7 @@ en:
   password: "Password"
   password_confirmation: "Password confirmation"
   are_you_sure: "Are you sure?"
-  are_you_sure_delete_account: "Are you sure you want to close your account? This can't be undone!"
+  are_you_sure_delete_account: "Are you sure you want to close your account? This can’t be undone!"
   fill_me_out: "Fill me out"
   back: "Back"
   public: "Public"
@@ -39,18 +39,18 @@ en:
   find_people: "Find people or #tags"
   _home: "Home"
   more: "More"
-  next: "next"
-  previous: "previous"
+  next: "Next"
+  previous: "Previous"
   _comments: "Comments"
-  all_aspects: "All Aspects"
-  no_results: "No Results Found"
+  all_aspects: "All aspects"
+  no_results: "No results found"
   _contacts: "Contacts"
   welcome: "Welcome!"
-  _terms: "terms"
+  _terms: "Terms"
   _statistics: "Statistics"
 
-  #for reference translation, the real activerecord english transations are actually
-  #in en-US, en-GB, and en-AU yml files
+  # For reference translation; the real ActiveRecord English transations are actually
+  # in the en-US, en-GB, and en-AU yml files.
   activerecord:
     errors:
       models:
@@ -70,7 +70,7 @@ en:
         contact:
           attributes:
             person_id:
-              taken: "must be unique among this user's contacts."
+              taken: "must be unique among this user’s contacts."
         request:
           attributes:
             from_id:
@@ -78,7 +78,7 @@ en:
         reshare:
           attributes:
             root_guid:
-              taken: "That good, huh?  You've already reshared that post!"
+              taken: "That good, eh?  You've already reshared that post!"
         poll:
           attributes:
             poll_answers:
@@ -86,10 +86,10 @@ en:
         poll_participation:
           attributes:
             poll:
-              already_participated: "You've already participated in this poll!"
+              already_participated: "You’ve already participated in this poll!"
   error_messages:
     helper:
-      invalid_fields: "Invalid Fields"
+      invalid_fields: "Invalid fields"
       correct_the_following_errors_and_try_again: "Correct the following errors and try again."
     post_not_public: "The post you are trying to view is not public!"
     post_not_public_or_not_exist: "The post you are trying to view is not public, or does not exist!"
@@ -98,41 +98,41 @@ en:
   admins:
     admin_bar:
       pages: "Pages"
-      user_search: "User Search"
-      weekly_user_stats: "Weekly User Stats"
-      pod_stats: "Pod Stats"
+      user_search: "User search"
+      weekly_user_stats: "Weekly user stats"
+      pod_stats: "Pod stats"
       report: "Reports"
       correlations: "Correlations"
       sidekiq_monitor: "Sidekiq monitor"
     correlations:
-      correlations_count: "Correlations with Sign In Count:"
+      correlations_count: "Correlations with sign-in count:"
     user_search:
       you_currently:
-        zero: "you currently have no invites left %{link}"
-        one: "you currently have one invite left %{link}"
-        other: "you currently have %{count} invites left %{link}"
-      view_profile: "view profile"
-      add_invites: "add invites"
-      close_account: "close account"
+        zero: "You currently have no invites left %{link}"
+        one: "You currently have one invite left %{link}"
+        other: "You currently have %{count} invites left %{link}"
+      view_profile: "View profile"
+      add_invites: "Add invites"
+      close_account: "Close account"
       are_you_sure: "Are you sure you want to close this account?"
       account_closing_scheduled: "The account of %{name} is scheduled to be closed. It will be processed in a few moments..."
-      email_to: "Email to Invite"
+      email_to: "Email to invite"
       under_13: "Show users that are under 13 (COPPA)"
       users:
         zero: "%{count} users found"
         one: "%{count} user found"
         other: "%{count} users found"
     user_entry:
-      id: 'ID'
-      guid: 'GUID'
-      email: 'Email'
-      diaspora_handle: 'Diaspora handle'
-      last_seen: 'last seen'
-      account_closed: 'account closed'
-      nsfw: '#nsfw'
-      unknown: 'unknown'
-      'yes': 'yes'
-      'no': 'no'
+      id: "ID"
+      guid: "GUID"
+      email: "Email"
+      diaspora_handle: "diaspora* handle"
+      last_seen: "Last seen"
+      account_closed: "Account closed"
+      nsfw: "#nsfw"
+      unknown: "Unknown"
+      'yes': "Yes"
+      'no': "No"
     weekly_user_stats:
       current_server: "Current server date is %{date}"
       amount_of:
@@ -141,11 +141,11 @@ en:
         other: "Number of new users this week: %{count}"
     stats:
       week: "Week"
-      2weeks: "2 Week"
+      2weeks: "2 weeks"
       month: "Month"
       daily: "Daily"
-      usage_statistic: "Usage Statistics"
-      go: "go"
+      usage_statistic: "Usage statistics"
+      go: "Go"
       display_results: "Displaying results from the <b>%{segment}</b> segment"
       posts:
         zero: "%{count} posts"
@@ -164,46 +164,46 @@ en:
         one: "%{count} user"
         other: "%{count} users"
       current_segment: "The current segment is averaging <b>%{post_yest}</b> posts per user, from <b>%{post_day}</b>"
-      50_most: "50 Most Popular Tags"
-      tag_name: "Tag Name: <b>%{name_tag}</b> Count: <b>%{count_tag}</b>"
+      50_most: "50 most popular tags"
+      tag_name: "Tag name: <b>%{name_tag}</b> Count: <b>%{count_tag}</b>"
   application:
     helper:
-      unknown_person: "unknown person"
+      unknown_person: "Unknown person"
       video_title:
-        unknown: "Unknown Video Title"
+        unknown: "Unknown video title"
   aspects:
-    zero: "no aspects"
+    zero: "No aspects"
     one: "1 aspect"
     other: "%{count} aspects"
     contacts_visible: "Contacts in this aspect will be able to see each other."
     contacts_not_visible: "Contacts in this aspect will not be able to see each other."
     edit:
-      grant_contacts_chat_privilege: "grant contacts in aspect chat privilege?"
-      make_aspect_list_visible: "make contacts in this aspect visible to each other?"
+      grant_contacts_chat_privilege: "Grant contacts in this aspect chat privilege?"
+      make_aspect_list_visible: "Make contacts in this aspect visible to each other?"
       remove_aspect: "Delete this aspect"
       confirm_remove_aspect: "Are you sure you want to delete this aspect?"
       add_existing: "Add an existing contact"
       set_visibility: "Set visibility"
       manage: "Manage"
       done: "Done"
-      rename: "rename"
+      rename: "Rename"
       aspect_list_is_visible: "Contacts in this aspect are able to see each other."
       aspect_list_is_not_visible: "Contacts in this aspect are not able to see each other."
       aspect_chat_is_enabled: "Contacts in this aspect are able to chat with you."
       aspect_chat_is_not_enabled: "Contacts in this aspect are not able to chat with you."
-      update: "update"
-      updating: "updating"
+      update: "Update"
+      updating: "Updating"
     aspect_contacts:
-      done_editing: "done editing"
+      done_editing: "Finished editing"
     show:
-      edit_aspect: "edit aspect"
+      edit_aspect: "Edit aspect"
     no_posts_message:
       start_talking: "Nobody has said anything yet!"
     no_contacts_message:
       you_should_add_some_more_contacts: "You should add some more contacts!"
       try_adding_some_more_contacts: "You can search or invite more contacts."
       or_spotlight:  "Or you can share with %{link}"
-      community_spotlight: "community spotlight"
+      community_spotlight: "Community spotlight"
     aspect_listings:
       select_all: "Select all"
       deselect_all: "Deselect all"
@@ -212,7 +212,7 @@ en:
     selected_contacts:
       view_all_community_spotlight: "See all community spotlight"
       view_all_contacts: "View all contacts"
-      no_contacts: "You don't have any contacts here yet."
+      no_contacts: "You don’t have any contacts here yet."
       manage_your_aspects: "Manage your aspects."
     new:
       name: "Name (only visible to you)"
@@ -227,14 +227,14 @@ en:
       success: "Your aspect, %{name}, has been successfully edited."
       failure: "Your aspect, %{name}, had too long name to be saved."
     move_contact:
-      failure: "didn't work %{inspect}"
+      failure: "Didn’t work %{inspect}"
       success: "Person moved to new aspect"
       error: "Error moving contact: %{inspect}"
     add_to_aspect:
       failure: "Failed to add contact to aspect."
       success: "Successfully added contact to aspect."
     helper:
-      remove: "remove"
+      remove: "Remove"
       aspect_not_empty: "Aspect not empty"
       are_you_sure: "Are you sure you want to delete this aspect?"
     seed:
@@ -250,19 +250,19 @@ en:
       unfollow_tag: "Stop following #%{tag}"
       handle_explanation: "This is your diaspora* ID. Like an email address, you can give this to people to reach you."
       no_contacts: "No contacts"
-      post_a_message: "post a message >>"
+      post_a_message: "Post a message >>"
       people_sharing_with_you: "People sharing with you"
 
       welcome_to_diaspora: "Welcome to diaspora*, %{name}!"
       introduce_yourself: "This is your stream.  Jump in and introduce yourself."
 
       new_here:
-        title: "Welcome New Users"
+        title: "Welcome new users"
         follow: "Follow %{link} and welcome new users to diaspora*!"
         learn_more: "Learn more"
 
       help:
-        need_help: "Need Help?"
+        need_help: "Need help?"
         here_to_help: "The diaspora* community is here!"
         do_you: "Do you:"
         have_a_question: "... have a %{link}?"
@@ -271,23 +271,23 @@ en:
         tag_bug: "bug"
         feature_suggestion: "... have a %{link} suggestion?"
         tag_feature: "feature"
-        tutorials_and_wiki: "%{faq}, %{tutorial} & %{wiki}: Help for your first steps."
+        tutorials_and_wiki: "%{faq}, %{tutorial} & %{wiki}: help for your first steps."
         tutorial_link_text: "Tutorials"
         email_feedback: "%{link} your feedback, if you prefer"
         email_link: "Email"
-        any_problem: "Any Problem?"
+        any_problem: "Got a problem?"
         contact_podmin: "Contact the administrator of your pod!"
-        mail_podmin: "Podmin E-Mail"
+        mail_podmin: "Podmin email"
       diaspora_id:
         heading: "diaspora* ID"
         content_1: "Your diaspora* ID is:"
-        content_2: "Give it to anyone and they'll be able to find you on diaspora*."
+        content_2: "Give it to anyone and they’ll be able to find you on diaspora*."
       services:
-        heading: "Connect Services"
+        heading: "Connect services"
         content: "You can connect the following services to diaspora*:"
 
     aspect_stream:
-      stay_updated: "Stay Updated"
+      stay_updated: "Stay updated"
       stay_updated_explanation: "Your main stream is populated with all of your contacts, tags you follow, and posts from some creative members of the community."
       make_something: "Make something"
 
@@ -304,7 +304,7 @@ en:
     explanation: "Post to diaspora* from anywhere by bookmarking this link => %{link}."
 
   comments:
-    zero: "no comments"
+    zero: "No comments"
     one: "1 comment"
     other: "%{count} comments"
     new_comment:
@@ -312,12 +312,12 @@ en:
       commenting: "Commenting..."
 
   reactions:
-    zero: "0 reactions"
+    zero: "No reactions"
     one: "1 reaction"
     other: "%{count} reactions"
 
   contacts:
-    zero: "contacts"
+    zero: "No contacts"
     one: "1 contact"
     other: "%{count} contacts"
     create:
@@ -325,45 +325,45 @@ en:
     sharing:
       people_sharing: "People sharing with you:"
     index:
-      add_to_aspect: "add contacts to %{name}"
+      add_to_aspect: "Add contacts to %{name}"
       start_a_conversation: "Start a conversation"
       add_a_new_aspect: "Add a new aspect"
       title: "Contacts"
-      your_contacts: "Your Contacts"
+      your_contacts: "Your contacts"
       no_contacts: "Looks like you need to add some contacts!"
       no_contacts_message: "Check out %{community_spotlight}"
       no_contacts_message_with_aspect: "Check out %{community_spotlight} or %{add_to_aspect_link}"
-      add_to_aspect_link: "add contacts to %{name}"
-      community_spotlight: "Community Spotlight"
-      my_contacts: "My Contacts"
-      all_contacts: "All Contacts"
+      add_to_aspect_link: "Add contacts to %{name}"
+      community_spotlight: "Community spotlight"
+      my_contacts: "My contacts"
+      all_contacts: "All contacts"
       only_sharing_with_me: "Only sharing with me"
       add_contact: "Add contact"
       remove_contact: "Remove contact"
       many_people_are_you_sure: "Are you sure you want to start a private conversation with more than %{suggested_limit} contacts? Posting to this aspect may be a better way to contact them."
-      user_search: "User Search"
+      user_search: "User search"
     spotlight:
-      community_spotlight: "Community Spotlight"
+      community_spotlight: "Community spotlight"
       suggest_member: "Suggest a member"
 
   conversations:
     index:
       conversations_inbox: "Conversations – Inbox"
       new_conversation: "New conversation"
-      no_conversation_selected: "no conversation selected"
-      create_a_new_conversation: "start a new conversation"
-      no_messages: "no messages"
+      no_conversation_selected: "No conversation selected"
+      create_a_new_conversation: "Start a new conversation"
+      no_messages: "No messages"
       inbox: "Inbox"
     conversation:
       participants: "Participants"
     show:
-      reply: "reply"
+      reply: "Reply"
       replying: "Replying..."
-      hide: "hide and mute conversation"
-      delete: "delete conversation"
+      hide: "Hide and mute conversation"
+      delete: "Delete conversation"
     new:
-      to: "to"
-      subject: "subject"
+      to: "To"
+      subject: "Subject"
       send: "Send"
       sending: "Sending..."
       abandon_changes: "Abandon changes?"
@@ -394,20 +394,20 @@ en:
     irc: "IRC"
     wiki: "wiki"
     markdown: "Markdown"
-    here: "here"
-    foundation_website: "diaspora foundation website"
-    third_party_tools: "third party tools"
-    getting_started_tutorial: "'Getting started' tutorial series"
+    here: "Here"
+    foundation_website: "diaspora* foundation website"
+    third_party_tools: "Third-party tools"
+    getting_started_tutorial: "“Getting started” tutorial series"
     getting_help:
       title: "Getting help"
       getting_started_q: "Help! I need some basic help to get me started!"
-      getting_started_a: "You're in luck. Try the %{tutorial_series} on our project site. It will take you step-by-step through the registration process and teach you all the basic things you need to know about using diaspora*."
+      getting_started_a: "You’re in luck. Try the %{tutorial_series} on our project site. It will take you step-by-step through the registration process and teach you all the basic things you need to know about using diaspora*."
       get_support_q: "What if my question is not answered in this FAQ? Where else can I get support?"
-      get_support_a_website: "visit our %{link}"
-      get_support_a_tutorials: "check out our %{tutorials}"
-      get_support_a_wiki: "search the %{link}"
-      get_support_a_irc: "join us on %{irc} (Live chat)"
-      get_support_a_hashtag: "ask in a public post on diaspora* using the %{question} hashtag"
+      get_support_a_website: "Visit our %{link}"
+      get_support_a_tutorials: "Check out our %{tutorials}"
+      get_support_a_wiki: "Search the %{link}"
+      get_support_a_irc: "Join us on %{irc} (live chat)"
+      get_support_a_hashtag: "Ask in a public post on diaspora* using the %{question} hashtag"
     account_and_data_management:
       title: "Account and data management"
       move_pods_q: "How do I move my seed (account) from one pod to another?"
@@ -415,39 +415,39 @@ en:
       download_data_q: "Can I download a copy of all of my data contained in my seed (account)?"
       download_data_a: "Yes. At the bottom of the Account tab of your settings page there are two buttons for downloading your data."
       close_account_q: "How do I delete my seed (account)?"
-      close_account_a: "Go to the bottom of your settings page and click the Close Account button."
+      close_account_a: "Go to the bottom of your settings page and click the “Close account” button."
       data_visible_to_podmin_q: "How much of my information can my pod administrator see?"
-      data_visible_to_podmin_a: "Communication *between* pods is always encrypted (using SSL and diaspora*'s own transport encryption), but the storage of data on pods is not encrypted. If they wanted to, the database administrator for your pod (usually the person running the pod) could access all your profile data and everything that you post (as is the case for most websites that store user data). Running your own pod provides more privacy since you then control access to the database."
+      data_visible_to_podmin_a: "Communication *between* pods is always encrypted (using SSL and diaspora*’s own transport encryption), but the storage of data on pods is not encrypted. If they wanted to, the database administrator for your pod (usually the person running the pod) could access all your profile data and everything that you post (as is the case for most websites that store user data). Running your own pod provides more privacy since you then control access to the database."
       data_other_podmins_q: "Can the administrators of other pods see my information?"
-      data_other_podmins_a: "Once you are sharing with someone on another pod, any posts you share with them and a copy of your profile data are stored (cached) on their pod, and are accessible to that pod's database administrator. When you delete a post or profile data it is deleted from your pod and any other pods where it had previously been stored."
+      data_other_podmins_a: "Once you are sharing with someone on another pod, any posts you share with them and a copy of your profile data are stored (cached) on their pod, and are accessible to that pod’s database administrator. When you delete a post or profile data it is deleted from your pod and any other pods where it had previously been stored."
     aspects:
       title: "Aspects"
       what_is_an_aspect_q: "What is an aspect?"
       what_is_an_aspect_a: "Aspects are the way you group your contacts on diaspora*. An aspect is one of the faces you show to the world. It might be who you are at work, or who you are to your family, or who you are to your friends in a club you belong to."
       who_sees_post_q: "When I post to an aspect, who sees it?"
-      who_sees_post_a: "If you make a limited post, it will only be visible the people you have put in that aspect (or those aspects, if it is made to multiple aspects). Contacts you have that aren't in the aspect have no way of seeing the post, unless you've made it public. Only public posts will ever be visible to anyone who you haven't placed into one of your aspects."
+      who_sees_post_a: "If you make a limited post, it will only be visible the people you have put in that aspect (or those aspects, if it is made to multiple aspects). Contacts you have that aren’t in the aspect have no way of seeing the post, unless you’ve made it public. Only public posts will ever be visible to anyone who you haven’t placed into one of your aspects."
       restrict_posts_i_see_q: "Can I restrict the posts I see to just those from certain aspects?"
-      restrict_posts_i_see_a: "Yes. Click on My Aspects in the side-bar and then click individual aspects in the list to select or deselect them. Only the posts by people in the selected aspects will appear in your stream."
+      restrict_posts_i_see_a: "Yes. Click on “My aspects” in the side-bar and then click individual aspects in the list to select or deselect them. Only the posts by people in the selected aspects will appear in your stream."
       contacts_know_aspect_q: "Do my contacts know which aspects I have put them in?"
       contacts_know_aspect_a: "No. They cannot see the name of the aspect under any circumstances."
       contacts_visible_q: "What does \"make contacts in this aspect visible to each other\" mean?"
-      contacts_visible_a: "If you check this option then contacts from that aspect will be able to see who else is in it, on your profile page under your picture. It's best to select this option only if the contacts in that aspect all know each other. They still won't be able to see what the aspect is called."
+      contacts_visible_a: "If you check this option then contacts from that aspect will be able to see who else is in it, on your profile page under your picture. It’s best to select this option only if the contacts in that aspect all know each other. They still won’t be able to see what the aspect is called."
       remove_notification_q: "If I remove someone from an aspect, or all of my aspects, are they notified of this?"
       remove_notification_a: "No."
       rename_aspect_q: "Can I rename an aspect?"
-      rename_aspect_a: "Yes. In your list of aspects on the left side of the main page, point your mouse at the aspect you want to rename. Click the little 'edit' pencil that appears to the right. Click rename in the box that appears."
+      rename_aspect_a: "Yes. In your list of aspects on the left side of the main page, point your mouse at the aspect you want to rename. Click the little “Edit” pencil that appears to the right. Click “Rename” in the box that appears."
       change_aspect_of_post_q: "Once I have posted something, can I change the aspect(s) that can see it?"
       change_aspect_of_post_a: "No, but you can always make a new post with the same content and post it to a different aspect."
       post_multiple_aspects_q: "Can I post content to multiple aspects at once?"
       post_multiple_aspects_a: "Yes. When you are making a post, use the aspect selector button to select or deselect aspects. Your post will be visible to all the aspects you select. You could also select the aspects you want to post to in the side-bar. When you post, the aspect(s) that you have selected in the list on the left will automatically be selected in the aspect selector when you start to make a new post."
       person_multiple_aspects_q: "Can I add a person to multiple aspects?"
-      person_multiple_aspects_a: "Yes. Go to your contacts page and click my contacts. For each contact you can use the menu on the right to add them to (or remove them from) as many aspects as you want. Or you can add them to a new aspect (or remove them from an aspect) by clicking the aspect selector button on their profile page. Or you can even just move the pointer over their name where you see it in the stream, and a 'hover-card' will appear. You can change the aspects they are in right there."
+      person_multiple_aspects_a: "Yes. Go to your contacts page and click on “My contacts”. For each contact you can use the menu on the right to add them to (or remove them from) as many aspects as you want. Or you can add them to a new aspect (or remove them from an aspect) by clicking the aspect selector button on their profile page. Or you can even just move the pointer over their name where you see it in the stream, and a “hover-card” will appear. You can change the aspects they are in right there."
       delete_aspect_q: "How do I delete an aspect?"
-      delete_aspect_a: "In your list of aspects on the left side of the main page, point your mouse at the aspect you want to delete. Click the little 'edit' pencil that appears on the right. Click the delete button in the box that appears."
+      delete_aspect_a: "In your list of aspects on the left side of the main page, point your mouse at the aspect you want to delete. Click the little “Edit” pencil that appears on the right. Click the “Delete this aspect” button in the box that appears."
     mentions:
       title: "Mentions"
       what_is_a_mention_q: "What is a \"mention\"?"
-      what_is_a_mention_a: "A mention is a link to a person's profile page that appears in a post. When someone is mentioned they receive a notification that calls their attention to the post."
+      what_is_a_mention_a: "A mention is a link to a person’s profile page that appears in a post. When someone is mentioned they receive a notification that calls their attention to the post."
       how_to_mention_q: "How do I mention someone when making a post?"
       how_to_mention_a: "Type the \"@\" sign and start typing their name. A drop down menu should appear to let you select them more easily. Note that it is only possible to mention people you have added to an aspect."
       mention_in_comment_q: "Can I mention someone in a comment?"
@@ -459,7 +459,7 @@ en:
       what_is_a_pod_q: "What is a pod?"
       what_is_a_pod_a: "A pod is a server running the diaspora* software and connected to the diaspora* network. \"Pod\" is a metaphor referring to pods on plants which contain seeds, in the way that a server contains a number of user accounts. There are many different pods. You can add friends from other pods and communicate with them. (You can think of a diaspora* pod as similar to an email provider: there are public pods, private pods, and with some effort you can even run your own)."
       find_people_q: "I just joined a pod, how can I find people to share with?"
-      find_people_a: "Invite your friends using the email link in the side-bar. Follow #tags to discover others who share your interests, and add those who post things that interest you to an aspect. Shout out that you're #newhere in a public post."
+      find_people_a: "Invite your friends using the email link in the side-bar. Follow #tags to discover others who share your interests, and add those who post things that interest you to an aspect. Shout out that you’re #newhere in a public post."
       use_search_box_q: "How do I use the search box to find particular individuals?"
       use_search_box_a: "If you know their full diaspora* ID (e.g. username@podname.org), you can find them by searching for it. If you are on the same pod you can search for just their username. An alternative is to search for them by their profile name (the name you see on screen). If a search does not work the first time, try it again."
     posts_and_posting:
@@ -478,16 +478,16 @@ en:
       size_of_images_q: "Can I customize the size of images in posts or comments?"
       size_of_images_a: "No. Images are resized automatically to fit the stream. Markdown does not have a code for specifying the size of an image."
       embed_multimedia_q: "How do I embed a video, audio, or other multimedia content into a post?"
-      embed_multimedia_a: "You can usually just paste the URL (e.g. http://www.youtube.com/watch?v=nnnnnnnnnnn ) into your post and the video or audio will be embedded automatically. Some of the sites that are supported are: YouTube, Vimeo, SoundCloud, Flickr and a few more. diaspora* uses oEmbed for this feature. We're supporting new sites all the time. Remember to always post simple, full links: no shortened links; no operators after the base URL; and give it a little time before you refresh the page after posting for seeing the preview."
+      embed_multimedia_a: "You can usually just paste the URL (e.g. http://www.youtube.com/watch?v=nnnnnnnnnnn ) into your post and the video or audio will be embedded automatically. Some of the sites that are supported are: YouTube, Vimeo, SoundCloud, Flickr and a few more. diaspora* uses oEmbed for this feature. We’re supporting new sites all the time. Remember to always post simple, full links: no shortened links; no operators after the base URL; and give it a little time before you refresh the page after posting for seeing the preview."
       character_limit_q: "What is the character limit for posts?"
-      character_limit_a: "65,535 characters. That's 65,395 more characters than you get on Twitter! ;)"
+      character_limit_a: "65,535 characters. That’s 65,395 more characters than you get on Twitter! ;)"
       char_limit_services_q: "What is the character limit for posts shared through a connected service with a smaller character count?"
-      char_limit_services_a: "In that case your post is limited to the smaller character count (140 in the case of Twitter; 1000 in the case of Tumblr), and the number of characters you have left to use is displayed when that service's icon is highlighted. You can still post to these services if your post is longer than their limit, but the text is truncated on those services."
-      stream_full_of_posts_q: "Why is my stream full of posts from people I don't know and don't share with?"
+      char_limit_services_a: "In that case your post is limited to the smaller character count (140 in the case of Twitter; 1000 in the case of Tumblr), and the number of characters you have left to use is displayed when that service’s icon is highlighted. You can still post to these services if your post is longer than their limit, but the text is truncated on those services."
+      stream_full_of_posts_q: "Why is my stream full of posts from people I don’t know and don’t share with?"
       stream_full_of_posts_a1: "Your stream is made up of three types of posts:"
       stream_full_of_posts_li1: "Posts by people you are sharing with, which come in two types: public posts and limited posts shared with an aspect that you are part of. To remove these posts from your stream, simply stop sharing with the person."
       stream_full_of_posts_li2: "Public posts containing one of the tags that you follow. To remove these, stop following the tag."
-      stream_full_of_posts_li3: "Public posts by people listed in the Community Spotlight. These can be removed by unchecking the “Show Community Spotlight in Stream?” option in the Account tab of your Settings."
+      stream_full_of_posts_li3: "Public posts by people listed in the community spotlight. These can be removed by unchecking the “Show community spotlight in stream?” option in the Account tab of your Settings."
     private_posts:
       title: "Private posts"
       who_sees_post_q: "When I post a message to an aspect (i.e., a private post), who can see it?"
@@ -502,16 +502,16 @@ en:
       title: "Private profiles"
       who_sees_profile_q: "Who sees my private profile?"
       who_sees_profile_a: "Any logged-in user that you are sharing with (meaning, you have added them to one of your aspects). However, people following you, but whom you do not follow, will see only your public information."
-      whats_in_profile_q: "What's in my private profile?"
-      whats_in_profile_a: "Biography, location, gender, and birthday. It's the stuff in the bottom section of the edit profile page. All this information is optional – it's up to you whether you fill it in. Logged-in users who you have added to your aspects are the only people who can see your private profile. They will also see the private posts that made to the aspect(s) they are in, mixed in with your public posts, when they visit your profile page."
+      whats_in_profile_q: "What’s in my private profile?"
+      whats_in_profile_a: "Biography, location, gender, and birthday. It’s the stuff in the bottom section of the “Edit profile” page. All this information is optional – it’s up to you whether you fill it in. Logged-in users who you have added to your aspects are the only people who can see your private profile. They will also see the private posts that made to the aspect(s) they are in, mixed in with your public posts, when they visit your profile page."
       who_sees_updates_q: "Who sees updates to my private profile?"
       who_sees_updates_a: "Anyone in your aspects sees changes to your private profile. "
     public_posts:
       title: "Public posts"
       who_sees_post_q: "When I post something publicly, who can see it?"
-      who_sees_post_a: "Anyone using the internet can potentially see a post you mark public, so make sure you really do want your post to be public. It's a great way of reaching out to the world."
+      who_sees_post_a: "Anyone using the internet can potentially see a post you mark public, so make sure you really do want your post to be public. It’s a great way of reaching out to the world."
       find_public_post_q: "How can other people find my public post?"
-      find_public_post_a: "Your public posts will appear in the streams of anyone following you. If you included #tags in your public post, anyone following those tags will find your post in their streams. Every public post also has a specific URL that anyone can view, even if they're not logged in - thus public posts may be linked to directly from Twitter, blogs, etc. Public posts may also be indexed by search engines."
+      find_public_post_a: "Your public posts will appear in the streams of anyone following you. If you included #tags in your public post, anyone following those tags will find your post in their streams. Every public post also has a specific URL that anyone can view, even if they’re not logged in - thus public posts may be linked to directly from Twitter, blogs, etc. Public posts may also be indexed by search engines."
       can_comment_reshare_like_q: "Who can comment on, reshare, or like my public post?"
       can_comment_reshare_like_a: "Any logged-in diaspora* user can comment on, reshare, or like your public post."
       see_comment_reshare_like_q: "When I comment on, reshare, or like a public post, who can see it?"
@@ -522,8 +522,8 @@ en:
       title: "Public profiles"
       who_sees_profile_q: "Who sees my public profile?"
       who_sees_profile_a: "Any logged-in diaspora* user, as well as the wider internet, can see it. Each profile has a direct URL, so it may be linked to directly from outside sites. It may be indexed by search engines."
-      whats_in_profile_q: "What's in my public profile"
-      whats_in_profile_a: "Your name, the five tags you chose to describe yourself, and your photo. It's the stuff in the top section of the edit profile page. You can make this profile information as identifiable or anonymous as you like. Your profile page also shows any public posts you have made."
+      whats_in_profile_q: "What’s in my public profile"
+      whats_in_profile_a: "Your name, the five tags you chose to describe yourself, and your photo. It’s the stuff in the top section of the “Edit profile” page. You can make this profile information as identifiable or anonymous as you like. Your profile page also shows any public posts you have made."
       who_sees_updates_q: "Who sees updates to my public profile?"
       who_sees_updates_a: "Anyone can see changes if they visit your profile page."
       what_do_tags_do_q: "What do the tags on my public profile do?"
@@ -537,19 +537,19 @@ en:
     sharing:
       title: "Sharing"
       add_to_aspect_q: "What happens when I add someone to one of my aspects? Or when someone adds me to one of their aspects?"
-      add_to_aspect_a1: "Let's say that Amy adds Ben to an aspect, but Ben has not (yet) added Amy to an aspect:"
+      add_to_aspect_a1: "Let’s say that Amy adds Ben to an aspect, but Ben has not (yet) added Amy to an aspect:"
       add_to_aspect_li1: "Ben will receive a notification that Amy has \"started sharing\" with Ben."
-      add_to_aspect_li2: "Amy will start to see Ben's public posts in her stream."
-      add_to_aspect_li3: "Amy will not see any of Ben's private posts."
-      add_to_aspect_li4: "Ben will not see Amy's public or private posts in his stream."
-      add_to_aspect_li5: "But if Ben goes to Amy's profile page, then he will see Amy's private posts that she makes to her aspect that has him in it (as well as her public posts which anyone can see there)."
-      add_to_aspect_li6: "Ben will be able to see Amy's private profile (bio, location, gender, birthday)."
-      add_to_aspect_li7: "Amy will appear under \"Only sharing with me\" on Ben's contacts page."
-      add_to_aspect_a2: "This is known as asymmetrical sharing. If and when Ben also adds Amy to an aspect then it would become mutual sharing, with both Amy's and Ben's public posts and relevant private posts appearing in each other's streams, etc. "
+      add_to_aspect_li2: "Amy will start to see Ben’s public posts in her stream."
+      add_to_aspect_li3: "Amy will not see any of Ben’s private posts."
+      add_to_aspect_li4: "Ben will not see Amy’s public or private posts in his stream."
+      add_to_aspect_li5: "But if Ben goes to Amy’s profile page, then he will see Amy’s private posts that she makes to her aspect that has him in it (as well as her public posts which anyone can see there)."
+      add_to_aspect_li6: "Ben will be able to see Amy’s private profile (bio, location, gender, birthday)."
+      add_to_aspect_li7: "Amy will appear under \"Only sharing with me\" on Ben’s contacts page."
+      add_to_aspect_a2: "This is known as asymmetrical sharing. If and when Ben also adds Amy to an aspect then it would become mutual sharing, with both Amy’s and Ben’s public posts and relevant private posts appearing in each other’s streams, etc. "
       only_sharing_q: "Who are the people listed in \"Only sharing with me\" on my contacts page?"
       only_sharing_a: "These are people that have added you to one of their aspects, but who are not (yet) in any of your aspects. In other words, they are sharing with you, but you are not sharing with them (asymmetrical sharing). If you add them to an aspect, they will then appear under that aspect and not under \"only sharing with you\". See above."
       list_not_sharing_q: "Is there a list of people whom I have added to one of my aspects, but who have not added me to one of theirs?"
-      list_not_sharing_a: "No, but you can see whether or not someone is sharing with you by visiting their profile page. If they are, the bar under their profile picture will be green; if not, it'll be grey. You should get a notification each time someone starts sharing with you."
+      list_not_sharing_a: "No, but you can see whether or not someone is sharing with you by visiting their profile page. If they are, the bar under their profile picture will be green; if not, it’ll be grey. You should get a notification each time someone starts sharing with you."
       see_old_posts_q: "When I add someone to an aspect, can they see older posts that I have already posted to that aspect?"
       see_old_posts_a: "No. They will only be able to see new posts to that aspect. They (and everyone else) can see your older public posts on your profile page, and they may also see them in their stream."
     tags:
@@ -557,9 +557,9 @@ en:
       what_are_tags_for_q: "What are tags for?"
       what_are_tags_for_a: "Tags are a way to categorize a post, usually by topic. Searching for a tag shows all posts with that tag that you can see (both public and private posts). This lets people who are interested in a given topic find public posts about it."
       tags_in_comments_q: "Can I put tags in comments or just in posts?"
-      tags_in_comments_a: "A tag added to a comment will still appear as a link to that tag's page, but it will not make that post (or comment) appear on that tag page. This only works for tags in posts."
+      tags_in_comments_a: "A tag added to a comment will still appear as a link to that tag’s page, but it will not make that post (or comment) appear on that tag page. This only works for tags in posts."
       followed_tags_q: "What are \"#Followed Tags\" and how do I follow a tag?"
-      followed_tags_a: "After searching for a tag you can click the button at the top of the tag's page to \"follow\" that tag. It will then appear in your list of followed tags on the left. Clicking one of your followed tags takes you to that tag's page so you can see recent posts containing that tag. Click on #Followed Tags to see a stream of posts that include one of any of your followed tags. "
+      followed_tags_a: "After searching for a tag you can click the button at the top of the tag’s page to \"follow\" that tag. It will then appear in your list of followed tags on the left. Clicking one of your followed tags takes you to that tag’s page so you can see recent posts containing that tag. Click on #Followed Tags to see a stream of posts that include one of any of your followed tags. "
       people_tag_page_q: "Who are the people listed on the left-hand side of a tag page?"
       people_tag_page_a: "They are people who have listed that tag to describe themselves in their public profile."
       filter_tags_q: "How can I filter/exclude some tags from my stream?"
@@ -567,10 +567,10 @@ en:
     keyboard_shortcuts:
       keyboard_shortcuts_q: "What keyboard shortcuts are available?"
       keyboard_shortcuts_a1: "In the stream view you can use the following keyboard shortcuts:"
-      keyboard_shortcuts_li1: "j - jump to the next post"
-      keyboard_shortcuts_li2: "k - jump to the previous post"
-      keyboard_shortcuts_li3: "c - comment on the current post"
-      keyboard_shortcuts_li4: "l - like the current post"
+      keyboard_shortcuts_li1: "j - Jump to the next post"
+      keyboard_shortcuts_li2: "k - Jump to the previous post"
+      keyboard_shortcuts_li3: "c - Comment on the current post"
+      keyboard_shortcuts_li4: "l - Like the current post"
       title: "Keyboard shortcuts"
     miscellaneous:
       title: "Miscellaneous"
@@ -578,10 +578,10 @@ en:
       back_to_top_a: "Yes. After scrolling down a page, click on the grey arrow that appears in the bottom right corner of your browser window."
       photo_albums_q: "Are there photo or video albums?"
       photo_albums_a: "No, not currently. However you can view a stream of their uploaded pictures from the Photos section in the side-bar of their profile page."
-      subscribe_feed_q: "Can I subscribe to someone's public posts with a feed reader?"
-      subscribe_feed_a: "Yes, but this is still not a polished feature and the formatting of the results is still pretty rough. If you want to try it anyway, go to someone's profile page and click the feed button in your browser, or you can copy the profile URL (i.e. https://joindiaspora.com/people/somenumber), and paste it into a feed reader. The resulting feed address looks like this: https://joindiaspora.com/public/username.atom – diaspora* uses Atom rather than RSS."
+      subscribe_feed_q: "Can I subscribe to someone’s public posts with a feed reader?"
+      subscribe_feed_a: "Yes, but this is still not a polished feature and the formatting of the results is still pretty rough. If you want to try it anyway, go to someone’s profile page and click the feed button in your browser, or you can copy the profile URL (i.e. https://joindiaspora.com/people/somenumber), and paste it into a feed reader. The resulting feed address looks like this: https://joindiaspora.com/public/username.atom – diaspora* uses Atom rather than RSS."
       diaspora_app_q: "Is there a diaspora* app for Android or iOS?"
-      diaspora_app_a: "There are several Android apps in very early development. Several are long-abandoned projects and so do not work well with the current version of diaspora*. Don't expect much from these apps at the moment. Currently the best way to access diaspora* from your mobile device is through a browser, because we've designed a mobile version of the site which should work well on all devices. There is currently no app for iOS. Again, diaspora* should work fine via your browser."
+      diaspora_app_a: "There are several Android apps in very early development. Several are long-abandoned projects and so do not work well with the current version of diaspora*. Don’t expect much from these apps at the moment. Currently the best way to access diaspora* from your mobile device is through a browser, because we’ve designed a mobile version of the site which should work well on all devices. There is currently no app for iOS. Again, diaspora* should work fine via your browser."
 
   invitation_codes:
     excited: "%{name} is excited to see you here."
@@ -592,7 +592,7 @@ en:
       no_more: "You have no more invitations."
       already_sent: "You already invited this person."
       already_contacts: "You are already connected with this person"
-      own_address: "You can't send an invitation to your own address."
+      own_address: "You can’t send an invitation to your own address."
       empty: "Please enter at least one email address."
       note_already_sent: "Invitations have already been sent to: %{emails}"
     new:
@@ -628,33 +628,33 @@ en:
       settings: "Settings"
       help: "Help"
       logout: "Log out"
-      blog: "blog"
-      login: "log in"
-      code: "code"
-      admin: "admin"
+      blog: "Blog"
+      login: "Log in"
+      code: "Code"
+      admin: "Admin"
       view_all: "View all"
       recent_notifications: "Recent notifications"
     application:
-      powered_by: "POWERED BY diaspora*"
-      whats_new: "what's new?"
-      toggle: "toggle mobile"
+      powered_by: "Powered by diaspora*"
+      whats_new: "What’s new?"
+      toggle: "Toggle mobile"
       public_feed: "Public diaspora* feed for %{name}"
-      your_aspects: "your aspects"
+      your_aspects: "Your aspects"
       back_to_top: "Back to top"
-      source_package: "download the source code package"
+      source_package: "Download the source code package"
 
   likes:
     likes:
       people_like_this:
-        zero: "no likes"
+        zero: "No likes"
         one: "%{count} like"
         other: "%{count} likes"
       people_like_this_comment:
-        zero: "no likes"
+        zero: "No likes"
         one: "%{count} like"
         other: "%{count} likes"
       people_dislike_this:
-        zero: "no dislikes"
+        zero: "No dislikes"
         one: "%{count} dislike"
         other: "%{count} dislikes"
 
@@ -672,9 +672,9 @@ en:
       one: "%{actors} commented on your post %{post_link}."
       other: "%{actors} commented on your post %{post_link}."
     also_commented:
-      zero: "%{actors} also commented on %{post_author}'s post %{post_link}."
-      one: "%{actors} also commented on %{post_author}'s post %{post_link}."
-      other: "%{actors} also commented on %{post_author}'s post %{post_link}."
+      zero: "%{actors} also commented on %{post_author}’s post %{post_link}."
+      one: "%{actors} also commented on %{post_author}’s post %{post_link}."
+      other: "%{actors} also commented on %{post_author}’s post %{post_link}."
     mentioned:
       zero: "%{actors} have mentioned you in the post %{post_link}."
       one: "%{actors} has mentioned you in the post %{post_link}."
@@ -710,8 +710,8 @@ en:
       mark_all_shown_as_read: "Mark all shown as read"
       mark_read: "Mark read"
       mark_unread: "Mark unread"
-      show_all: "show all"
-      show_unread: "show unread"
+      show_all: "Show all"
+      show_unread: "Show unread"
       all_notifications: "All Notifications"
       also_commented: "Also commented"
       comment_on_post: "Comment on post"
@@ -723,7 +723,7 @@ en:
         zero: "and nobody else"
         one: "and one more"
         other: "and %{count} others"
-      and: 'and'
+      and: "and"
     helper:
       new_notifications:
         zero: "No new notifications"
@@ -732,10 +732,10 @@ en:
 
   notifier:
     a_post_you_shared: "a post."
-    a_private_message: "There's a new private message in diaspora* for you to check out."
-    a_limited_post_comment: "There's a new comment on a limited post in diaspora* for you to check out."
+    a_private_message: "There’s a new private message in diaspora* for you to check out."
+    a_limited_post_comment: "There’s a new comment on a limited post in diaspora* for you to check out."
     email_sent_by_diaspora: "This email was sent by %{pod_name}. If you'd like to stop getting emails like this,"
-    click_here: "click here"
+    click_here: "Click here"
     hello: "Hello %{name}!"
     thanks: "Thanks,"
     to_change_your_notification_settings: "to change your notification settings"
@@ -745,9 +745,9 @@ en:
     started_sharing:
         subject: "%{name} started sharing with you on diaspora*"
         sharing: "has started sharing with you!"
-        view_profile: "View %{name}'s profile"
+        view_profile: "View %{name}’s profile"
     comment_on_post:
-        reply: "Reply or view %{name}'s post >"
+        reply: "Reply or view %{name}’s post >"
     mentioned:
         subject: "%{name} has mentioned you on diaspora*"
         mentioned: "mentioned you in a post:"
@@ -793,17 +793,17 @@ en:
 
         The diaspora* email robot!
     export_failure_email:
-      subject: "We're sorry, there was an issue with your data, %{name}"
+      subject: "We’re sorry, there was an issue with your data, %{name}"
       body: |-
         Hello %{name}
 
-        We''ve encountered an issue while processing your personal data for download.
+        We’ve encountered an issue while processing your personal data for download.
         Please try again!
 
         Cheers,
 
         The diaspora* email robot!
-    accept_invite: "Accept Your diaspora* invite!"
+    accept_invite: "Accept your diaspora* invite!"
     invited_you: "%{name} invited you to diaspora*"
     invite:
       message: |-
@@ -826,37 +826,37 @@ en:
       body: |-
         Hello,
         
-        It looks as though you no longer want your account at %{pod_url}, as you haven't used it for %{after_days} days. To ensure our active users get the best performance from this diaspora* pod, we'd like to remove unwanted accounts from our database.
+        It looks as though you no longer want your account at %{pod_url}, as you haven’t used it for %{after_days} days. To ensure our active users get the best performance from this diaspora* pod, we’d like to remove unwanted accounts from our database.
         
-        We'd love you to stay part of diaspora*'s community, and you're welcome to keep your account live if you want to.
+        We’d love you to stay part of diaspora*’s community, and you’re welcome to keep your account live if you want to.
         
-        If you want to keep your account live, all you need to do is to sign in to your account before %{remove_after}. When you sign in, take a moment to have a look around diaspora*. It has changed a lot since you last looked in, and we think you'll like the improvements we've made. Follow some #tags to find content you love.
+        If you want to keep your account live, all you need to do is to sign in to your account before %{remove_after}. When you sign in, take a moment to have a look around diaspora*. It has changed a lot since you last looked in, and we think you’ll like the improvements we’ve made. Follow some #tags to find content you love.
         
-        Sign in here: %{login_url}. If you've forgotten your sign-in details, you can ask for a reminder on that page.
+        Sign in here: %{login_url}. If you’ve forgotten your sign-in details, you can ask for a reminder on that page.
         
         Hoping to see you again,
 
         The diaspora* email robot!
   people:
-    zero: "no people"
+    zero: "No people"
     one: "1 person"
     other: "%{count} people"
     person:
       pending_request: "Pending request"
       already_connected: "Already connected"
-      thats_you: "That's you!"
-      add_contact: "add contact"
+      thats_you: "That’s you!"
+      add_contact: "Add contact"
     index:
       results_for: "Users matching %{search_term}"
       no_results: "Hey! You need to search for something."
-      couldnt_find_them: "Couldn't find them?"
+      couldnt_find_them: "Couldn’t find them?"
       search_handle: "Use their diaspora* ID (username@pod.tld) to be sure to find your friends."
       send_invite: "Still nothing? Send an invite!"
       no_one_found: "...and no one was found."
-      searching: "searching, please be patient..."
+      searching: "Searching, please be patient..."
       looking_for: "Looking for posts tagged %{tag_link}?"
     webfinger:
-      fail: "Sorry, we couldn't find %{handle}."
+      fail: "Sorry, we couldn’t find %{handle}."
     show:
       has_not_shared_with_you_yet: "%{name} has not shared any posts with you yet!"
       incoming_request: "%{name} wants to share with you"
@@ -864,56 +864,56 @@ en:
       to_accept_or_ignore: "to accept or ignore it."
       does_not_exist: "Person does not exist!"
       not_connected: "You are not sharing with this person"
-      recent_posts: "Recent Posts"
-      recent_public_posts: "Recent Public Posts"
+      recent_posts: "Recent posts"
+      recent_public_posts: "Recent public posts"
       see_all: "See all"
-      start_sharing: "start sharing"
+      start_sharing: "Start sharing"
       message: "Message"
       mention: "Mention"
       ignoring: "You are ignoring all posts from %{name}."
       closed_account: "This account has been closed."
     sub_header:
-      you_have_no_tags: "you have no tags!"
-      add_some: "add some"
-      edit: "edit"
+      you_have_no_tags: "You have no tags!"
+      add_some: "Add some"
+      edit: "Edit"
     profile_sidebar:
-      remove_contact: "remove contact"
+      remove_contact: "Remove contact"
       edit_my_profile: "Edit my profile"
       bio: "Bio"
       location: "Location"
       gender: "Gender"
       born: "Birthday"
       photos: "Photos"
-      in_aspects: "in aspects"
+      in_aspects: "In aspects"
       remove_from: "Remove %{name} from %{aspect}?"
     helper:
       results_for: " results for %{params}"
       is_sharing: "%{name} is sharing with you"
       is_not_sharing: "%{name} is not sharing with you"
     aspect_list:
-      edit_membership: "edit aspect membership"
+      edit_membership: "Edit aspect membership"
     add_contact_small:
-      add_contact_from_tag: "add contact from tag"
+      add_contact_from_tag: "Add contact from tag"
     add_contact:
-      invited_by: "you were invited by"
+      invited_by: "You were invited by"
 
   photos:
     show:
-      delete_photo: "Delete Photo"
-      make_profile_photo: "make profile photo"
-      update_photo: "Update Photo"
-      edit: "edit"
+      delete_photo: "Delete photo"
+      make_profile_photo: "Make profile photo"
+      update_photo: "Update photo"
+      edit: "Edit"
       edit_delete_photo: "Edit photo description / delete photo"
-      collection_permalink: "collection permalink"
+      collection_permalink: "Collection permalink"
       show_original_post: "Show original post"
     edit:
       editing: "Editing"
     photo:
-      view_all: "view all of %{name}'s photos"
+      view_all: "View all of %{name}’s photos"
     new:
-      new_photo: "New Photo"
-      back_to_list: "Back to List"
-      post_it: "post it!"
+      new_photo: "New photo"
+      back_to_list: "Back to list"
+      post_it: "Post it!"
     create:
       runtime_error: "Photo upload failed.  Are you sure that your seatbelt is fastened?"
       integrity_error: "Photo upload failed.  Are you sure that was an image?"
@@ -930,15 +930,15 @@ en:
     new_profile_photo:
       upload: "Upload a new profile photo!"
       or_select_one_existing: "or select one from your already existing %{photos}"
-    comment_email_subject: "%{name}'s photo"
+    comment_email_subject: "%{name}’s photo"
 
   posts:
     presenter:
       title: "A post from %{name}"
     show:
       destroy: "Delete"
-      permalink: "permalink"
-      not_found: "Sorry, we couldn't find that post."
+      permalink: "Permalink"
+      not_found: "Sorry, we couldn’t find that post."
       photos_by:
         zero: "No photos by %{author}"
         one: "One photo by %{author}"
@@ -946,7 +946,7 @@ en:
       reshare_by: "Reshare by %{author}"
 
   report:
-    title: "Reports Overview"
+    title: "Reports overview"
     post_label: "<b>Post</b>: %{title}"
     comment_label: "<b>Comment</b>:<br>%{data}"
     reported_label: "<b>Reported by</b> %{person}"
@@ -963,8 +963,8 @@ en:
 
   share_visibilites:
     update:
-      post_hidden_and_muted: "%{name}'s post has been hidden, and notifications have been muted."
-      see_it_on_their_profile: "If you want to see updates on this post, visit %{name}'s profile page."
+      post_hidden_and_muted: "%{name}’s post has been hidden, and notifications have been muted."
+      see_it_on_their_profile: "If you want to see updates on this post, visit %{name}’s profile page."
 
   profiles:
     edit:
@@ -977,7 +977,7 @@ en:
       your_birthday: "Your birthday"
       your_tags: "Describe yourself in 5 words"
 
-      your_tags_placeholder: "like #movies #kittens #travel #teacher #newyork"
+      your_tags_placeholder: "Like #movies #kittens #travel #teacher #newyork"
 
       your_bio: "Your bio"
       your_location: "Your location"
@@ -985,7 +985,7 @@ en:
       update_profile: "Update profile"
       allow_search: "Allow for people to search for you within diaspora*"
       edit_profile: "Edit profile"
-      nsfw_explanation: "NSFW (‘not safe for work’) is diaspora*’s self-governing community standard for content which may not be suitable to view while at work. If you plan to share such material frequently, please check this option so that everything you share will be hidden from people’s streams unless they choose to view them."
+      nsfw_explanation: "NSFW (“not safe for work”) is diaspora*’s self-governing community standard for content which may not be suitable to view while at work. If you plan to share such material frequently, please check this option so that everything you share will be hidden from people’s streams unless they choose to view them."
       nsfw_explanation2: "If you choose not to select this option, please add the #nsfw tag each time you share such material."
       nsfw_check: "Mark everything I share as NSFW"
     update:
@@ -997,7 +997,7 @@ en:
       create_my_account: "Create my account!"
 
       join_the_movement: "Join the movement!"
-      sign_up_message: "Social Networking with a ♥"
+      sign_up_message: "Social networking with a ♥"
 
       enter_email: "Enter an email"
       enter_username: "Pick a username (only letters, numbers, and underscores)"
@@ -1015,10 +1015,10 @@ en:
       terms: "By creating an account you accept the %{terms_link}."
       terms_link: "terms of service"
     create:
-      success: "You've joined diaspora*!"
+      success: "You’ve joined diaspora*!"
     edit:
       edit: "Edit %{name}"
-      leave_blank: "(leave blank if you don't want to change it)"
+      leave_blank: "(leave blank if you don’t want to change it)"
       password_to_confirm: "(we need your current password to confirm your changes)"
       unhappy: "Unhappy?"
       update: "Update"
@@ -1036,40 +1036,40 @@ en:
       ignore: "Ignored contact request."
     create:
       sending: "Sending"
-      sent: "You've asked to share with %{name}.  They should see it next time they log in to diaspora*."
+      sent: "You’ve asked to share with %{name}.  They should see it next time they log in to diaspora*."
     new_request_to_person:
-      sent: "sent!"
+      sent: "Sent!"
     helper:
       new_requests:
-        zero: "no new requests"
-        one: "new request!"
+        zero: "No new requests"
+        one: "New request!"
         other: "%{count} new requests!"
   reshares:
     reshare:
-      reshared_via: "reshared via"
+      reshared_via: "Reshared via"
       reshare_original: "Reshare original"
       reshare:
         zero: "Reshare"
         one: "1 reshare"
         other: "%{count} reshares"
       show_original: "Show original"
-      reshare_confirmation: "Reshare %{author}'s post?"
+      reshare_confirmation: "Reshare %{author}’s post?"
       deleted: "Original post deleted by author."
     create:
       failure: "There was an error resharing this post."
-    comment_email_subject: "%{resharer}'s reshare of %{author}'s post"
+    comment_email_subject: "%{resharer}’s reshare of %{author}’s post"
   services:
     index:
-      logged_in_as: "logged in as"
-      disconnect: "disconnect"
-      really_disconnect: "disconnect %{service}?"
+      logged_in_as: "Logged in as"
+      disconnect: "Disconnect"
+      really_disconnect: "Disconnect %{service}?"
       connect_to_twitter: "Connect to Twitter"
       connect_to_facebook: "Connect to Facebook"
       connect_to_tumblr: "Connect to Tumblr"
-      connect_to_wordpress: "Connect to Wordpress"
+      connect_to_wordpress: "Connect to WordPress"
       edit_services: "Edit services"
-      no_services: 'You have not connected any services yet.'
-      services_explanation: 'Connecting to services gives you the ability to publish your posts to them as you write them in diaspora*.'
+      no_services: "You have not connected any services yet."
+      services_explanation: "Connecting to services gives you the ability to publish your posts to them as you write them in diaspora*."
     create:
       success: "Authentication successful."
       failure: "Authentication failed."
@@ -1078,26 +1078,26 @@ en:
     destroy:
       success: "Successfully deleted authentication."
     failure:
-      error: "there was an error connecting that service"
+      error: "There was an error connecting to that service"
     inviter:
       join_me_on_diaspora: "Join me on diaspora*"
       click_link_to_accept_invitation: "Follow this link to accept your invitation"
     finder:
       fetching_contacts: "diaspora* is populating your %{service} friends, please check back in a few minutes."
-      service_friends: "%{service} Friends"
+      service_friends: "%{service} friends"
       no_friends: "No Facebook friends found."
     remote_friend:
-      resend: "resend"
-      invite: "invite"
+      resend: "Resend"
+      invite: "Invite"
       not_on_diaspora: "Not yet on diaspora*"
 
   blocks:
     create:
-      success: "Alright, you won't see that user in your stream again. #silencio!"
-      failure: "I couldn't ignore that user.  #evasion"
+      success: "All right, you won’t see that user in your stream again. #silencio!"
+      failure: "I couldn’t ignore that user.  #evasion"
     destroy:
-      success: "Let's see what they have to say! #sayhello"
-      failure: "I couldn't stop ignoring that user.  #evasion"
+      success: "Let’s see what they have to say! #sayhello"
+      failure: "I couldn’t stop ignoring that user.  #evasion"
 
   shared:
     aspect_dropdown:
@@ -1112,18 +1112,18 @@ en:
       share: "Share"
       preview: "Preview"
       post_a_message_to: "Post a message to %{aspect}"
-      make_public: "make public"
-      all: "all"
+      make_public: "Make public"
+      all: "All"
       upload_photos: "Upload photos"
       get_location: "Get your location"
       remove_location: "Remove location"
-      all_contacts: "all contacts"
-      share_with: "share with"
-      whats_on_your_mind: "What's on your mind?"
-      publishing_to: "publishing to: "
+      all_contacts: "All contacts"
+      share_with: "Share with"
+      whats_on_your_mind: "What’s on your mind?"
+      publishing_to: "Publishing to: "
       discard_post: "Discard post"
       new_user_prefill:
-        newhere: "NewHere"
+        newhere: "newhere"
         hello: "Hey everyone, I’m #%{new_user_tag}. "
         i_like: "I’m interested in %{tags}. "
         invited_by: "Thanks for the invite, "
@@ -1144,7 +1144,7 @@ en:
       invites: "Invites"
       invite_someone: "Invite someone"
       invitations_left: "%{count} left"
-      dont_have_now: "You don't have any right now, but more invites are coming soon!"
+      dont_have_now: "You don’t have any right now, but more invites are coming soon!"
       invites_closed: "Invites are currently closed on this diaspora* pod"
       invite_your_friends: "Invite your friends"
       from_facebook: "From Facebook"
@@ -1153,13 +1153,13 @@ en:
     reshare:
       reshare: "Reshare"
     public_explain:
-      control_your_audience: "Control your Audience"
+      control_your_audience: "Control your audience"
       new_user_welcome_message: "Use #hashtags to classify your posts and find people who share your interests.  Call out awesome people with @Mentions"
       visibility_dropdown: "Use this dropdown to change visibility of your post.  (We suggest you make this first one public.)"
       title: "Set up connected services"
       share: "Share"
       outside: "Public messages will be available for others outside of diaspora* to see."
-      logged_in: "logged in to %{service}"
+      logged_in: "Logged in to %{service}"
       manage: "Manage connected services"
       atom_feed: "Atom feed"
     notification:
@@ -1169,9 +1169,9 @@ en:
     stream_element:
       viewable_to_anyone: "This post is viewable to anyone on the web"
       connect_to_comment: "Connect to this user to comment on their post"
-      currently_unavailable: 'commenting currently unavailable'
-      via: "via %{link}"
-      via_mobile: "via mobile"
+      currently_unavailable: "Commenting currently unavailable"
+      via: "Via %{link}"
+      via_mobile: "Via mobile"
       ignore_user: "Ignore %{name}"
       ignore_user_description: "Ignore and remove user from all aspects?"
       hide_and_mute: "Hide and mute post"
@@ -1180,10 +1180,10 @@ en:
       dislike: "Dislike"
       shared_with: "Shared with: %{aspect_names}"
       nsfw: "This post has been flagged as NSFW by its author. %{link}"
-      show: "show"
+      show: "Show"
     footer:
-      logged_in_as: "logged in as %{name}"
-      your_aspects: "your aspects"
+      logged_in_as: "Logged in as %{name}"
+      your_aspects: "Your aspects"
   status_messages:
     new:
       mentioning: "Mentioning: %{person}"
@@ -1212,37 +1212,37 @@ en:
         other: "%{count} people tagged with %{tag}"
       follow: "Follow #%{tag}"
       following: "Following #%{tag}"
-      stop_following: "Stop Following #%{tag}"
+      stop_following: "Stop following #%{tag}"
       none: "The empty tag does not exist!"
   tag_followings:
     create:
-      success: "Hooray!  You're now following #%{name}."
+      success: "Hooray!  You’re now following #%{name}."
       failure: "Failed to follow #%{name}.  Are you already following it?"
       none: "You cannot follow a blank tag!"
     destroy:
-      success: "Alas! You aren't following #%{name} anymore."
+      success: "Alas! You aren’t following #%{name} any more."
       failure: "Failed to stop following #%{name}. Maybe you already stopped following it?"
 
   streams:
-    community_spotlight_stream: "Community Spotlight"
+    community_spotlight_stream: "Community spotlight"
     aspects_stream: "Aspects"
     mentioned_stream: "@Mentions"
-    followed_tags_stream: "#Followed Tags"
+    followed_tags_stream: "#Followed tags"
 
     mentions:
       title: "@Mentions"
       contacts_title: "People who mentioned you"
 
     comment_stream:
-      title: "Commented Posts"
+      title: "Commented posts"
       contacts_title: "People whose posts you commented on"
 
     like_stream:
-      title: "Like Stream"
+      title: "Like stream"
       contacts_title: "People whose posts you like"
 
     followed_tag:
-      title: "#Followed Tags"
+      title: "#Followed tags"
       contacts_title: "People who dig these tags"
       add_a_tag: "Add a tag"
       follow: "Follow"
@@ -1252,94 +1252,90 @@ en:
       contacts_title: "People who dig this tag"
 
     public:
-      title: "Public Activity"
-      contacts_title: "Recent Posters"
+      title: "Public activity"
+      contacts_title: "Recent posters"
 
     multi:
       title: "Stream"
-      contacts_title: "People in your Stream"
+      contacts_title: "People in your stream"
 
     aspects:
-      title: "My Aspects"
+      title: "My aspects"
 
     activity:
-      title: "My Activity"
+      title: "My activity"
   users:
     edit:
-      export_data: "Export data"
-      photo_export_unavailable: "Photo exporting currently unavailable"
-      close_account_text: "Close account"
-      change_language: "Change language"
-      change_password: "Change password"
+      edit_account: "Edit account"
+      change: "Change"
+      your_handle: "Your diaspora* ID"
+      your_email: "Your email"
       change_email: "Change email"
+      email_awaiting_confirmation: "We have sent you an activation link to %{unconfirmed_email}. Until you follow this link and activate the new address, we will continue to use your original address %{email}."
+      change_password: "Change password"
       new_password: "New password"
       current_password: "Current password"
       current_password_expl: "the one you sign in with..."
       character_minimum_expl: "must be at least six characters"
-      export_in_progress: 'We are currently processing your data. Please check back in a few moments.'
-      last_exported_at: '(Last updated at %{timestamp})'
-      request_export: 'request my profile data'
-      download_export: 'download my profile'
-      request_export_update: 'refresh my profile data'
-      download_photos: "download my photos"
-      your_handle: "Your diaspora* ID"
-      your_email: "Your email"
-      edit_account: "Edit account"
+      change_language: "Change language"
+      stream_preferences: "Stream preferences"
+      show_community_spotlight: "Show “community spotlight” in stream"
+      show_getting_started: "Show “getting started” hints"
+      getting_started: "New user preferences"
+      following: "Sharing settings"
+      auto_follow_back: "Automatically share with users who start sharing with you"
+      auto_follow_aspect: "Aspect for users you automatically share with:"
       receive_email_notifications: "Receive email notifications when:"
       started_sharing: "someone starts sharing with you"
-      someone_reported: "someone sent a report"
+      someone_reported: "someone sends a report"
       mentioned: "you are mentioned in a post"
       liked: "someone likes your post"
       reshared: "someone reshares your post"
       comment_on_post: "someone comments on your post"
-      also_commented: "someone comments on a post you've commented on"
+      also_commented: "someone comments on a post you’ve commented on"
       private_message: "you receive a private message"
-      change: "Change"
-      email_awaiting_confirmation: "We have sent you an activation link to %{unconfirmed_email}. Until you follow this link and activate the new address, we will continue to use your original address %{email}."
-      stream_preferences: "Stream preferences"
-      show_community_spotlight: "Show Community Spotlight in stream"
-      show_getting_started: 'Show Getting Started hints'
-      getting_started: 'New user preferences'
-      following: "Sharing settings"
-      auto_follow_back: "Automatically share with users who start sharing with you"
-      auto_follow_aspect: "Aspect for automatically added contacts:"
+      download_export: "Download my profile"
+      request_export: "Request my profile data"
+      request_export_update: "Refresh my profile data"
+      download_xml: "Download my data (XML)"
+      download_photos: "Download my photos"
+      export_data: "Export data"
+      export_in_progress: "We are currently processing your data. Please check back in a few moments."
+      last_exported_at: "(Last updated at %{timestamp})"
+      photo_export_unavailable: "Photo exporting currently unavailable"
 
       close_account:
-        dont_go: "Hey, please don't go!"
-        make_diaspora_better: "We'd love you to stay and help us make diaspora* better instead of leaving. If you really do want to leave, however, here's what will happen next:"
-        mr_wiggles: 'Mr Wiggles will be sad to see you go'
-        what_we_delete: "We will delete all of your posts and profile data as soon as possible. Your comments on other people's posts will still appear, but they will be associated with your diaspora* ID rather than your name."
+        dont_go: "Hey, please don’t go!"
+        make_diaspora_better: "We’d love you to stay and help us make diaspora* better instead of leaving. If you really do want to leave, however, here’s what will happen next:"
+        mr_wiggles: "Mr Wiggles will be sad to see you go"
+        what_we_delete: "We will delete all of your posts and profile data as soon as possible. Your comments on other people’s posts will still appear, but they will be associated with your diaspora* ID rather than your name."
         locked_out: "You will get signed out and locked out of your account until it has been deleted."
         lock_username: "Your username will be locked. You will not be able create a new account on this pod with the same ID."
-        no_turning_back: "There is no turning back! If you're really sure, enter your password below."
-        if_you_want_this: "If you really want this to happen, type in your password below and click 'Close Account'"
+        no_turning_back: "There is no turning back! If you’re really sure, enter your password below."
+        if_you_want_this: "If you really want this to happen, type in your password below and click “Close account”"
 
     privacy_settings:
-      title: "Privacy Settings"
-      ignored_users: "Ignored Users"
+      title: "Privacy settings"
       strip_exif: "Strip metadata such as location, author, and camera model from uploaded images (recommended)"
-      stop_ignoring: "Stop ignoring"
-      no_user_ignored_message: "You are currently ignoring no other user"
-      change: "Change"
+      ignored_users: "Ignored users"
+      stop_ignoring: "stop ignoring"
+      no_user_ignored_message: "You are not currently ignoring any other user"
 
     destroy:
       success: "Your account has been locked. It may take 20 minutes for us to finish closing your account. Thank you for trying diaspora*."
       no_password: "Please enter your current password to close your account."
-      wrong_password: "The entered password didn't match your current password."
+      wrong_password: "The entered password didn’t match your current password."
+
     getting_started:
       well_hello_there: "Well, hello there!"
-      community_welcome: "diaspora*'s community is happy to have you aboard!"
-
+      community_welcome: "diaspora*’s community is happy to have you aboard!"
       awesome_take_me_to_diaspora: "Awesome! Take me to diaspora*"
-
       who_are_you: "Who are you?"
       connect_to_facebook: "We can speed things up a bit by %{link} to diaspora*. This will pull your name and photo, and enable cross-posting."
-      connect_to_facebook_link: "hooking up your Facebook account"
-
+      connect_to_facebook_link: "Hooking up your Facebook account"
       what_are_you_in_to: "What are you into?"
-      hashtag_explanation: "Hashtags allow you to talk about and follow your interests.  They're also a great way to find new people on diaspora*."
+      hashtag_explanation: "Hashtags allow you to talk about and follow your interests.  They’re also a great way to find new people on diaspora*."
       hashtag_suggestions: "Try following tags like #art, #movies, #gif, etc."
-
       saved: "Saved!"
 
     update:
@@ -1368,10 +1364,10 @@ en:
     next_label: "next &raquo;"
 
   webfinger:
-    fetch_failed: "failed to fetch webfinger profile for %{profile_url}"
-    hcard_fetch_failed: "there was a problem fetching the hcard for %{account}"
-    xrd_fetch_failed: "there was an error getting the xrd from account %{account}"
-    not_enabled: "webfinger does not seem to be enabled for %{account}'s host"
+    fetch_failed: "Failed to fetch webfinger profile for %{profile_url}"
+    hcard_fetch_failed: "There was a problem fetching the hcard for %{account}"
+    xrd_fetch_failed: "There was an error getting the xrd from account %{account}"
+    not_enabled: "Webfinger does not seem to be enabled for %{account}’s host"
     no_person_constructed: "No person could be constructed from this hcard."
 
   simple_captcha:

--- a/config/locales/javascript/javascript.en.yml
+++ b/config/locales/javascript/javascript.en.yml
@@ -6,15 +6,15 @@
 en:
   javascripts:
     confirm_dialog: "Are you sure?"
-    confirm_unload: "Please confirm that you want to leave this page - data you have entered won't be saved."
+    confirm_unload: "Please confirm that you want to leave this page. Data you have entered won’t be saved."
     delete: "Delete"
     ignore: "Ignore"
     report:
       prompt: "Please enter a reason:"
-      prompt_default: "offensive content"
+      prompt_default: "e.g. offensive content"
       name: "Report"
       status:
-        created: "The report was successfully created"
+        created: "The report has successfully been created"
         exists: "The report already exists"
     ignore_user: "Ignore this user?"
     ignore_failed: "Unable to ignore this user"
@@ -25,7 +25,7 @@ en:
     and: "and"
     comma: ","
     edit: "Edit"
-    no_results: "No Results Found"
+    no_results: "No results found"
     timeago:
       prefixAgo: ""
       prefixFromNow: ""
@@ -49,13 +49,13 @@ en:
       aspect_list_is_visible: "Contacts in this aspect are able to see each other."
       aspect_list_is_not_visible: "Contacts in this aspect are not able to see each other."
       remove_contact: "Remove contact"
-      error_add: "Couldn't add <%= name %> to the aspect :("
-      error_remove: "Couldn't remove <%= name %> from the aspect :("
+      error_add: "Couldn’t add <%= name %> to the aspect :("
+      error_remove: "Couldn’t remove <%= name %> from the aspect :("
       search_no_results: "No contacts found"
 
-    my_activity: "My Activity"
+    my_activity: "My activity"
     my_stream: "Stream"
-    my_aspects: "My Aspects"
+    my_aspects: "My aspects"
 
     videos:
       watch: "Watch this video on <%= provider %>"
@@ -63,8 +63,8 @@ en:
     search_for: "Search for <%= name %>"
     publisher:
       at_least_one_aspect: "You must publish to at least one aspect"
-      limited: "Limited - your post will only be seen by people you are sharing with"
-      public: "Public - your post will be visible to everyone and found by search engines"
+      limited: "Limited: your post will only be seen by people you are sharing with"
+      public: "Public: your post will be visible to everyone and found by search engines"
       near_from: "Posted from: <%= location %>"
       option: "Answer"
       add_option: "Add an answer"
@@ -82,24 +82,24 @@ en:
       all_aspects: "All aspects"
       stopped_sharing_with: "You have stopped sharing with <%= name %>."
       started_sharing_with: "You have started sharing with <%= name %>!"
-      error: "Couldn't start sharing with <%= name %>.  Are you ignoring them?"
-      error_remove: "Couldn't remove <%= name %> from the aspect :("
+      error: "Couldn’t start sharing with <%= name %>.  Are you ignoring them?"
+      error_remove: "Couldn’t remove <%= name %> from the aspect :("
       toggle:
         zero: "Select aspects"
         one: "In <%= count %> aspect"
         other: "In <%= count %> aspects"
-    show_more: "show more"
+    show_more: "Show more"
     failed_to_like: "Failed to like!"
     failed_to_post_message: "Failed to post message!"
     failed_to_remove: "Failed to remove the entry!"
     comments:
-      show: "show all comments"
-      hide: "hide comments"
+      show: "Show all comments"
+      hide: "Hide comments"
       no_comments: "There are no comments yet."
     reshares:
-      duplicate: "That good, huh?  You've already reshared that post!"
+      duplicate: "That good, eh?  You’ve already reshared that post!"
       successful: "The post was successfully reshared!"
-      post: "Reshare <%= name %>'s post?"
+      post: "Reshare <%= name %>’s post?"
     aspect_navigation:
       select_all: "Select all"
       deselect_all: "Deselect all"
@@ -107,8 +107,8 @@ en:
       add_an_aspect: "+ Add an aspect"
     getting_started:
       hey: "Hey, <%= name %>!"
-      no_tags: "Hey, you haven't followed any tags!  Continue anyway?"
-      alright_ill_wait: "Alright, I'll wait."
+      no_tags: "Hey, you haven’t followed any tags!  Continue anyway?"
+      alright_ill_wait: "All right, I’ll wait."
       preparing_your_stream: "Preparing your personalized stream..."
     photo_uploader:
       looking_good: "OMG, you look awesome!"
@@ -118,9 +118,9 @@ en:
       size_error: "{file} is too large, maximum file size is {sizeLimit}."
       empty: "{file} is empty, please select files again without it."
     tags:
-      wasnt_that_interesting: "OK, I suppose #<%= tagName %> wasn't all that interesting..."
+      wasnt_that_interesting: "OK, I suppose #<%= tagName %> wasn’t all that interesting..."
     people:
-      not_found: "and no one was found..."
+      not_found: "... and no one was found"
       mention: "Mention"
       message: "Message"
       edit_my_profile: "Edit my profile"
@@ -129,9 +129,9 @@ en:
         is_sharing: "<%= name %> is sharing with you"
         is_not_sharing: "<%= name %> is not sharing with you"
     profile:
-      edit: "edit"
-      add_some: "add some"
-      you_have_no_tags: "you have no tags!"
+      edit: "Edit"
+      add_some: "Add some"
+      you_have_no_tags: "You have no tags!"
       ignoring: "You are ignoring all posts from <%= name %>."
       bio: "Bio"
       location: "Location"
@@ -156,7 +156,7 @@ en:
       unlike: "Unlike"
       reshare: "Reshare"
       comment: "Comment"
-      original_post_deleted: "Original post deleted by author."
+      original_post_deleted: "Original post deleted by author"
       show_nsfw_post: "Show post"
       show_nsfw_posts: "Show all"
       hide_nsfw_posts: "Hide #nsfw posts"
@@ -180,7 +180,7 @@ en:
         other: "Show <%= count %> more comments"
 
       followed_tag:
-        title: "#Followed Tags"
+        title: "#Followed tags"
         contacts_title: "People who dig these tags"
         add_a_tag: "Add a tag"
         follow: "Follow"
@@ -188,7 +188,7 @@ en:
       tags:
         follow: "Follow #<%= tag %>"
         following: "Following #<%= tag %>"
-        stop_following: "Stop Following #<%= tag %>"
+        stop_following: "Stop following #<%= tag %>"
 
     header:
       home: "Home"
@@ -204,10 +204,10 @@ en:
 
       search: "Search"
 
-      recent_notifications: "Recent Notifications"
+      recent_notifications: "Recent notifications"
       mark_all_as_read: "Mark all as read"
       view_all: "View all"
-      close: "close"
+      close: "Close"
 
     viewer:
       stop_following_post: "Stop following post"
@@ -217,7 +217,7 @@ en:
       reshare: "Reshare"
       reshared: "Reshared"
       comment: "Comment"
-      home: "HOME"
+      home: "Home"
 
     poll:
       vote: "Vote"

--- a/features/desktop/connects_users.feature
+++ b/features/desktop/connects_users.feature
@@ -122,6 +122,6 @@ Feature: following and being followed
     And I add the person to my "Unicorns" aspect
 
     When I go to "bob@bob.bob"'s page
-    Then I should see "All Aspects"
+    Then I should see "All aspects"
     Then I should see a "#mention_button" within "#profile_buttons"
     Then I should see a "#message_button" within "#profile_buttons"

--- a/features/desktop/follows_tags.feature
+++ b/features/desktop/follows_tags.feature
@@ -35,7 +35,7 @@ Feature: posting
     Then I should see "#boss from the #boss tag page" within "body"
 
   Scenario: can stop following a tag from the tag page
-    When I press "Following #boss"
+    When I press "Stop following #boss"
     And I go to the followed tags stream page
     Then I should not see "#boss" within "#tags_list"
 

--- a/features/desktop/manages_aspects.feature
+++ b/features/desktop/manages_aspects.feature
@@ -59,7 +59,7 @@ Feature: User manages contacts
     And I follow "Cat People"
     And I click on selector "#change_aspect_name"
     And I fill in "aspect_name" with "Unicorn People"
-    And I press "update"
+    And I press "Update"
     Then I should see "Unicorn People" within "#aspect_name"
 
   Scenario: clicking on the contacts link in the header with zero contacts directs a user to the featured users page
@@ -69,7 +69,7 @@ Feature: User manages contacts
 
     And I click on my name in the header
     When I follow "Contacts"
-    Then I should see "Community Spotlight" within ".span9"
+    Then I should see "Community spotlight" within ".span9"
 
   Scenario: clicking on the contacts link in the header with contacts does not send a user to the featured users page
     Given I am signed in
@@ -78,4 +78,4 @@ Feature: User manages contacts
 
     And I click on my name in the header
     When I follow "Contacts"
-    Then I should not see "Community Spotlight" within ".span9"
+    Then I should not see "Community spotlight" within ".span9"

--- a/features/desktop/oembed.feature
+++ b/features/desktop/oembed.feature
@@ -20,25 +20,25 @@ Feature: oembed
   Scenario: Post an unsecure video link
     Given I expand the publisher
     When I click the publisher and post "http://mytube.com/watch?v=M3r2XDceM6A&format=json"
-    And I follow "My Aspects"
+    And I follow "My aspects"
     Then I should not see a video player
     And I should see "http://mytube.com/watch?v=M3r2XDceM6A&format=json" within ".stream_element"
 
   Scenario: Post an unsecure rich-typed link
     Given I expand the publisher
     When I click the publisher and post "http://myrichtube.com/watch?v=M3r2XDceM6A&format=json"
-    And I follow "My Aspects"
+    And I follow "My aspects"
     Then I should not see a video player
     And I should see "http://myrichtube.com/watch?v=M3r2XDceM6A&format=json" within ".stream_element"
 
   Scenario: Post a photo link
     Given I expand the publisher
     When I click the publisher and post "http://farm4.static.flickr.com/3123/2341623661_7c99f48bbf_m.jpg"
-    And I follow "My Aspects"
+    And I follow "My aspects"
     Then I should see a "img" within ".stream_element"
 
   Scenario: Post an unsupported text link
     Given I expand the publisher
     When I click the publisher and post "http://www.we-do-not-support-oembed.com/index.html"
-    And I follow "My Aspects"
+    And I follow "My aspects"
     Then I should see "http://www.we-do-not-support-oembed.com/index.html" within ".stream_element"

--- a/features/desktop/posts_from_main_page.feature
+++ b/features/desktop/posts_from_main_page.feature
@@ -23,7 +23,7 @@ Feature: posting from the main page
       And ".options_and_submit" is hidden
       When I expand the publisher
       Then I should see "You can use Markdown to format your post" within "#publisher-images"
-      Then I should see "All Aspects" within ".options_and_submit"
+      Then I should see "All aspects" within ".options_and_submit"
       Then I should see "Preview" within ".options_and_submit"
 
     Scenario: post a text-only message to all aspects

--- a/features/desktop/signs_up.feature
+++ b/features/desktop/signs_up.feature
@@ -31,7 +31,7 @@ Feature: new user registration
     When I follow "awesome_button"
     And I reject the alert
     Then I should be on the getting started page
-    And I should see a flash message containing "Alright, I'll wait."
+    And I should see a flash message containing "All right, I’ll wait."
 
   Scenario: new user skips the setup wizard
     When I follow "awesome_button"
@@ -44,7 +44,7 @@ Feature: new user registration
     And I confirm the alert
     Then I should be on the stream page
     When I submit the publisher
-    Then "Hey everyone, I’m #NewHere." should be post 1
+    Then "Hey everyone, I’m #newhere." should be post 1
 
   Scenario: new user with some tags posts first status message
     When I fill in the following:
@@ -54,7 +54,7 @@ Feature: new user registration
     And I follow "awesome_button"
     Then I should be on the stream page
     When I submit the publisher
-    Then "Hey everyone, I’m #NewHere. I’m interested in #rockstar." should be post 1
+    Then "Hey everyone, I’m #newhere. I’m interested in #rockstar." should be post 1
 
   Scenario: closing a popover clears getting started
     When I follow "awesome_button"

--- a/features/desktop/single_post_view_moderation.feature
+++ b/features/desktop/single_post_view_moderation.feature
@@ -50,7 +50,7 @@
     And I click to report the post
     And I confirm the alert
     
-    And I should see a flash message containing "The report was successfully created"
+    And I should see a flash message containing "The report has successfully been created"
     
   Scenario: delete own post
     Given I expand the publisher

--- a/features/desktop/stops_following_users.feature
+++ b/features/desktop/stops_following_users.feature
@@ -35,7 +35,7 @@ Feature: Unfollowing
 
     And I remove the first person from the aspect
 
-    When I follow "My Contacts"
+    When I follow "My contacts"
     Then I should have 0 contacts in "Besties"
 
     When I sign out

--- a/features/mobile/activity_stream.feature
+++ b/features/mobile/activity_stream.feature
@@ -6,19 +6,19 @@ Feature: Viewing my activity on the steam mobile page
 
   Background:
     Given a user with username "alice"
-    And "alice@alice.alice" has a public post with text "Hello! i am #newhere"
+    And "alice@alice.alice" has a public post with text "Hello! I am #newhere"
     When I toggle the mobile view
     And I sign in as "alice@alice.alice" on the mobile website
 
   Scenario: Show my activity empty
     When I open the drawer
-    And I follow "My Activity"
-    Then I should see "My Activity"
-    And I should not see "Hello! i am #newhere"
+    And I follow "My activity"
+    Then I should see "My activity"
+    And I should not see "Hello! I am #newhere"
 
   Scenario: Show post on my activity
     When I click on selector "a.image_link.like_action.inactive"
     And I open the drawer
-    And I follow "My Activity"
-    Then I should see "My Activity"
-    And I should see "Hello! i am #newhere" within ".ltr"
+    And I follow "My activity"
+    Then I should see "My activity"
+    And I should see "Hello! I am #newhere" within ".ltr"

--- a/features/mobile/drawer.feature
+++ b/features/mobile/drawer.feature
@@ -17,7 +17,7 @@ Feature: Naviguate between pages using the header menu and the drawer
     
   Scenario: naviguate to the stream page
     When I open the drawer
-    And I follow "My Activity"
+    And I follow "My activity"
     And I click on selector "#header_title"
     Then I should see "There are no posts yet." within "#main_stream"
     
@@ -31,7 +31,7 @@ Feature: Naviguate between pages using the header menu and the drawer
     
   Scenario: naviguate to the publisher page
     When I click on selector "#compose_badge"
-    Then I should see "All Aspects" within "#new_status_message"
+    Then I should see "All aspects" within "#new_status_message"
     
   Scenario: search a user
     When I open the drawer
@@ -45,8 +45,8 @@ Feature: Naviguate between pages using the header menu and the drawer
     
   Scenario: naviguate to my activity page
     When I open the drawer
-    And I follow "My Activity"
-    Then I should see "My Activity" within "#main"
+    And I follow "My activity"
+    Then I should see "My activity" within "#main"
     
   Scenario: naviguate to my mentions page
     Given Alice has a post mentioning Bob
@@ -58,7 +58,7 @@ Feature: Naviguate between pages using the header menu and the drawer
   Scenario: naviguate to my aspects page
     Given "bob@bob.bob" has a public post with text "bob's text"
     When I open the drawer
-    And I follow "My Aspects"
+    And I follow "My aspects"
     Then I should see "Besties" within "#all_aspects + li > ul"
     And I follow "Besties"
     Then I should see "bob's text" within "#main_stream"
@@ -66,7 +66,7 @@ Feature: Naviguate between pages using the header menu and the drawer
   Scenario: naviguate to the followed tags page
     Given "bob@bob.bob" has a public post with text "bob is da #boss"
     When I open the drawer
-    And I follow "#Followed Tags"
+    And I follow "#Followed tags"
     Then I should see "#boss" within "#followed_tags + li > ul"
     And I follow "#boss"
     Then I should see "bob is da #boss" within "#main_stream"

--- a/features/mobile/reactions.feature
+++ b/features/mobile/reactions.feature
@@ -15,7 +15,7 @@ Feature: reactions mobile post
     And I sign in as "bob@bob.bob" on the mobile website
 
   Scenario: like on a mobile post
-    When I should see "0 reactions" within ".show_comments"
+    When I should see "No reactions" within ".show_comments"
     And I click on selector "span.show_comments"
     And I click on selector "a.image_link.like_action.inactive"
     Then I should see a "a.image_link.like_action.active"

--- a/features/mobile/reshare.feature
+++ b/features/mobile/reshare.feature
@@ -21,7 +21,7 @@ Feature: resharing from the mobile
     And I confirm the alert
     Then I should see a "a.image_link.reshare_action.active"
     When I go to the stream page
-    Then I should see "reshared via" within ".reshare_via"
+    Then I should see "Reshared via" within ".reshare_via"
 
   Scenario: Resharing a post from a single post page that is reshared
     Given the post with text "reshare this!" is reshared by "eve@eve.eve"
@@ -31,7 +31,7 @@ Feature: resharing from the mobile
     And I confirm the alert
     Then I should see a "a.image_link.reshare_action.active"
     When I go to the stream page
-    Then I should see "reshared via" within ".reshare_via"
+    Then I should see "Reshared via" within ".reshare_via"
 
   Scenario: Delete original reshared post
     Given "alice@alice.alice" has a public post with text "Don't reshare this!"
@@ -41,8 +41,8 @@ Feature: resharing from the mobile
     And I log out
     And I sign in as "bob@bob.bob"
     And I toggle the mobile view
-    Then I should see "Original post deleted by author." within ".reshare"
+    Then I should see "Original post deleted by author" within ".reshare"
     And I log out
     And I sign in as "eve@eve.eve" on the mobile website
     And I toggle the mobile view
-    Then I should see "Original post deleted by author." within ".reshare"
+    Then I should see "Original post deleted by author" within ".reshare"

--- a/features/step_definitions/aspects_steps.rb
+++ b/features/step_definitions/aspects_steps.rb
@@ -44,7 +44,7 @@ When /^I click on "([^"]*)" aspect edit icon$/ do |aspect_name|
 end
 
 When /^I select only "([^"]*)" aspect$/ do |aspect_name|
-  click_link 'My Aspects'
+  click_link 'My aspects'
   within('#aspects_list') do
     click_link 'Deselect all'
     current_scope.should have_no_css '.selected'

--- a/spec/javascripts/app/views/aspects_dropdown_view_spec.js
+++ b/spec/javascripts/app/views/aspects_dropdown_view_spec.js
@@ -4,7 +4,7 @@ describe("app.views.AspectsDropdown", function(){
     Diaspora.I18n.reset({
       'aspect_dropdown': {
         'select_aspects': "Select aspects",
-        'all_aspects': "All Aspects",
+        'all_aspects': "All aspects",
         'toggle': {
           'zero': "Select aspects",
           'one': "In <%= count %> aspect",


### PR DESCRIPTION
This PR follows the vote in https://www.loomio.org/d/kY0wClao to use sentence case throughout the UI for the English locale, and fixes #5520. I have also made a few minor changes to the English, and changed special characters to `&ldquo;`, `&nash;`, etc.

Have amended the two locale files affected (building on the work in #5579) and have amended the cuke tests which were broken by the changes to capitalisation.

For now I have just changed the text strings in the tests, as using the I18n.t('string') syntax doesn't work in the features themselves, only in the step-definitions. I don't want to hold up this PR while I work out how to make tests text-independent, so I'll do that in a separate PR.

I wanted to get this work finished today, but would like to wait a couple more days just in case serious objections arise to using sentence case for titles of parts of the app ('My activity', 'My aspects', etc.). They shouldn't, given the vote, but it's just possible that some voters didn't realise that these titles would be included, so I'd like to double-check that before proceeding.
