### PR TITLE
Fixed moderation-button-position when viewing reshare

### DIFF
--- a/app/assets/stylesheets/single-post-view.css.scss
+++ b/app/assets/stylesheets/single-post-view.css.scss
@@ -41,9 +41,19 @@
         margin-left: 8px;
         margin-right: 8px;
       }
+      .post-context {
+        font-size: 12px;
+
+        #single-post-moderation {
+          margin-left: 5px;
+
+          > div.info {
+            display: inline-block;
+          }
+        }
+      }
       .post-time a {
         color: $text-grey;
-        display: block;
         font-size: 12px;
       }
       .avatar {

--- a/app/assets/templates/single-post-viewer/single-post-content_tpl.jst.hbs
+++ b/app/assets/templates/single-post-viewer/single-post-content_tpl.jst.hbs
@@ -58,7 +58,9 @@
           {{/if}}
           <div class='status-message-location' />
         </div>
-        <div id='single-post-moderation' />
+        {{#unless root}}
+          <div id='single-post-moderation' />
+        {{/unless}}
       </div>
     </div>
     {{#unless root}}
@@ -79,11 +81,14 @@
             {{name}}
           {{/linkToAuthor}}
         </span>
-        <span class="post-time">
-          <a href="/posts/{{id}}">
-            <time datetime="{{created_at}}" title="{{localTime created_at}}" />
-          </a>
-        </span>
+        <div class="post-context">
+          <span class="post-time">
+            <a href="/posts/{{id}}">
+              <time datetime="{{created_at}}" title="{{localTime created_at}}" />
+            </a>
+          </span>
+          <span id='single-post-moderation' />
+        </div>
       </div>
       <div id='single-post-actions' class='span4' />
     </div>


### PR DESCRIPTION
Fix for  #5591 
I placed the icons left to the post-time because they kind of belong to the metadata of the reshare and I didn't want three rows next to the avatar, making the reshare-info take up more space.

![bildschirmfoto - 28 01 2015 - 14 18 17](https://cloud.githubusercontent.com/assets/1184859/5938187/d3dc68f2-a6f8-11e4-9acb-aad2119ba461.png)
