### PR TITLE
Hide sign up button when registration are disabled

### DIFF
--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -8,7 +8,7 @@
       = link_to content_tag(:div, nil, class: 'diaspora_header_logo branding-header-logo'), root_path
 
       %ul#landing_nav
-        - unless current_page?(controller: :registrations, action: :new)
+        - if AppConfig.settings.enable_registrations? && !current_page?(controller: :registrations, action: :new)
           %li= link_to t('devise.shared.links.sign_up'), new_user_registration_path, class: 'login'
         %li= link_to t('devise.shared.links.sign_in'), new_user_session_path, class: 'login'
       #lightbox


### PR DESCRIPTION
We should hide the sign up button when the registration are closed, especially with #5391 which adds the header on every not connected pages.
