### PR TITLE
Remove photo export from settings

### DIFF
--- a/app/assets/javascripts/view.js
+++ b/app/assets/javascripts/view.js
@@ -58,12 +58,6 @@ var View = {
       $(this).siblings("#tag_following_submit").removeClass('hidden');
     });
 
-    /* photo exporting in the works */
-    $("#photo-export-button").bind("click", function(evt){
-      evt.preventDefault();
-      alert($(this).attr('title'));
-    });
-
     $(document.body).click(this.dropdowns.removeFocus);
 
     $('a[rel*=facebox]').facebox();

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -195,9 +195,6 @@
             .small-horizontal-spacer
               = link_to t('.request_export'), export_profile_user_path, :class => "button"
 
-          .small-horizontal-spacer
-          = link_to t('.download_photos'), "#", :class => "button", :id => "photo-export-button", :title => t('.photo_export_unavailable')
-
         .span6
           %h3
             = t('.close_account_text')

--- a/app/views/users/edit.mobile.haml
+++ b/app/views/users/edit.mobile.haml
@@ -174,9 +174,6 @@
     - else
       .small-horizontal-spacer
         = link_to t('.request_export'), export_profile_user_path, :class => "button"
-    %br
-    %br
-    = link_to t('.download_photos'), "#", :class => "btn", :id => "photo-export-button", :title => t('.photo_export_unavailable')
 
   .span-5.last
     %h4

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -1300,12 +1300,9 @@ en:
       download_export: "Download my profile"
       request_export: "Request my profile data"
       request_export_update: "Refresh my profile data"
-      download_xml: "Download my data (XML)"
-      download_photos: "Download my photos"
       export_data: "Export data"
       export_in_progress: "We are currently processing your data. Please check back in a few moments."
       last_exported_at: "(Last updated at %{timestamp})"
-      photo_export_unavailable: "Photo exporting currently unavailable"
 
       close_account:
         dont_go: "Hey, please don’t go!"


### PR DESCRIPTION
It is not working so the link on the settings page is useless. This PR also removes some unused strings that are related to photo/profile export from the locales.
