### PR TITLE
5604 better avatar error handling

### DIFF
--- a/app/assets/javascripts/app/views.js
+++ b/app/assets/javascripts/app/views.js
@@ -46,6 +46,10 @@ app.views.Base = Backbone.View.extend({
     this.$el
       .html(this.template(presenter))
       .attr("data-template", _.last(this.templateName.split("/")));
+
+    // add avatar fallback if it can't be loaded
+    this.$el.find(this.avatars.selector).error(this.avatars.fallback);
+
     this.postRenderTemplate();
   },
 
@@ -136,6 +140,13 @@ app.views.Base = Backbone.View.extend({
         });
     }
   },
+
+  avatars: {
+    fallback: function(evt) {
+      $(this).attr("src", ImagePaths.get("user/default.png"));
+    },
+    selector: "img.avatar"
+  }
 });
 
 app.views.StaticContentView = app.views.Base.extend({

--- a/app/assets/javascripts/view.js
+++ b/app/assets/javascripts/view.js
@@ -26,9 +26,6 @@ var View = {
       .on('click', this.dropdowns.selector, this.dropdowns.click)
       .on('keypress', this.dropdowns.selector, this.dropdowns.click);
 
-    /* Avatars */
-    $(this.avatars.selector).error(this.avatars.fallback);
-
     /* Clear forms after successful submit, this is some legacy dan hanson stuff, do we still want it? */
     $.fn.clearForm = function() {
       return this.each(function() {
@@ -107,13 +104,6 @@ var View = {
     },
     selector: ".dropdown > .toggle",
     parentSelector: ".dropdown > .wrapper"
-  },
-
-  avatars: {
-    fallback: function(evt) {
-      $(this).attr("src", ImagePaths.get("user/default.png"));
-    },
-    selector: "img.avatar"
   }
 };
 

--- a/app/assets/stylesheets/stream_element.css.scss
+++ b/app/assets/stylesheets/stream_element.css.scss
@@ -85,7 +85,7 @@
     }
   }
 
-  .reshare {
+  div.reshare {
     border-left: 2px solid $border-grey;
     margin-top: 3px;
 

--- a/app/assets/stylesheets/stream_element_blueprint.css.scss
+++ b/app/assets/stylesheets/stream_element_blueprint.css.scss
@@ -202,7 +202,7 @@
   }
 }
 
-.stream_element .post-content .reshare {
+.stream_element .post-content div.reshare {
   border-left: 2px solid $border-grey;
 }
 


### PR DESCRIPTION
This is a fix for #5604.

The solution was already in the code, but at the wrong place. When the code was executed at it's original position, the views were not yet rendered - so there were no elements to attach event handlers to.
I moved the code which adds event handler to the general view-render method... so it will be executed after each view is rendered (and only for the newly rendered view, to avoid doubling of event listeners).

I'm not quite happy with adding such a minor code-fixing-thing to THE MAIN VIEW-RENDER method... if you know what I mean  :smirk: . It seems a bit misplaced or can lead to people adding many more general fix things there...

Another solution could be to add the line `views.js:51` to a `postRenderTemplate()` in every view with avatars in its templates. This would mean the code would only be executed when it is needed, making the whole process a bit faster when there are no avatars in a view ... but the implementing person of a new view must know about this and add the method to the new view (making the implementing a bit more troublesome).
