### PR TITLE
Enable and configure Hound for Ruby

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -2,5 +2,7 @@ java_script:
   enabled: true
   config_file: config/.jshint.json
   ignore_file: config/.jshint_ignore
+
 ruby:
-  enabled: false
+  enabled: true
+  config_file: config/.ruby-style.yml

--- a/config/.ruby-style.yml
+++ b/config/.ruby-style.yml
@@ -1,0 +1,3 @@
+StringLiterals:
+  Enabled: true
+  EnforcedStyle: single_quotes


### PR DESCRIPTION
I noticed Hound comments related to double comments were being ignored. This change configures Hound to prefer single quotes.

@jhass any other Ruby style preferences?
