### PR TITLE
respect http/https in image paths

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -99,31 +99,26 @@ class Profile < ActiveRecord::Base
     self.attributes.merge(update_hash){|key, old, new| old.blank? ? new : old}
   end
 
-  def image_url= url
-    return image_url if url == ''
-    if url.nil? || url.match(/^https?:\/\//)
-      super(url)
-    else
-      super(absolutify_local_url(url))
+  def _set_image_url (att, url)
+    if not url.blank?
+      path = url[/(https?:\/\/(.(?!\/))*.)?(.*)/, 3]
+      if not path.match(/^\//)
+        path += '/'
+      end
+      self[att] = path
     end
+  end
+
+  def image_url= url
+    _set_image_url(:image_url, url)
   end
 
   def image_url_small= url
-    return image_url if url == ''
-    if url.nil? || url.match(/^https?:\/\//)
-      super(url)
-    else
-      super(absolutify_local_url(url))
-    end
+    _set_image_url(:image_url_small, url)
   end
 
   def image_url_medium= url
-    return image_url if url == ''
-    if url.nil? || url.match(/^https?:\/\//)
-      super(url)
-    else
-      super(absolutify_local_url(url))
-    end
+    _set_image_url(:image_url_medium, url)
   end
 
   def date= params

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -100,30 +100,18 @@ class Profile < ActiveRecord::Base
   end
 
   def image_url= url
-    return image_url if url == ''
-    if url.nil? || url.match(/^https?:\/\//)
-      super(url)
-    else
-      super(absolutify_local_url(url))
-    end
+    return image_url if url == '' or url.nil?
+    super(url[/(https?:\/\/(.(?!\/))*.)?(.*)/, 3])
   end
 
   def image_url_small= url
-    return image_url if url == ''
-    if url.nil? || url.match(/^https?:\/\//)
-      super(url)
-    else
-      super(absolutify_local_url(url))
-    end
+    return image_url if url == '' or url.nil?
+    super(url[/(https?:\/\/(.(?!\/))*.)?(.*)/, 3])
   end
 
   def image_url_medium= url
-    return image_url if url == ''
-    if url.nil? || url.match(/^https?:\/\//)
-      super(url)
-    else
-      super(absolutify_local_url(url))
-    end
+    return image_url if url == '' or url.nil?
+    super(url[/(https?:\/\/(.(?!\/))*.)?(.*)/, 3])
   end
 
   def date= params

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -46,7 +46,7 @@ describe Profile, :type => :model do
 
       it 'sets full name to first name' do
         @from_omniauth = {'name' => 'bob jones', 'description' => 'this is my bio', 'location' => 'sf', 'image' => 'http://cats.com/gif.gif'}
-        
+
         profile = Profile.new
         expect(profile.from_omniauth_hash(@from_omniauth)['first_name']).to eq('bob jones')
       end
@@ -117,7 +117,7 @@ describe Profile, :type => :model do
       profile = FactoryGirl.build(:profile, :location => "a"*255)
       expect(profile).to be_valid
     end
-   
+
     it "cannot be 256 characters" do
       profile = FactoryGirl.build(:profile, :location => "a"*256)
       expect(profile).not_to be_valid
@@ -135,14 +135,19 @@ describe Profile, :type => :model do
       expect {@profile.image_url = ""}.not_to change(@profile, :image_url)
     end
 
-    it 'makes relative urls absolute' do
-      @profile.image_url = "/relative/url"
-      expect(@profile.image_url).to eq("#{@pod_url}/relative/url")
+    it 'makes absolute urls relative' do
+      @profile.image_url = "https://host/bar/relative/url"
+      expect(@profile.image_url).to eq("/bar/relative/url")
     end
 
-    it "doesn't change absolute urls" do
-      @profile.image_url = "http://not/a/relative/url"
-      expect(@profile.image_url).to eq("http://not/a/relative/url")
+    it 'adds a leading "/" to a relative path if there is node' do
+      @profile.image_url = "foo/bar/baz"
+      expect(@profile.image_url).to eq("/foo/bar/baz")
+    end
+
+    it "doesn't change rel urls that start with a /" do
+      @profile.image_url = "/foo/bar/baz/relative/url"
+      expect(@profile.image_url).to eq("/foo/bar/baz/relative/url")
     end
   end
 
@@ -157,7 +162,7 @@ describe Profile, :type => :model do
       expect(new_profile.tag_string).to include('#rafi')
     end
   end
-  
+
   describe 'serialization' do
     let(:person) {FactoryGirl.build(:person,:diaspora_handle => "foobar" )}
 
@@ -173,7 +178,7 @@ describe Profile, :type => :model do
       xml = person.profile.to_diaspora_xml
       expect(xml).to include "#one"
     end
-    
+
     it 'includes location' do
       person.profile.location = 'Dark Side, Moon'
       person.profile.save
@@ -334,7 +339,7 @@ describe Profile, :type => :model do
   describe "#clearable_fields" do
     it 'returns the current profile fields' do
       profile = FactoryGirl.build :profile
-      expect(profile.send(:clearable_fields).sort).to eq( 
+      expect(profile.send(:clearable_fields).sort).to eq(
       ["diaspora_handle",
       "first_name",
       "last_name",


### PR DESCRIPTION
when running on http, paths to public/uploaded/images... would still be prefixed with https.
make those paths respect the pod's mode of operation
