### PR TITLE
Add invitation link to contacts page

### DIFF
--- a/app/views/contacts/_sidebar.html.haml
+++ b/app/views/contacts/_sidebar.html.haml
@@ -1,7 +1,14 @@
 %h3
   = t('contacts.index.title')
 = render 'contacts/aspect_listings'
+%hr
 - if AppConfig.settings.community_spotlight.enable?
-  %hr
   .text-center.spotlight
     = link_to t('contacts.spotlight.community_spotlight'), community_spotlight_path, :class => "element_selector"
+.text-center
+  .btn.btn-link{ 'data-toggle' => 'modal', 'data-target' => '#invitationsModal'}
+    = t('invitations.new.invite_someone_to_join')
+  = render 'shared/modal',
+      :path => new_user_invitation_path,
+      :id => 'invitationsModal',
+      :title => t('invitations.new.invite_someone_to_join')

--- a/app/views/contacts/index.html.haml
+++ b/app/views/contacts/index.html.haml
@@ -21,6 +21,9 @@
             %p
               != t('.no_contacts_message',
                    :community_spotlight => link_to(t('.community_spotlight'), community_spotlight_path))
+            %p
+              .btn.btn-link{ 'data-toggle' => 'modal', 'data-target' => '#invitationsModal'}
+                = t('invitations.new.invite_someone_to_join')
 
 -if @aspect
   #new_conversation_pane


### PR DESCRIPTION
Fixes #2874. This adds the invitation link under the aspect list on the contacts page. If you have no contacts yet you will also see the link under the 'no contacts' message.

![](https://cloud.githubusercontent.com/assets/3798614/6160778/c4f38c1a-b267-11e4-8c87-41964dbd00e4.png)
