### PR TITLE
add repeat: false to options

### DIFF
--- a/app/workers/fetch_webfinger.rb
+++ b/app/workers/fetch_webfinger.rb
@@ -4,7 +4,7 @@
 
 module Workers
   class FetchWebfinger < Base
-    sidekiq_options queue: :socket_webfinger
+    sidekiq_options queue: :socket_webfinger, retry: false
 
     def perform(account)
       person = Webfinger.new(account).fetch


### PR DESCRIPTION
It does not make a whole lot of sense to repeat the webfingers over and over again. if they fail they are very likely to fail again in a few seconds. if you want to retry you would have to use exponential backoff
