### PR TITLE
5638 added avatar fallback to notification dropdown

### DIFF
--- a/app/assets/javascripts/widgets/notifications-badge.js
+++ b/app/assets/javascripts/widgets/notifications-badge.js
@@ -108,6 +108,9 @@
             self.getMoreNotifications();
         }
       });
+
+      // add avatar fallback if it can't be loaded
+      self.dropdownNotifications.find(app.views.Base.prototype.avatars.selector).error(app.views.Base.prototype.avatars.fallback);
     };
   };
 


### PR DESCRIPTION
This is a fix for the missing avatar fallback replacement which @jaywink noticed. This is an addition to #5638
