### PR TITLE
Bootstrap stream: add spinner and improve comment box

### DIFF
--- a/app/assets/stylesheets/comments.css.scss
+++ b/app/assets/stylesheets/comments.css.scss
@@ -36,7 +36,13 @@
     }
     padding-left: 12px;
     width: 95%;
+    display: none;
   }
-  .comment_box { width: 95%; }
-  .comment_box:focus, .comment_box:valid { min-height: 100px; }
+  .comment_box {
+    width: 95%;
+    height: 30px;
+  }
+  .comment_box:focus, .comment_box:valid {
+    & + .submit_button { display: block; }
+  }
 }

--- a/app/assets/stylesheets/new-templates.css.scss
+++ b/app/assets/stylesheets/new-templates.css.scss
@@ -14,6 +14,7 @@
 @import 'new_styles/base';
 @import 'new_styles/buttons';
 @import 'new_styles/interactions';
+@import 'new_styles/spinner';
 
 /* font overrides */
 @import 'new_styles/typography';

--- a/app/assets/stylesheets/new_styles/_interactions.scss
+++ b/app/assets/stylesheets/new_styles/_interactions.scss
@@ -2,9 +2,16 @@
   .controls {
     z-index: 6;
     float: right;
-    .comment_report {
+    .post_report, .comment_report {
       display: inline-block;
       .icons-report {
+        height: 14px;
+        width: 14px;
+      }
+    }
+    .block_user {
+      display: inline-block;
+      .icons-ignoreuser {
         height: 14px;
         width: 14px;
       }


### PR DESCRIPTION
This fixes two issues mentioned in #5247. It adds the ajax-spinner to the stream and improves the comment box. The height of the comment box is now set to 30px (just like in the blueprint stream) and only expands when someone enters some text that is too big. (done by js like for the blueprint stream) The submit button will be hidden unless the comment box is focused or there is some text in the comment box.
