### PR TITLE
fix code overflow in mobile comments #5586

### DIFF
--- a/app/assets/stylesheets/mobile/mobile.css.scss
+++ b/app/assets/stylesheets/mobile/mobile.css.scss
@@ -12,6 +12,11 @@ a {
   text-decoration: none;
 }
 
+code {
+    white-space: normal;
+    word-wrap: break-word;
+  }
+
 body {
   background: {
     image: image-url('texture/hatched-light.jpg');


### PR DESCRIPTION
Fix for code overflow in mobile view comments (issue #5586).
Tested for Firefox Android 4.4 : 
![screenshot_overflow_mobile_comments](https://cloud.githubusercontent.com/assets/6507951/6214657/5b42f21a-b5fa-11e4-9168-21c80544d459.png)

SpF, your overflow specialist since 3 PR.
