### PR TITLE
Fix notification for new conversations

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -20,7 +20,7 @@ class Conversation < ActiveRecord::Base
   def max_participants
     errors.add(:max_participants, "too many participants") if participants.count > 20
   end
-  
+
   def local_recipients
     recipients.each do |recipient|
       if recipient.local?
@@ -86,7 +86,7 @@ class Conversation < ActiveRecord::Base
   end
 
   def receive(user, person)
-    cnv = Conversation.find_or_create_by!(self.attributes)
+    cnv = Conversation.create_with(self.attributes).find_or_create_by!(guid: guid)
 
     self.participants.each do |participant|
       ConversationVisibility.find_or_create_by(conversation_id: cnv.id, person_id: participant.id)

--- a/features/desktop/conversations.feature
+++ b/features/desktop/conversations.feature
@@ -20,5 +20,7 @@ Feature: private conversations
     And "Alice Awesome" should be part of active conversation
     And I should see "hello, alice!" within ".stream_container"
     When I sign in as "alice@alice.alice"
-    And I reply with "hey, how you doing?"
+    Then I should have 1 unread private message
+    And I should have 1 email delivery
+    When I reply with "hey, how you doing?"
     Then I should see "hey, how you doing?" within ".stream_container"

--- a/features/step_definitions/conversations_steps.rb
+++ b/features/step_definitions/conversations_steps.rb
@@ -4,6 +4,10 @@ Then /^"([^"]*)" should be part of active conversation$/ do |name|
   end
 end
 
+Then /^I should have (\d+) unread private messages?$/ do |n_unread|
+  find("header #conversations_badge .badge_count").should have_content(n_unread)
+end
+
 Then /^I send a message with subject "([^"]*)" and text "([^"]*)" to "([^"]*)"$/ do |subject, text, person|
   step %(I am on the conversations page)
   within("#conversation_new", match: :first) do


### PR DESCRIPTION
Fixes #5330, maybe introduced by [this commit](https://github.com/diaspora/diaspora/commit/33c3b38f2f8c6ede39b1357eb3cb49f18543cdce). The spec I posted in #5330 wasn't working but I wrote a cucumber feature.
