### PR TITLE
5690 update stream on reshare

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -135,6 +135,7 @@ diaspora.yml file**. The existing settings from 0.4.x and before will not work a
 * Fix code overflow for the mobile website [#5675](https://github.com/diaspora/diaspora/pull/5675)
 * Strip Unicode format characters prior post processing [#5680](https://github.com/diaspora/diaspora/pull/5680)
 * Disable email notifications for closed user accounts [#5640](https://github.com/diaspora/diaspora/pull/5640)
+* Add reshares to the stream view immediately
 
 ## Features
 * Don't pull jQuery from a CDN by default [#5105](https://github.com/diaspora/diaspora/pull/5105)

--- a/app/assets/javascripts/app/models/post/interactions.js
+++ b/app/assets/javascripts/app/models/post/interactions.js
@@ -103,23 +103,21 @@ app.models.Post.Interactions = Backbone.Model.extend({
       , reshare = this.post.reshare()
       , flash = new Diaspora.Widgets.FlashMessages();
 
-    reshare.save({}, {
-      success : function(){
+    reshare.save()
+      .done(function(){
         flash.render({
           success: true,
           notice: Diaspora.I18n.t("reshares.successful")
         });
-      },
-      error: function(){
+        interactions.reshares.add(reshare);
+        if (app.stream) {app.stream.addNow(reshare)}
+        interactions.trigger("change");
+      })
+      .fail(function(){
         flash.render({
           success: false,
           notice: Diaspora.I18n.t("reshares.duplicate")
         });
-      }
-    }).done(function(){
-        interactions.reshares.add(reshare);
-      }).done(function(){
-        interactions.trigger("change");
       });
 
     app.instrument("track", "Reshare");

--- a/spec/javascripts/app/models/post/interacations_spec.js
+++ b/spec/javascripts/app/models/post/interacations_spec.js
@@ -40,4 +40,30 @@ describe("app.models.Post.Interactions", function(){
       expect(this.interactions.likes.length).toEqual(0);
     });
   });
+
+  describe("reshare", function() {
+    var ajax_success = { status: 200, responseText: [] };
+
+    beforeEach(function(){
+      this.reshare = this.interactions.post.reshare();
+    });
+
+    it("triggers a change on the model", function() {
+      spyOn(this.interactions, "trigger");
+
+      this.interactions.reshare();
+      jasmine.Ajax.requests.mostRecent().respondWith(ajax_success);
+
+      expect(this.interactions.trigger).toHaveBeenCalledWith("change");
+    });
+
+    it("adds the reshare to the stream", function() {
+      app.stream = { addNow: $.noop };
+      spyOn(app.stream, "addNow");
+      this.interactions.reshare();
+      jasmine.Ajax.requests.mostRecent().respondWith(ajax_success);
+
+      expect(app.stream.addNow).toHaveBeenCalledWith(this.reshare);
+    });
+  });
 });


### PR DESCRIPTION
This is supposed to fix issue #5690.

While the immediate adding new reshares to the stream now works, the re-shares count is not updated for this newly reshared post. I tried to fix that, but unsuccessfully. I think `app.views.Reshare` in `content_view.js` is responsible for doing this, but I couldn't make it work.
