### PR TITLE
add middleware to redirect undigested assets

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,4 +71,6 @@ Diaspora::Application.configure do
   if AppConfig.environment.assets.host.present?
     config.action_controller.asset_host = AppConfig.environment.assets.host.get
   end
+
+  config.middleware.use UndigestedAssets
 end

--- a/lib/undigested_assets.rb
+++ b/lib/undigested_assets.rb
@@ -1,0 +1,36 @@
+
+class UndigestedAssets
+  def initialize(app)
+    @app = app
+    @asset_prefix = Rails.configuration.assets.prefix
+
+    load_manifest
+  end
+
+  def call(env)
+    if m = (env['PATH_INFO'] || '').match(/#{@asset_prefix}\/(.+)/i)
+      file = m[1]
+
+      if manifest_available? && undigested_file?(file)
+        return [307, { "Location" => File.join('', @asset_prefix, @manifest[file])}, ["See other"]]
+      end
+    end
+
+    @app.call(env)
+  end
+
+  private
+
+  def load_manifest
+    manifest_path = Dir.glob(Rails.root.join("public", "assets", "manifest-*.json")).first
+    @manifest = JSON.load(File.new(manifest_path))["assets"] if File.exists?(manifest_path)
+  end
+
+  def undigested_file?(filename)
+    @manifest.has_key?(filename)
+  end
+
+  def manifest_available?
+    !@manifest.nil?
+  end
+end


### PR DESCRIPTION
pretty simple, just redirect the request to the digested version determined by the asset manifest.
don't know if this can be tested easily, since it's really production-specific.

should fix #5280 
