### PR TITLE
Add tests for liking and unliking posts

### DIFF
--- a/features/desktop/likes.feature
+++ b/features/desktop/likes.feature
@@ -1,0 +1,40 @@
+@javascript
+Feature: Liking posts
+  In order to show my appreciation
+  As a friendly person
+  I want to like their posts
+
+  Background:
+    Given following users exist:
+      | username    | email             |
+      | Bob Jones   | bob@bob.bob       |
+      | Alice Smith | alice@alice.alice |
+    And a user with email "bob@bob.bob" is connected with "alice@alice.alice"
+    And "bob@bob.bob" has a public post with text "I like unicorns"
+    And I sign in as "alice@alice.alice"
+
+  Scenario: Liking and unliking a post from the stream
+    When I am on the home page
+    Then I should see "Bob"
+    And I should see "I like unicorns"
+    When I like the post "I like unicorns" in the stream
+    Then I should see a ".likes" within "#main_stream .stream_element"
+    
+    When I unlike the post "I like unicorns" in the stream
+    Then I should not see a ".likes" within "#main_stream .stream_element"
+
+  Scenario: Liking and unliking a post from a single post page
+    When I open the show page of the "I like unicorns" post
+    And I click to like the post
+    Then I should see a ".count" within "#single-post-interactions"
+    
+    When I click to unlike the post
+    Then I should not see a ".count" within "#single-post-interactions"
+
+  Scenario: Someone likes my post
+    When I am on the home page
+    And I like the post "I like unicorns" in the stream
+    And I sign out
+    And I sign in as "bob@bob.bob"
+    And I am on the home page
+    Then I should see a ".likes" within "#main_stream .stream_element"

--- a/features/step_definitions/single_post_view_steps.rb
+++ b/features/step_definitions/single_post_view_steps.rb
@@ -13,3 +13,8 @@ end
 And /^I click to delete the post/ do
   find('.remove_post').click
 end
+
+And /^I click to (?:like|unlike) the post/ do
+  like_show_page_post
+end
+

--- a/features/step_definitions/stream_steps.rb
+++ b/features/step_definitions/stream_steps.rb
@@ -1,5 +1,5 @@
-Then /^I like the post "([^"]*)"$/ do |post_text|
-  like_post(post_text)
+When /^I (?:like|unlike) the post "([^"]*)" in the stream$/ do |post_text|
+  like_stream_post(post_text)
 end
 
 Then /^"([^"]*)" should be post (\d+)$/ do |post_text, position|

--- a/features/support/publishing_cuke_helpers.rb
+++ b/features/support/publishing_cuke_helpers.rb
@@ -88,15 +88,21 @@ module PublishingCukeHelpers
     find(".stream_element", text: text)
   end
 
-  def like_post(post_text)
-    within_post(post_text) do
-      click_link 'Like'
-    end
-  end
-
   def within_post(post_text)
     within find_post_by_text(post_text) do
       yield
+    end
+  end
+
+  def like_stream_post(post_text)
+    within_post(post_text) do
+      find(:css, 'a.like').click
+    end
+  end
+
+  def like_show_page_post
+    within("#single-post-actions") do
+      find(:css, 'a.like').click
     end
   end
 


### PR DESCRIPTION
I noticed there were no tests in the desktop suite for 'like' interactions. There are now.
