### PR TITLE
fix tag button overflow

### DIFF
--- a/app/assets/stylesheets/tag.scss
+++ b/app/assets/stylesheets/tag.scss
@@ -35,4 +35,14 @@ h1.tag {
       }
     }
   }
+  .span7 {
+    .tag-following-action {
+      max-width: 100%;
+      input[type="submit"] {
+        overflow-x: hidden;
+        text-overflow: ellipsis;
+        max-width: 100%;
+      }    
+    }
+  }
 }

--- a/app/assets/templates/tag_following_action_tpl.jst.hbs
+++ b/app/assets/templates/tag_following_action_tpl.jst.hbs
@@ -1,4 +1,4 @@
-<div class="pull-right">
+<div class="pull-right tag-following-action">
   <form accept-charset="UTF-8" action="/tag_followings" method="post">
       <input type="submit" class="btn 
       {{#if tag_is_followed }}


### PR DESCRIPTION
Before: 
![before](https://cloud.githubusercontent.com/assets/6507951/6577061/70482e58-c73b-11e4-8608-3f95b96a3291.png)

After:
![after](https://cloud.githubusercontent.com/assets/6507951/6577069/7ac6d4c4-c73b-11e4-9f02-6c34f617d504.png)

"Normal behavior" (small tag):
![small_tag](https://cloud.githubusercontent.com/assets/6507951/6577083/8b362472-c73b-11e4-9e0b-fee57c7171bc.png)
