### PR TITLE
Change overflow-x to overflow for long tag button

### DIFF
--- a/app/assets/stylesheets/tag.scss
+++ b/app/assets/stylesheets/tag.scss
@@ -39,7 +39,7 @@ h1.tag {
     .tag-following-action {
       max-width: 100%;
       input[type="submit"] {
-        overflow-x: hidden;
+        overflow: hidden;
         text-overflow: ellipsis;
         max-width: 100%;
       }    


### PR DESCRIPTION
My bad  (on [this PR](https://github.com/diaspora/diaspora/pull/5752)).

Before (horizontal scroll):
![fix-before](https://cloud.githubusercontent.com/assets/6507951/6629797/520c072e-c912-11e4-9c1e-975407919003.png)

After:
![fix-after](https://cloud.githubusercontent.com/assets/6507951/6629805/602e82c8-c912-11e4-9125-4d049de5613d.png)
