### PR TITLE
Fix for 5745 - conversation pagination design is broken

### DIFF
--- a/app/assets/stylesheets/conversations.scss
+++ b/app/assets/stylesheets/conversations.scss
@@ -180,6 +180,21 @@
     a:hover {
       text-decoration: none;
     }
+    .pagination {
+      margin-left: auto;
+      margin-right: auto;
+      text-align: center;
+      
+      .disabled a {
+        background: $background-grey;
+      }
+    }
+  }
+}
+
+@media (max-width: 1354px) {
+  #left_pane #conversation_inbox .pagination ul > li > a {
+    padding: 4px 7px;
   }
 }
 

--- a/app/assets/stylesheets/mobile/mobile.scss
+++ b/app/assets/stylesheets/mobile/mobile.scss
@@ -847,6 +847,22 @@ form#new_user.new_user input.btn {
   text-shadow: 1px 1px 20px rgb(126, 240, 77);
 }
 
+#conversation_inbox {
+  .pagination {
+    margin-left: auto;
+    margin-right: auto;
+    text-align: center;
+    
+    ul > li > a {
+      padding: 4px 8px;
+    }
+    
+    .disabled a{
+      background: $background-grey;
+    }
+  }
+}
+
 input#user_password, #user_username, #user_password_confirmation, #user_email {
   height: 30px;
 }

--- a/app/views/conversations/index.haml
+++ b/app/views/conversations/index.haml
@@ -21,7 +21,7 @@
             - else
               #no_conversations
                 = t('.no_messages')
-            = will_paginate @conversations, :renderer => WillPaginate::ActionView::BootstrapLinkRenderer
+            = will_paginate @conversations, :previous_label => '&laquo;', :next_label => '&raquo;', :inner_window => 1, :renderer => WillPaginate::ActionView::BootstrapLinkRenderer
 
     .span8
       - if @conversation

--- a/app/views/conversations/index.mobile.haml
+++ b/app/views/conversations/index.mobile.haml
@@ -27,4 +27,4 @@
         %i
           = t('.no_messages')
 
-  = will_paginate @conversations, :renderer => WillPaginate::ActionView::BootstrapLinkRenderer
+  = will_paginate @conversations, :previous_label => '&laquo;', :next_label => '&raquo;', :inner_window => 1, :outer_window => 0, :renderer => WillPaginate::ActionView::BootstrapLinkRenderer


### PR DESCRIPTION
Fix #5745 

Before:
![5745-10-before](https://cloud.githubusercontent.com/assets/6507951/6678196/dbe9b3d8-cc37-11e4-9a85-07b3345612f0.png)
(oh, sorry for "En attente de...")

After:
![5745-10](https://cloud.githubusercontent.com/assets/6507951/6678199/e219efc0-cc37-11e4-8222-92f338a4b63b.png)

Default value for `:inner_window` was `4`. I set `1`. Now it display **one** item around current page.
Default value for `:outer_window` was `1`, it displayed one item before the last one.

Page 1:
![5745-1](https://cloud.githubusercontent.com/assets/6507951/6678233/78893cc2-cc38-11e4-8be3-8fc7e9fd8c89.png)

Page 3:
![5745-3](https://cloud.githubusercontent.com/assets/6507951/6678271/f8ced4aa-cc38-11e4-87f7-22eadcb517a9.png)
