### PR TITLE
Fix frontend regressions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -61,6 +61,9 @@ Podmins can now set the currency for donations, and use an unhosted button if th
 a hosted one. Note: you need to **copy the new settings from diaspora.yml.example to your
 diaspora.yml file**. The existing settings from 0.4.x and before will not work any more.
 
+## Custom splash page changes
+diaspora* no longer adds a `div.container` to wrap custom splash pages. This adds the ability for podmins to write home pages using Bootstrap's fluid design. Podmins who added a custom splash page in `app/views/home/_show.{html,mobile}.haml` need to wrap the contents into a `div.container` to keep the old design.
+
 ## Refactor
 * Redesign contacts page [#5153](https://github.com/diaspora/diaspora/pull/5153)
 * Improve profile page design on mobile [#5084](https://github.com/diaspora/diaspora/pull/5084)

--- a/app/assets/stylesheets/oembed.scss
+++ b/app/assets/stylesheets/oembed.scss
@@ -1,7 +1,7 @@
 .oembed {
   background: image-url("ajax-loader2.gif") no-repeat center center;
-  margin: 10px auto;
   width: 100%;
+  .thumb, iframe { margin: 10px auto; }
   .thumb {
     @include video-overlay;
   }

--- a/app/views/admins/correlations.haml
+++ b/app/views/admins/correlations.haml
@@ -1,12 +1,12 @@
+.container
+  %div
+    = render :partial => 'admins/admin_bar'
 
-%div
-  = render :partial => 'admins/admin_bar'
-
-%div.row
-  %div.span12
-    %h1
-      = t('.correlations_count')
-    %ul
-      - @correlations_hash.keys.each do |k|
-        %li
-          = "#{k.to_s}, #{@correlations_hash[k]}"
+  %div.row
+    %div.span12
+      %h1
+        = t('.correlations_count')
+      %ul
+        - @correlations_hash.keys.each do |k|
+          %li
+            = "#{k.to_s}, #{@correlations_hash[k]}"

--- a/app/views/admins/stats.html.haml
+++ b/app/views/admins/stats.html.haml
@@ -1,56 +1,56 @@
+.container
+  %div
+    = render :partial => 'admins/admin_bar'
 
-%div
-  = render :partial => 'admins/admin_bar'
+  %h1
+    = t('.usage_statistic')
 
-%h1
-  = t('.usage_statistic')
+  %div.pull-right
+    = form_tag('/admins/stats', :method => 'get', class: 'form-inline') do
+      %select{:name => 'range'}
+        %option{:value => 'daily', :selected => ('selected' if params[:range] == 'daily')}
+          = t('.daily')
+        %option{:value => 'week', :selected => ('selected' if params[:range] == 'week')}
+          = t('.week')
+        %option{:value => '2weeks', :selected => ('selected' if params[:range] == '2weeks')}
+          = t('.2weeks')
+        %option{:value => 'month', :selected => ('selected' if params[:range] == 'month')}
+          = t('.month')
 
-%div.pull-right
-  = form_tag('/admins/stats', :method => 'get', class: 'form-inline') do
-    %select{:name => 'range'}
-      %option{:value => 'daily', :selected => ('selected' if params[:range] == 'daily')}
-        = t('.daily')
-      %option{:value => 'week', :selected => ('selected' if params[:range] == 'week')}
-        = t('.week')
-      %option{:value => '2weeks', :selected => ('selected' if params[:range] == '2weeks')}
-        = t('.2weeks')
-      %option{:value => 'month', :selected => ('selected' if params[:range] == 'month')}
-        = t('.month')
+      = submit_tag t('.go'), class: 'btn btn-primary'
 
-    = submit_tag t('.go'), class: 'btn btn-primary'
+  %h3
+    != t('.display_results', :segment => @segment)
 
-%h3
-  != t('.display_results', :segment => @segment)
+  %div.row
+    - [:posts, :comments, :aspect_memberships, :users].each do |name|
+      - model = eval("@#{name.to_s}")
+      - if name == :aspect_memberships
+        - name = t('.shares', :count => model[:yesterday])
+      - if name == :posts
+        - name = t('.posts', :count => model[:yesterday])
+      - if name == :comments
+        - name = t('.comments', :count => model[:yesterday])
+      - if name == :users
+        - name = t('.users', :count => model[:yesterday])
 
-%div.row
-  - [:posts, :comments, :aspect_memberships, :users].each do |name|
-    - model = eval("@#{name.to_s}")
-    - if name == :aspect_memberships
-      - name = t('.shares', :count => model[:yesterday])
-    - if name == :posts
-      - name = t('.posts', :count => model[:yesterday])
-    - if name == :comments
-      - name = t('.comments', :count => model[:yesterday])
-    - if name == :users
-      - name = t('.users', :count => model[:yesterday])
+      .span3
+        %h2{:style => 'font-weight:bold;'}
+          = name.to_s
+        %h4
+          = model[:day_before]
+          %span.percent_change{:class => (model[:change] > 0 ? "green" : "red")}
+            = "(#{model[:change]}%)"
 
-    .span3
-      %h2{:style => 'font-weight:bold;'}
-        = name.to_s
-      %h4
-        = model[:day_before]
-        %span.percent_change{:class => (model[:change] > 0 ? "green" : "red")}
-          = "(#{model[:change]}%)"
+  %div.row
+    %div.span12
+      %p.alert.alert-info.text-center
+        != t('.current_segment', :post_yest => @posts[:yesterday]/@user_count.to_f, :post_day => @posts[:day_before]/@user_count.to_f)
 
-%div.row
-  %div.span12
-    %p.alert.alert-info.text-center
-      != t('.current_segment', :post_yest => @posts[:yesterday]/@user_count.to_f, :post_day => @posts[:day_before]/@user_count.to_f)
-
-%div.row
-  %div.span12
-    %h3= t('.50_most')
-    %ul
-    - @popular_tags.each do |name,count|
-      %li
-        != t('.tag_name', :name_tag => name, :count_tag => count)
+  %div.row
+    %div.span12
+      %h3= t('.50_most')
+      %ul
+      - @popular_tags.each do |name,count|
+        %li
+          != t('.tag_name', :name_tag => name, :count_tag => count)

--- a/app/views/admins/user_search.html.haml
+++ b/app/views/admins/user_search.html.haml
@@ -1,49 +1,49 @@
+.container
+  %div
+    = render :partial => 'admins/admin_bar'
 
-%div
-  = render :partial => 'admins/admin_bar'
+  %div.row
+    %div.user_search.span9
+      %h3= t('admins.admin_bar.user_search')
+      = form_for @search, url: {action: 'user_search'}, html: {method: :get, class: 'form-horizontal'} do |f|
+        %div.control-group
+          = f.label :username, t('username'), class: 'control-label'
+          %div.controls
+            = f.text_field :username
 
-%div.row
-  %div.user_search.span9
-    %h3= t('admins.admin_bar.user_search')
-    = form_for @search, url: {action: 'user_search'}, html: {method: :get, class: 'form-horizontal'} do |f|
-      %div.control-group
-        = f.label :username, t('username'), class: 'control-label'
-        %div.controls
-          = f.text_field :username
+        %div.control-group
+          = f.label :email, t('email'), class: 'control-label'
+          %div.controls
+            = f.text_field :email
 
-      %div.control-group
-        = f.label :email, t('email'), class: 'control-label'
-        %div.controls
-          = f.text_field :email
+        %div.control-group
+          = f.label :guid, t('admins.user_entry.guid'), class: 'control-label'
+          %div.controls
+            = f.text_field :guid
 
-      %div.control-group
-        = f.label :guid, t('admins.user_entry.guid'), class: 'control-label'
-        %div.controls
-          = f.text_field :guid
+        %div.control-group
+          %div.controls
+            = f.label :under13 do
+              = f.check_box :under13
+              = t('.under_13')
+            = submit_tag t('admins.stats.go')
 
-      %div.control-group
-        %div.controls
-          = f.label :under13 do
-            = f.check_box :under13
-            = t('.under_13')
-          = submit_tag t('admins.stats.go')
+    %div.more_invites.span3
+      %h3= t('shared.invitations.invites')
 
-  %div.more_invites.span3
-    %h3= t('shared.invitations.invites')
+      != t('.you_currently', :count => current_user.invitation_code.count, :link => link_to(t(".add_invites"), add_invites_path(current_user.invitation_code)))
 
-    != t('.you_currently', :count => current_user.invitation_code.count, :link => link_to(t(".add_invites"), add_invites_path(current_user.invitation_code)))
+      = form_tag 'admin_inviter', method: :get do
+        = t('.email_to')
+        = text_field_tag 'identifier'
+        = submit_tag t('services.remote_friend.invite')
 
-    = form_tag 'admin_inviter', method: :get do
-      = t('.email_to')
-      = text_field_tag 'identifier'
-      = submit_tag t('services.remote_friend.invite')
+  %div.row
+    %div.span12
+      %div.alert.alert-info.text-center= t('.users', :count => @users.count)
 
-%div.row
-  %div.span12
-    %div.alert.alert-info.text-center= t('.users', :count => @users.count)
-
-%div.row
-  %div.users.span12
-    %ul.media-list
-      - @users.each do |user|
-        = render partial: 'user_entry', locals: { user: user }
+  %div.row
+    %div.users.span12
+      %ul.media-list
+        - @users.each do |user|
+          = render partial: 'user_entry', locals: { user: user }

--- a/app/views/admins/weekly_user_stats.haml
+++ b/app/views/admins/weekly_user_stats.haml
@@ -1,17 +1,17 @@
+.container
+  %div
+    = render :partial => 'admins/admin_bar'
 
-%div
-  = render :partial => 'admins/admin_bar'
+  %h2
+    = t('.current_server', date: Time.now.to_date)
 
-%h2
-  = t('.current_server', date: Time.now.to_date)
+  %div.pull-right
+    = form_tag('/admins/weekly_user_stats', method: 'get', class: 'form-inline') do
+      = select_tag(:week, options_for_select(@created_users_by_week.keys.reverse), selected: @selected_week)
+      = submit_tag t('admins.stats.go'), class: 'btn btn-primary'
 
-%div.pull-right
-  = form_tag('/admins/weekly_user_stats', method: 'get', class: 'form-inline') do
-    = select_tag(:week, options_for_select(@created_users_by_week.keys.reverse), selected: @selected_week)
-    = submit_tag t('admins.stats.go'), class: 'btn btn-primary'
-
-= t('.amount_of', count: @counter)
-%br
-- @created_users_by_week[@selected_week].each do |m|
-  = link_to m, "/u/#{m}"
+  = t('.amount_of', count: @counter)
   %br
+  - @created_users_by_week[@selected_week].each do |m|
+    = link_to m, "/u/#{m}"
+    %br

--- a/app/views/report/index.html.haml
+++ b/app/views/report/index.html.haml
@@ -1,29 +1,29 @@
+.container
+  %div
+    = render :partial => 'admins/admin_bar'
 
-%div
-  = render :partial => 'admins/admin_bar'
-
-%div.row
-  %div.span12
-    %h1
-      = t('report.title')
-    %div#reports
-      - @reports.each do |r|
-        - username = User.find_by_id(r.user_id).username
-        %div.content
-          %span.text
-            = report_content(r.item_id, r.item_type)
-          %span
-            = raw t('report.reported_label', person: link_to(username, user_profile_path(username)))
-          %span
-            = t('report.reason_label', text: r.text)
-        %div.options.text-right
-          %span
-            = button_to t('report.review_link'), report_path(r.id, :type => r.item_type),
-              :class => "btn btn-info btn-small",
-              method: :put
-          %span
-            = button_to t('report.delete_link'), report_path(r.id, :type => r.item_type),
-              :data => { :confirm => t('report.confirm_deletion') },
-              :class => "btn btn-danger btn-small",
-              method: :delete
-        %div.clear
+  %div.row
+    %div.span12
+      %h1
+        = t('report.title')
+      %div#reports
+        - @reports.each do |r|
+          - username = User.find_by_id(r.user_id).username
+          %div.content
+            %span.text
+              = report_content(r.item_id, r.item_type)
+            %span
+              = raw t('report.reported_label', person: link_to(username, user_profile_path(username)))
+            %span
+              = t('report.reason_label', text: r.text)
+          %div.options.text-right
+            %span
+              = button_to t('report.review_link'), report_path(r.id, :type => r.item_type),
+                :class => "btn btn-info btn-small",
+                method: :put
+            %span
+              = button_to t('report.delete_link'), report_path(r.id, :type => r.item_type),
+                :data => { :confirm => t('report.confirm_deletion') },
+                :class => "btn btn-danger btn-small",
+                method: :delete
+          %div.clear


### PR DESCRIPTION
- Fixes a oembed style regression introduced in #5809. The oembed div in posts had some margin even if there was no content.
- Adds missing `.container` divs to admin pages
- Adds a note to the changelog to inform podmins about changes for their custom splash pages.
