### PR TITLE
Fix tag overflow mobile page

### DIFF
--- a/app/assets/stylesheets/mobile/mobile.scss
+++ b/app/assets/stylesheets/mobile/mobile.scss
@@ -1204,3 +1204,8 @@ select#aspect_ids_ {
     background-color: $light-green;
   }
 }
+
+/* --- Tag page --- */
+#app #main h1 {
+  word-wrap: break-word;
+}


### PR DESCRIPTION
Another overflow...

Before:
![overflow-tag-mobile-before](https://cloud.githubusercontent.com/assets/6507951/6896637/ba3bf578-d6ed-11e4-9512-dfc63ab29795.png)

After:
![overflow-tag-mobile-after](https://cloud.githubusercontent.com/assets/6507951/6896636/ba1d3a3e-d6ed-11e4-984b-bb16506e0fc2.png)

Maybe it's a little bit huge. What you think?

I'm using _EditorConfig_, so it must ok for indent, but if not, tell me :) 
