### PR TITLE
Reaction expand to comment list's top rather than to the bottom.

### DIFF
--- a/app/assets/javascripts/mobile/mobile.js
+++ b/app/assets/javascripts/mobile/mobile.js
@@ -152,7 +152,7 @@ $(document).ready(function(){
             parent.append($(data).find('.comments_container').html());
             link.addClass('active');
             existingCommentsContainer.show();
-            scrollToOffset(parent, commentsContainer());
+            scrollToCommentsList(parent);
             commentsContainer().find('time.timeago').timeago();
           }
         });
@@ -169,12 +169,19 @@ $(document).ready(function(){
         success: function(data){
           parent.append(data);
           link.addClass('active');
-          scrollToOffset(parent, commentsContainer());
+          scrollToCommentsList(parent);
           commentsContainer().find('time.timeago').timeago();
         }
       });
     }
   });
+
+  var scrollToCommentsList = function(container, speed) {
+    var speed = speed || 1000;
+      $('html,body').animate({
+        scrollTop: container.offset().top
+      }, speed);
+  };
 
   var scrollToOffset = function(parent, commentsContainer){
     var commentCount = commentsContainer.find("li.comment").length;

--- a/app/assets/javascripts/mobile/mobile.js
+++ b/app/assets/javascripts/mobile/mobile.js
@@ -137,18 +137,17 @@ $(document).ready(function(){
       activeElements.removeClass('inactive').addClass('active');
 
       // Show or hide the new comment form depending on 'show_form' param
-      var newCommentForm = commentsContainer().find('.new_comment')
-          addCommentLink = commentsContainer().find('.add_comment_bottom_link')
-          ;
+      var newCommentForm = commentsContainer().find('.new_comment'),
+          addCommentLink = commentsContainer().find('.add_comment_bottom_link');
       if (show_form) {
         newCommentForm.show();
         addCommentLink.hide();
         // Scroll to the comment list or to the form
-        scrollToOffset(parent, commentsContainer())
+        scrollToOffset(parent, commentsContainer());
       } else {
         newCommentForm.hide();
         addCommentLink.show();
-        scrollToCommentsList(parent)
+        scrollToCommentsList(parent);
       }
 
       commentsContainer().find('time.timeago').timeago();
@@ -221,8 +220,8 @@ $(document).ready(function(){
         commentsContainer = function(){ return parent.find(".comment_container").first(); };
 
       // Show or hide the new comment form depending on 'show_form' param
-      var newCommentForm = commentsContainer().find('.new_comment')
-          addCommentLink = commentsContainer().find('.add_comment_bottom_link')
+      var newCommentForm = commentsContainer().find('.new_comment'),
+          addCommentLink = commentsContainer().find('.add_comment_bottom_link');
 
       if (addCommentLink.is(":visible")) {
         newCommentForm.show();

--- a/app/assets/stylesheets/mobile/mobile.scss
+++ b/app/assets/stylesheets/mobile/mobile.scss
@@ -124,6 +124,7 @@ h3 {
   }
 
   .comment {
+    list-style: none;
     padding: {
       top: 10px;
       bottom: 5px;

--- a/app/helpers/mobile_helper.rb
+++ b/app/helpers/mobile_helper.rb
@@ -9,33 +9,33 @@ module MobileHelper
       absolute_root = reshare?(post) ? post.absolute_root : post
 
       if absolute_root && absolute_root.author != current_user.person
-        reshare = Reshare.where(:author_id => current_user.person_id,
-                                :root_guid => absolute_root.guid).first
+        reshare = Reshare.where(author_id: current_user.person_id,
+                                root_guid: absolute_root.guid).first
         klass = reshare.present? ? "active" : "inactive"
-        link_to "", reshares_path(:root_guid => absolute_root.guid), :title => t('reshares.reshare.reshare_confirmation', :author => absolute_root.author_name), :class => "image_link reshare_action #{klass}"
+        link_to "", reshares_path(root_guid: absolute_root.guid), title: t("reshares.reshare.reshare_confirmation", author: absolute_root.author_name), class: "image_link reshare_action #{klass}"
       end
     end
   end
 
   def mobile_like_icon(post)
     if current_user && current_user.liked?(post)
-      link_to "", post_like_path(post.id, current_user.like_for(post).id), :class => "image_link like_action active"
+      link_to "", post_like_path(post.id, current_user.like_for(post).id), class: "image_link like_action active"
     else
-      link_to "", post_likes_path(post.id), :class => "image_link like_action inactive"
+      link_to "", post_likes_path(post.id), class: "image_link like_action inactive"
     end
   end
 
   def mobile_comment_icon(post)
-    link_to "", post_comments_path(post, :format => "mobile"), :class => "image_link comment_action inactive"
+    link_to "", post_comments_path(post, format: "mobile"), class: "image_link comment_action inactive"
   end
 
   def reactions_link(post)
     reactions_count = post.comments_count + post.likes_count
     if reactions_count > 0
-      link_to "#{t('reactions', :count => reactions_count)}", post_comments_path(post, :format => "mobile"), :class => 'show_comments'
+      link_to "#{t('reactions', count: reactions_count)}", post_comments_path(post, format: "mobile"), class: "show_comments"
     else
       html = "<span class='show_comments'>"
-      html << "#{t('reactions', :count => reactions_count)}"
+      html << "#{t('reactions', count: reactions_count)}"
       html << "</span>"
     end
   end

--- a/app/helpers/mobile_helper.rb
+++ b/app/helpers/mobile_helper.rb
@@ -12,21 +12,21 @@ module MobileHelper
         reshare = Reshare.where(:author_id => current_user.person_id,
                                 :root_guid => absolute_root.guid).first
         klass = reshare.present? ? "active" : "inactive"
-        link_to '', reshares_path(:root_guid => absolute_root.guid), :title => t('reshares.reshare.reshare_confirmation', :author => absolute_root.author_name), :class => "image_link reshare_action #{klass}"
+        link_to "", reshares_path(:root_guid => absolute_root.guid), :title => t('reshares.reshare.reshare_confirmation', :author => absolute_root.author_name), :class => "image_link reshare_action #{klass}"
       end
     end
   end
 
   def mobile_like_icon(post)
     if current_user && current_user.liked?(post)
-      link_to '', post_like_path(post.id, current_user.like_for(post).id), :class => "image_link like_action active"
+      link_to "", post_like_path(post.id, current_user.like_for(post).id), :class => "image_link like_action active"
     else
-      link_to '', post_likes_path(post.id), :class => "image_link like_action inactive"
+      link_to "", post_likes_path(post.id), :class => "image_link like_action inactive"
     end
   end
 
   def mobile_comment_icon(post)
-    link_to '', post_comments_path(post, :format => "mobile"), :class => "image_link comment_action inactive"
+    link_to "", post_comments_path(post, :format => "mobile"), :class => "image_link comment_action inactive"
   end
 
   def reactions_link(post)

--- a/app/helpers/mobile_helper.rb
+++ b/app/helpers/mobile_helper.rb
@@ -26,7 +26,7 @@ module MobileHelper
   end
 
   def mobile_comment_icon(post)
-    link_to '', new_post_comment_path(post), :class => "image_link comment_action inactive"
+    link_to '', post_comments_path(post, :format => "mobile"), :class => "image_link comment_action inactive"
   end
 
   def reactions_link(post)

--- a/app/views/shared/_post_stats.mobile.haml
+++ b/app/views/shared/_post_stats.mobile.haml
@@ -18,4 +18,5 @@
         = image_tag "icons/arrow_up_small.png"
         
       - if user_signed_in? 
-        = link_to t("comments.new_comment.comment"), new_post_comment_path(@post), class: "add_comment_bottom_link btn comment_action inactive"
+        = link_to t("comments.new_comment.comment"), new_post_comment_path(@post), class: "hide add_comment_bottom_link btn inactive"
+        = render partial: "comments/new_comment", :format => "mobile", locals: {post_id: @post.id}

--- a/features/mobile/reactions.feature
+++ b/features/mobile/reactions.feature
@@ -34,7 +34,6 @@ Feature: reactions mobile post
     And I should see "1 reaction" within ".show_comments"
     And I click on selector "a.show_comments"
     And I should see "1" within ".comment_count"
-    When I click on selector "a.image_link.comment_action.inactive"
-    And I click on selector "a.remove"
+    When I click on selector "a.remove"
     And I confirm the alert
     Then I should not see "1 reaction" within ".show_comments"


### PR DESCRIPTION
Add logic to show comment form or reactions depending on execution path
- if the user clicks 'reactions' link the reactions view is displayed
  - the reactions view displays a button to show the comment form
  - the screen is scrolled to the top of the reactions view
- if the user clicks the 'pen' icon the reactions view is displayed
  - the reactions view displays the comment form and is focused
  - the screen is scrolled to the bottom of the reactions view

Added logic to displayed the 'comment' button after successfully commenting
- when the user comments on a post
  - the comment form is hidden
  - the 'comment' button is shown again

Fixed #5757 btw
edit: Updated description to reflect logic changes
