### PR TITLE
Contacts page: remove broken title from 'Start a conversation' button

### DIFF
--- a/app/helpers/contacts_helper.rb
+++ b/app/helpers/contacts_helper.rb
@@ -7,9 +7,7 @@ module ContactsHelper
   end
 
   def start_a_conversation_link(aspect, contacts_size)
-    suggested_limit = 16
     conv_opts = { class: "conversation_button contacts_button"}
-    conv_opts[:title] = t('.many_people_are_you_sure', suggested_limit: suggested_limit) if contacts_size > suggested_limit
 
     content_tag :span, conv_opts do
       content_tag(:i, nil, :class => 'entypo mail contacts-header-icon', :title => t('contacts.index.start_a_conversation'), 'data-toggle' => 'modal', 'data-target' => '#conversationModal')

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -324,7 +324,6 @@ en:
       only_sharing_with_me: "Only sharing with me"
       add_contact: "Add contact"
       remove_contact: "Remove contact"
-      many_people_are_you_sure: "Are you sure you want to start a private conversation with more than %{suggested_limit} contacts? Posting to this aspect may be a better way to contact them."
       user_search: "Contact search"
     spotlight:
       community_spotlight: "Community spotlight"


### PR DESCRIPTION
We added a broken title but didn't display it anywhere so I removed it. Fixes #5825.
