### PR TITLE
Move default_url_options to application.rb

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -102,5 +102,12 @@ module Diaspora
 
     # Will be default with Rails 5
     config.active_record.raise_in_transactional_callbacks = true
+
+    # Setup action mailer early
+    config.action_mailer.default_url_options = {
+      protocol: AppConfig.pod_uri.scheme,
+      host:     AppConfig.pod_uri.authority
+    }
+    config.action_mailer.asset_host = AppConfig.pod_uri.to_s
   end
 end

--- a/config/initializers/mailer_config.rb
+++ b/config/initializers/mailer_config.rb
@@ -4,11 +4,6 @@
 require Rails.root.join('lib', 'messagebus', 'mailer')
 
 Diaspora::Application.configure do
-  config.action_mailer.default_url_options = {
-    protocol: AppConfig.pod_uri.scheme,
-    host:     AppConfig.pod_uri.authority
-  }
-  config.action_mailer.asset_host = AppConfig.pod_uri.to_s
   config.action_mailer.perform_deliveries = AppConfig.mail.enable?
 
   unless Rails.env == 'test' || !AppConfig.mail.enable?
@@ -36,7 +31,7 @@ Diaspora::Application.configure do
         enable_starttls_auto: false,
         openssl_verify_mode:  AppConfig.mail.smtp.openssl_verify_mode.get
       }
-      
+
       if AppConfig.mail.smtp.authentication != "none"
         smtp_settings.merge!({
           authentication:       AppConfig.mail.smtp.authentication.gsub('-', '_').to_sym,
@@ -45,7 +40,7 @@ Diaspora::Application.configure do
           enable_starttls_auto: AppConfig.mail.smtp.starttls_auto?
         })
       end
-      
+
       config.action_mailer.smtp_settings = smtp_settings
     else
       $stderr.puts "WARNING: Mailer turned on with unknown method #{AppConfig.mail.method}. Mail won't work."


### PR DESCRIPTION
Apparently the subclasses got loaded before the initializers
were run, thus not inheriting the config.
