### PR TITLE
Don't add mentions and reshares to all streams

### DIFF
--- a/app/assets/javascripts/app/models/post/interactions.js
+++ b/app/assets/javascripts/app/models/post/interactions.js
@@ -110,7 +110,9 @@ app.models.Post.Interactions = Backbone.Model.extend({
           notice: Diaspora.I18n.t("reshares.successful")
         });
         interactions.reshares.add(reshare);
-        if (app.stream) {app.stream.addNow(reshare)}
+        if (app.stream && /^\/(?:stream|activity|aspects)/.test(app.stream.basePath())) {
+          app.stream.addNow(reshare);
+        }
         interactions.trigger("change");
       })
       .fail(function(){

--- a/app/assets/javascripts/app/views/publisher_view.js
+++ b/app/assets/javascripts/app/views/publisher_view.js
@@ -195,7 +195,9 @@ app.views.Publisher = Backbone.View.extend({
           self.view_poll_creator.trigger('publisher:sync');
         }
 
-        if(app.stream) app.stream.addNow(statusMessage.toJSON());
+        if(app.stream && !self.standalone){
+          app.stream.addNow(statusMessage.toJSON());
+        }
 
         // clear state
         self.clear();

--- a/spec/javascripts/app/views/publisher_view_spec.js
+++ b/spec/javascripts/app/views/publisher_view_spec.js
@@ -4,7 +4,7 @@
  */
 
 describe("app.views.Publisher", function() {
-  describe("standalone", function() {
+  context("standalone", function() {
     beforeEach(function() {
       // TODO should be jasmine helper
       loginAs({name: "alice", avatar : {small : "http://avatar.com/photo.jpg"}});
@@ -21,6 +21,16 @@ describe("app.views.Publisher", function() {
 
     it("hides the post preview button in standalone mode", function() {
       expect(this.view.$('.post_preview_button').is(':visible')).toBeFalsy();
+    });
+
+    describe("createStatusMessage", function(){
+      it("doesn't add the status message to the stream", function() {
+        app.stream = { addNow: $.noop };
+        spyOn(app.stream, "addNow");
+        this.view.createStatusMessage($.Event());
+        jasmine.Ajax.requests.mostRecent().respondWith({ status: 200, responseText: "{\"id\": 1}" });
+        expect(app.stream.addNow).not.toHaveBeenCalled();
+      });
     });
   });
 
@@ -127,6 +137,14 @@ describe("app.views.Publisher", function() {
         spyOn(this.view, "handleTextchange");
         this.view.createStatusMessage($.Event());
         expect(this.view.handleTextchange).toHaveBeenCalled();
+      });
+
+      it("adds the status message to the stream", function() {
+        app.stream = { addNow: $.noop };
+        spyOn(app.stream, "addNow");
+        this.view.createStatusMessage($.Event());
+        jasmine.Ajax.requests.mostRecent().respondWith({ status: 200, responseText: "{\"id\": 1}" });
+        expect(app.stream.addNow).toHaveBeenCalled();
       });
     });
 


### PR DESCRIPTION
- Don't add posts from standalone publisher. Fixes #4672.
- Only add reshares to the default, activity and aspects stream. Fixes #5795.

I added some jasmine tests so this PR should fix the bugs. Unfortunately I am currently not able to really check that because of #5837.
