### PR TITLE
Limited post content excluded from subject of comment email

### DIFF
--- a/app/mailers/notification_mailers/comment_on_post.rb
+++ b/app/mailers/notification_mailers/comment_on_post.rb
@@ -6,7 +6,11 @@ module NotificationMailers
       @comment = Comment.find(comment_id)
 
       @headers[:from] = "\"#{@comment.author_name} (diaspora*)\" <#{AppConfig.mail.sender_address}>"
-      @headers[:subject] = "Re: #{@comment.comment_email_subject}"
+      if @comment.public?
+        @headers[:subject] = "Re: #{@comment.comment_email_subject}"
+      else
+        @headers[:subject] = I18n.t("notifier.comment_on_post.limited_subject")
+      end
     end
   end
 end

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -742,6 +742,7 @@ en:
         sharing: "has started sharing with you!"
         view_profile: "View %{name}’s profile"
     comment_on_post:
+        limited_subject: "There's a new comment on a post you commented"
         reply: "Reply or view %{name}’s post >"
     mentioned:
         subject: "%{name} has mentioned you on diaspora*"

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -318,6 +318,26 @@ describe Notifier, :type => :mailer do
     end
   end
 
+  context "limited comments" do
+    let(:commented_limited_post) {
+      bob.post(:status_message, to: :all, public: false,
+        text: "### Limited headline \r\n It's **really** sunny outside today")
+    }
+    let(:limited_comment) { eve.comment!(commented_limited_post, "Totally is") }
+
+    describe ".comment_on_limited_post" do
+      let(:limited_comment_mail) { Notifier.comment_on_post(bob.id, person.id, limited_comment.id).deliver_now }
+
+      it "SUBJECT: does not show limited message" do
+        expect(limited_comment_mail.subject).not_to include("Limited headline")
+      end
+
+      it "BODY: does not show limited message" do
+        expect(limited_comment_mail.body.encoded).not_to include("Limited headline")
+      end
+    end
+  end
+
   describe 'hashtags' do
     it 'escapes hashtags' do
       mails = Notifier.admin("#Welcome to bureaucracy!", [bob])


### PR DESCRIPTION
Currently, when a user comments a limited post, a email is sent to all participants of that post.

Email subject contains first 70 chars of post text. I expect no part of limited text to be disclosed in email notification.

What subject do you expect for a comment to a limited post?
