### PR TITLE
Disable auto follow back on aspect deletion

### DIFF
--- a/app/controllers/aspects_controller.rb
+++ b/app/controllers/aspects_controller.rb
@@ -44,14 +44,20 @@ class AspectsController < ApplicationController
   end
 
   def destroy
-    @aspect = current_user.aspects.where(:id => params[:id]).first
+    @aspect = current_user.aspects.where(id: params[:id]).first
 
     begin
+      if current_user.auto_follow_back && @aspect.id == current_user.auto_follow_back_aspect.id
+        current_user.update(auto_follow_back: false, auto_follow_back_aspect: nil)
+        flash[:notice] = I18n.t "aspects.destroy.success_auto_follow_back", name: @aspect.name
+      else
+        flash[:notice] = I18n.t "aspects.destroy.success", name: @aspect.name
+      end
       @aspect.destroy
-      flash[:notice] = I18n.t 'aspects.destroy.success', :name => @aspect.name
     rescue ActiveRecord::StatementInvalid => e
-      flash[:error] = I18n.t 'aspects.destroy.failure', :name => @aspect.name
+      flash[:error] = I18n.t "aspects.destroy.failure", name: @aspect.name
     end
+
     if request.referer.include?('contacts')
       redirect_to contacts_path
     else

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -215,7 +215,8 @@ en:
       failure: "Aspect creation failed."
     destroy:
       success: "%{name} was successfully removed."
-      failure: "%{name} is not empty and could not be removed."
+      success_auto_follow_back: "%{name} was successfully removed. You used this aspect to automatically follow back users. Check your user settings to select a new auto follow back aspect."
+      failure: "%{name} could not be removed."
     update:
       success: "Your aspect, %{name}, has been successfully edited."
       failure: "Your aspect, %{name}, had too long name to be saved."

--- a/db/migrate/20150403192408_remove_deleted_aspects_from_auto_follow_back.rb
+++ b/db/migrate/20150403192408_remove_deleted_aspects_from_auto_follow_back.rb
@@ -1,0 +1,11 @@
+class RemoveDeletedAspectsFromAutoFollowBack < ActiveRecord::Migration
+  def up
+    User.where.not(auto_follow_back_aspect_id: Aspect.select(:id))
+      .where(auto_follow_back: true)
+      .update_all(auto_follow_back: false, auto_follow_back_aspect_id: nil)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150220001357) do
+ActiveRecord::Schema.define(version: 20150403192408) do
 
   create_table "account_deletions", force: :cascade do |t|
     t.string   "diaspora_handle", limit: 255

--- a/spec/controllers/aspects_controller_spec.rb
+++ b/spec/controllers/aspects_controller_spec.rb
@@ -112,6 +112,54 @@ describe AspectsController, :type => :controller do
     end
   end
 
+  describe "#destroy" do
+    before do
+      @alices_aspect_1 = alice.aspects.create(name: "Contacts")
+    end
+
+    context "with no auto follow back aspect" do
+      it "destoys the aspect" do
+        expect(alice.aspects.to_a).to include @alices_aspect_1
+        post :destroy, id: @alices_aspect_1.id
+        expect(alice.reload.aspects.to_a).not_to include @alices_aspect_1
+      end
+
+      it "renders a flash message on success" do
+        post :destroy, id: @alices_aspect_1.id
+        expect(flash[:notice]).to eq(I18n.t("aspects.destroy.success", name: @alices_aspect_1.name))
+        expect(flash[:error]).to be_blank
+      end
+    end
+
+    context "with the aspect set as auto follow back" do
+      before do
+        alice.auto_follow_back = true
+        alice.auto_follow_back_aspect = @alices_aspect_1
+        alice.save
+      end
+
+      it "destoys the aspect" do
+        expect(alice.aspects.to_a).to include @alices_aspect_1
+        post :destroy, id: @alices_aspect_1.id
+        expect(alice.reload.aspects.to_a).not_to include @alices_aspect_1
+      end
+
+      it "disables auto follow back" do
+        expect(alice.auto_follow_back).to be(true)
+        expect(alice.auto_follow_back_aspect).to eq(@alices_aspect_1)
+        post :destroy, id: @alices_aspect_1.id
+        expect(alice.auto_follow_back).to be(false)
+        expect(alice.auto_follow_back_aspect).to eq(nil)
+      end
+
+      it "renders a flash message telling you to set a new auto follow back aspect" do
+        post :destroy, id: @alices_aspect_1.id
+        expect(flash[:notice]).to eq(I18n.t("aspects.destroy.success_auto_follow_back", name: @alices_aspect_1.name))
+        expect(flash[:error]).to be_blank
+      end
+    end
+  end
+
   describe "#toggle_contact_visibility" do
     it 'sets contacts visible' do
       @alices_aspect_1.contacts_visible = false


### PR DESCRIPTION
Fixes #5845. 
- When deleting the auto follow back aspect it displays a flash message "%{name} was successfully removed. You used this aspect to automatically follow back users. Check your user settings to select a new auto follow back aspect." and disables the auto follow back feature.
- Changes the flash message `aspects.destroy.failure` from "%{name} is not empty and could not be removed." to "%{name} could not be removed." because we also remove aspects that are not empty.
