### PR TITLE
Remove 'manage services' link in standalone mode

### DIFF
--- a/app/assets/javascripts/app/views/publisher_view.js
+++ b/app/assets/javascripts/app/views/publisher_view.js
@@ -59,11 +59,13 @@ app.views.Publisher = Backbone.View.extend({
       this.el_input.val( this.el_hiddenInput.val() );
     }
 
-    // hide close and preview buttons, in case publisher is standalone
+    // hide close and preview buttons and manage services link
+    // in case publisher is standalone
     // (e.g. bookmarklet, mentions popup)
     if( this.standalone ) {
-      this.$('#hide_publisher').hide();
+      this.$("#hide_publisher").hide();
       this.el_preview.hide();
+      this.$(".question_mark").hide();
     }
 
     // this has to be here, otherwise for some reason the callback for the

--- a/app/assets/stylesheets/publisher.scss
+++ b/app/assets/stylesheets/publisher.scss
@@ -30,13 +30,15 @@
 
     .options_and_submit {
       #publisher_service_icons {
-        .btn-link { text-decoration: none; }
-        .btn-link.question_mark .entypo { color: $text-grey; }
-        .btn-link.question_mark:hover .entypo { color: $black; }
-        .btn-link.service_icon {
+        margin-right: 10px;
+        .btn-link {
           padding-left: 5px;
           padding-right: 5px;
+          text-decoration: none;
         }
+        .btn-link.question_mark { margin-left: 5px; }
+        .btn-link.question_mark .entypo { color: $text-grey; }
+        .btn-link.question_mark:hover .entypo { color: $black; }
         .dim { opacity: 0.3; }
         .social_media_logos-wordpress-16x16 {
           display: inline-block;

--- a/spec/javascripts/app/views/publisher_view_spec.js
+++ b/spec/javascripts/app/views/publisher_view_spec.js
@@ -16,11 +16,15 @@ describe("app.views.Publisher", function() {
     });
 
     it("hides the close button in standalone mode", function() {
-      expect(this.view.$('#hide_publisher').is(':visible')).toBeFalsy();
+      expect(this.view.$("#hide_publisher").is(":visible")).toBeFalsy();
     });
 
     it("hides the post preview button in standalone mode", function() {
-      expect(this.view.$('.post_preview_button').is(':visible')).toBeFalsy();
+      expect(this.view.$(".post_preview_button").is(":visible")).toBeFalsy();
+    });
+
+    it("hides the manage services link in standalone mode", function() {
+      expect(this.view.$(".question_mark").is(":visible")).toBeFalsy();
     });
 
     describe("createStatusMessage", function(){


### PR DESCRIPTION
Fixes #4671. I had to add some small style changes because of the missing services link in the standalone mode.

**normal mode** (top: old, bottom: new)
![normal mode](https://cloud.githubusercontent.com/assets/3798614/7044310/6b1551d6-ddf2-11e4-98fe-8961710f69e5.png)

**standalone mode** (top: old, bottom: new)
![standalone mode](https://cloud.githubusercontent.com/assets/3798614/7044311/6b170a3a-ddf2-11e4-8082-af7bfb2b067c.png)
