### PR TITLE
use "CONVERT TO" to change the encoding for the table and all character columns

### DIFF
--- a/db/migrate/20150106050733_set_mysql_to_unicode_mb4.rb
+++ b/db/migrate/20150106050733_set_mysql_to_unicode_mb4.rb
@@ -25,24 +25,8 @@ class SetMysqlToUnicodeMb4 < ActiveRecord::Migration
     execute "ALTER DATABASE `#{ActiveRecord::Base.connection.current_database}` CHARACTER SET #{encoding} COLLATE #{collation};"
 
     tables.each do |table|
-      execute "ALTER TABLE `#{table}` CHARACTER SET = #{encoding} COLLATE #{collation}"
+      execute "ALTER TABLE `#{table}` CONVERT TO CHARACTER SET #{encoding} COLLATE #{collation}"
     end
-
-    character_columns.each do |table, columns|
-      columns.each do |column|
-        execute "ALTER TABLE `#{table}` CHANGE `#{column.name}` `#{column.name}` #{column.sql_type} CHARACTER SET #{encoding} COLLATE #{collation} #{column.null ? 'NULL' : 'NOT NULL'} #{"DEFAULT '#{column.default}'" if column.has_default?};"
-      end
-    end
-  end
-
-  def character_columns
-    # build a hash with all the columns that contain characters
-    @character_columns ||= Hash[tables.map {|table|
-      col = columns(table)
-        .select {|column| column.type == :string || column.type == :text }
-      next if col.empty?
-      [table, col]
-    }.compact]
   end
 
   def shorten_indexes


### PR DESCRIPTION
see: https://dev.mysql.com/doc/refman/5.6/en/charset-conversion.html

> To convert all character columns in a table, the ALTER TABLE ... CONVERT TO CHARACTER SET charset statement may be useful.

I have tested this on a 13GB db with mariadb (production db from nerdpol.ch):
http://paste.coding4.coffee/?7b0c98e4a2e931a4#znl7Al/rLS/a3T3AaBYiP7Ujvnl9TpCvMtimZKShSS0=

with the old migration it took OVER 9000 seconds.
