### PR TITLE
fix control icon alignment in chromium browser

### DIFF
--- a/app/assets/stylesheets/new_styles/_interactions.scss
+++ b/app/assets/stylesheets/new_styles/_interactions.scss
@@ -7,7 +7,7 @@
       color: $text-grey;
       font-size: $font-size-text;
       line-height: $line-height;
-      vertical-align: top;
+      vertical-align: middle;
       &:hover { color: $text; }
       &.cross { font-size: $line-height; }
     }


### PR DESCRIPTION
The X icon in chromium was not aligned. In Firefox it was OK, now it's 2px lower, but OK. :)

It is still slightly different, but better than before.
### Chromium:

before:
![chromium-before](https://cloud.githubusercontent.com/assets/458548/7238273/633d6594-e7a1-11e4-976a-07ce2239ff9a.png)
after:
![chromium-after](https://cloud.githubusercontent.com/assets/458548/7238289/7b6b8bdc-e7a1-11e4-8193-e301f1f76ebd.png)
### Firefox:

before:
![firefox-before](https://cloud.githubusercontent.com/assets/458548/7238304/934120d2-e7a1-11e4-9c5a-94f671d0be2e.png)
after:
![firefox-after](https://cloud.githubusercontent.com/assets/458548/7238306/988b2056-e7a1-11e4-8edf-b223fc93688d.png)
