### PR TITLE
Fix uppercase registration/login labels and btn style

### DIFF
--- a/app/assets/stylesheets/mobile/mobile.scss
+++ b/app/assets/stylesheets/mobile/mobile.scss
@@ -154,6 +154,7 @@ h3 {
 
   .login-container {
     padding: 10px;
+    label, legend { text-transform: uppercase; }
   }
 }
 

--- a/app/views/registrations/new.mobile.haml
+++ b/app/views/registrations/new.mobile.haml
@@ -18,25 +18,25 @@
         %fieldset
           %legend
             = image_tag('branding/header-logo2x.png', :height => 40, :width => 40)
-            = t('aspects.aspect_stream.make_something').upcase
+            = t('aspects.aspect_stream.make_something')
 
           .control-group
-            = f.label :username, t('username').upcase
+            = f.label :username, t('username')
             .controls
               = f.text_field :username, :placeholder => "jedi_guy"
 
             .control-group
-              = f.label :email, t('email').upcase
+              = f.label :email, t('email')
               .controls
                 = f.text_field :email, :placeholder => "luke@hoth.net"
 
             .control-group
-              = f.label :password, t('password').upcase
+              = f.label :password, t('password')
               .controls
                 = f.password_field :password, :placeholder => "••••••••"
 
             .control-group
-              = f.label :password_confirmation, t('password_confirmation').upcase
+              = f.label :password_confirmation, t('password_confirmation')
               .controls
                 = f.password_field :password_confirmation, :placeholder => "••••••••"
 
@@ -50,7 +50,7 @@
 
             .controls
               = f.submit t('registrations.new.create_my_account'), :class => 'btn primary', :disable_with => t('registrations.new.submitting')
-              = link_to t('devise.sessions.new.sign_in'), new_user_session_path(), :class => 'btn primary', :style => "float: right;"
+              = link_to t('devise.sessions.new.sign_in'), new_user_session_path(), :class => 'btn btn-link', :style => "float: right;"
 
 %footer
   = link_to t('layouts.application.toggle'), toggle_mobile_path

--- a/app/views/sessions/new.mobile.haml
+++ b/app/views/sessions/new.mobile.haml
@@ -22,15 +22,15 @@
           %fieldset
             %legend
               = image_tag('branding/header-logo2x.png', :height => 40, :width => 40)
-              = t('devise.sessions.new.login').upcase
-          
+              = t('devise.sessions.new.login')
+
             .control-group
-              = f.label :username, t('username').upcase
+              = f.label :username, t('username')
               .controls
                 = f.text_field :username, :autofocus => true
 
             .control-group
-              = f.label :password , t('password').upcase
+              = f.label :password , t('password')
               .controls
                 = f.password_field :password
 
@@ -39,7 +39,7 @@
             .controls
               = f.submit t('devise.sessions.new.sign_in'), :class => 'btn primary'
               - if display_registration_link?
-                = link_to t('devise.shared.links.sign_up'), new_registration_path(resource_name), :class => 'btn primary', :style => "float: right;"
+                = link_to t('devise.shared.links.sign_up'), new_registration_path(resource_name), :class => 'btn btn-link', :style => "float: right;"
 
   %footer
     - if display_password_reset_link?


### PR DESCRIPTION
Fixes #5272 and #5596.
![registration01](https://cloud.githubusercontent.com/assets/3798614/7241858/718b5b3a-e7bd-11e4-9df2-b5f06cd66aa1.png)
![registration02](https://cloud.githubusercontent.com/assets/3798614/7241855/71766c02-e7bd-11e4-8cb5-7633be00ca39.png)
![registration03](https://cloud.githubusercontent.com/assets/3798614/7241857/71799418-e7bd-11e4-9d72-75308221532d.png)
![registration04](https://cloud.githubusercontent.com/assets/3798614/7241856/7177555e-e7bd-11e4-926c-278ae81a44a5.png)
