### PR TITLE
Update markdown-it, disable fuzzy links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,7 +92,7 @@ gem "js-routes",                                        "1.0.0"
 source "https://rails-assets.org" do
   gem "rails-assets-jquery",                              "1.11.1" # Should be kept in sync with jquery-rails
 
-  gem "rails-assets-markdown-it",                         "4.1.2"
+  gem "rails-assets-markdown-it",                         "4.2.0"
   gem "rails-assets-markdown-it-hashtag",                 "0.3.0"
   gem "rails-assets-markdown-it-diaspora-mention",        "0.3.0"
   gem "rails-assets-markdown-it-sanitizer",               "0.3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -507,7 +507,7 @@ GEM
     rails-assets-jquery.slimscroll (1.3.3)
       rails-assets-jquery (>= 1.7)
     rails-assets-markdown-it--markdown-it-for-inline (0.1.0)
-    rails-assets-markdown-it (4.1.2)
+    rails-assets-markdown-it (4.2.0)
     rails-assets-markdown-it-diaspora-mention (0.3.0)
     rails-assets-markdown-it-hashtag (0.3.0)
     rails-assets-markdown-it-sanitizer (0.3.0)
@@ -773,7 +773,7 @@ DEPENDENCIES
   rails-assets-jquery-idletimer (= 1.0.1)!
   rails-assets-jquery-placeholder (= 2.1.1)!
   rails-assets-jquery-textchange (= 0.2.3)!
-  rails-assets-markdown-it (= 4.1.2)!
+  rails-assets-markdown-it (= 4.2.0)!
   rails-assets-markdown-it--markdown-it-for-inline (= 0.1.0)!
   rails-assets-markdown-it-diaspora-mention (= 0.3.0)!
   rails-assets-markdown-it-hashtag (= 0.3.0)!

--- a/app/assets/javascripts/app/helpers/text_formatter.js
+++ b/app/assets/javascripts/app/helpers/text_formatter.js
@@ -52,6 +52,7 @@
 
     // xmpp: should behave like mailto:
     md.linkify.add('xmpp:','mailto:');
+    md.linkify.set({ fuzzyLink: false });
 
     // Bootstrap table markup
     md.renderer.rules.table_open = function () { return '<table class="table table-striped">\n'; };

--- a/spec/javascripts/app/helpers/text_formatter_spec.js
+++ b/spec/javascripts/app/helpers/text_formatter_spec.js
@@ -96,9 +96,8 @@ describe("app.helpers.textFormatter", function(){
         "http://www.yahooligans.com",
         "http://obama.com",
         "http://japan.co.jp",
-        "www.mygreat-example-website.de",
-        "www.jenseitsderfenster.de",  // from issue #3468
-        "www.google.com",
+        "http://www.mygreat-example-website.de",
+        "http://www.jenseitsderfenster.de",  // from issue #3468
         "xmpp:podmin@pod.tld",
         "mailto:podmin@pod.tld"
       ];
@@ -119,7 +118,6 @@ describe("app.helpers.textFormatter", function(){
     it("adds a missing http://", function() {
       expect(this.formatter('[test](www.google.com)')).toContain('href="http://www.google.com"');
       expect(this.formatter('[test](http://www.google.com)')).toContain('href="http://www.google.com"');
-      expect(this.formatter('www.google.com')).toContain('href="http://www.google.com"');
     });
 
     it("respects code blocks", function() {


### PR DESCRIPTION
Now `http://` or `https://` is required for links. This fixes false positives like `0.5.0.0` or `test.sh`.
