### PR TITLE
fix notification mails for limited posts

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@
 * Return 406 when requesting a JSON representation of people/:guid/contacts [#5849](https://github.com/diaspora/diaspora/pull/5849)
 * Destroy Participation when removing interactions with a post [#5852](https://github.com/diaspora/diaspora/pull/5852)
 * Hide manage services link in the publisher on certain pages [#5854](https://github.com/diaspora/diaspora/pull/5854)
+* Fix notification mails for limited posts [#5877](https://github.com/diaspora/diaspora/pull/5877)
 
 ## Features
 * Hide post title of limited post in comment notification email [#5843](https://github.com/diaspora/diaspora/pull/5843)

--- a/app/helpers/notifier_helper.rb
+++ b/app/helpers/notifier_helper.rb
@@ -4,9 +4,7 @@ module NotifierHelper
   # @param opts [Hash] Optional hash.  Accepts :length parameters.
   # @return [String] The formatted post.
   def post_message(post, opts={})
-    if !post.public?
-      I18n.translate 'notifier.a_private_message'
-    elsif post.respond_to? :message
+    if post.respond_to? :message
       post.message.plain_text_without_markdown
     else
       I18n.translate 'notifier.a_post_you_shared'

--- a/app/views/notifier/liked.markerb
+++ b/app/views/notifier/liked.markerb
@@ -1,6 +1,10 @@
+<% if @notification.like_target.public? %>
 <%= "#{t('.liked', :name => "#{@notification.sender_name}")}:" %>
 
 <%= post_message(@notification.like_target, :process_newlines => true) %>
+<% else %>
+<%= "#{t('notifier.liked.limited_post', :name => "#{@notification.sender_name}")}." %>
+<% end %>
 
 [<%= t('.view_post') %>][1]
 

--- a/app/views/notifier/mentioned.markerb
+++ b/app/views/notifier/mentioned.markerb
@@ -1,4 +1,8 @@
+<% if @notification.post.public? %>
 <%= post_message(@notification.post, :process_newlines => true) %>
+<% else %>
+<%= t('notifier.mentioned.limited_post') %>
+<% end %>
 
 [<%= t('notifier.comment_on_post.reply', :name => @notification.post_author_name) %>][1]
 

--- a/app/views/notifier/private_message.markerb
+++ b/app/views/notifier/private_message.markerb
@@ -1,4 +1,4 @@
-<%= post_message(@notification.message, :process_newlines => true) %>
+<%= t('notifier.a_private_message') %>
 
 [<%= t('.reply_to_or_view') %>][1]
 

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -759,10 +759,12 @@ en:
     mentioned:
         subject: "%{name} has mentioned you on diaspora*"
         mentioned: "mentioned you in a post:"
+        limited_post: "You were mentioned in a limited post."
     private_message:
         reply_to_or_view: "Reply to or view this conversation >"
     liked:
         liked: "%{name} liked your post"
+        limited_post: "%{name} liked your limited post"
         view_post: "View post >"
     reshared:
         reshared: "%{name} reshared your post"

--- a/spec/helpers/notifier_helper_spec.rb
+++ b/spec/helpers/notifier_helper_spec.rb
@@ -11,16 +11,10 @@ describe NotifierHelper, :type => :helper do
       @markdown_post = FactoryGirl.create(:status_message,
         text: "[link](http://diasporafoundation.org) **bold text** *other text*", public: true)
       @striped_markdown_post = "link (http://diasporafoundation.org) bold text other text"
-      
-      @limited_post = FactoryGirl.create(:status_message, text: "This is top secret post. Shhhhhhhh!!!", public: false)
-    end
-    
-    it 'strip markdown in the post' do
-      expect(post_message(@markdown_post)).to eq(@striped_markdown_post)
     end
 
-    it 'hides the private content' do
-      expect(post_message(@limited_post)).not_to include("secret post")
+    it 'strip markdown in the post' do
+      expect(post_message(@markdown_post)).to eq(@striped_markdown_post)
     end
   end
 
@@ -31,17 +25,17 @@ describe NotifierHelper, :type => :helper do
       @markdown_comment.post.public = true
       @markdown_comment.text = "[link](http://diasporafoundation.org) **bold text** *other text*"
       @striped_markdown_comment = "link (http://diasporafoundation.org) bold text other text"
-      
+
       # comment for limited post
       @limited_comment = FactoryGirl.create(:comment)
       @limited_comment.post.public = false
       @limited_comment.text = "This is top secret comment. Shhhhhhhh!!!"
     end
-    
+
     it 'strip markdown in the comment' do
       expect(comment_message(@markdown_comment)).to eq(@striped_markdown_comment)
     end
-    
+
     it 'hides the private content' do
       expect(comment_message(@limited_comment)).not_to include("secret comment")
     end


### PR DESCRIPTION
there were mails like this:

> XYZ liked your post:
> 
> There's a new private message in diaspora\* for you to check out.
