### PR TITLE
Fix the IE version number extractor to work without space between MSIE and the version number

### DIFF
--- a/lib/rack/chrome_frame.rb
+++ b/lib/rack/chrome_frame.rb
@@ -65,7 +65,7 @@ module Rack
     end
 
     def ie_version(ua_string)
-      ua_string.match(/MSIE (\S+)/)[1].to_f
+      ua_string.match(/MSIE ?(\S+)/)[1].to_f
     end
   end
 end

--- a/spec/lib/rack/chrome_frame_spec.rb
+++ b/spec/lib/rack/chrome_frame_spec.rb
@@ -18,7 +18,7 @@ describe Rack::ChromeFrame do
   context "non-IE browser" do
     let(:ua_string) { "another browser chromeframe" }
 
-    it "shouldn't complain about the browser" do
+    it "shouldn't complain about the browser and shouldn't have chrome frame" do
       expect(subject.body).not_to match(/chrome=1/)
       expect(subject.body).not_to match(/Diaspora doesn't support your version of Internet Explorer/)
     end
@@ -27,7 +27,7 @@ describe Rack::ChromeFrame do
   context "IE8 without chromeframe" do
     let(:ua_string) { "MSIE 8" }
 
-    it "shouldn't complain about the browser" do
+    it "shouldn't complain about the browser and shouldn't have chrome frame" do
       expect(subject.body).not_to match(/chrome=1/)
       expect(subject.body).not_to match(/Diaspora doesn't support your version of Internet Explorer/)
     end
@@ -36,7 +36,7 @@ describe Rack::ChromeFrame do
   context "IE7 without chromeframe" do
     let(:ua_string) { "MSIE 7" }
 
-    it "shouldn't complain about the browser" do
+    it "should complain about the browser" do
       expect(subject.body).not_to match(/chrome=1/)
       expect(subject.body).to match(/Diaspora doesn't support your version of Internet Explorer/)
     end
@@ -46,10 +46,18 @@ describe Rack::ChromeFrame do
   context "any IE with chromeframe" do
     let(:ua_string) { "MSIE number chromeframe" }
 
-    it "shouldn't complain about the browser" do
+    it "shouldn't complain about the browser and should have chrome frame" do
       expect(subject.body).to match(/chrome=1/)
       expect(subject.body).not_to match(/Diaspora doesn't support your version of Internet Explorer/)
     end
     specify {expect(@response.headers["Content-Length"]).to eq(@response.body.length.to_s)}
+  end
+
+  context "Specific case with no space after MSIE" do
+    let(:ua_string) { "Mozilla/4.0 (compatible; MSIE8.0; Windows NT 6.0) .NET CLR 2.0.50727" }
+
+    it "shouldn't complain about the browser" do
+      expect(subject.body).not_to match(/Diaspora doesn't support your version of Internet Explorer/)
+    end
   end
 end


### PR DESCRIPTION
Close #5858

I'd like to add a test to see if `ie_version()` returns the right number but I don't know how to call this method from the spec.
