### PR TITLE
Fix unconventional image asset inclusion in css asset

### DIFF
--- a/app/assets/stylesheets/vendor/autoSuggest.css
+++ b/app/assets/stylesheets/vendor/autoSuggest.css
@@ -13,7 +13,7 @@ ul.as-selections {
 }
 
 ul.as-selections.loading {
-  background: url('<%= image_path("ajax-loader.gif") %>')  right center no-repeat;
+  background: asset_path("ajax-loader.gif")  right center no-repeat;
 }
 
 ul.as-selections li {


### PR DESCRIPTION
Instead of using .css.erb, it's more conventional to use the asset_path helper in the css file.
