### PR TITLE
Issue #5874 Fix styled links

### DIFF
--- a/app/assets/stylesheets/new_styles/_typography.scss
+++ b/app/assets/stylesheets/new_styles/_typography.scss
@@ -17,11 +17,7 @@
   weight : normal;
 }
 
-body, p, h1, h2, h3, h4, h5, h6, textarea, input, * {
+body, p, h1, h2, h3, h4, h5, h6, textarea, input {
   font-family : "Helvetica Neue", Helvetica, sans-serif;
   font-weight : normal;
-}
-
-a {
-  font-family : inherit;
 }


### PR DESCRIPTION
I don't think applying font-weight to \* is a good idea. This fixes the issue where you're unable to make bold links. I could not reproduce the appended asterisk.
