### PR TITLE
Issue #5508: Remove post_presenter from initializers

### DIFF
--- a/config/initializers/load_libraries.rb
+++ b/config/initializers/load_libraries.rb
@@ -9,9 +9,6 @@ require 'erb'
 require 'redcarpet/render_strip'
 require 'typhoeus'
 
-# Presenters
-require 'post_presenter'
-
 # Our libs
 require 'diaspora'
 require 'direction_detector'


### PR DESCRIPTION
Libraries included in the initializer are not reloaded automatically. It's also not necessary because rails automatically loads classes in app/ as long as they follow conventions.
