### PR TITLE
Issue #5485: Reset comment submit button on mobile if request fails

### DIFF
--- a/app/assets/javascripts/mobile/mobile.js
+++ b/app/assets/javascripts/mobile/mobile.js
@@ -262,7 +262,10 @@ $(document).ready(function(){
       commentCount.text(commentCount.text().replace(/(\d+)/, function(match){ return parseInt(match) + 1; }));
       commentActionLink.addClass("inactive");
       bottomBar.find('time.timeago').timeago();
-    }, 'html');
+    }, 'html').fail(function(){
+      var submitButton = form.find("input[type=submit]");
+      submitButton.removeAttr("disabled").val(submitButton.data("ujs:enableWith"));
+    });
   });
 
 


### PR DESCRIPTION
This is a temporary hackish fix for the comment button freezing on the mobile interface, proper error handling should be implemented in the controllers, a validation fail shouldn't trigger an exception.
