### PR TITLE
Check request.format :mobile in home controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@
 #   the COPYRIGHT file.
 
 class ApplicationController < ActionController::Base
+  before_action :force_tablet_html
   has_mobile_fu
   protect_from_forgery :except => :receive
 
@@ -38,9 +39,7 @@ class ApplicationController < ActionController::Base
 
   # Overwriting the sign_out redirect path method
   def after_sign_out_path_for(resource_or_scope)
-    # mobile_fu's is_mobile_device? wasn't working here for some reason...
-    # it may have been just because of the test env.
-    if request.env['HTTP_USER_AGENT'].try(:match, /mobile/i)
+    if is_mobile_device?
       root_path
     else
       new_user_session_path
@@ -124,10 +123,11 @@ class ApplicationController < ActionController::Base
   def mobile_switch
     if session[:mobile_view] == true && request.format.html?
       request.format = :mobile
-    elsif request.format.tablet?
-      # we currently don't have any special tablet views...
-      request.format = :html
     end
+  end
+
+  def force_tablet_html
+    session[:tablet_view] = false
   end
 
   def after_sign_in_path_for(resource)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,15 +7,17 @@ class HomeController < ApplicationController
     partial_dir = Rails.root.join("app", "views", "home")
     if user_signed_in?
       redirect_to stream_path
-    elsif is_mobile_device?
+    elsif request.format == :mobile
       if partial_dir.join("_show.mobile.haml").exist? ||
-         partial_dir.join("_show.mobile.erb").exist?
+         partial_dir.join("_show.mobile.erb").exist? ||
+         partial_dir.join("_show.haml").exist?
         render :show
       else
         redirect_to user_session_path
       end
     elsif partial_dir.join("_show.html.haml").exist? ||
-          partial_dir.join("_show.html.erb").exist?
+          partial_dir.join("_show.html.erb").exist? ||
+          partial_dir.join("_show.haml").exist?
       render :show
     else
       render :default,

--- a/app/views/home/show.haml
+++ b/app/views/home/show.haml
@@ -3,4 +3,7 @@
 -#   the COPYRIGHT file.
 
 
-=render :partial => 'home/show' rescue  "put something in app/views/home/_show.html"
+- content_for :page_title do
+  = pod_name
+
+= render partial: "home/show"

--- a/app/views/home/show.html.haml
+++ b/app/views/home/show.html.haml
@@ -1,9 +1,0 @@
--#   Copyright (c) 2010-2011, Diaspora Inc.  This file is
--#   licensed under the Affero General Public License version 3 or later.  See
--#   the COPYRIGHT file.
-
-
-- content_for :page_title do
-  = pod_name
-
-= render :partial => 'home/show'

--- a/features/mobile/activity_stream.feature
+++ b/features/mobile/activity_stream.feature
@@ -1,4 +1,4 @@
-@javascript
+@javascript @mobile
 Feature: Viewing my activity on the steam mobile page
   In order to navigate Diaspora*
   As a mobile user
@@ -7,7 +7,6 @@ Feature: Viewing my activity on the steam mobile page
   Background:
     Given a user with username "alice"
     And "alice@alice.alice" has a public post with text "Hello! I am #newhere"
-    When I toggle the mobile view
     And I sign in as "alice@alice.alice" on the mobile website
 
   Scenario: Show my activity empty

--- a/features/mobile/closes_account.feature
+++ b/features/mobile/closes_account.feature
@@ -1,4 +1,4 @@
-@javascript
+@javascript @mobile
 Feature: Close account
  In order to close an existing account
  As a user
@@ -6,8 +6,7 @@ Feature: Close account
 
   Scenario: user closes account
     Given I am signed in
-    When I toggle the mobile view
-    And I go to the users edit page
+    When I go to the users edit page
     And I put in my password in "close_account_password"
     And I press "close_account_confirm"
     And I confirm the alert

--- a/features/mobile/conversations.feature
+++ b/features/mobile/conversations.feature
@@ -1,4 +1,4 @@
-@javascript
+@javascript @mobile
 Feature: private conversations mobile
     In order to be talkative
     As a mobile user
@@ -8,7 +8,6 @@ Feature: private conversations mobile
     Given a user with username "bob"
     And a user named "Alice Awesome" with email "alice@alice.alice"
     And a user with username "bob" is connected with "alice_awesome"
-    When I toggle the mobile view
     And I sign in as "bob@bob.bob" on the mobile website
 
   Scenario: send and delete a mobile message

--- a/features/mobile/drawer.feature
+++ b/features/mobile/drawer.feature
@@ -1,7 +1,7 @@
-@javascript
-Feature: Naviguate between pages using the header menu and the drawer
+@javascript @mobile
+Feature: Navigate between pages using the header menu and the drawer
   As a user
-  I want to be able naviguate between the pages of the mobile version
+  I want to be able navigate between the pages of the mobile version
 
   Background:
     Given following users exist:
@@ -11,25 +11,22 @@ Feature: Naviguate between pages using the header menu and the drawer
       
     And I sign in as "alice@alice.alice"
     And a user with email "bob@bob.bob" is connected with "alice@alice.alice"
-    And I search for "#boss"
-    And I press "Follow #boss"
-    And I toggle the mobile view
     
-  Scenario: naviguate to the stream page
+  Scenario: navigate to the stream page
     When I open the drawer
     And I follow "My activity"
     And I click on selector "#header_title"
     Then I should see "There are no posts yet." within "#main_stream"
     
-  Scenario: naviguate to the notification page
+  Scenario: navigate to the notification page
     When I click on selector "#notification_badge"
     Then I should see "Notifications" within "#main"
     
-  Scenario: naviguate to the conversation page
+  Scenario: navigate to the conversation page
     When I click on selector "#conversations_badge"
     Then I should see "Inbox" within "#main"
     
-  Scenario: naviguate to the publisher page
+  Scenario: navigate to the publisher page
     When I click on selector "#compose_badge"
     Then I should see "All aspects" within "#new_status_message"
     
@@ -43,19 +40,19 @@ Feature: Naviguate between pages using the header menu and the drawer
     And I search for "#bob"
     Then I should see "#bob" within "#main > h1"
     
-  Scenario: naviguate to my activity page
+  Scenario: navigate to my activity page
     When I open the drawer
     And I follow "My activity"
     Then I should see "My activity" within "#main"
     
-  Scenario: naviguate to my mentions page
+  Scenario: navigate to my mentions page
     Given Alice has a post mentioning Bob
     And I sign in as "bob@bob.bob"    
     When I open the drawer
     And I follow "@Mentions"
     Then I should see "Bob Jones" within ".stream_element"
     
-  Scenario: naviguate to my aspects page
+  Scenario: navigate to my aspects page
     Given "bob@bob.bob" has a public post with text "bob's text"
     When I open the drawer
     And I follow "My aspects"
@@ -63,25 +60,29 @@ Feature: Naviguate between pages using the header menu and the drawer
     And I follow "Besties"
     Then I should see "bob's text" within "#main_stream"
     
-  Scenario: naviguate to the followed tags page
+  Scenario: navigate to the followed tags page
     Given "bob@bob.bob" has a public post with text "bob is da #boss"
+    And I toggle the mobile view
+    And I search for "#boss"
+    And I press "Follow #boss"
+    And I toggle the mobile view
     When I open the drawer
     And I follow "#Followed tags"
     Then I should see "#boss" within "#followed_tags + li > ul"
     And I follow "#boss"
     Then I should see "bob is da #boss" within "#main_stream"
     
-  Scenario: naviguate to my profile page
+  Scenario: navigate to my profile page
     When I open the drawer
     And I follow "Profile"
     Then I should see "Alice" within "#author_info"
     
-  Scenario: naviguate to my mentions page
+  Scenario: navigate to my mentions page
     When I open the drawer
     And I follow "Contacts"
     Then I should see "Contacts" within "#main"
     
-  Scenario: naviguate to my mentions page
+  Scenario: navigate to my mentions page
     When I open the drawer
     And I follow "Settings"
     Then I should see "Settings" within "#main"

--- a/features/mobile/edits_profile.feature
+++ b/features/mobile/edits_profile.feature
@@ -1,8 +1,7 @@
-@javascript
+@javascript @mobile
 Feature: editing the profile in the mobile view
   Scenario: editing profile fields
     Given I am signed in
-    And I toggle the mobile view
     And I go to the edit profile page
 
     When I fill in the following:

--- a/features/mobile/getting_started.feature
+++ b/features/mobile/getting_started.feature
@@ -1,9 +1,8 @@
-@javascript
+@javascript @mobile
 Feature: editing the getting started in the mobile view
 
   Background:
-    Given I toggle the mobile view
-    And I am on the login page
+    Given I am on the login page
     When I follow "Sign up"
     And I fill in the new user form
     And I submit the form

--- a/features/mobile/home.feature
+++ b/features/mobile/home.feature
@@ -1,0 +1,12 @@
+@javascript @mobile
+Feature: Visit the landing page of the pod
+  In order to find out more about the pod
+  As a user
+  I want to see the landing page
+
+  Scenario: Visit the home page
+    When I am on the root page
+    Then I should see "LOG IN"
+    When I toggle the mobile view
+    And I go to the root page
+    Then I should see "Welcome, friend"

--- a/features/mobile/invitations.feature
+++ b/features/mobile/invitations.feature
@@ -1,9 +1,6 @@
-@javascript
+@javascript @mobile
 Feature: Invitations
 
-  Background:
-    Given I toggle the mobile view
-  
   Scenario: Accepting an invitation
     When I visit alice's invitation code url
     When I fill in the new user form

--- a/features/mobile/logged_out_browsing.feature
+++ b/features/mobile/logged_out_browsing.feature
@@ -1,4 +1,4 @@
-@javascript
+@javascript @mobile
 Feature: Browsing Diaspora as a logged out user mobile
     In order to view public diaspora content
     as a random internet user
@@ -8,12 +8,14 @@ Feature: Browsing Diaspora as a logged out user mobile
       Given a user named "Bob Jones" with email "bob@bob.bob"
       And "bob@bob.bob" has a public post with text "public stuff"
       And I sign in as "bob@bob.bob"
-      And I comment "this also" on "public stuff"
+      And I click on selector "a.image_link.comment_action.inactive"
+      And I fill in the following:
+          | text            | this also    |
+      And I press "Comment"
       And I log out
 
     Scenario: Visiting a profile page
-      When I toggle the mobile view
-      And I am on "bob@bob.bob"'s page
+      When I am on "bob@bob.bob"'s page
       Then I should see "public stuff" within ".ltr"
       And I click on selector "a.show_comments"
       And I should see "this also" within ".comment"

--- a/features/mobile/multiphoto.feature
+++ b/features/mobile/multiphoto.feature
@@ -1,4 +1,4 @@
-@javascript
+@javascript @mobile
 Feature: viewing photos on the mobile main page
   In order to navigate Diaspora*
   As a mobile user
@@ -6,9 +6,7 @@ Feature: viewing photos on the mobile main page
 
   Background:
     Given a user with username "bob"
-
-    When I toggle the mobile view
-    And I sign in as "bob@bob.bob" on the mobile website
+    When I sign in as "bob@bob.bob" on the mobile website
     And I click on selector "#compose_badge"
 
   Scenario: view full size image

--- a/features/mobile/people_aspects.feature
+++ b/features/mobile/people_aspects.feature
@@ -1,4 +1,4 @@
-@javascript
+@javascript @mobile
 Feature: adding and removing people from aspects
     In order to add people to my contacts
     As a mobile user
@@ -9,7 +9,6 @@ Feature: adding and removing people from aspects
         | username   |
         | bob        |
         | alice      |
-      And I toggle the mobile view
       And I sign in as "bob@bob.bob" on the mobile website
 
     Scenario: verify different states of the cover button

--- a/features/mobile/posts_from_main_page.feature
+++ b/features/mobile/posts_from_main_page.feature
@@ -1,4 +1,4 @@
-@javascript
+@javascript @mobile
 Feature: posting from the mobile main page
     In order to navigate Diaspora*
     As a mobile user
@@ -9,7 +9,6 @@ Feature: posting from the mobile main page
         | username   |
         | bob        |
         | alice      |
-      And I toggle the mobile view
       And I am on the home page
       And I sign in as "bob@bob.bob" on the mobile website
       And a user with username "bob" is connected with "alice"
@@ -24,7 +23,7 @@ Feature: posting from the mobile main page
       And I append "I am eating yogurt" to the mobile publisher
       And I select "Unicorns" from "aspect_ids_"
       And I press "Share"
-      When I visit the mobile stream page
+      When I go to the stream page
       Then I should see "I am eating yogurt"
       When I click on selector "a.remove"
       And I confirm the alert
@@ -36,11 +35,11 @@ Feature: posting from the mobile main page
       Then I should see an uploaded image within the photo drop zone
       And I should see "button.png completed"
       When I press "Share"
-      When I visit the mobile stream page
+      When I go to the stream page
       Then I should see a "img" within ".stream_element div.photo_attachments"
       When I log out
       And I sign in as "alice@alice.alice" on the mobile website
-      When I visit the mobile stream page
+      When I go to the stream page
       Then I should see a "img" within ".stream_element div.photo_attachments"
 
     Scenario: back out of posting a photo-only post

--- a/features/mobile/reactions.feature
+++ b/features/mobile/reactions.feature
@@ -1,4 +1,4 @@
-@javascript
+@javascript @mobile
 Feature: reactions mobile post
   In order to navigate Diaspora*
   As a mobile user
@@ -11,7 +11,6 @@ Feature: reactions mobile post
       | Alice Smith | alice@alice.alice |
     And a user with email "bob@bob.bob" is connected with "alice@alice.alice"
     When "alice@alice.alice" has posted a status message with a photo
-    And I toggle the mobile view
     And I sign in as "bob@bob.bob" on the mobile website
 
   Scenario: like on a mobile post

--- a/features/mobile/reshare.feature
+++ b/features/mobile/reshare.feature
@@ -1,4 +1,4 @@
-@javascript
+@javascript @mobile
 Feature: resharing from the mobile
   In order to make Diaspora more viral
   As a mobile user
@@ -16,7 +16,6 @@ Feature: resharing from the mobile
     And I sign in as "alice@alice.alice"
 
   Scenario: Resharing a post from a single post page
-    When I toggle the mobile view
     And I click on selector "a.image_link.reshare_action.inactive"
     And I confirm the alert
     Then I should see a "a.image_link.reshare_action.active"
@@ -26,7 +25,6 @@ Feature: resharing from the mobile
   Scenario: Resharing a post from a single post page that is reshared
     Given the post with text "reshare this!" is reshared by "eve@eve.eve"
     And a user with email "alice@alice.alice" is connected with "eve@eve.eve"
-    When I toggle the mobile view
     And I click on the first selector "a.image_link.reshare_action.inactive"
     And I confirm the alert
     Then I should see a "a.image_link.reshare_action.active"
@@ -36,11 +34,12 @@ Feature: resharing from the mobile
   Scenario: Delete original reshared post
     Given "alice@alice.alice" has a public post with text "Don't reshare this!"
     And the post with text "Don't reshare this!" is reshared by "bob@bob.bob"
+    When I toggle the mobile view
     And I am on "alice@alice.alice"'s page
-    When I click to delete the first post
+    And I click to delete the first post
     And I log out
-    And I sign in as "bob@bob.bob"
     And I toggle the mobile view
+    And I sign in as "bob@bob.bob"
     Then I should see "Original post deleted by author" within ".reshare"
     And I log out
     And I sign in as "eve@eve.eve" on the mobile website

--- a/features/mobile/signs_up.feature
+++ b/features/mobile/signs_up.feature
@@ -1,12 +1,11 @@
-@javascript
+@javascript @mobile
 Feature: New user registration
   In order to use Diaspora*
   As a mobile user
   I want to register an account
 
   Background:
-    Given I toggle the mobile view
-    And I am on the login page
+    Given I am on the login page
     And I follow "Sign up"
 
   Scenario: user signs up and goes to getting started

--- a/features/mobile/tags.feature
+++ b/features/mobile/tags.feature
@@ -1,11 +1,10 @@
-@javascript
+@javascript @mobile
 Feature: Interacting with tags
 
   Background:
     Given a user with username "alice"
     And "alice@alice.alice" has a public post with text "Hello! i am #newhere"
     When I sign in as "alice@alice.alice"
-    And I toggle the mobile view
 
   Scenario: Searching for a tag
     When I visit the mobile search page

--- a/features/step_definitions/custom_web_steps.rb
+++ b/features/step_definitions/custom_web_steps.rb
@@ -88,10 +88,10 @@ And /^I hover over the "([^"]+)"$/ do |element|
 end
 
 When /^I prepare the deletion of the first post$/ do
-  within(find('.stream .stream_element')) do
-    ctrl = find('.control-icons')
+  within(find(".stream .stream_element", match: :first)) do
+    ctrl = find(".control-icons")
     ctrl.hover
-    ctrl.find('.remove_post').click
+    ctrl.find(".remove_post").click
   end
 end
 

--- a/features/step_definitions/mobile_steps.rb
+++ b/features/step_definitions/mobile_steps.rb
@@ -2,28 +2,8 @@ When /^I toggle the mobile view$/ do
   visit('/mobile/toggle')
 end
 
-When /^I visit the mobile home page$/ do
-  visit('/users/sign_in.mobile')
-end
-
-When /^I visit the mobile registration page$/ do
-  visit('/users/sign_up.mobile')
-end
-
-When /^I visit the mobile getting started page$/ do
-  visit('/getting_started.mobile')
-end
-
 Given /^I visit the mobile publisher page$/ do
   visit('/status_messages/new.mobile')
-end
-
-When /^I visit the mobile stream page$/ do
-  visit('/stream.mobile')
-end
-
-When /^I visit the mobile aspects page$/ do
-  visit('/aspects.mobile')
 end
 
 When /^I visit the mobile search page$/ do

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,16 +1,16 @@
-require 'rubygems'
+require "rubygems"
 
 ENV["RAILS_ENV"] ||= "test"
 
  # Have all rests run with english browser locale
-ENV['LANG'] = 'C'
+ENV["LANG"] = "C"
 
-require 'cucumber/rails'
+require "cucumber/rails"
 
-require 'capybara/rails'
-require 'capybara/cucumber'
-require 'capybara/session'
-#require 'cucumber/rails/capybara_javascript_emulation' # Lets you click links with onclick javascript handlers without using @culerity or @javascript
+require "capybara/rails"
+require "capybara/cucumber"
+require "capybara/session"
+require "selenium/webdriver"
 
 # Ensure we know the appservers port
 Capybara.server_port = AppConfig.pod_uri.port
@@ -18,11 +18,19 @@ Rails.application.routes.default_url_options[:host] = AppConfig.pod_uri.host
 Rails.application.routes.default_url_options[:port] = AppConfig.pod_uri.port
 
 # Use a version of Firefox defined by environment variable, if set
+Selenium::WebDriver::Firefox::Binary.path = ENV["FIREFOX_BINARY_PATH"] || Selenium::WebDriver::Firefox::Binary.path
+
 Capybara.register_driver :selenium do |app|
-  require 'selenium/webdriver'
-  Selenium::WebDriver::Firefox::Binary.path = ENV['FIREFOX_BINARY_PATH'] || Selenium::WebDriver::Firefox::Binary.path
-  Capybara::Selenium::Driver.new(app, :browser => :firefox)
+  Capybara::Selenium::Driver.new(app, browser: :firefox)
 end
+
+Capybara.register_driver :mobile do |app|
+  profile = Selenium::WebDriver::Firefox::Profile.new
+  profile["general.useragent.override"] = "Mozilla/5.0 (Mobile; rv:18.0) Gecko/18.0 Firefox/18.0"
+  Capybara::Selenium::Driver.new(app, profile: profile)
+end
+
+Capybara.default_driver = :selenium
 
 # Capybara defaults to XPath selectors rather than Webrat's default of CSS3. In
 # order to ease the transition to Capybara we set the default here. If you'd

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -2,36 +2,40 @@
 #   licensed under the Affero General Public License version 3 or later.  See
 #   the COPYRIGHT file.
 
-require 'spec_helper'
+require "spec_helper"
 
-describe HomeController, :type => :controller do
-  describe '#show' do
-    it 'does not redirect' do
-      sign_out :user
+describe HomeController, type: :controller do
+  describe "#show" do
+    it "does not redirect for :html" do
       get :show
       expect(response).not_to be_redirect
     end
 
-    context 'redirection' do
+    it "redirects for :mobile" do
+      get :show, format: :mobile
+      expect(response).to redirect_to(user_session_path)
+    end
+
+    context "redirection" do
       before do
         sign_in alice
       end
 
-      it 'points to the stream if a user has contacts' do
-        get :show, :home => true
+      it "points to the stream if a user has contacts" do
+        get :show, home: true
         expect(response).to redirect_to(stream_path)
       end
     end
   end
 
-  describe '#toggle_mobile' do
-    it 'changes :mobile to :html' do
+  describe "#toggle_mobile" do
+    it "changes :mobile to :html" do
       session[:mobile_view] = true
       get :toggle_mobile
       expect(session[:mobile_view]).to be false
     end
 
-    it 'changes :html to :mobile' do
+    it "changes :html to :mobile" do
       session[:mobile_view] = nil
       get :toggle_mobile
       expect(session[:mobile_view]).to be true

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -2,9 +2,9 @@
 #   licensed under the Affero General Public License version 3 or later.  See
 #   the COPYRIGHT file.
 
-require 'spec_helper' 
+require "spec_helper"
 
-describe SessionsController, :type => :controller do
+describe SessionsController, type: :controller do
   include Devise::TestHelpers
 
   let(:mock_access_token) { Object.new }
@@ -25,7 +25,7 @@ describe SessionsController, :type => :controller do
     end
 
     it "redirects to /stream for a mobile user" do
-      @request.env['HTTP_USER_AGENT'] = 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8B117 Safari/6531.22.7'
+      request.headers["X_MOBILE_DEVICE"] = true
       post :create, {"user" => {"remember_me" => "0", "username" => @user.username, "password" => "evankorth"}}
       expect(response).to be_redirect
       expect(response.location).to match /^#{stream_url}\??$/
@@ -42,7 +42,7 @@ describe SessionsController, :type => :controller do
     end
 
     it "redirects to / for a mobile user" do
-      @request.env['HTTP_USER_AGENT'] = 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8B117 Safari/6531.22.7'
+      request.headers["X_MOBILE_DEVICE"] = true
       delete :destroy
       expect(response).to redirect_to root_path
     end


### PR DESCRIPTION
Fixes #4518.
- additional check if the request format is `:mobile` in the home controller
- allow using `app/home/_show.haml` instead of `_show.html.haml` and `_show.mobile.haml`
- merge `show.html.haml` and `show.mobile.haml`
