### PR TITLE
Bump open_graph_reader

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -130,7 +130,7 @@ gem "redcarpet",         "3.2.3"
 gem "twitter-text",      "1.11.0"
 gem "roxml",             "3.1.6"
 gem "ruby-oembed",       "0.8.14"
-gem "open_graph_reader", "0.5.0"
+gem "open_graph_reader", "0.6.0"
 
 # Services
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -437,7 +437,7 @@ GEM
       omniauth-oauth (~> 1.0)
     omniauth-wordpress (0.2.1)
       omniauth-oauth2 (~> 1.1.0)
-    open_graph_reader (0.5.0)
+    open_graph_reader (0.6.0)
       faraday (~> 0.9.0)
       nokogiri (~> 1.6)
     orm_adapter (0.5.0)
@@ -763,7 +763,7 @@ DEPENDENCIES
   omniauth-tumblr (= 1.1)
   omniauth-twitter (= 1.0.1)
   omniauth-wordpress (= 0.2.1)
-  open_graph_reader (= 0.5.0)
+  open_graph_reader (= 0.6.0)
   pry
   pry-byebug
   pry-debundle

--- a/config/initializers/open_graph_reader.rb
+++ b/config/initializers/open_graph_reader.rb
@@ -1,6 +1,7 @@
 OpenGraphReader.configure do |config|
   config.synthesize_title      = true
   config.synthesize_url        = true
+  config.synthesize_full_url   = true
   config.synthesize_image_url  = true
   config.guess_datetime_format = true
 end


### PR DESCRIPTION
It now returns the origin for a missing og:url
