### PR TITLE
limit the GET request to the bookmarklet to ~2000 chars

### DIFF
--- a/app/assets/javascripts/bookmarklet.js
+++ b/app/assets/javascripts/bookmarklet.js
@@ -1,6 +1,9 @@
 // @license magnet:?xt=urn:btih:0b31508aeb0634b347b8270c7bee4d411b5d4109&dn=agpl-3.0.txt AGPL-v3-or-Later
 
 var bookmarklet = function(url, width, height, opts) {
+  var maxLen = 1900; // max GET request length, see #3076
+  var maxTitleLen = 128; // cut title after this length, if too long
+
   // calculate popup dimensions & placement
   var dim = function() {
     var  w = window,
@@ -20,7 +23,15 @@ var bookmarklet = function(url, width, height, opts) {
       sel = w.getSelection ? w.getSelection() :
             d.getSelection ? d.getSelection() :
             d.selection.createRange().text,
-    notes = sel.toString();
+    notes = sel.toString(),
+      len = maxLen - href.length;
+
+    if( (title+notes).length > len ) {
+      // shorten the text to fit in a GET request
+      if( title.length > maxTitleLen ) title = title.substr(0, maxTitleLen) + " ...";
+      if( notes.length > (len-maxTitleLen) ) notes = notes.substr(0, len-maxTitleLen) + " ...";
+    }
+
     return "url=" + encodeURIComponent(href) +
            "&title=" + encodeURIComponent(title) +
            "&notes=" + encodeURIComponent(notes);

--- a/spec/javascripts/bookmarklet-spec.js
+++ b/spec/javascripts/bookmarklet-spec.js
@@ -1,0 +1,26 @@
+
+describe("bookmarklet", function(){
+  var fakeUrl = "http://pod.example.com/bookmarklet";
+
+  it("opens a popup window", function(){
+    spyOn(window, "open").and.returnValue(true);
+    bookmarklet(fakeUrl, 800, 600);
+    jasmine.clock().tick(1);
+    expect(window.open).toHaveBeenCalled();
+  });
+
+  it("shortens the GET string to less than 2000 characters", function(){
+    var url,
+        selTxt = new Array(1000).join("abcdefghijklmnopqrstuvwxyz1234567890");
+
+    spyOn(window, "open").and.callFake(function(_url){
+      url = _url;
+      return true;
+    });
+    spyOn(window, "getSelection").and.returnValue(selTxt);
+
+    bookmarklet(fakeUrl, 800, 600);
+    jasmine.clock().tick(1);
+    expect(url.length).toBeLessThan(2000);
+  });
+});

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -13,6 +13,7 @@ src_files:
   # Precompile all scripts together for the test environment
   - assets/jasmine-load-all.js
   - assets/jasmine-jquery.js
+  - assets/bookmarklet.js
 
 # stylesheets
 #


### PR DESCRIPTION
fixes #3076 
adds some jasmine specs for the bookmarklet code snippet
