### PR TITLE
Suppress some more exceptions in workers

### DIFF
--- a/app/workers/base.rb
+++ b/app/workers/base.rb
@@ -14,7 +14,10 @@ module Workers
     rescue Diaspora::ContactRequiredUnlessRequest,
            Diaspora::RelayableObjectWithoutParent,
            # Friendica seems to provoke these
-           Diaspora::AuthorXMLAuthorMismatch => e
+           Diaspora::AuthorXMLAuthorMismatch,
+           # We received a private object to our public endpoint, again something
+           # Friendica seems to provoke
+           Diaspora::NonPublic => e
       Rails.logger.info("error on receive: #{e.class}")
     rescue ActiveRecord::RecordInvalid => e
       Rails.logger.info("failed to save received object: #{e.record.errors.full_messages}")

--- a/app/workers/base.rb
+++ b/app/workers/base.rb
@@ -13,12 +13,22 @@ module Workers
       yield
     rescue Diaspora::ContactRequiredUnlessRequest,
            Diaspora::RelayableObjectWithoutParent,
-            # Friendica seems to provoke these
+           # Friendica seems to provoke these
            Diaspora::AuthorXMLAuthorMismatch => e
       Rails.logger.info("error on receive: #{e.class}")
     rescue ActiveRecord::RecordInvalid => e
       Rails.logger.info("failed to save received object: #{e.record.errors.full_messages}")
       raise e unless e.message.match(/already been taken/)
+    rescue ActiveRecord::RecordNotUnique => e
+      Rails.logger.info("failed to save received object: #{e.record.errors.full_messages}")
+      raise e unless %w(
+        index_comments_on_guid
+        index_likes_on_guid
+        index_posts_on_guid
+        "duplicate key in table 'comments'"
+        "duplicate key in table 'likes'"
+        "duplicate key in table 'posts'"
+      ).any? {|index| e.message.include? index }
     end
   end
 end

--- a/lib/postzord/receiver/public.rb
+++ b/lib/postzord/receiver/public.rb
@@ -56,7 +56,7 @@ class Postzord::Receiver::Public < Postzord::Receiver
   # @return [Object]
   def save_object
     @object = Diaspora::Parser::from_xml(@salmon.parsed_data)
-    raise "Object is not public" if object_can_be_public_and_it_is_not?
+    raise Diaspora::NonPublic if object_can_be_public_and_it_is_not?
     raise Diaspora::RelayableObjectWithoutParent if object_must_have_parent_and_does_not?
     raise Diaspora::AuthorXMLAuthorMismatch if author_does_not_match_xml_author?
     @object.save! if @object && @object.respond_to?(:save!)


### PR DESCRIPTION
Based on a production-analysis I have done on Geraspora, looking at the top reasons for jobs to fail. Suppressing those will reduce the amount of retries.
- `Diaspora::PostNotFetchable` is raised by the new fetchers trying to fetch missing posts. This is already a failure prevention method and there is no reason to retry fetching posts here.
- `ActiveRecord::RecordNotUnique` seems to be a frequent exception caused by Friendica nodes doing multiple pushes of posts/comments/likes. I analyzed over 3100 samples collected by Sentry and I was not able to find any actual GUID collisions, all incoming contents matched the ones that already were stored in the database. Since our GUID has a pretty high entropy, I feel like it is safe to mute those.

The filter for `ActiveRecord::RecordNotUnique` contains six cases, three for PostgreSQL and three for MySQL. As far as I can tell, there is unfortunately no nicer way to check the actual reason for collision.
