### PR TITLE
Mute ActiveRecord::RecordInvalid due to ignores

### DIFF
--- a/app/workers/base.rb
+++ b/app/workers/base.rb
@@ -21,7 +21,10 @@ module Workers
       Rails.logger.info("error on receive: #{e.class}")
     rescue ActiveRecord::RecordInvalid => e
       Rails.logger.info("failed to save received object: #{e.record.errors.full_messages}")
-      raise e unless e.message.match(/already been taken/)
+      raise e unless %w(
+        "already been taken"
+        "is ignored by the post author"
+      ).any? {|reason| e.message.include? reason }
     rescue ActiveRecord::RecordNotUnique => e
       Rails.logger.info("failed to save received object: #{e.message}")
       raise e unless %w(

--- a/app/workers/base.rb
+++ b/app/workers/base.rb
@@ -23,7 +23,7 @@ module Workers
       Rails.logger.info("failed to save received object: #{e.record.errors.full_messages}")
       raise e unless e.message.match(/already been taken/)
     rescue ActiveRecord::RecordNotUnique => e
-      Rails.logger.info("failed to save received object: #{e.record.errors.full_messages}")
+      Rails.logger.info("failed to save received object: #{e.message}")
       raise e unless %w(
         index_comments_on_guid
         index_likes_on_guid


### PR DESCRIPTION
Follow up for #5938 because I missed a `ActiveRecord::RecordInvalid` and @jhass was to faster with the merge. Also contains a commit to change the message to get logged for `ActiveRecord::RecordNotUnique` since we usually do not have `.records` there.
