### PR TITLE
Mobile: manage followed tags

### DIFF
--- a/app/assets/javascripts/mobile/tag_following.js
+++ b/app/assets/javascripts/mobile/tag_following.js
@@ -1,7 +1,8 @@
 $(document).ready(function(){
   $(".tag_following_action").bind("tap click", function(evt){
     evt.preventDefault();
-    var button = $(this),
+    var tagFollowing,
+        button = $(this),
         tagName = button.data("name");
 
     if(button.hasClass("btn-success")){
@@ -19,11 +20,11 @@ $(document).ready(function(){
         button.removeClass("btn-success").addClass("btn-danger");
         button.text(Diaspora.I18n.t("stream.tags.stop_following", {tag: tagName}));
       }).fail(function() {
-        alert(Diaspora.I18n.t("stream.tags.follow_error", {name: "#" + tagName}));
+        alert(Diaspora.I18n.t("stream.tags.follow_error", {tag: tagName}));
       });
     }
     else if(button.hasClass("btn-danger")){
-      var tagFollowing = _.findWhere(gon.preloads.tagFollowings,{name: tagName});
+      tagFollowing = _.findWhere(gon.preloads.tagFollowings, {name: tagName});
       if(!tagFollowing) { return; }
       $.ajax({
         url: Routes.tagFollowing(tagFollowing.id),
@@ -36,7 +37,28 @@ $(document).ready(function(){
         button.removeClass("btn-danger").addClass("btn-success");
         button.text(Diaspora.I18n.t("stream.tags.follow", {tag: tagName}));
       }).fail(function() {
-        alert(Diaspora.I18n.t("stream.tags.stop_following_error", {name: "#" + tagName}));
+        alert(Diaspora.I18n.t("stream.tags.stop_following_error", {tag: tagName}));
+      });
+    }
+    else if(button.hasClass("only-delete")){
+      tagFollowing = _.findWhere(gon.preloads.tagFollowings, {name: tagName});
+      if(!tagFollowing ||
+        !confirm(Diaspora.I18n.t("stream.tags.stop_following_confirm", {tag: tagName}))) { return; }
+
+      $.ajax({
+        url: Routes.tagFollowing(tagFollowing.id),
+        dataType: "json",
+        type: "DELETE",
+        headers: {
+          "Accept": "application/json, text/javascript, */*; q=0.01"
+        }
+      }).done(function() {
+        button.closest("li").remove();
+        if($("ul.followed_tags li").length === 0){
+          $(".well").removeClass("hidden");
+        }
+      }).fail(function() {
+        alert(Diaspora.I18n.t("stream.tags.stop_following_error", {tag: tagName}));
       });
     }
   });

--- a/app/assets/stylesheets/mobile/mobile.scss
+++ b/app/assets/stylesheets/mobile/mobile.scss
@@ -6,6 +6,7 @@
 @import "_flash_messages";
 
 @import "header";
+@import "mobile/tags";
 
 a {
   color: #2489ce;

--- a/app/assets/stylesheets/mobile/tags.scss
+++ b/app/assets/stylesheets/mobile/tags.scss
@@ -1,0 +1,28 @@
+ul.followed_tags {
+  list-style: none;
+  margin: 0px;
+
+  > li {
+    background-color: $white;
+    border: 1px solid $border-grey;
+    border-radius: 5px;
+    box-shadow: 0 1px 2px rgba($border-dark-grey, 0.5);
+    font-weight: bold;
+    margin-bottom: 10px;
+    padding: 10px;
+
+    .tag_name {
+      margin-right: 30px;
+      word-break: break-all;
+    }
+
+    .tag_following_action {
+      font-size: 30px;
+      font-weight: bold;
+      line-height: 10px;
+      margin: 0;
+      padding: 0;
+      &:hover { text-decoration: none }
+    }
+  }
+}

--- a/app/controllers/tag_followings_controller.rb
+++ b/app/controllers/tag_followings_controller.rb
@@ -7,6 +7,7 @@ class TagFollowingsController < ApplicationController
   before_action :authenticate_user!
 
   respond_to :json
+  respond_to :html, only: [:manage]
 
   # POST /tag_followings
   # POST /tag_followings.xml
@@ -47,5 +48,10 @@ class TagFollowingsController < ApplicationController
     respond_to do |format|
       format.json{ render(:json => tags.to_json, :status => 200) }
     end
+  end
+
+  def manage
+    redirect_to followed_tags_stream_path unless request.format == :mobile
+    gon.preloads[:tagFollowings] = tags
   end
 end

--- a/app/views/layouts/application.mobile.haml
+++ b/app/views/layouts/application.mobile.haml
@@ -98,6 +98,9 @@
                   - current_user.followed_tags.each do |tag|
                     %li
                       = tag_link(tag)
+                  - if current_user.followed_tags.length > 0
+                    %li.manage_followed_tags
+                      = link_to t("tag_followings.manage.title"), manage_tag_followings_path
               %li
                 = link_to user_profile_path(current_user.username) do
                   = t('layouts.header.profile')

--- a/app/views/tag_followings/manage.mobile.haml
+++ b/app/views/tag_followings/manage.mobile.haml
@@ -1,0 +1,18 @@
+%h3= t("tag_followings.manage.title")
+
+-if current_user.followed_tags.length == 0
+  .well
+    %h4
+      = t("tag_followings.manage.no_tags")
+
+-else
+  .well.hidden
+    %h4
+      = t("tag_followings.manage.no_tags")
+  %ul.followed_tags
+    - current_user.followed_tags.each do |tag|
+      %li
+        .pull-right.btn.btn-link.only-delete.tag_following_action{data: {name: tag}}
+          &times;
+        .tag_name
+          = "##{tag}"

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -1262,6 +1262,9 @@ en:
     destroy:
       success: "Alas! You aren’t following #%{name} any more."
       failure: "Failed to stop following #%{name}. Maybe you already stopped following it?"
+    manage:
+      title: "Manage followed tags"
+      no_tags: "You aren't following any tags."
 
   streams:
     community_spotlight_stream: "Community spotlight"

--- a/config/locales/javascript/javascript.en.yml
+++ b/config/locales/javascript/javascript.en.yml
@@ -206,8 +206,9 @@ en:
         follow: "Follow #<%= tag %>"
         following: "Following #<%= tag %>"
         stop_following: "Stop following #<%= tag %>"
-        follow_error: "Couldn’t follow <%= name %> :("
-        stop_following_error: "Couldn’t stop following <%= name %> :("
+        stop_following_confirm: "Stop following #<%= tag %>?"
+        follow_error: "Couldn’t follow #<%= tag %> :("
+        stop_following_error: "Couldn’t stop following #<%= tag %> :("
 
     header:
       home: "Home"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,7 +94,11 @@ Diaspora::Application.routes.draw do
 
   resources :tags, :only => [:index]
 
-  resources "tag_followings", :only => [:create, :destroy, :index]
+  resources "tag_followings", only: %i(create destroy index) do
+    collection do
+      get :manage
+    end
+  end
 
   get 'tags/:name' => 'tags#show', :as => 'tag'
 

--- a/features/mobile/drawer.feature
+++ b/features/mobile/drawer.feature
@@ -8,50 +8,50 @@ Feature: Navigate between pages using the header menu and the drawer
       | username     | email             |
       | Bob Jones    | bob@bob.bob       |
       | Alice Smith  | alice@alice.alice |
-      
+
     And I sign in as "alice@alice.alice"
     And a user with email "bob@bob.bob" is connected with "alice@alice.alice"
-    
+
   Scenario: navigate to the stream page
     When I open the drawer
     And I follow "My activity"
     And I click on selector "#header_title"
     Then I should see "There are no posts yet." within "#main_stream"
-    
+
   Scenario: navigate to the notification page
     When I click on selector "#notification_badge"
     Then I should see "Notifications" within "#main"
-    
+
   Scenario: navigate to the conversation page
     When I click on selector "#conversations_badge"
     Then I should see "Inbox" within "#main"
-    
+
   Scenario: navigate to the publisher page
     When I click on selector "#compose_badge"
     Then I should see "All aspects" within "#new_status_message"
-    
+
   Scenario: search a user
     When I open the drawer
     And I search for "Bob"
     Then I should see "Users matching Bob" within "#search_title"
-    
+
   Scenario: search for a tag
     When I open the drawer
     And I search for "#bob"
     Then I should see "#bob" within "#main > h1"
-    
+
   Scenario: navigate to my activity page
     When I open the drawer
     And I follow "My activity"
     Then I should see "My activity" within "#main"
-    
+
   Scenario: navigate to my mentions page
     Given Alice has a post mentioning Bob
-    And I sign in as "bob@bob.bob"    
+    And I sign in as "bob@bob.bob"
     When I open the drawer
     And I follow "@Mentions"
     Then I should see "Bob Jones" within ".stream_element"
-    
+
   Scenario: navigate to my aspects page
     Given "bob@bob.bob" has a public post with text "bob's text"
     When I open the drawer
@@ -59,7 +59,7 @@ Feature: Navigate between pages using the header menu and the drawer
     Then I should see "Besties" within "#all_aspects + li > ul"
     And I follow "Besties"
     Then I should see "bob's text" within "#main_stream"
-    
+
   Scenario: navigate to the followed tags page
     Given "bob@bob.bob" has a public post with text "bob is da #boss"
     And I toggle the mobile view
@@ -71,17 +71,29 @@ Feature: Navigate between pages using the header menu and the drawer
     Then I should see "#boss" within "#followed_tags + li > ul"
     And I follow "#boss"
     Then I should see "bob is da #boss" within "#main_stream"
-    
+
+  Scenario: navigate to the manage followed tags page
+    Given "bob@bob.bob" has a public post with text "bob is da #boss"
+    And I toggle the mobile view
+    And I search for "#boss"
+    And I press "Follow #boss"
+    And I toggle the mobile view
+    When I open the drawer
+    And I follow "#Followed tags"
+    Then I should see "Manage followed tags" within "#followed_tags + li > ul"
+    And I follow "Manage followed tags"
+    Then I should see "#boss" within "ul.followed_tags"
+
   Scenario: navigate to my profile page
     When I open the drawer
     And I follow "Profile"
     Then I should see "Alice" within "#author_info"
-    
+
   Scenario: navigate to my mentions page
     When I open the drawer
     And I follow "Contacts"
     Then I should see "Contacts" within "#main"
-    
+
   Scenario: navigate to my mentions page
     When I open the drawer
     And I follow "Settings"

--- a/features/mobile/tags.feature
+++ b/features/mobile/tags.feature
@@ -30,3 +30,15 @@ Feature: Interacting with tags
     Then I should see "Follow #newhere" within ".tag_following_action"
     When I am on the home page
     Then I should not see "Hello! I am #newhere"
+
+  Scenario: Manage tags
+    When I click on selector ".tag_following_action"
+    Then I should see "Stop following #newhere" within ".tag_following_action"
+    When I am on the manage tag followings page
+    Then I should see "#newhere" within "ul.followed_tags"
+
+    When I click on selector ".tag_following_action.only-delete"
+    And I confirm the alert
+    Then I should see "You aren't following any tags."
+    When I am on the home page
+    Then I should not see "Hello! I am #newhere"

--- a/spec/controllers/tag_followings_controller_spec.rb
+++ b/spec/controllers/tag_followings_controller_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+describe TagFollowingsController, type: :controller do
+  describe "#manage" do
+    context "not signed in" do
+      it "redirects html requests" do
+        get :manage
+        expect(response).to redirect_to new_user_session_path
+      end
+
+      it "redirects mobile requests" do
+        get :manage, format: :mobile
+        expect(response).to redirect_to new_user_session_path(format: :mobile)
+      end
+    end
+    context "signed in" do
+      before do
+        sign_in :user, alice
+      end
+
+      it "redirects html requests" do
+        get :manage
+        expect(response).to redirect_to followed_tags_stream_path
+      end
+
+      it "does not redirect mobile requests" do
+        get :manage, format: :mobile
+        expect(response).not_to be_redirect
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #5367.
![manage followed tags](https://cloud.githubusercontent.com/assets/3798614/7554374/6fbc53f4-f726-11e4-9adb-0af60953998d.png)
