### PR TITLE
Fix inactive user removal not respecting configuration for daily limits

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -39,6 +39,7 @@ Ruby 2.0 is no longer officially supported.
 * Use correct branding in Atom feed [#5929](https://github.com/diaspora/diaspora/pull/5929)
 * Update the configurate gem to avoid issues by missed missing settings keys [#5934](https://github.com/diaspora/diaspora/pull/5934)
 * ContactPresenter#full_hash_with_person did not contain relationship information [#5936](https://github.com/diaspora/diaspora/pull/5936)
+* Fix inactive user removal not respecting configuration for daily limits [#5953](https://github.com/diaspora/diaspora/pull/5953)
 
 ## Features
 * Hide post title of limited post in comment notification email [#5843](https://github.com/diaspora/diaspora/pull/5843)

--- a/app/workers/queue_users_for_removal.rb
+++ b/app/workers/queue_users_for_removal.rb
@@ -22,7 +22,7 @@ module Workers
         # and queue accounts for closing to sidekiq
         # for those who have not signed in, skip warning and queue removal
         # in +1 days
-        users.find_each do |user|
+        users.each do |user|
           if user.sign_in_count > 0
             remove_at = Time.now + AppConfig.settings.maintenance.remove_old_users.warn_days.to_i.days
           else


### PR DESCRIPTION
It seems ActiveRecord ignores .limit() if .find_each() is used to iterate the query (http://stackoverflow.com/a/6680541/1489738). Using .each() instead. Added a test.
