### PR TITLE
Add popover/tooltip about email visibility to registration/settings page

### DIFF
--- a/app/assets/javascripts/app/pages/registration.js
+++ b/app/assets/javascripts/app/pages/registration.js
@@ -1,0 +1,10 @@
+// @license magnet:?xt=urn:btih:0b31508aeb0634b347b8270c7bee4d411b5d4109&dn=agpl-3.0.txt AGPL-v3-or-Later
+app.pages.Registration = Backbone.View.extend({
+  initialize: function() {
+    $("input#user_email").popover({
+      placement: "left",
+      trigger: "focus"
+    }).popover("show");
+  }
+});
+// @license-end

--- a/app/assets/javascripts/app/pages/settings.js
+++ b/app/assets/javascripts/app/pages/settings.js
@@ -1,0 +1,7 @@
+// @license magnet:?xt=urn:btih:0b31508aeb0634b347b8270c7bee4d411b5d4109&dn=agpl-3.0.txt AGPL-v3-or-Later
+app.pages.Settings = Backbone.View.extend({
+  initialize: function() {
+    $(".settings_visibilty").tooltip({placement: "top"});
+  }
+});
+// @license-end

--- a/app/assets/javascripts/app/router.js
+++ b/app/assets/javascripts/app/router.js
@@ -7,6 +7,8 @@ app.Router = Backbone.Router.extend({
     "help": "help",
     "contacts": "contacts",
     "conversations": "conversations",
+    "user/edit": "settings",
+    "users/sign_up": "registration",
 
     //new hotness
     "posts/:id": "singlePost",
@@ -58,6 +60,14 @@ app.Router = Backbone.Router.extend({
 
   conversations: function() {
     app.conversations = new app.views.Conversations();
+  },
+
+  registration: function() {
+    app.page = new app.pages.Registration();
+  },
+
+  settings: function() {
+    app.page = new app.pages.Settings();
   },
 
   singlePost : function(id) {

--- a/app/assets/stylesheets/new_styles/_settings.scss
+++ b/app/assets/stylesheets/new_styles/_settings.scss
@@ -18,3 +18,5 @@
   max-width: 200px;
   margin-bottom: 10px;
 }
+
+.settings_visibilty { margin-left: 10px; }

--- a/app/views/registrations/_form.haml
+++ b/app/views/registrations/_form.haml
@@ -2,9 +2,15 @@
 
   %fieldset
     %label
-      = f.label :user_email, t('registrations.new.email'), class: 'control-label'
+      = f.label :user_email, t("registrations.new.email"), class: "control-label"
     %i.entypo.mail
-    = f.email_field :email, class: "input-block-level form-control", placeholder: t('registrations.new.email'), title: t('registrations.new.enter_email'), required: true
+    = f.email_field :email,
+      autofocus: true,
+      class: "input-block-level form-control",
+      data: {content: t("users.edit.your_email_private")},
+      placeholder: t("registrations.new.email"),
+      required: true,
+      title: t("registrations.new.enter_email")
 
     %label.control-label{for: "user_username"}
       = t('registrations.new.username')

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -25,7 +25,8 @@
         .span6
           %h3
             = t('.your_email')
-          %small= t('.your_email_private')
+            %i.entypo.lock.gray.settings_visibilty{title: t("users.edit.your_email_private")}
+
           = form_for 'user', :url => user_path, :html => { :method => :put } do |f|
             = f.error_messages
             .form-inline

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -25,6 +25,7 @@
         .span6
           %h3
             = t('.your_email')
+          %small= t('.your_email_private')
           = form_for 'user', :url => user_path, :html => { :method => :put } do |f|
             = f.error_messages
             .form-inline

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -1312,6 +1312,7 @@ en:
       change: "Change"
       your_handle: "Your diaspora* ID"
       your_email: "Your email"
+      your_email_private: "Your email will never be seen by other users"
       change_email: "Change email"
       email_awaiting_confirmation: "We have sent you an activation link to %{unconfirmed_email}. Until you follow this link and activate the new address, we will continue to use your original address %{email}."
       change_password: "Change password"


### PR DESCRIPTION
Fixes #5315, supersedes #5692.
![registration](https://cloud.githubusercontent.com/assets/3798614/7600262/ec3161d8-f909-11e4-8f60-762110ac3fad.png)
![settings](https://cloud.githubusercontent.com/assets/3798614/7600261/ec1f0ce0-f909-11e4-9a68-efefcf90a8c7.png)
