### PR TITLE
Improve participation counter migration

### DIFF
--- a/db/migrate/20150404193023_participation_counter.rb
+++ b/db/migrate/20150404193023_participation_counter.rb
@@ -2,24 +2,31 @@ class ParticipationCounter < ActiveRecord::Migration
   def up
     add_column :participations, :count, :int, null: false, default: 1
 
-    posts_count = Post.select("COUNT(posts.id)")
-                  .where("posts.id = participations.target_id")
-                  .where("posts.author_id = participations.author_id")
-                  .to_sql
-    likes_count = Like.select("COUNT(likes.id)")
-                  .where("likes.target_id = participations.target_id")
-                  .where("likes.author_id = participations.author_id")
-                  .to_sql
     comments_count = Comment.select("COUNT(comments.id)")
                      .where("comments.commentable_id = participations.target_id")
                      .where("comments.author_id = participations.author_id")
                      .to_sql
-    polls_count = PollParticipation.select("COUNT(*)")
-                  .where("poll_participations.author_id = participations.author_id")
-                  .joins(:poll)
-                  .where("polls.status_message_id = participations.target_id")
-                  .to_sql
-    Participation.update_all("count = (#{posts_count}) + (#{likes_count}) + (#{comments_count}) + (#{polls_count})")
+
+    Participation.update_all("count = (#{comments_count})")
+
+    execute "UPDATE participations
+              SET count = count + 1
+              WHERE (participations.author_id, participations.target_id) in
+                (SELECT posts.author_id, posts.id FROM posts)"
+
+    execute "UPDATE participations
+              SET count = count + 1
+              WHERE (participations.author_id, participations.target_id) in
+                (SELECT likes.author_id, likes.target_id FROM likes)"
+
+    execute "UPDATE participations
+              SET count = count + 1
+              WHERE (participations.author_id, participations.target_id) in
+                (SELECT poll_participations.author_id, polls.status_message_id
+                 FROM poll_participations
+                   INNER JOIN polls
+                     ON polls.id = poll_participations.poll_id)"
+
     Participation.where(count: 0).delete_all
   end
 


### PR DESCRIPTION
Continuing PR #5852 

Improve counter participation migration by splitting update query.

Testing in big DBs really appreciate.
