### PR TITLE
Disable autocorrect/autocapitalize for the username first letter

### DIFF
--- a/app/views/sessions/new.mobile.haml
+++ b/app/views/sessions/new.mobile.haml
@@ -27,7 +27,7 @@
             .control-group
               = f.label :username, t('username')
               .controls
-                = f.text_field :username, :autofocus => true
+                = f.text_field :username, :autofocus => true, :autocapitalize => 'none', :autocorrect => 'off'
 
             .control-group
               = f.label :password , t('password')


### PR DESCRIPTION
Disable autocorrect/autocapitalize for the username first letter in the login form on mobile
