### PR TITLE
Replaces the zipzip gem with the rubyzip gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -173,9 +173,9 @@ gem "rails-timeago",           "2.11.0"
 
 gem "logging-rails", "0.5.0", require: "logging/rails"
 
-# Workarounds
-# https://github.com/rubyzip/rubyzip#important-note
-gem "zip-zip"
+# # Workarounds
+# # https://github.com/rubyzip/rubyzip#important-note
+gem "rubyzip"
 
 # Prevent occasions where minitest is not bundled in
 # packaged versions of ruby. See following issues/prs:

--- a/Gemfile
+++ b/Gemfile
@@ -173,9 +173,9 @@ gem "rails-timeago",           "2.11.0"
 
 gem "logging-rails", "0.5.0", require: "logging/rails"
 
-# # Workarounds
-# # https://github.com/rubyzip/rubyzip#important-note
-gem "rubyzip"
+# Reading and writing zip files
+
+gem "rubyzip", "1.1.7"
 
 # Prevent occasions where minitest is not bundled in
 # packaged versions of ruby. See following issues/prs:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -718,8 +718,6 @@ GEM
     will_paginate (3.0.7)
     xpath (2.0.0)
       nokogiri (~> 1.3)
-    zip-zip (0.3)
-      rubyzip (>= 1.0.0)
 
 PLATFORMS
   ruby
@@ -830,6 +828,7 @@ DEPENDENCIES
   rspec-rails (= 3.2.1)
   rubocop (= 0.31.0)
   ruby-oembed (= 0.8.14)
+  rubyzip
   sass-rails (= 5.0.1)
   selenium-webdriver (= 2.45.0)
   shoulda-matchers (= 2.8.0)
@@ -851,4 +850,3 @@ DEPENDENCIES
   uuid (= 2.3.7)
   webmock (= 1.21.0)
   will_paginate (= 3.0.7)
-  zip-zip

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -828,7 +828,7 @@ DEPENDENCIES
   rspec-rails (= 3.2.1)
   rubocop (= 0.31.0)
   ruby-oembed (= 0.8.14)
-  rubyzip
+  rubyzip (= 1.1.7)
   sass-rails (= 5.0.1)
   selenium-webdriver (= 2.45.0)
   shoulda-matchers (= 2.8.0)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -325,7 +325,7 @@ class User < ActiveRecord::Base
   def perform_export_photos!
     temp_zip = Tempfile.new([username, '_photos.zip'])
     begin
-      Zip::ZipOutputStream.open(temp_zip.path) do |zos|
+      Zip::OutputStream.open(temp_zip.path) do |zos|
         photos.each do |photo|
           begin
             photo_file = photo.unprocessed_image.file

--- a/config/initializers/rubyzip.rb
+++ b/config/initializers/rubyzip.rb
@@ -1,7 +1,0 @@
-# https://github.com/rubyzip/rubyzip#configuration
-# Zip.setup do |c|
-#   c.on_exists_proc = true
-#   c.continue_on_exists_proc = true
-#   c.unicode_names = true
-#   c.default_compression = Zlib::BEST_COMPRESSION
-# end

--- a/config/initializers/rubyzip.rb
+++ b/config/initializers/rubyzip.rb
@@ -1,0 +1,7 @@
+# https://github.com/rubyzip/rubyzip#configuration
+# Zip.setup do |c|
+#   c.on_exists_proc = true
+#   c.continue_on_exists_proc = true
+#   c.unicode_names = true
+#   c.default_compression = Zlib::BEST_COMPRESSION
+# end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1065,14 +1065,14 @@ describe User, :type => :model do
       expect(@user.exported_photos_at).to be_present
       expect(@user.exporting_photos).to be_falsey
       expect(@user.exported_photos_file.filename).to match /.zip/
-      expect(Zip::ZipFile.open(@user.exported_photos_file.path).entries.count).to eq(1)
+      expect(Zip::File.open(@user.exported_photos_file.path).entries.count).to eq(1)
     end
 
     it "does not add empty entries when photo not found" do
       File.unlink @user.photos.first.unprocessed_image.path
       @user.perform_export_photos!
       expect(@user.exported_photos_file.filename).to match /.zip/
-      expect(Zip::ZipFile.open(@user.exported_photos_file.path).entries.count).to eq(0)
+      expect(Zip::File.open(@user.exported_photos_file.path).entries.count).to eq(0)
     end
   end
 


### PR DESCRIPTION
The PR replaces the zipzip gem with the rubyzip gem. There was a time when the selenium-webdriver gem needed the zipzip gem to interface with rubyzip < 1 but the current version of selenium-webdriver uses rubyzip ~> 1.

The only place other than from selenium-webdriver that rubyzip is used is in the user model (User.new.perform_export_photos! - https://github.com/diaspora/diaspora/blob/develop/app/models/user.rb#L328)

Also added an initializer for rubyzip configurations in case anyone wanted or needed the ability to configure it.

Hopefully this helps and let me know if there are any issues with it, thanks!
