### PR TITLE
Only return the current_users participation for post interactions

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -11,8 +11,7 @@ class Post < ActiveRecord::Base
   include Diaspora::Commentable
   include Diaspora::Shareable
 
-
-  has_many :participations, :dependent => :delete_all, :as => :target
+  has_many :participations, dependent: :delete_all, as: :target, inverse_of: :target
 
   attr_accessor :user_like
 

--- a/app/presenters/post_interaction_presenter.rb
+++ b/app/presenters/post_interaction_presenter.rb
@@ -1,0 +1,30 @@
+class PostInteractionPresenter
+  def initialize(post, current_user)
+    @post = post
+    @current_user = current_user
+  end
+
+  def as_json(_options={})
+    {
+      likes:          as_api(@post.likes),
+      reshares:       PostPresenter.collection_json(@post.reshares, @current_user),
+      comments:       CommentPresenter.as_collection(@post.comments.order("created_at ASC")),
+      participations: as_api(participations),
+      comments_count: @post.comments_count,
+      likes_count:    @post.likes_count,
+      reshares_count: @post.reshares_count
+    }
+  end
+
+  def participations
+    return @post.participations.none unless @current_user
+    @post.participations.where(author: @current_user.person)
+  end
+
+  def as_api(collection)
+    collection.includes(author: :profile).map {|element|
+      element.as_api_response(:backbone)
+    }
+  end
+end
+

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -92,28 +92,3 @@ class PostPresenter
   end
 
 end
-
-class PostInteractionPresenter
-  def initialize(post, current_user)
-    @post = post
-    @current_user = current_user
-  end
-
-  def as_json(options={})
-    {
-        likes:          as_api(@post.likes),
-        reshares:       PostPresenter.collection_json(@post.reshares, @current_user),
-        comments:       CommentPresenter.as_collection(@post.comments.order("created_at ASC")),
-        participations: as_api(@post.participations),
-        comments_count: @post.comments_count,
-        likes_count:    @post.likes_count,
-        reshares_count: @post.reshares_count
-    }
-  end
-
-  def as_api(collection)
-    collection.includes(:author => :profile).map do |element|
-      element.as_api_response(:backbone)
-    end
-  end
-end

--- a/spec/presenters/post_ineraction_presenter_spec.rb
+++ b/spec/presenters/post_ineraction_presenter_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+
+describe PostInteractionPresenter do
+  let(:status_message_without_participation) {
+    FactoryGirl.create(:status_message_without_participation)
+  }
+  let(:status_message_with_participations) {
+    FactoryGirl.create(:status_message_with_participations, participants: [alice, bob])
+  }
+
+  context "with an user" do
+    context "without a participation" do
+      let(:presenter) { PostInteractionPresenter.new(status_message_without_participation, alice) }
+
+      it "returns an empty array for participations" do
+        expect(presenter.as_json[:participations]).to be_empty
+      end
+    end
+
+    context "with a participation" do
+      let(:presenter) { PostInteractionPresenter.new(status_message_with_participations, alice) }
+
+      it "returns the users own participation only" do
+        expect(presenter.as_json[:participations]).to eq [alice.participations.first.as_api_response(:backbone)]
+      end
+    end
+  end
+
+  context "without an user" do
+    let(:presenter) { PostInteractionPresenter.new(status_message_with_participations, nil) }
+
+    it "returns an empty array" do
+      expect(presenter.as_json[:participations]).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
Nobody needs to know who else participated.
