### PR TITLE
Change markdown-content hr style #5987

### DIFF
--- a/app/assets/stylesheets/stream_element.scss
+++ b/app/assets/stylesheets/stream_element.scss
@@ -111,9 +111,8 @@
     position: relative;
     .markdown-content hr {
       width: 85%;
-      margin: 0.8em auto 0.8em auto;
+      margin: 0.8em auto;
       border-top: 1px solid $border-grey;
-      border-bottom: 0px;
     }
     .expander {
       position: absolute;

--- a/app/assets/stylesheets/stream_element.scss
+++ b/app/assets/stylesheets/stream_element.scss
@@ -109,7 +109,9 @@
   .collapsible {
     overflow: hidden;
     position: relative;
-
+    .markdown-content hr {
+      border-bottom: 1px solid $border-grey;
+    }
     .expander {
       position: absolute;
       bottom: 0;

--- a/app/assets/stylesheets/stream_element.scss
+++ b/app/assets/stylesheets/stream_element.scss
@@ -110,7 +110,10 @@
     overflow: hidden;
     position: relative;
     .markdown-content hr {
-      border-bottom: 1px solid $border-grey;
+      width: 85%;
+      margin: 0.8em auto 0.8em auto;
+      border-top: 1px solid $border-grey;
+      border-bottom: 0px;
     }
     .expander {
       position: absolute;


### PR DESCRIPTION
The hr tag in the markdown-content was #eee,
and thus almost invisible. It has been changed to
$border-gray (currently #ddd) to be consistent
with the other hr tags.
