### PR TITLE
Atom feed: set post title length to 50 and use configured pod name in the feed title

### DIFF
--- a/app/views/users/public.atom.builder
+++ b/app/views/users/public.atom.builder
@@ -10,7 +10,7 @@ atom_feed({'xmlns:thr' => 'http://purl.org/syndication/thread/1.0',
 
   feed.tag! :generator, 'Diaspora', :uri => "#{AppConfig.pod_uri.to_s}"
   feed.title "#{@user.name}'s Public Feed"
-  feed.subtitle "Updates from #{@user.name} on diaspora*"
+  feed.subtitle "Updates from #{@user.name} on #{AppConfig.settings.pod_name}"
   feed.logo "#{@user.image_url(:thumb_small)}"
   feed.updated @posts[0].created_at if @posts.length > 0
   feed.tag! :link, :rel => 'avatar', :type => 'image/jpeg', 'media:width' => '100',
@@ -30,7 +30,7 @@ atom_feed({'xmlns:thr' => 'http://purl.org/syndication/thread/1.0',
     feed.entry post, :url => "#{@user.url}p/#{post.id}",
       :id => "#{@user.url}p/#{post.id}" do |entry|
 
-      entry.title post.message.title
+      entry.title post.message.title(length: 50)
       entry.content post.message.markdownified(disable_hovercards: true), :type => 'html'
       entry.tag! 'activity:verb', 'http://activitystrea.ms/schema/1.0/post'
       entry.tag! 'activity:object-type', 'http://activitystrea.ms/schema/1.0/note'


### PR DESCRIPTION
Fixes #5517.
