### PR TITLE
Truncate post title to 20 characters for notifications

### DIFF
--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -8,13 +8,23 @@ module NotificationsHelper
 
     if note.instance_of?(Notifications::Mentioned)
       if post = note.linked_object
-        translation(target_type, :actors => actors, :count => actors_count, :post_link => link_to(post_page_title(post), post_path(post)).html_safe)
+        translation(target_type,
+                    actors:    actors,
+                    count:     actors_count,
+                    post_link: link_to(post_page_title(post), post_path(post)).html_safe)
       else
         t(note.deleted_translation_key, :actors => actors, :count => actors_count).html_safe
       end
     elsif note.instance_of?(Notifications::CommentOnPost) || note.instance_of?(Notifications::AlsoCommented) || note.instance_of?(Notifications::Reshared) || note.instance_of?(Notifications::Liked)
       if post = note.linked_object
-        translation(target_type, :actors => actors, :count => actors_count, :post_author => h(post.author_name), :post_link => link_to(post_page_title(post), post_path(post), 'data-ref' => post.id, :class => 'hard_object_link').html_safe)
+        translation(target_type,
+                    actors:      actors,
+                    count:       actors_count,
+                    post_author: h(post.author_name),
+                    post_link:   link_to(post_page_title(post),
+                                         post_path(post),
+                                         data:  {ref: post.id},
+                                         class: "hard_object_link").html_safe)
       else
         t(note.deleted_translation_key, :actors => actors, :count => actors_count).html_safe
       end

--- a/app/models/services/wordpress.rb
+++ b/app/models/services/wordpress.rb
@@ -1,30 +1,31 @@
-class Services::Wordpress < Service
-  MAX_CHARACTERS = 1000
+module Services
+  class Wordpress < Service
+    MAX_CHARACTERS = 1000
 
-  attr_accessor :username, :password, :host, :path
+    attr_accessor :username, :password, :host, :path
 
-  # uid = blog_id
+    # uid = blog_id
 
-  def provider
-    "wordpress"
-  end
-
-  def post post, url=''
-    res = Faraday.new(url: "https://public-api.wordpress.com").post do |req|
-      req.url "/rest/v1/sites/#{self.uid}/posts/new"
-      req.body = post_body(post).to_json
-      req.headers['Authorization'] = "Bearer #{self.access_token}"
-      req.headers['Content-Type'] = 'application/json'
+    def provider
+      "wordpress"
     end
 
-    JSON.parse res.env[:body]
-  end
+    def post(post, _url="")
+      res = Faraday.new(url: "https://public-api.wordpress.com").post do |req|
+        req.url "/rest/v1/sites/#{uid}/posts/new"
+        req.body = post_body(post).to_json
+        req.headers["Authorization"] = "Bearer #{access_token}"
+        req.headers["Content-Type"] = "application/json"
+      end
 
-  def post_body post
-    {
-     title: post.message.title(length: 40),
-     content: post.message.markdownified(disable_hovercards: true)
-    }
-  end
+      JSON.parse res.env[:body]
+    end
 
+    def post_body(post)
+      {
+        title:   post.message.title,
+        content: post.message.markdownified(disable_hovercards: true)
+      }
+    end
+  end
 end

--- a/app/models/status_message.rb
+++ b/app/models/status_message.rb
@@ -128,7 +128,7 @@ class StatusMessage < Post
   end
 
   def comment_email_subject
-    message.title length: 70
+    message.title
   end
 
   def first_photo_url(*args)

--- a/app/views/users/public.atom.builder
+++ b/app/views/users/public.atom.builder
@@ -30,7 +30,7 @@ atom_feed({'xmlns:thr' => 'http://purl.org/syndication/thread/1.0',
     feed.entry post, :url => "#{@user.url}p/#{post.id}",
       :id => "#{@user.url}p/#{post.id}" do |entry|
 
-      entry.title post.message.title(length: 50)
+      entry.title post.message.title
       entry.content post.message.markdownified(disable_hovercards: true), :type => 'html'
       entry.tag! 'activity:verb', 'http://activitystrea.ms/schema/1.0/post'
       entry.tag! 'activity:object-type', 'http://activitystrea.ms/schema/1.0/note'

--- a/lib/diaspora/message_renderer.rb
+++ b/lib/diaspora/message_renderer.rb
@@ -213,9 +213,8 @@ module Diaspora
 
     # Get a short summary of the message
     # @param [Hash] opts Additional options
-    # @option opts [Integer] :length (20 | first heading) Truncate the title to
-    #   this length. If not given defaults to 20 and to not truncate
-    #   if a heading is found.
+    # @option opts [Integer] :length (70) Truncate the title to
+    #   this length. If not given defaults to 70.
     def title opts={}
       # Setext-style header
       heading = if /\A(?<setext_content>.{1,200})\n(?:={1,200}|-{1,200})(?:\r?\n|$)/ =~ @raw_message.lstrip
@@ -227,12 +226,10 @@ module Diaspora
 
       heading &&= self.class.new(heading).plain_text_without_markdown
 
-      if heading && opts[:length]
-        heading.truncate opts[:length]
-      elsif heading
-        heading
+      if heading
+        heading.truncate opts.fetch(:length, 70)
       else
-        plain_text_without_markdown squish: true, truncate: opts.fetch(:length, 20)
+        plain_text_without_markdown squish: true, truncate: opts.fetch(:length, 70)
       end
     end
 

--- a/spec/lib/diaspora/message_renderer_spec.rb
+++ b/spec/lib/diaspora/message_renderer_spec.rb
@@ -30,9 +30,10 @@ describe Diaspora::MessageRenderer do
         end
       end
 
-      context 'without a Markdown header of less than 200 characters on first line ' do
-        it 'truncates posts to the 20 first characters' do
-          expect(message("Very, very, very long post").title).to eq "Very, very, very ..."
+      context "without a Markdown header of less than 200 characters on first line" do
+        it "truncates posts to the 70 first characters" do
+          text = "Chillwave heirloom small batch semiotics, brunch cliche yr gluten-free whatever bitters selfies."
+          expect(message(text).title).to eq "Chillwave heirloom small batch semiotics, brunch cliche yr gluten-f..."
         end
       end
     end

--- a/spec/models/services/wordpress_spec.rb
+++ b/spec/models/services/wordpress_spec.rb
@@ -1,33 +1,37 @@
-require 'spec_helper'
+require "spec_helper"
 
-describe Services::Wordpress, :type => :model do
-  
+describe Services::Wordpress, type: :model do
   before do
     @user = alice
-    @post = @user.post(:status_message, 
-                       :text => "Hello there. This is a **Wordpress** post that we hope to turn into something else.", 
-                       :to => @user.aspects.first.id)
-                       
-    @service = Services::Wordpress.new(:nickname => "andrew", 
-                                       :access_token => "abc123", 
-                                       :uid => "123")
+    @post = @user.post(:status_message,
+                       text: "Hello there. This is a **Wordpress** post that we hope to turn into something else.",
+                       to:   @user.aspects.first.id)
+
+    @service = Services::Wordpress.new(nickname:     "andrew",
+                                       access_token: "abc123",
+                                       uid:          "123")
     @user.services << @service
   end
-  
+
   describe "#post" do
-    it 'posts a status message to wordpress' do
-      stub_request(:post, "https://public-api.wordpress.com/rest/v1/sites/123/posts/new").to_return(:status => 200, :body => {:ID => 68}.to_json, :headers => {})
+    it "posts a status message to wordpress" do
+      stub_request(:post, "https://public-api.wordpress.com/rest/v1/sites/123/posts/new").to_return(
+        status:  200,
+        body:    {ID: 68}.to_json,
+        headers: {}
+      )
       @service.post(@post)
     end
   end
-  
+
   describe "#post_body" do
     it "truncates content for use in title" do
-      expect(@service.post_body(@post)[:title]).to eq("Hello there. This is a Wordpress post...")
+      expect(@service.post_body(@post)[:title]).to eq(
+        "Hello there. This is a Wordpress post that we hope to turn into som..."
+      )
     end
     it "converts markdown tags" do
       expect(@service.post_body(@post)[:content]).to match("<strong>Wordpress</strong>")
     end
   end
-  
 end


### PR DESCRIPTION
Before the title could have been 200 characters long if there was a heading in the post. Now the length is consistent.
![](https://cloud.githubusercontent.com/assets/3798614/7903944/8c071ffa-07eb-11e5-9b21-1b4f17932c78.png)
![](https://cloud.githubusercontent.com/assets/3798614/7903945/8c0d1e78-07eb-11e5-9257-189b55ef130c.png)
