### PR TITLE
Change line height to 20px to fix entypo form icon placement

### DIFF
--- a/app/assets/stylesheets/new_styles/_forms.scss
+++ b/app/assets/stylesheets/new_styles/_forms.scss
@@ -80,6 +80,7 @@ form.block-form {
 
     .entypo {
       position: absolute;
+      line-height: 20px;
       top: 10px;
       left: 10px;
       width: 20px;


### PR DESCRIPTION
The introductory forms now look like follows:

![screen shot 2015-06-02 at 8 22 00 pm](https://cloud.githubusercontent.com/assets/6329898/7934784/9812ffaa-0965-11e5-9cab-e9e0ec1a4058.png)
![screen shot 2015-06-02 at 8 22 22 pm](https://cloud.githubusercontent.com/assets/6329898/7934787/9a6cf8dc-0965-11e5-825a-2c50b6223886.png)
![screen shot 2015-06-02 at 8 23 14 pm](https://cloud.githubusercontent.com/assets/6329898/7934788/9ce75580-0965-11e5-8cc4-37a69b13ccfa.png)
