### PR TITLE
Fix for too long username in notification dropdown

### DIFF
--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -176,6 +176,10 @@ body > header {
             height: 35px;
           }
 
+          .media-body {
+            word-break: break-all;
+          }
+
           .pull-right > .aspect_membership_dropdown { display: none; }
           .unread-toggle { margin: 10px; }
 


### PR DESCRIPTION
Fix for [Long username breaks notifications dropdown](https://github.com/diaspora/diaspora/pull/6015#issuecomment-107565374).
Before:

![bs3_diaspora_too_long_pseudo_notification](https://cloud.githubusercontent.com/assets/6507951/7915807/495cce76-0880-11e5-84c8-a9799060b167.png)

After:

![bs3_diaspora_too_long_pseudo_notification_ok2](https://cloud.githubusercontent.com/assets/6507951/7917270/5141aeaa-0889-11e5-9446-90a3e772289d.png)
