### PR TITLE
Bootstrap3: fix likes avatars and conversation participants

### DIFF
--- a/app/assets/stylesheets/conversations.scss
+++ b/app/assets/stylesheets/conversations.scss
@@ -50,7 +50,7 @@
       background-color: lighten($blue,5%);
       cursor: pointer;
       .participants {
-        height: 25px;
+        height: 31px;
         margin-top: 5px;
         padding-top: 5px;
         border-color: rgba($border-grey, 1)

--- a/app/assets/stylesheets/stream_element.scss
+++ b/app/assets/stylesheets/stream_element.scss
@@ -66,7 +66,7 @@
       margin-top: 10px;
       font-size: 12px;
       line-height: 16px;
-      .bd { display: inline-block; }
+      .author-name, .bd { display: inline-block; }
       .entypo.heart {
         display: inline-block;
         font-size: 16px;


### PR DESCRIPTION
For conversations the participant avatars (which are visible on hover) were cut off. The avatars for likes were displayed one below another.
