### PR TITLE
change path to uma.jpg to /assets

### DIFF
--- a/spec/javascripts/helpers/factory.js
+++ b/spec/javascripts/helpers/factory.js
@@ -44,9 +44,9 @@ var factory = {
       "id": id,
       "diaspora_id": "bob@bob.com",
       "avatar":{
-        "large":"http://localhost:3000/images/user/uma.jpg",
-        "medium":"http://localhost:3000/images/user/uma.jpg",
-        "small":"http://localhost:3000/images/user/uma.jpg"}
+        "large":"http://localhost:3000/assets/user/uma.jpg",
+        "medium":"http://localhost:3000/assets/user/uma.jpg",
+        "small":"http://localhost:3000/assets/user/uma.jpg"}
     };
 
     return _.extend(defaultAttrs, overrides);


### PR DESCRIPTION
While running jasmine-tests I got 404 requests in my development-pod. The images were moved to /assets

But this doesn't affect tests...
