### PR TITLE
Fix Bootstrap 3 regression: add email visibility icon to settings page

### DIFF
--- a/app/assets/javascripts/app/pages/settings.js
+++ b/app/assets/javascripts/app/pages/settings.js
@@ -1,7 +1,7 @@
 // @license magnet:?xt=urn:btih:0b31508aeb0634b347b8270c7bee4d411b5d4109&dn=agpl-3.0.txt AGPL-v3-or-Later
 app.pages.Settings = Backbone.View.extend({
   initialize: function() {
-    $(".settings_visibilty").tooltip({placement: "top"});
+    $(".settings_visibility").tooltip({placement: "top"});
   }
 });
 // @license-end

--- a/app/assets/stylesheets/new_styles/_settings.scss
+++ b/app/assets/stylesheets/new_styles/_settings.scss
@@ -22,7 +22,7 @@
   }
 }
 
-.settings_visibilty { margin-left: 10px; }
+.settings_visibility { margin-left: 10px; }
 
 #profile_bio {
   width: 100%;

--- a/app/views/users/_edit.haml
+++ b/app/views/users/_edit.haml
@@ -17,7 +17,10 @@
           %p
             %b= current_user.diaspora_handle
         .col-md-6
-          %h3= t('.your_email')
+          %h3
+            = t(".your_email")
+            %i.entypo.lock.gray.settings_visibility{title: t("users.edit.your_email_private")}
+
 
           = form_for 'user', url: user_path, html: { method: :put, class: "form-horizontal col-md-12" , id: "email-form"} do |f|
             = f.error_messages


### PR DESCRIPTION
Fixes #5315. The Bootstrap 3 port removed the code for the icon. This PR re-adds it and also fixes a typo.
