### PR TITLE
make sql and federation debug-logging configurable

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -35,6 +35,9 @@ defaults:
       logrotate:
         enable: true
         days: 7
+      debug:
+        sql: false
+        federation: false
   server:
     listen: '0.0.0.0:3000'
     rails_environment: 'development'

--- a/config/diaspora.yml.example
+++ b/config/diaspora.yml.example
@@ -149,6 +149,17 @@ configuration: ## Section
         ## The number of days to keep (default=7)
         #days: 7
 
+      ## Debug logging
+      debug: ## Section
+
+        ## Enables the debug-logging for SQL (default=false)
+        ## This logs every SQL-statement!
+        #sql: true
+
+        ## Enables the federation-debug-log (default=false)
+        ## This logs all XMLs that are used for the federation
+        #federation: true
+
   ## Settings affecting how ./script/server behaves.
   server: ## Section
     ## Where the appserver should listen to (default=unix:tmp/diaspora.sock)

--- a/config/logging.rb
+++ b/config/logging.rb
@@ -79,8 +79,14 @@ Logging::Rails.configure do |config|
   #
   #     config.log_to = %w[stdout file]
   #
-  Logging.logger.root.level = config.log_level
   Logging.logger.root.appenders = config.log_to unless config.log_to.empty?
+
+  # Default log-level (development=debug, production=info)
+  Logging.logger.root.level = config.log_level
+
+  # log-levels from the diaspora.yml for SQL and federation debug-logging
+  Logging.logger[ActiveRecord::Base].level = AppConfig.environment.logging.debug.sql? ? :debug : :info
+  Logging.logger["XMLLogger"].level = AppConfig.environment.logging.debug.federation? ? :debug : :info
 
   # Under Phusion Passenger smart spawning, we need to reopen all IO streams
   # after workers have forked.


### PR DESCRIPTION
by default both are disabled now, you can enable them in the diaspora.yml if you need them.
