### PR TITLE
fix-overflow-in-publisher-bookmarklet

### DIFF
--- a/app/assets/stylesheets/mentions.scss
+++ b/app/assets/stylesheets/mentions.scss
@@ -27,6 +27,7 @@
     margin-left: -1px;
     position: absolute;
     right: 0;
+    bottom: 0;
     z-index: 10000;
 
     ul {

--- a/app/assets/stylesheets/publisher.scss
+++ b/app/assets/stylesheets/publisher.scss
@@ -54,6 +54,10 @@
       background-color: white;
       border-radius: 3px;
       border: 1px solid $border-dark-grey;
+      
+      &.active > .mentions-input-box {
+        overflow-y: hidden;
+      }
 
       input[type='text']#status_message_text {
         border: none;


### PR DESCRIPTION
Fixing overflow in publisher bookmarklet when the selected text exceeds the size of the textarea.

![_publisher-overflow](https://cloud.githubusercontent.com/assets/914785/8145382/1c312e80-1206-11e5-9861-68b229dd8056.jpg)
It overlaps the text about use of markdown and prevents to click the link and the entypo icons.
