### PR TITLE
Fix Bootstrap 3 regression: close account

### DIFF
--- a/app/assets/javascripts/mobile/mobile.js
+++ b/app/assets/javascripts/mobile/mobile.js
@@ -13,6 +13,7 @@
 //= require fileuploader-custom
 //= require rails-timeago
 //= require underscore
+//= require bootstrap
 //= require diaspora
 //= require helpers/i18n
 //= require widgets/timeago

--- a/app/views/users/_close_account_modal.haml
+++ b/app/views/users/_close_account_modal.haml
@@ -1,41 +1,44 @@
-.modal.hide.fade{ id: "closeAccountModal", tabindex: "-1", role: "dialog", aria: { labelledby: "closeAccountModalLabel", hidden: "true" }}
-  .modal-header
-    %button.close{type: "button", data: {dismiss: "modal"}, aria: {hidden: "true" }}
-      &times;
-    %h3{ id:"closeAccountModalLabel"}
-      = t("users.edit.close_account.dont_go")
-  .modal-body
-    .row-fluid
-      .text-center
-        = image_tag "sadcat.jpg"
-        %h4
-          %strong
-            = t("users.edit.close_account.mr_wiggles")
+.modal.fade{ id:       "closeAccountModal",
+             tabindex: "-1",
+             role:     "dialog",
+             aria:     { labelledby: "closeAccountModalLabel", hidden: "true" }}
+  .modal-dialog
+    .modal-content
+      .modal-header
+        %button.close{type: "button", data: {dismiss: "modal"}, aria: {hidden: "true" }}
+          &times;
+        %h3.modal-title{ id:"closeAccountModalLabel"}
+          = t("users.edit.close_account.dont_go")
+      = form_for "user", url: user_path, html: { method: :delete } do |f|
+        .modal-body
+          .text-center
+            = image_tag "sadcat.jpg", class: "img-responsive center-block"
+            %h4
+              %strong
+                = t("users.edit.close_account.mr_wiggles")
 
-    .small-horizontal-spacer
+          = t("users.edit.close_account.make_diaspora_better")
 
-    .row-fluid
-      .span12
-        = t("users.edit.close_account.make_diaspora_better")
+          %ol
+            %li
+              = t("users.edit.close_account.what_we_delete")
+            %li
+              = t("users.edit.close_account.locked_out")
+            %li
+              = t("users.edit.close_account.lock_username")
 
-        .small-horizontal-spacer
-
-        %ul
-          %li
-            = t("users.edit.close_account.what_we_delete")
-          %li
-            = t("users.edit.close_account.locked_out")
-          %li
-            = t("users.edit.close_account.lock_username")
-        %p
           %strong
             = t("users.edit.close_account.no_turning_back")
 
-        = form_for "user", url: user_path, html: { method: :delete } do |f|
+          .small-horizontal-spacer
           = f.error_messages
-
-          %p
+          .form-group
             = f.label :close_account_password, t("users.edit.current_password"), for: :close_account_password
-            = f.password_field :current_password, id: :close_account_password
-          %p
-            = f.submit t('users.edit.close_account_text'), class: "btn btn-danger", id: "close_account_confirm", data: { confirm: t("are_you_sure_delete_account") }
+            = f.password_field :current_password, id: :close_account_password, class: "form-control"
+        .modal-footer
+          .btn.btn-default{type: "button", data: {dismiss: "modal"}, aria: {hidden: "true"}}
+            = t("cancel")
+          = f.submit t("users.edit.close_account_text"),
+            class: "btn btn-danger",
+            id:    "close_account_confirm",
+            data:  { confirm: t("are_you_sure_delete_account") }

--- a/app/views/users/edit.haml
+++ b/app/views/users/edit.haml
@@ -191,56 +191,6 @@
         .col-lg-5
           %h3.text-right
             = t('.close_account_text')
-
-          - if mobile
-            = form_for "user", url: user_path, html: { method: :delete } do |f|
-              = f.error_messages
-              .form-group
-                .clearfix= f.label :close_account_password, t("users.edit.current_password"), for: :close_account_password,
-                        class: "pull-right", style: "padding-top: 9px;"
-                .small-horizontal-spacer
-                .clearfix= f.password_field :current_password, id: :close_account_password, class: "form-control"
-                %p
-                .clearfix= f.submit t('users.edit.close_account_text'), class: "btn btn-danger pull-right",
-                        id: "close_account_confirm", data: { confirm: t("are_you_sure_delete_account") }
-
-          - if not mobile
-            =link_to t('.close_account_text'), '#close_account_pane', rel: 'facebox',
-                    class: "btn btn-danger pull-right", id: "close_account"
-
-            .hidden#close_account_pane{rel: 'facebox'}
-              #inner_account_delete
-                %h1
-                  = t('.close_account.dont_go')
-                %p
-                  = t('.close_account.make_diaspora_better')
-                .row
-                  .col-md-6
-                    = image_tag 'sadcat.jpg'
-                    .small-horizontal-spacer
-                    %small
-                      %b
-                        = t('.close_account.mr_wiggles')
-                  .col-md-6
-                    %ul
-                      %li
-                        = t('.close_account.what_we_delete')
-                      %li
-                        = t('.close_account.locked_out')
-                      %li
-                        = t('.close_account.lock_username')
-                    %p
-                      %b
-                        = t('.close_account.no_turning_back')
-
-                    = form_for 'user', url: user_path, html: { method: :delete } do |f|
-                      = f.error_messages
-
-                      %p
-                        = f.label :close_account_password, t('.current_password'), for: :close_account_password
-                        = f.password_field :current_password, id: :close_account_password
-                      %p
-                        .small-horizontal-spacer
-                        = f.submit t('.close_account_text'), class: "btn btn-danger", id: "close_account_confirm",
-                                data: { confirm: t('are_you_sure_delete_account') }
-.small-horizontal-spacer
+          .btn.btn-danger.pull-right{ id: "close_account", data: {toggle: "modal", target: "#closeAccountModal"}}
+            = t(".close_account_text")
+          = render "close_account_modal"

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,1 +1,0 @@
-= render "edit", mobile: false

--- a/app/views/users/edit.mobile.haml
+++ b/app/views/users/edit.mobile.haml
@@ -1,1 +1,0 @@
-= render "edit", mobile: true

--- a/features/desktop/closes_account.feature
+++ b/features/desktop/closes_account.feature
@@ -8,7 +8,8 @@ Feature: Close account
     Given I am signed in
     When I go to the users edit page
     And I click on selector "#close_account"
-    And I put in my password in "close_account_password"
+    Then I should see "Hey, please don’t go!" within "#closeAccountModal"
+    When I put in my password in "close_account_password"
     And I press "close_account_confirm"
     And I confirm the alert
     Then I should be on the new user session page

--- a/features/mobile/closes_account.feature
+++ b/features/mobile/closes_account.feature
@@ -7,7 +7,9 @@ Feature: Close account
   Scenario: user closes account
     Given I am signed in
     When I go to the users edit page
-    And I put in my password in "close_account_password"
+    And I click on selector "#close_account"
+    Then I should see "Hey, please don’t go!" within "#closeAccountModal"
+    When I put in my password in "close_account_password"
     And I press "close_account_confirm"
     And I confirm the alert
 


### PR DESCRIPTION
The Bootstrap 3 port removed some of the work I did in #5913. This PR fixes the regression and adds the Bootstrap modal to the mobile view.
## desktop

![close account desktop](https://cloud.githubusercontent.com/assets/3798614/8148325/23a4f8f8-1298-11e5-9969-4123aa9855e5.png)
## mobile

![close account mobile 1](https://cloud.githubusercontent.com/assets/3798614/8148351/1f8c1dd6-1299-11e5-9b66-de866af91187.png)
![close account mobile 2](https://cloud.githubusercontent.com/assets/3798614/8148350/1f89a574-1299-11e5-9c8a-20d23f04bb74.png)
