### PR TITLE
Remove top margin for first heading in a post

### DIFF
--- a/app/assets/stylesheets/markdown-content.scss
+++ b/app/assets/stylesheets/markdown-content.scss
@@ -8,4 +8,10 @@
     &:first-child { margin-top: 0; }
     &:last-child { margin-bottom: 0; }
   }
+
+  h1, h2, h3, h4, h5, h6 {
+    &:first-child {
+      margin-top: 0;
+    }
+  }
 }


### PR DESCRIPTION
That is, if it's the first element in the post

I think that's more consistent with posts that don't start with a heading.
That gap always felt wrong to me

I think that's more consistent with posts that don't start with a heading.
That gap always felt wrong to me..
