### PR TITLE
A minor typo on the tag list that was causing an empty element to be created

### DIFF
--- a/app/assets/templates/tag_following_tpl.jst.hbs
+++ b/app/assets/templates/tag_following_tpl.jst.hbs
@@ -1,4 +1,4 @@
-<a href="#" id="unfollow_{{name}}" rel="nofollow" class="action delete_tag_following pull-right" title="{{t "delete"}}">&times;<a/>
+<a href="#" id="unfollow_{{name}}" rel="nofollow" class="action delete_tag_following pull-right" title="{{t "delete"}}">&times;</a>
 <a href="/tags/{{name}}" class="selectable">
   #{{ name }}
 </a>


### PR DESCRIPTION
![captura de pantalla 2015-06-17 a la s 06 28 34](https://cloud.githubusercontent.com/assets/340766/8204426/f590e782-14be-11e5-840c-709c13eeb41b.png)
