### PR TITLE
Fix issue with too long username and post link in notifications dropdown

### DIFF
--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -177,7 +177,10 @@ body > header {
           }
 
           .media-body {
-            word-break: break-all;
+            a {
+              display: inline-block;
+              word-break: break-all;
+            }
           }
 
           .pull-right > .aspect_membership_dropdown { display: none; }


### PR DESCRIPTION
To avoid this:

![overflow_too_long_username_dropdown_wrong](https://cloud.githubusercontent.com/assets/6507951/8235046/00a9a48e-15e0-11e5-8256-12475fd98855.png)

I pushed [this PR](https://github.com/diaspora/diaspora/pull/6049), but it breaks display too:

![overflow_too_long_username_dropdown_mistake](https://cloud.githubusercontent.com/assets/6507951/8235065/19d14ffc-15e0-11e5-8d78-caceab46b21f.png)

With this PR, I select `a` to be sure:

![overflow_too_long_username_dropdown_ok](https://cloud.githubusercontent.com/assets/6507951/8235094/3e4552ac-15e0-11e5-9688-46de65d616f9.png)

Sorry for the previous PR.
