### PR TITLE
Add link to pod statistics in right navigation

### DIFF
--- a/app/views/shared/_links.haml
+++ b/app/views/shared/_links.haml
@@ -2,6 +2,7 @@
 %li= link_to 'wiki', "https://wiki.diasporafoundation.org"
 %li= link_to t('layouts.application.whats_new'), changelog_url
 %li= link_to t('layouts.header.code') + " " + pod_version, "#{source_url}", {:title => t('layouts.application.source_package')}
+%li= link_to t("layouts.application.statistics_link"), statistics_path
 %li= link_to(t('layouts.application.toggle'), toggle_mobile_path)
 - if AppConfig.settings.terms.enable?
     %li= link_to(t('_terms'), terms_path)

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -645,6 +645,7 @@ en:
     application:
       powered_by: "Powered by diaspora*"
       whats_new: "What’s new?"
+      statistics_link: "Pod statistics"
       toggle: "Toggle mobile"
       public_feed: "Public diaspora* feed for %{name}"
       your_aspects: "Your aspects"


### PR DESCRIPTION
Result:

![link_for_stat](https://cloud.githubusercontent.com/assets/6507951/8236905/f2bb52b2-15eb-11e5-99ec-ab3989df918f.png)
