### PR TITLE
Fixed more-button wording when there are <15 posts

### DIFF
--- a/app/views/shared/_stream_more_button.mobile.haml
+++ b/app/views/shared/_stream_more_button.mobile.haml
@@ -3,7 +3,7 @@
     %a.more-link.paginate{:href => next_page_path}
       %h1
         = t("more")
--elsif params[:max_time].present?
+-elsif params[:max_time].present? || @stream.stream_posts.length > 0
   #pagination
     %div.no-more-posts
       %h2

--- a/features/mobile/more-button.feature
+++ b/features/mobile/more-button.feature
@@ -1,5 +1,5 @@
 @javascript @mobile
-Feature: posting from the mobile main page
+Feature: using the more button on mobile stream
     As a mobile user
     I want to navigate the stream
     And I want to test the text of the more-button in different environments
@@ -23,21 +23,8 @@ Feature: posting from the mobile main page
 
     Scenario: There are 15 posts
       Given I am on the home page
+      Given there are 15 public posts from "bob@bob.bob"
       And "bob@bob.bob" has a public post with text "post 1"
-      And "bob@bob.bob" has a public post with text "post 2"
-      And "bob@bob.bob" has a public post with text "post 3"
-      And "bob@bob.bob" has a public post with text "post 4"
-      And "bob@bob.bob" has a public post with text "post 5"
-      And "bob@bob.bob" has a public post with text "post 6"
-      And "bob@bob.bob" has a public post with text "post 7"
-      And "bob@bob.bob" has a public post with text "post 8"
-      And "bob@bob.bob" has a public post with text "post 9"
-      And "bob@bob.bob" has a public post with text "post 10"
-      And "bob@bob.bob" has a public post with text "post 11"
-      And "bob@bob.bob" has a public post with text "post 12"
-      And "bob@bob.bob" has a public post with text "post 13"
-      And "bob@bob.bob" has a public post with text "post 14"
-      And "bob@bob.bob" has a public post with text "post 15"
 
       When I go to the stream page
       Then I should see "More"
@@ -47,22 +34,7 @@ Feature: posting from the mobile main page
 
     Scenario: There are 15 +1 posts
       Given I am on the home page
-      And "bob@bob.bob" has a public post with text "post 1"
-      And "bob@bob.bob" has a public post with text "post 2"
-      And "bob@bob.bob" has a public post with text "post 3"
-      And "bob@bob.bob" has a public post with text "post 4"
-      And "bob@bob.bob" has a public post with text "post 5"
-      And "bob@bob.bob" has a public post with text "post 6"
-      And "bob@bob.bob" has a public post with text "post 7"
-      And "bob@bob.bob" has a public post with text "post 8"
-      And "bob@bob.bob" has a public post with text "post 9"
-      And "bob@bob.bob" has a public post with text "post 10"
-      And "bob@bob.bob" has a public post with text "post 11"
-      And "bob@bob.bob" has a public post with text "post 12"
-      And "bob@bob.bob" has a public post with text "post 13"
-      And "bob@bob.bob" has a public post with text "post 14"
-      And "bob@bob.bob" has a public post with text "post 15"
-      And "bob@bob.bob" has a public post with text "post 16"
+      Given there are 16 public posts from "bob@bob.bob"
 
       When I go to the stream page
       Then I should see "More"

--- a/features/mobile/more-button.feature
+++ b/features/mobile/more-button.feature
@@ -1,0 +1,71 @@
+@javascript @mobile
+Feature: posting from the mobile main page
+    As a mobile user
+    I want to navigate the stream
+    And I want to test the text of the more-button in different environments
+
+    Background:
+      Given a user with username "bob"
+      And I sign in as "bob@bob.bob" on the mobile website
+
+    Scenario: There are no posts
+      Given I am on the home page
+
+      When I go to the stream page
+      Then I should see "There are no posts yet."
+
+    Scenario: There are <15 posts
+      Given I am on the home page
+      And "bob@bob.bob" has a public post with text "post 1"
+
+      When I go to the stream page
+      Then I should see "You have reached the end of the stream."
+
+    Scenario: There are 15 posts
+      Given I am on the home page
+      And "bob@bob.bob" has a public post with text "post 1"
+      And "bob@bob.bob" has a public post with text "post 2"
+      And "bob@bob.bob" has a public post with text "post 3"
+      And "bob@bob.bob" has a public post with text "post 4"
+      And "bob@bob.bob" has a public post with text "post 5"
+      And "bob@bob.bob" has a public post with text "post 6"
+      And "bob@bob.bob" has a public post with text "post 7"
+      And "bob@bob.bob" has a public post with text "post 8"
+      And "bob@bob.bob" has a public post with text "post 9"
+      And "bob@bob.bob" has a public post with text "post 10"
+      And "bob@bob.bob" has a public post with text "post 11"
+      And "bob@bob.bob" has a public post with text "post 12"
+      And "bob@bob.bob" has a public post with text "post 13"
+      And "bob@bob.bob" has a public post with text "post 14"
+      And "bob@bob.bob" has a public post with text "post 15"
+
+      When I go to the stream page
+      Then I should see "More"
+
+      When I click on selector ".more-link"
+      Then I should see "You have reached the end of the stream."
+
+    Scenario: There are 15 +1 posts
+      Given I am on the home page
+      And "bob@bob.bob" has a public post with text "post 1"
+      And "bob@bob.bob" has a public post with text "post 2"
+      And "bob@bob.bob" has a public post with text "post 3"
+      And "bob@bob.bob" has a public post with text "post 4"
+      And "bob@bob.bob" has a public post with text "post 5"
+      And "bob@bob.bob" has a public post with text "post 6"
+      And "bob@bob.bob" has a public post with text "post 7"
+      And "bob@bob.bob" has a public post with text "post 8"
+      And "bob@bob.bob" has a public post with text "post 9"
+      And "bob@bob.bob" has a public post with text "post 10"
+      And "bob@bob.bob" has a public post with text "post 11"
+      And "bob@bob.bob" has a public post with text "post 12"
+      And "bob@bob.bob" has a public post with text "post 13"
+      And "bob@bob.bob" has a public post with text "post 14"
+      And "bob@bob.bob" has a public post with text "post 15"
+      And "bob@bob.bob" has a public post with text "post 16"
+
+      When I go to the stream page
+      Then I should see "More"
+
+      When I click on selector ".more-link"
+      Then I should see "You have reached the end of the stream."

--- a/features/step_definitions/posts_steps.rb
+++ b/features/step_definitions/posts_steps.rb
@@ -27,6 +27,13 @@ Given /^"([^"]*)" has a public post with text "([^"]*)"$/ do |email, text|
   user.post(:status_message, :text => text, :public => true, :to => user.aspect_ids)
 end
 
+Given /^there are (\d+) public posts from "([^"]*)"$/ do |n_posts, email|
+  user = User.find_by_email(email)
+  (1..n_posts.to_i).each do |n|
+    user.post(:status_message, text: "post nr. #{n}", public: true, to: user.aspect_ids)
+  end
+end
+
 Given /^"([^"]*)" has a non public post with text "([^"]*)"$/ do |email, text|
   user = User.find_by_email(email)
   user.post(:status_message, :text => text, :public => false, :to => user.aspect_ids)


### PR DESCRIPTION
Added the scenario where there are <15 posts and the user should see "You have reached the end of the stream.".

"More" is only shown when there are 15 (maximum posts on a page) or more (we won't know, since the amount of items is limited by 15) posts. This can lead to one page showing 15 posts and the "More"-Button and when the button is clicked the next page presents a "You have reached the end of the stream."-Message.
Technically correct and without additional data from the database / an extra query I don't think this could get more convenient.

This fixes #6093 
