### PR TITLE
Fix autocomplete

### DIFF
--- a/app/assets/stylesheets/autocomplete.scss
+++ b/app/assets/stylesheets/autocomplete.scss
@@ -19,6 +19,7 @@
 }
 
 .ac_results li {
+  color: white;
   margin: 0px;
   padding: 2px 5px {
     left: 50px;
@@ -47,16 +48,15 @@
 }
 
 .ac_odd {
-  background-color: #fafafa;
+  background-color: $navbar-inverse-bg;
 }
 
 .ac_even {
-  background-color: #fff;
+  background-color: darken($navbar-inverse-bg, 3%);
 }
 
 .ac_over {
-  background-color: #3F8FBA;
-  color: white;
+  background-color: $brand-primary;
 }
 
 .ac_results {

--- a/vendor/assets/javascripts/jquery.autocomplete-custom.js
+++ b/vendor/assets/javascripts/jquery.autocomplete-custom.js
@@ -571,7 +571,7 @@ $.Autocompleter.Select = function (options, input, select, config) {
 		element = $("<div/>")
 		.hide()
 		.addClass(options.resultsClass)
-		.css("position", "absolute")
+		.css("position", "fixed")
 		.appendTo(document.body);
 
 		list = $("<ul/>").appendTo(element).mouseover( function(event) {


### PR DESCRIPTION
- position: fixed for search results: otherwise the search results move when you scroll down / up
- use the background color of the navbar for search results. Saw that on framaspere-redesign and thought that it would be also nice for the default diaspora\* design

![search results](https://cloud.githubusercontent.com/assets/3798614/8273022/8412069a-185b-11e5-96d4-4db4b458f543.png)
