### PR TITLE
6115 add guid to comments and posts for user export

### DIFF
--- a/app/serializers/export/comment_serializer.rb
+++ b/app/serializers/export/comment_serializer.rb
@@ -1,6 +1,7 @@
 module Export
   class CommentSerializer < ActiveModel::Serializer
-    attributes :text,
+    attributes :guid,
+               :text,
                :post_guid
 
     def post_guid

--- a/app/serializers/export/post_serializer.rb
+++ b/app/serializers/export/post_serializer.rb
@@ -1,6 +1,7 @@
 module Export
   class PostSerializer < ActiveModel::Serializer
-    attributes :text,
+    attributes :guid,
+               :text,
                :public,
                :diaspora_handle,
                :type,

--- a/spec/serializers/comment_serializer_spec.rb
+++ b/spec/serializers/comment_serializer_spec.rb
@@ -1,0 +1,10 @@
+require "spec_helper"
+
+describe Export::CommentSerializer do
+  let(:comment) { FactoryGirl.create(:comment) }
+  subject(:json_output) { Export::CommentSerializer.new(comment).to_json }
+
+  it { is_expected.to include("\"guid\":\"#{comment.guid}\"") }
+  it { is_expected.to include("\"post_guid\":\"#{comment.post.guid}\"") }
+  it { is_expected.to include("\"text\":\"#{comment.text}\"") }
+end

--- a/spec/serializers/comment_serializer_spec.rb
+++ b/spec/serializers/comment_serializer_spec.rb
@@ -4,7 +4,7 @@ describe Export::CommentSerializer do
   let(:comment) { create(:comment) }
   subject(:json_output) { Export::CommentSerializer.new(comment).to_json }
 
-  it { is_expected.to include("\"guid\":\"#{comment.guid}\"") }
-  it { is_expected.to include("\"post_guid\":\"#{comment.post.guid}\"") }
-  it { is_expected.to include("\"text\":\"#{comment.text}\"") }
+  it { is_expected.to include %("guid":"#{comment.guid}") }
+  it { is_expected.to include %("post_guid":"#{comment.post.guid}") }
+  it { is_expected.to include %("text":"#{comment.text}") }
 end

--- a/spec/serializers/comment_serializer_spec.rb
+++ b/spec/serializers/comment_serializer_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe Export::CommentSerializer do
-  let(:comment) { FactoryGirl.create(:comment) }
+  let(:comment) { create(:comment) }
   subject(:json_output) { Export::CommentSerializer.new(comment).to_json }
 
   it { is_expected.to include("\"guid\":\"#{comment.guid}\"") }

--- a/spec/serializers/post_serializer_spec
+++ b/spec/serializers/post_serializer_spec
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+describe Export::PostSerializer do
+  let(:post) { create(:status_message_with_photo) }
+  subject(:json_output) { Export::PostSerializer.new(post).to_json }
+  subject(:json_output) { Export::PostSerializer.new(post).to_json }
+
+  it { is_expected.to include("\"guid\":\"#{post.guid}\"") }
+  it { is_expected.to include("\"text\":\"#{post.text}\"") }
+  it { is_expected.to include("\"public\":#{post.public}") }
+  it { is_expected.to include("\"diaspora_handle\":\"#{post.diaspora_handle}\"") }
+  it { is_expected.to include("\"type\":\"#{post.type}\"") }
+  it { is_expected.to include("\"image_url\":#{post.image_url}") }
+  it { is_expected.to include("\"image_height\":#{post.image_height}") }
+  it { is_expected.to include("\"image_width\":#{post.image_width}") }
+  it { is_expected.to include("\"likes_count\":#{post.likes_count}") }
+  it { is_expected.to include("\"comments_count\":#{post.comments_count}") }
+  it { is_expected.to include("\"reshares_count\":#{post.reshares_count}") }
+  it { is_expected.to include("\"created_at\":\"#{post.created_at.to_s[0, 4]}") }
+end

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -3,7 +3,6 @@ require "spec_helper"
 describe Export::PostSerializer do
   let(:post) { create(:status_message_with_photo) }
   subject(:json_output) { Export::PostSerializer.new(post).to_json }
-  subject(:json_output) { Export::PostSerializer.new(post).to_json }
 
   it { is_expected.to include("\"guid\":\"#{post.guid}\"") }
   it { is_expected.to include("\"text\":\"#{post.text}\"") }

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -4,16 +4,17 @@ describe Export::PostSerializer do
   let(:post) { create(:status_message_with_photo) }
   subject(:json_output) { Export::PostSerializer.new(post).to_json }
 
-  it { is_expected.to include("\"guid\":\"#{post.guid}\"") }
-  it { is_expected.to include("\"text\":\"#{post.text}\"") }
-  it { is_expected.to include("\"public\":#{post.public}") }
-  it { is_expected.to include("\"diaspora_handle\":\"#{post.diaspora_handle}\"") }
-  it { is_expected.to include("\"type\":\"#{post.type}\"") }
-  it { is_expected.to include("\"image_url\":#{post.image_url}") }
-  it { is_expected.to include("\"image_height\":#{post.image_height}") }
-  it { is_expected.to include("\"image_width\":#{post.image_width}") }
-  it { is_expected.to include("\"likes_count\":#{post.likes_count}") }
-  it { is_expected.to include("\"comments_count\":#{post.comments_count}") }
-  it { is_expected.to include("\"reshares_count\":#{post.reshares_count}") }
-  it { is_expected.to include("\"created_at\":\"#{post.created_at.to_s[0, 4]}") }
+  it { is_expected.to include %("guid":"#{post.guid}") }
+  it { is_expected.to include %("text":"#{post.text}") }
+  it { is_expected.to include %("public":#{post.public}) }
+  it { is_expected.to include %("diaspora_handle":"#{post.diaspora_handle}") }
+  it { is_expected.to include %("type":"#{post.type}") }
+  it { is_expected.to include %("image_url":#{post.image_url}) }
+  it { is_expected.to include %("image_height":#{post.image_height}) }
+  it { is_expected.to include %("image_width":#{post.image_width}) }
+  it { is_expected.to include %("likes_count":#{post.likes_count}) }
+  it { is_expected.to include %("comments_count":#{post.comments_count}) }
+  it { is_expected.to include %("reshares_count":#{post.reshares_count}) }
+  it { is_expected.to include %("created_at":"#{post.created_at.to_s[0, 4]}) }
+  it { is_expected.to include %("created_at":"#{post.created_at.strftime('%FT%T.%LZ')}) }
 end


### PR DESCRIPTION
We (@zaziemo and I) added the guid for posts & comments in the user export and also some tests for the serializers.

We can add more tests for the other serializers that would be something useful. 

Note: In the post_serializer_spec the check for the created_at Date only checks for the year because the to_json method ruins the Date Format. 
I tried setting:
`ActiveSupport::JSON::Encoding.use_standard_json_time_format = false`
but it didn't help much.

We can try to look into it more or maybe it is not that important.
