### PR TITLE
Update rails assets gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -285,7 +285,7 @@ group :development, :test do
   # Jasmine (client side application tests (JS))
   gem "jasmine",                   "2.3.0"
   gem "jasmine-jquery-rails",      "2.0.3"
-  gem "rails-assets-jasmine-ajax", "3.1.1", source: "https://rails-assets.org"
+  gem "rails-assets-jasmine-ajax", "3.2.0", source: "https://rails-assets.org"
   gem "sinon-rails",               "1.15.0"
 
   # silence assets

--- a/Gemfile
+++ b/Gemfile
@@ -108,7 +108,7 @@ source "https://rails-assets.org" do
 
   gem "rails-assets-jeresig--jquery.hotkeys",       "0.2.0"
   gem "rails-assets-jquery-idletimer",              "1.0.1"
-  gem "rails-assets-jquery-placeholder",            "2.1.1"
+  gem "rails-assets-jquery-placeholder",            "2.1.2"
   gem "rails-assets-jquery-textchange",             "0.2.3"
   gem "rails-assets-perfect-scrollbar",             "0.6.2"
   gem "rails-assets-jakobmattsson--jquery-elastic", "1.6.11"

--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,7 @@ source "https://rails-assets.org" do
   gem "rails-assets-markdown-it--markdown-it-for-inline", "0.1.1"
   gem "rails-assets-markdown-it-sub",                     "1.0.0"
   gem "rails-assets-markdown-it-sup",                     "1.0.0"
-  gem "rails-assets-highlightjs",                         "8.5.0"
+  gem "rails-assets-highlightjs",                         "8.6.0"
 
   # jQuery plugins
 

--- a/Gemfile
+++ b/Gemfile
@@ -95,7 +95,7 @@ gem "js-routes",         "1.0.1"
 source "https://rails-assets.org" do
   gem "rails-assets-jquery",                              "1.11.2" # Should be kept in sync with jquery-rails
 
-  gem "rails-assets-markdown-it",                         "4.3.0"
+  gem "rails-assets-markdown-it",                         "4.4.0"
   gem "rails-assets-markdown-it-hashtag",                 "0.3.1"
   gem "rails-assets-markdown-it-diaspora-mention",        "0.3.0"
   gem "rails-assets-markdown-it-sanitizer",               "0.3.2"

--- a/Gemfile
+++ b/Gemfile
@@ -110,7 +110,7 @@ source "https://rails-assets.org" do
   gem "rails-assets-jquery-idletimer",              "1.0.1"
   gem "rails-assets-jquery-placeholder",            "2.1.2"
   gem "rails-assets-jquery-textchange",             "0.2.3"
-  gem "rails-assets-perfect-scrollbar",             "0.6.2"
+  gem "rails-assets-perfect-scrollbar",             "0.6.3"
   gem "rails-assets-jakobmattsson--jquery-elastic", "1.6.11"
   gem "rails-assets-autosize",                      "3.0.6"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -112,7 +112,7 @@ source "https://rails-assets.org" do
   gem "rails-assets-jquery-textchange",             "0.2.3"
   gem "rails-assets-perfect-scrollbar",             "0.6.3"
   gem "rails-assets-jakobmattsson--jquery-elastic", "1.6.11"
-  gem "rails-assets-autosize",                      "3.0.6"
+  gem "rails-assets-autosize",                      "3.0.8"
 end
 
 # Localization

--- a/Gemfile
+++ b/Gemfile
@@ -107,7 +107,6 @@ source "https://rails-assets.org" do
   # jQuery plugins
 
   gem "rails-assets-jeresig--jquery.hotkeys",       "0.2.0"
-  gem "rails-assets-jquery-idletimer",              "1.0.1"
   gem "rails-assets-jquery-placeholder",            "2.1.2"
   gem "rails-assets-jquery-textchange",             "0.2.3"
   gem "rails-assets-perfect-scrollbar",             "0.6.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -569,7 +569,7 @@ GEM
     rails-assets-markdown-it-sanitizer (0.3.2)
     rails-assets-markdown-it-sub (1.0.0)
     rails-assets-markdown-it-sup (1.0.0)
-    rails-assets-perfect-scrollbar (0.6.2)
+    rails-assets-perfect-scrollbar (0.6.3)
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
     rails-dom-testing (1.0.6)
@@ -860,7 +860,7 @@ DEPENDENCIES
   rails-assets-markdown-it-sanitizer (= 0.3.2)!
   rails-assets-markdown-it-sub (= 1.0.0)!
   rails-assets-markdown-it-sup (= 1.0.0)!
-  rails-assets-perfect-scrollbar (= 0.6.2)!
+  rails-assets-perfect-scrollbar (= 0.6.3)!
   rails-i18n (= 4.0.4)
   rails-timeago (= 2.11.0)
   rails_admin (= 0.6.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -541,7 +541,7 @@ GEM
       rails-assets-jquery-fullscreen (~> 1.1.4)
       rails-assets-jquery-ui (~> 1.10.4)
       rails-assets-jquery.slimscroll (~> 1.3.3)
-    rails-assets-highlightjs (8.5.0)
+    rails-assets-highlightjs (8.6.0)
     rails-assets-jakobmattsson--jquery-elastic (1.6.11)
       rails-assets-jquery (>= 1.2.6)
     rails-assets-jasmine (2.3.4)
@@ -845,7 +845,7 @@ DEPENDENCIES
   rails (= 4.2.3)
   rails-assets-autosize (= 3.0.6)!
   rails-assets-diaspora_jsxc (~> 0.1.1)!
-  rails-assets-highlightjs (= 8.5.0)!
+  rails-assets-highlightjs (= 8.6.0)!
   rails-assets-jakobmattsson--jquery-elastic (= 1.6.11)!
   rails-assets-jasmine-ajax (= 3.1.1)!
   rails-assets-jeresig--jquery.hotkeys (= 0.2.0)!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -563,7 +563,7 @@ GEM
     rails-assets-jquery.slimscroll (1.3.6)
       rails-assets-jquery (>= 1.7)
     rails-assets-markdown-it--markdown-it-for-inline (0.1.1)
-    rails-assets-markdown-it (4.3.0)
+    rails-assets-markdown-it (4.4.0)
     rails-assets-markdown-it-diaspora-mention (0.3.0)
     rails-assets-markdown-it-hashtag (0.3.1)
     rails-assets-markdown-it-sanitizer (0.3.2)
@@ -853,7 +853,7 @@ DEPENDENCIES
   rails-assets-jquery-idletimer (= 1.0.1)!
   rails-assets-jquery-placeholder (= 2.1.1)!
   rails-assets-jquery-textchange (= 0.2.3)!
-  rails-assets-markdown-it (= 4.3.0)!
+  rails-assets-markdown-it (= 4.4.0)!
   rails-assets-markdown-it--markdown-it-for-inline (= 0.1.1)!
   rails-assets-markdown-it-diaspora-mention (= 0.3.0)!
   rails-assets-markdown-it-hashtag (= 0.3.1)!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -553,7 +553,6 @@ GEM
     rails-assets-jquery-colorbox (1.5.15)
       rails-assets-jquery (>= 1.3.2)
     rails-assets-jquery-fullscreen (1.1.4)
-    rails-assets-jquery-idletimer (1.0.1)
     rails-assets-jquery-placeholder (2.1.2)
       rails-assets-jquery (>= 1.6)
     rails-assets-jquery-textchange (0.2.3)
@@ -850,7 +849,6 @@ DEPENDENCIES
   rails-assets-jasmine-ajax (= 3.1.1)!
   rails-assets-jeresig--jquery.hotkeys (= 0.2.0)!
   rails-assets-jquery (= 1.11.2)!
-  rails-assets-jquery-idletimer (= 1.0.1)!
   rails-assets-jquery-placeholder (= 2.1.2)!
   rails-assets-jquery-textchange (= 0.2.3)!
   rails-assets-markdown-it (= 4.4.0)!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -534,7 +534,7 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.2.3)
       sprockets-rails
-    rails-assets-autosize (3.0.6)
+    rails-assets-autosize (3.0.8)
     rails-assets-diaspora_jsxc (0.1.1)
       rails-assets-jquery (~> 1.11.1)
       rails-assets-jquery-colorbox (~> 1.5.14)
@@ -843,7 +843,7 @@ DEPENDENCIES
   rack-rewrite (= 1.5.1)
   rack-ssl (= 1.4.1)
   rails (= 4.2.3)
-  rails-assets-autosize (= 3.0.6)!
+  rails-assets-autosize (= 3.0.8)!
   rails-assets-diaspora_jsxc (~> 0.1.1)!
   rails-assets-highlightjs (= 8.6.0)!
   rails-assets-jakobmattsson--jquery-elastic (= 1.6.11)!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -554,7 +554,7 @@ GEM
       rails-assets-jquery (>= 1.3.2)
     rails-assets-jquery-fullscreen (1.1.4)
     rails-assets-jquery-idletimer (1.0.1)
-    rails-assets-jquery-placeholder (2.1.1)
+    rails-assets-jquery-placeholder (2.1.2)
       rails-assets-jquery (>= 1.6)
     rails-assets-jquery-textchange (0.2.3)
       rails-assets-jquery
@@ -851,7 +851,7 @@ DEPENDENCIES
   rails-assets-jeresig--jquery.hotkeys (= 0.2.0)!
   rails-assets-jquery (= 1.11.2)!
   rails-assets-jquery-idletimer (= 1.0.1)!
-  rails-assets-jquery-placeholder (= 2.1.1)!
+  rails-assets-jquery-placeholder (= 2.1.2)!
   rails-assets-jquery-textchange (= 0.2.3)!
   rails-assets-markdown-it (= 4.4.0)!
   rails-assets-markdown-it--markdown-it-for-inline (= 0.1.1)!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -545,7 +545,7 @@ GEM
     rails-assets-jakobmattsson--jquery-elastic (1.6.11)
       rails-assets-jquery (>= 1.2.6)
     rails-assets-jasmine (2.3.4)
-    rails-assets-jasmine-ajax (3.1.1)
+    rails-assets-jasmine-ajax (3.2.0)
       rails-assets-jasmine (~> 2)
     rails-assets-jeresig--jquery.hotkeys (0.2.0)
       rails-assets-jquery (>= 1.4.2)
@@ -846,7 +846,7 @@ DEPENDENCIES
   rails-assets-diaspora_jsxc (~> 0.1.1)!
   rails-assets-highlightjs (= 8.6.0)!
   rails-assets-jakobmattsson--jquery-elastic (= 1.6.11)!
-  rails-assets-jasmine-ajax (= 3.1.1)!
+  rails-assets-jasmine-ajax (= 3.2.0)!
   rails-assets-jeresig--jquery.hotkeys (= 0.2.0)!
   rails-assets-jquery (= 1.11.2)!
   rails-assets-jquery-placeholder (= 2.1.2)!

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -16,7 +16,6 @@
 //= require jquery.events.input
 //= require jakobmattsson-jquery-elastic
 //= require jquery.mentionsInput
-//= require jquery-idletimer/dist/idle-timer
 //= require jquery.infinitescroll-custom
 //= require jquery.autocomplete-custom
 //= require jquery-ui/core


### PR DESCRIPTION
Updates a few rails-assets gems and removes jquery-idletimer which was introduced in https://github.com/diaspora/diaspora/commit/2c0cfa53dceaeb276b0f15e2e27ec502792963c5 but there were no matches for `idle` in `app/` anymore. (except for the `require` line in `app/assets/javascripts/main.js`) If we would still use jquery-idletimer there would be some `idleTimer()` call somewhere. (See https://github.com/thorst/jquery-idletimer)
