### PR TITLE
Fix default home page

### DIFF
--- a/app/views/home/default.haml
+++ b/app/views/home/default.haml
@@ -18,13 +18,13 @@
       = image_tag "landing/cog.png"
 
       %p
-      Look at
-      %code.helpful{title: "General pod configuration (location to upload photos, SSL certs, etc.)"}
-        config/diaspora.yml.example
-      and
-      %code.helpful{title: "MySQL username/password"}
-        config/database.yml.example
-      for help.
+        Look at
+        %code.helpful{title: "General pod configuration (location to upload photos, SSL certs, etc.)"}
+          config/diaspora.yml.example
+        and
+        %code.helpful{title: "MySQL username/password"}
+          config/database.yml.example
+        for help.
 
     .col-md-4
       %h2 Try it out

--- a/app/views/home/default.haml
+++ b/app/views/home/default.haml
@@ -48,7 +48,7 @@
     %ul#links
       %ul.section
         %li= link_to "Codebase", "http://github.com/diaspora/diaspora", title: "Git repository"
-        %li= link_to "Documentation", "http://wiki.diasporafoundation.org", title: "Wiki on github"
+        %li= link_to "Documentation", "http://wiki.diasporafoundation.org", title: "Project wiki"
       %ul.section
         %li= link_to "IRC - General", "http://webchat.freenode.net/?channels=diaspora", title: "#diaspora"
         %li= link_to "IRC - Development", "http://webchat.freenode.net/?channels=diaspora-dev", title: "#diaspora-dev"


### PR DESCRIPTION
Hi!

In this PR I just fix indentation level for `p` block in default home page, and remove GitHub reference from wiki link title, because:

> [Please refer to that one instead of the information here](https://github.com/diaspora/diaspora/wiki/Home/0d45a6ac30090074f1744a0bcbe07c142eb3bd8d)

:)
