### PR TITLE
Issue #6137: Add focus:not(:hover) color

### DIFF
--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -26,6 +26,7 @@ header > .dark-header > nav {
       margin-left: 20px;
       & > li { height: 50px; }
       .dropdown > a:focus { outline: 0px none; }
+      .dropdown > a:focus:not(:hover){color:#9d9d9d;}
       .dropdown-open {
         background-color: $dropdown-bg;
         & > a { color: $dropdown-link-color; }

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -22,11 +22,11 @@ header > .dark-header > nav {
       }
     }
     .navbar-nav:not(.nav-badges) > li > a { font-weight: bold; }
+    .navbar-nav > li > a { color:$navbar-inverse-link-color; }
     .nav-badges {
       margin-left: 20px;
       & > li { height: 50px; }
       .dropdown > a:focus { outline: 0px none; }
-      .nav-badge:focus:not(:hover){color:$navbar-inverse-link-color;}
       .dropdown-open {
         background-color: $dropdown-bg;
         & > a { color: $dropdown-link-color; }

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -22,7 +22,7 @@ header > .dark-header > nav {
       }
     }
     .navbar-nav:not(.nav-badges) > li > a { font-weight: bold; }
-    .navbar-nav > li > a { color:$navbar-inverse-link-color; }
+    .navbar-nav > li > a:focus:not(:hover) { color:$navbar-inverse-link-color; }
     .nav-badges {
       margin-left: 20px;
       & > li { height: 50px; }

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -26,7 +26,7 @@ header > .dark-header > nav {
       margin-left: 20px;
       & > li { height: 50px; }
       .dropdown > a:focus { outline: 0px none; }
-      .dropdown > a:focus:not(:hover){color:#9d9d9d;}
+      .nav-badge:focus:not(:hover){color:$navbar-inverse-link-color;}
       .dropdown-open {
         background-color: $dropdown-bg;
         & > a { color: $dropdown-link-color; }


### PR DESCRIPTION
Thanks for pointing me towards the workflow page @jhass. And i've also linked my account with my commits. Now back to CSS. This commit changes the hover away color of the .dropdown instead of .nav-badge which I think is convenient.
