### PR TITLE
Add js for aria-labelledby in conversations

### DIFF
--- a/app/assets/javascripts/app/views/conversations_form_view.js
+++ b/app/assets/javascripts/app/views/conversations_form_view.js
@@ -29,6 +29,7 @@ app.views.ConversationsForm = Backbone.View.extend({
       emptyText: Diaspora.I18n.t("no_results"),
       preFill: this.prefill
     }).focus();
+    $("#contact_ids").attr("aria-labelledby", "toLabel");
   },
 
   keyDown : function(evt) {


### PR DESCRIPTION
I forgot to add this line in #6227. `#conctact_ids` is added by our js so we also need to add the attribute with js.
