### PR TITLE
Add viewport to desktop view

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,7 +11,8 @@
     %meta{charset:  'utf-8'}/
     %meta{"http-equiv" => "Content-Type", :content=>"text/html; charset=utf-8"}/
     %meta{name:  "description", content:  "diaspora*"}/
-    %meta{name:  "author", content:  "Diaspora, Inc."}/
+    %meta{name:  "author", content:  "diaspora* contributors"}/
+    %meta{name:  "viewport", content:  "width=device-width, initial-scale=1"}/
 
     %link{rel:  'shortcut icon', href:  "#{image_path('favicon.png')}" }
 


### PR DESCRIPTION
Since some part of the desktop view are now responsive, we should specify a viewport to make them usable. Notice the menu, the size of the font of users posts and the size of the publisher.
## **Before**

![2015-07-22-19-26-12](https://cloud.githubusercontent.com/assets/930064/8832750/07fe5906-30ab-11e5-9e9a-295711871396.png)
![2015-07-22-19-48-05](https://cloud.githubusercontent.com/assets/930064/8832755/11e7fe36-30ab-11e5-99fb-b939fd729543.png)
## **After**

![2015-07-22-19-44-37](https://cloud.githubusercontent.com/assets/930064/8832762/1d023c32-30ab-11e5-8bf5-1960ec2524be.png)
![2015-07-22-19-44-44](https://cloud.githubusercontent.com/assets/930064/8832767/23bd945e-30ab-11e5-8fc5-f9c65b3b865e.png)
