### PR TITLE
Add my aspects link in the header

### DIFF
--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -23,7 +23,6 @@ header > .dark-header > nav {
     }
     .navbar-nav:not(.nav-badges) > li > a { font-weight: bold; }
     .nav-badges {
-      margin-left: 20px;
       & > li { height: 50px; }
       .dropdown > a:focus { outline: 0px none; }
       .dropdown-open {

--- a/app/assets/templates/header_tpl.jst.hbs
+++ b/app/assets/templates/header_tpl.jst.hbs
@@ -17,6 +17,7 @@
         <div class="collapse navbar-collapse" id="navbar-collapse">
           <ul class="nav navbar-nav navbar-left">
             <li><a href="/stream">{{t "my_stream"}}</a></li>
+            <li><a href="/aspects">{{t "my_aspects"}}</a></li>
             <li><a href="/activity">{{t "my_activity"}}</a></li>
           </ul>
 


### PR DESCRIPTION
Add a link to the /aspects page in the header.
Users usually have too many contact to be interested by the raw stream, so the /aspects page becomes the "root" page. This link allows to access it directly from anywhere. It is a customization @taratatach did on diaspora-fr years ago and which was well welcomed, so I propose to merge it upstream, = here :)
