### PR TITLE
Enable the jasmine testsuite to work across LAN

### DIFF
--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -76,3 +76,6 @@ src_dir:
 # spec_dir: spec/javascripts
 #
 spec_dir: spec/javascripts
+
+rack_options:
+  Host: '0.0.0.0'


### PR DESCRIPTION
Enable the jasmine testsuite to work across LAN by setting its Host variable to "0.0.0.0" (instead of default 127.0.0.1) so you could test it with a foreign web browser.
