### PR TITLE
Add location and polls to mobile website

### DIFF
--- a/app/assets/stylesheets/mobile/mobile.scss
+++ b/app/assets/stylesheets/mobile/mobile.scss
@@ -10,6 +10,7 @@
 @import "mobile/tags";
 @import "mobile/conversations";
 @import "mobile/settings";
+@import "mobile/polls";
 
 a {
   color: #2489ce;

--- a/app/assets/stylesheets/mobile/mobile.scss
+++ b/app/assets/stylesheets/mobile/mobile.scss
@@ -10,7 +10,7 @@
 @import "mobile/tags";
 @import "mobile/conversations";
 @import "mobile/settings";
-@import "mobile/polls";
+@import "mobile/stream_element";
 
 a {
   color: #2489ce;

--- a/app/assets/stylesheets/mobile/polls.scss
+++ b/app/assets/stylesheets/mobile/polls.scss
@@ -1,8 +1,0 @@
-.stream_element .poll {
-  border-top: 1px solid $border-grey;
-  margin-top: 20px;
-  padding-top: 10px;
-  .poll-head .question {
-    font-weight: bold;
-  }
-}

--- a/app/assets/stylesheets/mobile/polls.scss
+++ b/app/assets/stylesheets/mobile/polls.scss
@@ -1,0 +1,8 @@
+.stream_element .poll {
+  border-top: 1px solid $border-grey;
+  margin-top: 20px;
+  padding-top: 10px;
+  .poll-head .question {
+    font-weight: bold;
+  }
+}

--- a/app/assets/stylesheets/mobile/stream_element.scss
+++ b/app/assets/stylesheets/mobile/stream_element.scss
@@ -1,0 +1,16 @@
+.stream_element {
+  .location {
+    color: $text-grey;
+    font-size: $font-size-small;
+    white-space: normal;
+  }
+
+  .poll {
+    border-top: 1px solid $border-grey;
+    margin-top: 20px;
+    padding-top: 10px;
+    .poll-head .question {
+      font-weight: bold;
+    }
+  }
+}

--- a/app/views/shared/_post_info.mobile.haml
+++ b/app/views/shared/_post_info.mobile.haml
@@ -30,3 +30,6 @@
           = t('public')
         - else
           = t('limited')
+    - if !post.is_a?(Reshare) and post.location
+      .location
+        = t("posts.show.location", location: post.location.address)

--- a/app/views/status_messages/_poll.mobile.haml
+++ b/app/views/status_messages/_poll.mobile.haml
@@ -1,0 +1,25 @@
+.poll
+  .poll-head
+    .poll-stats.pull-right
+      = t("polls.votes", count: poll.participation_count)
+    .question
+      = poll.question
+  .poll-content
+    - poll.poll_answers.each do |answer|
+      .result-row
+        .result-head
+          - percentage = 0
+          - if poll.participation_count > 0
+            - percentage = (answer.vote_count / poll.participation_count * 100).round
+          .percentage.pull-right
+            = "#{percentage}%"
+          .answer
+            = answer.answer
+        .progress
+          .progress-bar{role:  "progressbar",
+                        aria:  {valuenow: "#{percentage}",
+                                valuemin: "0",
+                                valuemax: "100"},
+                        style: "width: #{percentage}%;"}
+            %span.sr-only
+              = "#{percentage}%"

--- a/app/views/status_messages/_status_message.mobile.haml
+++ b/app/views/status_messages/_status_message.mobile.haml
@@ -17,31 +17,7 @@
 %div{:class => direction_for(post.text)}
   != post.message.markdownified
   - if post.poll
-    .poll
-      .poll-head
-        .poll-stats.pull-right
-          = t("polls.votes", count: post.poll.participation_count)
-        .question
-          = post.poll.question
-      .poll-content
-        - post.poll.poll_answers.each do |answer|
-          .result-row
-            .result-head
-              - percentage = 0
-              - if post.poll.participation_count > 0
-                - percentage = (answer.vote_count / post.poll.participation_count * 100).round
-              .percentage.pull-right
-                = "#{percentage}%"
-              .answer
-                = answer.answer
-            .progress
-              .progress-bar{role:  "progressbar",
-                            aria:  {valuenow: "#{percentage}",
-                                    valuemin: "0",
-                                    valuemax: "100"},
-                            style: "width: #{percentage}%;"}
-                %span.sr-only
-                  = "#{percentage}%"
+    = render "status_messages/poll", poll: post.poll
   - if post.o_embed_cache
     != o_embed_html post.o_embed_cache
   - if post.open_graph_cache

--- a/app/views/status_messages/_status_message.mobile.haml
+++ b/app/views/status_messages/_status_message.mobile.haml
@@ -16,8 +16,34 @@
 
 %div{:class => direction_for(post.text)}
   != post.message.markdownified
+  - if post.poll
+    .poll
+      .poll-head
+        .poll-stats.pull-right
+          = t("polls.votes", count: post.poll.participation_count)
+        .question
+          = post.poll.question
+      .poll-content
+        - post.poll.poll_answers.each do |answer|
+          .result-row
+            .result-head
+              - percentage = 0
+              - if post.poll.participation_count > 0
+                - percentage = (answer.vote_count / post.poll.participation_count * 100).round
+              .percentage.pull-right
+                = "#{percentage}%"
+              .answer
+                = answer.answer
+            .progress
+              .progress-bar{role:  "progressbar",
+                            aria:  {valuenow: "#{percentage}",
+                                    valuemin: "0",
+                                    valuemax: "100"},
+                            style: "width: #{percentage}%;"}
+                %span.sr-only
+                  = "#{percentage}%"
   - if post.o_embed_cache
     != o_embed_html post.o_embed_cache
-  -if post.open_graph_cache
+  - if post.open_graph_cache
     .opengraph
       != og_html post.open_graph_cache

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -985,6 +985,7 @@ en:
     presenter:
       title: "A post from %{name}"
     show:
+      location: "Posted from: %{location}"
       destroy: "Delete"
       permalink: "Permalink"
       not_found: "Sorry, we couldn’t find that post."

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -975,6 +975,12 @@ en:
       or_select_one_existing: "or select one from your already existing %{photos}"
     comment_email_subject: "%{name}’s photo"
 
+  polls:
+    votes:
+      zero: "%{count} votes so far"
+      one: "%{count} vote so far"
+      other: "%{count} votes so far"
+
   posts:
     presenter:
       title: "A post from %{name}"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -99,6 +99,12 @@ FactoryGirl.define do
       end
     end
 
+    factory(:status_message_with_location) do
+      after(:build) do |sm|
+        FactoryGirl.create(:location, status_message: sm)
+      end
+    end
+
     factory(:status_message_with_photo) do
       sequence(:text) {|n| "There are #{n} ninjas in this photo." }
       after(:build) do |sm|
@@ -134,6 +140,7 @@ FactoryGirl.define do
   end
 
   factory(:location) do
+    address "unicorn city"
     lat 1
     lng 2
   end

--- a/spec/integration/mobile_posts_spec.rb
+++ b/spec/integration/mobile_posts_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+
+describe PostsController, type: :request do
+  context "with a poll" do
+    let(:sm) { FactoryGirl.build(:status_message_with_poll, public: true) }
+
+    it "displays the poll" do
+      get "/posts/#{sm.id}", format: :mobile
+
+      expect(response.status).to eq(200)
+      expect(response.body).to match(/div class='poll'/)
+      expect(response.body).to match(/#{sm.poll.poll_answers.first.answer}/)
+    end
+  end
+
+  context "with a location" do
+    let(:sm) { FactoryGirl.build(:status_message_with_location, public: true) }
+
+    it "displays the location" do
+      get "/posts/#{sm.id}", format: :mobile
+
+      expect(response.status).to eq(200)
+      expect(response.body).to match(/div class='location'/)
+      expect(response.body).to match(/#{I18n.t("posts.show.location", location: sm.location.address)}/)
+    end
+  end
+end


### PR DESCRIPTION
This just adds them to the stream and the SPV. You are still unable to create a post with locations and polls from the mobile website. Voting is also not possible. This PR just implements the basics. Everything else should happen in other PRs.

![](https://cloud.githubusercontent.com/assets/3798614/8852965/927ddc84-3158-11e5-8f7d-0b3e7858b33d.png)
