### PR TITLE
Disable rubocop ambiguous regex

### DIFF
--- a/features/step_definitions/.rubocop.yml
+++ b/features/step_definitions/.rubocop.yml
@@ -1,0 +1,5 @@
+inherit_from:
+  - ../../.rubocop.yml
+  
+Lint/AmbiguousRegexpLiteral:
+  Enabled: false


### PR DESCRIPTION
```
features/step_definitions/password_flow_steps.rb:28:6: W: Ambiguous regexp literal. Parenthesize the method arguments if it's surely a regexp literal, or add a whitespace to the right of the / if it should be a division.
When /^I use received valid bearer tokens to access user info$/ do
     ^
```

Otherwise all step definitions will have to be parenthesized 
