### PR TITLE
Set the appendComment handler only for the time of posting new comment.

### DIFF
--- a/app/assets/javascripts/app/views/comment_stream_view.js
+++ b/app/assets/javascripts/app/views/comment_stream_view.js
@@ -20,7 +20,6 @@ app.views.CommentStream = app.views.Base.extend({
   },
 
   setupBindings: function() {
-    this.model.comments.bind('add', this.appendComment, this);
     this.model.bind("commentsExpanded", this.storeTextareaValue, this);
     this.model.bind("commentsExpanded", this.render, this);
   },
@@ -49,6 +48,7 @@ app.views.CommentStream = app.views.Base.extend({
     this.$(".comment_box").val("");
     this.$(".comment_box").css("height", "");
     if(commentText) {
+      this.model.comments.bind("add", this.appendComment, this);
       this.model.comment(commentText);
       return this;
     } else {
@@ -66,6 +66,7 @@ app.views.CommentStream = app.views.Base.extend({
   appendComment: function(comment) {
     // Set the post as the comment's parent, so we can check
     // on post ownership in the Comment view.
+    this.model.comments.unbind("add", this.appendComment);
     comment.set({parent : this.model.toJSON()});
 
     this.$(".comments").append(new app.views.Comment({


### PR DESCRIPTION
If you look at comment expand process with javascript debugger, you
will notice that at first comments get added to existing stream ("add"
event handler of model.comments gets launched because of model.comments.fetch).
Then the comment stream gets empty and then filled by the postRenderTemplate
handler.

We don't need to process an "add" event on fetching of an expanding comments.
We need to run the "add" event handler only when we add comment through
the commenting form.

This patch moves the "add" handler binding to createComment function and
unbinds handler just after new comment was appended. Thus, unnecessary
job of adding fetched comments is avoided saving user's browser's resourses.
