### PR TITLE
Disable the handlebars auto-indent feature

### DIFF
--- a/config/initializers/handlebars_assets.rb
+++ b/config/initializers/handlebars_assets.rb
@@ -1,0 +1,1 @@
+HandlebarsAssets::Config.options = {preventIndent: true}


### PR DESCRIPTION
Fixes #6253.

> `preventIndent`: By default an indented partial-call causes the output of the whole partial being indented by the same amount. This leads to unexpected behavior when the partial writes `pre`-tags. Setting this option to `true` will disable the auto-indent feature.

(http://handlebarsjs.com/reference.html)
