### PR TITLE
Override bootstrap list group default

### DIFF
--- a/app/assets/stylesheets/_application.scss
+++ b/app/assets/stylesheets/_application.scss
@@ -1,9 +1,9 @@
-@import "bootstrap-complete.scss";
-
 @import 'perfect-scrollbar';
 
 @import "colors";
+@import "bootstrap-complete.scss";
 @import 'mixins';
+
 
 /* core */
 @import 'media-box';

--- a/app/assets/stylesheets/bootstrap-variables.scss
+++ b/app/assets/stylesheets/bootstrap-variables.scss
@@ -9,10 +9,10 @@
 //
 //## Gray and brand colors for use across Bootstrap.
 
-// $gray-base:              #000
+$gray-base:              #000;
 // $gray-darker:            lighten($gray-base, 13.5%) // #222
 // $gray-dark:              lighten($gray-base, 20%)   // #333
-// $gray:                   lighten($gray-base, 33.5%) // #555
+$gray:                   lighten($gray-base, 33.5%); // #555
 // $gray-light:             lighten($gray-base, 46.7%) // #777
 // $gray-lighter:           lighten($gray-base, 93.5%) // #eee
 
@@ -667,24 +667,23 @@ $navbar-collapse-max-height: 480px;
 //== List group
 //
 //##
-
 //** Background color on `.list-group-item`
-// $list-group-bg:                 #fff
+$list-group-bg: $sidebars-background;
 //** `.list-group-item` border color
-// $list-group-border:             #ddd
+$list-group-border: $border-grey;
 //** List group border radius
-// $list-group-border-radius:      $border-radius-base
+$list-group-border-radius: 0;
 
 //** Background color of single list items on hover
-// $list-group-hover-bg:           #f5f5f5
+$list-group-hover-bg: $blue;
 //** Text color of active list items
-// $list-group-active-color:       $component-active-color
+$list-group-active-color: $white;
 //** Background color of active list items
-// $list-group-active-bg:          $component-active-bg
+$list-group-active-bg: $gray;
 //** Border color of active list elements
 // $list-group-active-border:      $list-group-active-bg
 //** Text color for content within active list items
-// $list-group-active-text-color:  lighten($list-group-active-bg, 40%)
+$list-group-active-text-color: $white;
 
 //** Text color of disabled list items
 // $list-group-disabled-color:      $gray-light
@@ -694,7 +693,7 @@ $navbar-collapse-max-height: 480px;
 // $list-group-disabled-text-color: $list-group-disabled-color
 
 // $list-group-link-color:         #555
-// $list-group-link-hover-color:   $list-group-link-color
+$list-group-link-hover-color: $white;
 // $list-group-link-heading-color: #333
 
 

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -1,3 +1,4 @@
+@import "colors";
 @import "bootstrap-variables";
 
 body {

--- a/app/assets/stylesheets/mobile/mobile.scss
+++ b/app/assets/stylesheets/mobile/mobile.scss
@@ -1,5 +1,5 @@
-@import "bootstrap-complete";
 @import "colors";
+@import "bootstrap-complete";
 @import "_mixins";
 @import "vendor/autoSuggest";
 @import "_flash_messages";

--- a/app/assets/stylesheets/navbar_left.scss
+++ b/app/assets/stylesheets/navbar_left.scss
@@ -31,8 +31,6 @@
     }
   }
 
-  .selected, .selected a { color: $black; }
-
   .hoverable {
     border-bottom: 1px solid $border-grey;
     color: $link-grey;


### PR DESCRIPTION
Now that https://github.com/diaspora/diaspora/pull/6309 is merged, it's time to unify the other views. I started by overriding the bootstrap list-group component to make it use the same colors than our new sidebars. Please tell me if that's the way to go.

**Before**
![before](https://cloud.githubusercontent.com/assets/930064/9451222/a4c7a10e-4aad-11e5-8c24-d8f7c65e2a19.png)
**After**
![after](https://cloud.githubusercontent.com/assets/930064/9451223/a4ca6f56-4aad-11e5-857d-17a6b754ae58.png)

Of course this is only the component, each views has to be modified to correctly adapt, but that's a beginning.
