### PR TITLE
Unify left navbar

### DIFF
--- a/app/assets/stylesheets/_application.scss
+++ b/app/assets/stylesheets/_application.scss
@@ -79,12 +79,13 @@
 @import 'oembed';
 @import 'post-content';
 
-/* right bar */
+/* nav bar */
+@import 'layout';
+@import 'navbar_left';
 @import 'navbar_right';
 
 /* contacts */
 @import 'contacts';
-@import 'navbar_left';
 
 /* code */
 @import 'new_styles/code';

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1,0 +1,21 @@
+.left-navbar {
+  height: 100%;
+  padding: 0px;
+
+  & > h3 {
+    padding-left: 15px;
+  }
+
+  .list-group-item {
+    border-left: 0px;
+    border-right: 0px;
+  }
+}
+
+
+.left-navbar-fixed-background { // To be reused by navbar_left
+  background: $sidebars-background;
+  border-right: 1px solid $light-grey;
+  position: fixed;
+  height: 100%;
+}

--- a/app/views/notifications/index.html.haml
+++ b/app/views/notifications/index.html.haml
@@ -1,9 +1,9 @@
 .container-fluid#notifications_container
   .row
-    .col-md-3
+    .col-md-3.left-navbar.left-navbar-fixed-background
       %h3
         = t('.notifications')
-      .list-group
+      %nav.list-group
         %a.list-group-item{class: ('active' unless params[:type] && @grouped_unread_notification_counts.has_key?(params[:type])), href: '/notifications' + (params[:show] == 'unread' ? '?show=unread' : '') }
           %span.pull-right.badge{class: ("hidden" unless @unread_notification_count > 0)}
             = @unread_notification_count
@@ -26,7 +26,7 @@
                 %i.entypo-add-user
             = t('.'+key)
 
-    .col-md-9.stream.notifications
+    .col-md-9.col-md-offset-3.stream.notifications
       .row.header
         .col-md-12
           .btn-toolbar.pull-right


### PR DESCRIPTION
Based on https://github.com/diaspora/diaspora/pull/6345 here is how the notification page can look:

![capture d ecran 2015-08-24 a 22 50 14](https://cloud.githubusercontent.com/assets/930064/9452101/b513a44a-4ab2-11e5-9ca4-1ce2f4aa134b.png)

The points I would like to discuss:
- I feel like the list-group and the title is not separated enough. I also have this feeling on the stream page even if the avatar helps. I think about adding `.list-group-item:first-child { border-top-color: darken($light-grey, 12%); }`. To increase the size of the border doesn't work well.
- The border in the main div to separate the "mark as read" buttons of the notifications is now touching the navbar and is not aligned with the other borders. That feels weird.
- The stream doesn't have the sticky footer but this page does. I start feeling that we have too much grey here. This is not a blocking point though.
