### PR TITLE
Beautify ignored people list and add diaspora handle for identification

### DIFF
--- a/app/assets/stylesheets/mobile/settings.scss
+++ b/app/assets/stylesheets/mobile/settings.scss
@@ -29,3 +29,12 @@
     padding: 1rem;
   }
 }
+
+#blocked_people {
+  .blocked_person {
+    border-bottom: 1px solid $border-grey;
+    margin-top: 0;
+    .avatar { max-width: 35px; }
+    .info { color: $text; }
+  }
+}

--- a/app/assets/stylesheets/people.scss
+++ b/app/assets/stylesheets/people.scss
@@ -28,3 +28,19 @@
     .info { font-size: $font-size-small; }
   }
 }
+#blocked_people {
+  .blocked_person {
+    border-bottom: 1px solid $border-grey;
+    padding: 10px;
+    margin: 0px;
+    font-size: 13px;
+    line-height: 16px;
+    min-height: 50px;
+    .avatar {
+      width: 50px;
+      height: 50px;
+    }
+    .info { font-size: $font-size-small; }
+    .btn-danger { margin-top: 9px; }
+  }
+}

--- a/app/views/users/_blocked_person.haml
+++ b/app/views/users/_blocked_person.haml
@@ -1,0 +1,12 @@
+.media.blocked_person{id: person.id}
+  .pull-right
+    = link_to t("users.privacy_settings.stop_ignoring"), block_path(block),  class: "btn btn-danger", method: :delete
+  .media-object.pull-left
+    = person_image_link(person, size: :thumb_small)
+  .media-body
+    = person_link(person)
+    .info.diaspora_handle
+      = block.person.diaspora_handle
+    .info.tags
+      = Diaspora::Taggable.format_tags(person.profile.tag_string)
+  .clearfix

--- a/app/views/users/_privacy_settings.haml
+++ b/app/views/users/_privacy_settings.haml
@@ -18,7 +18,7 @@
                   = t('.strip_exif')
                 = f.submit t('users.edit.change'), class: 'btn btn-primary pull-right'
       %hr
-      
+
       .row
         .col-md-12
           %h3
@@ -27,9 +27,7 @@
           - if @blocks.length.zero?
             %p
               = t('.no_user_ignored_message')
-
-          - @blocks.each do |block|
-            = block.person_name
-            \-
-            = link_to t('.stop_ignoring'), block_path(block),
-              method: :delete
+          - else
+            #blocked_people
+              - @blocks.each do |block|
+                = render partial: "blocked_person", locals: {block: block, person: block.person}

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -1387,7 +1387,7 @@ en:
       title: "Privacy settings"
       strip_exif: "Strip metadata such as location, author, and camera model from uploaded images (recommended)"
       ignored_users: "Ignored users"
-      stop_ignoring: "stop ignoring"
+      stop_ignoring: "Stop ignoring"
       no_user_ignored_message: "You are not currently ignoring any other user"
 
     destroy:


### PR DESCRIPTION
In the current "ignored user" list you can only see the name if the ignored profile - and nothing else. Since people rename themselves and maybe some people are named the same, the ignoring user needs more information to review the ignored user list.

I enhanced this view and adapted the template from user search results into this list, providing much more information and a modernized "Stop ignoring" button. I checked the style on mobile and desktop on firefox.

Things I'm not sure about:
- mobile: the font-color of the diaspora handle is grey and maybe hard to read. I could change that to black.
- I used the full name of the translation string on the blocked_person template, because I felt that string belongs to the category, but since I created a new partial, the naming scheme is different. Any suggestions how to change this - or is `users.privacy_settings.stop_ignoring` okay as translation string identifier?

Desktop:
![desktop](https://cloud.githubusercontent.com/assets/1184859/9480642/930d7e16-4b84-11e5-9b99-55ebdf92d62b.png)

Mobile View:
![mobile](https://cloud.githubusercontent.com/assets/1184859/9480641/92a4da28-4b84-11e5-882a-278eea7dadab.png)
