### PR TITLE
Fix mobile pagination for notifications view

### DIFF
--- a/app/assets/stylesheets/mobile/mobile.scss
+++ b/app/assets/stylesheets/mobile/mobile.scss
@@ -647,7 +647,7 @@ form#new_user.new_user input.btn {
   text-shadow: 1px 1px 20px rgb(126, 240, 77);
 }
 
-#conversation_inbox {
+#conversation_inbox, .notifications {
   div.pagination {
     width: 100%;
     margin-left: auto;

--- a/app/views/notifications/index.mobile.haml
+++ b/app/views/notifications/index.mobile.haml
@@ -24,4 +24,9 @@
                   .time_notif
                     = timeago(note.created_at)
 
-  = will_paginate @notifications, renderer: WillPaginate::ActionView::BootstrapLinkRenderer
+  = will_paginate @notifications,
+    previous_label: "&laquo;",
+    next_label: "&raquo;",
+    inner_window: 1,
+    outer_window: 0,
+    renderer: WillPaginate::ActionView::BootstrapLinkRenderer


### PR DESCRIPTION
Before:

![pagination_mobile_notifications_before](https://cloud.githubusercontent.com/assets/6507951/9562086/c6071e82-4e61-11e5-8cb1-aa74a99932b1.png)

After:

![pagination_mobile_notifications_after](https://cloud.githubusercontent.com/assets/6507951/9562085/c5f6fb4c-4e61-11e5-92ed-4ec227363b6f.png)
