### PR TITLE
Change default autofollow_on_join_user

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -98,7 +98,7 @@ defaults:
     pod_name: 'diaspora*'
     enable_registrations: true
     autofollow_on_join: true
-    autofollow_on_join_user: 'diasporahq@joindiaspora.com'
+    autofollow_on_join_user: 'hq@pod.diaspora.software'
     welcome_message:
       enabled: false
       subject: 'Welcome Message'

--- a/config/diaspora.yml.example
+++ b/config/diaspora.yml.example
@@ -404,11 +404,11 @@ configuration: ## Section
     ## follow an account upon creation.
     #autofollow_on_join: true
 
-    ## Auto-follow account (default='diasporahq@joindiaspora.com')
+    ## Auto-follow account (default='hq@pod.diaspora.software')
     ## The diaspora* HQ account keeps users up to date with news about Diaspora.
     ## If you set another auto-follow account (for example your podmin account),
     ## please consider resharing diaspora* HQ's posts for your pod's users!
-    #autofollow_on_join_user: 'diasporahq@joindiaspora.com'
+    #autofollow_on_join_user: 'hq@pod.diaspora.software'
 
     ## Welcome Message settings
     welcome_message: ##Section


### PR DESCRIPTION
Due to performance of joindiaspora.com, a decision was made to set up a project pod that hosts the official support and news autofollow account (see https://www.loomio.org/d/tyZdcGNo/diasporahq-account-move-to-a-project-pod). The new account is hq@pod.diaspora.software.
