### PR TITLE
Stop Tumblr posting to all blogs

### DIFF
--- a/app/models/services/tumblr.rb
+++ b/app/models/services/tumblr.rb
@@ -16,16 +16,18 @@ class Services::Tumblr < Service
   def post(post, url='')
     body = build_tumblr_post(post, url)
     user_info = JSON.parse(client.get("/v2/user/info").body)
-    blogs = user_info["response"]["user"]["blogs"].map { |blog| URI.parse(blog['url']) }
+    blogs = user_info["response"]["user"]["blogs"]
+    primaryblog = blogs.find(blogs[0]) {|blog| blog["primary"] }
     tumblr_ids = {}
-    blogs.each do |blog|
-      resp = client.post("/v2/blog/#{blog.host}/post", body)
-      if resp.code == "201"
-        tumblr_ids[blog.host.to_s] = JSON.parse(resp.body)["response"]["id"]
-      end
+
+    blogurl = URI.parse(primaryblog["url"])
+    resp = client.post("/v2/blog/#{blogurl.host}/post", body)
+    if resp.code == "201"
+      tumblr_ids[blogurl.host.to_s] = JSON.parse(resp.body)["response"]["id"]
+    end
+
     post.tumblr_ids = tumblr_ids.to_json
     post.save
-    end
   end
 
   def build_tumblr_post(post, url)

--- a/spec/models/services/tumblr_spec.rb
+++ b/spec/models/services/tumblr_spec.rb
@@ -11,17 +11,19 @@ describe Services::Tumblr, :type => :model do
 
   describe '#post' do
     it 'posts a status message to tumblr and saves the returned ids' do
-      response = double(body: '{"response": {"user": {"blogs": [{"url": "http://foo.tumblr.com"}]}}}')
+      response = double(body: '{"response": {"user": {"blogs":
+       [{"primary": false, "url": "http://foo.tumblr.com"},
+        {"primary": true, "url": "http://bar.tumblr.com"}]}}}')
       expect_any_instance_of(OAuth::AccessToken).to receive(:get)
       .with("/v2/user/info")
       .and_return(response)
 
       response = double(code: "201", body: '{"response": {"id": "bla"}}')
       expect_any_instance_of(OAuth::AccessToken).to receive(:post)
-      .with("/v2/blog/foo.tumblr.com/post", @service.build_tumblr_post(@post, ''))
+      .with("/v2/blog/bar.tumblr.com/post", @service.build_tumblr_post(@post, ""))
       .and_return(response)
 
-      expect(@post).to receive(:tumblr_ids=).with({"foo.tumblr.com" => "bla"}.to_json)
+      expect(@post).to receive(:tumblr_ids=).with({"bar.tumblr.com" => "bla"}.to_json)
 
       @service.post(@post)
     end


### PR DESCRIPTION
Based on meitar/diaspora@b5c01598.

Is a small improvement to issue #3938, but not the optimal solution - the optimal solution would probably involve treating Tumblr blogs as contacts, able to be put in aspects and crossposting anything posted to those aspects.  At the very least, an ideal solution should allow the user to choose which blog to post to, rather than forcing the primary only, as this version does.
