### PR TITLE
Fix for tag overflow - fixes #6142

### DIFF
--- a/app/assets/stylesheets/tag.scss
+++ b/app/assets/stylesheets/tag.scss
@@ -28,7 +28,7 @@ h1.tag {
     h4 { margin: 25px 0 15px; }
     .side_stream #people_stream {
       .name { display: block; }
-      .name, .diaspora_handle, .tags {
+      .name, .diaspora_handle {
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;


### PR DESCRIPTION
Can't keep `text-overflow: ellipsis` with BS3 for tags in tag page.

Large screen

![capture d ecran de 2015-09-11 17 08 38](https://cloud.githubusercontent.com/assets/6507951/9818415/b48ba30c-58a8-11e5-83bc-3d704b45ae0a.png)

Smaller screen

![capture d ecran de 2015-09-11 17 09 14](https://cloud.githubusercontent.com/assets/6507951/9818416/b48f0e48-58a8-11e5-9ba0-bc6ebec9973f.png)
