### PR TITLE
Enabling markdown-it-html5-embed plugin so user can embed audio and video

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,6 +103,7 @@ source "https://rails-assets.org" do
   gem "rails-assets-markdown-it--markdown-it-for-inline", "0.1.1"
   gem "rails-assets-markdown-it-sub",                     "1.0.0"
   gem "rails-assets-markdown-it-sup",                     "1.0.0"
+  gem "rails-assets-markdown-it-html5-embed",             "0.1.0"
   gem "rails-assets-highlightjs",                         "8.6.0"
   gem "rails-assets-typeahead.js",                        "0.11.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -579,6 +579,7 @@ GEM
     rails-assets-markdown-it (4.4.0)
     rails-assets-markdown-it-diaspora-mention (0.3.0)
     rails-assets-markdown-it-hashtag (0.3.1)
+    rails-assets-markdown-it-html5-embed (0.1.0)
     rails-assets-markdown-it-sanitizer (0.3.2)
     rails-assets-markdown-it-sub (1.0.0)
     rails-assets-markdown-it-sup (1.0.0)
@@ -877,6 +878,7 @@ DEPENDENCIES
   rails-assets-markdown-it--markdown-it-for-inline (= 0.1.1)!
   rails-assets-markdown-it-diaspora-mention (= 0.3.0)!
   rails-assets-markdown-it-hashtag (= 0.3.1)!
+  rails-assets-markdown-it-html5-embed (= 0.1.0)!
   rails-assets-markdown-it-sanitizer (= 0.3.2)!
   rails-assets-markdown-it-sub (= 1.0.0)!
   rails-assets-markdown-it-sup (= 1.0.0)!

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -31,6 +31,7 @@
 //= require markdown-it-sanitizer
 //= require markdown-it-sub
 //= require markdown-it-sup
+//= require markdown-it-html5-embed
 //= require highlightjs
 //= require clear-form
 //= require typeahead.js


### PR DESCRIPTION
Enabling markdown-it-html5-embed plugin so user can embed audio and video using markdown syntax in the HTML5 way (solves #4601).
