### PR TITLE
Hide publisher cancel button on xsmall screens

### DIFF
--- a/app/assets/stylesheets/publisher.scss
+++ b/app/assets/stylesheets/publisher.scss
@@ -48,15 +48,6 @@
         }
       }
 
-      $sm-xs-average: ($screen-sm + $screen-xs) / 2;
-      @media(max-width: $sm-xs-average) {
-        #hide_publisher {
-          display: block;
-          width: 100%;
-          margin-bottom: 5px;
-        }
-      }
-
       @media(max-width: $screen-xs) {
         .btn-toolbar {
           width: 100%;

--- a/app/views/publisher/_publisher.html.haml
+++ b/app/views/publisher/_publisher.html.haml
@@ -55,7 +55,7 @@
           .spinner
       .options_and_submit.col-sm-12
         .public_toggle.clearfix
-          .btn.btn-default.pull-left#hide_publisher{title: t("shared.publisher.discard_post")}
+          .btn.btn-default.pull-left.hidden-xs#hide_publisher{title: t("shared.publisher.discard_post")}
             %span.text= t("cancel")
 
           .btn-toolbar.pull-right


### PR DESCRIPTION
As said on https://github.com/diaspora/diaspora/pull/6336 I think the "Remove all text" feature of the publisher is not that useful compare to the risk of a misclick on that very big button.
