### PR TITLE
Improved getting_started redirect

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -139,7 +139,12 @@ class ApplicationController < ActionController::Base
   end
 
   def current_user_redirect_path
-    current_user.getting_started? ? getting_started_path : stream_path
+    # If getting started is active AND the user has not completed the getting_started page
+    if current_user.getting_started? && !current_user.basic_profile_present?
+      getting_started_path
+    else
+      stream_path
+    end
   end
 
   def gon_set_appconfig

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -422,6 +422,10 @@ class User < ActiveRecord::Base
     Postzord::Dispatcher.build(self, profile).post
   end
 
+  def basic_profile_present?
+    tag_followings.any? || profile[:image_url]
+  end
+
   ###Helpers############
   def self.build(opts = {})
     u = User.new(opts.except(:person, :id))

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -20,7 +20,7 @@ describe ApplicationController, :type => :controller do
       get :index
       expect(response.headers['X-Diaspora-Version']).to include AppConfig.version.number.get
     end
-    
+
     context 'with git info' do
       before do
         allow(AppConfig).to receive(:git_available?).and_return(true)
@@ -86,8 +86,34 @@ describe ApplicationController, :type => :controller do
         alice.update_attribute(:getting_started, true)
       end
 
-      it "redirects to getting started if the user has getting started set to true" do
+      it "redirects to getting started if the user has getting started set to true and a blank profile" do
         expect(@controller.send(:after_sign_in_path_for, alice)).to eq(getting_started_path)
+      end
+    end
+
+    context "getting started true and one tag present on user" do
+      before do
+        alice.update_attribute(:getting_started, true)
+        @tag = ActsAsTaggableOn::Tag.create!(name: "partytimeexcellent")
+        allow(@controller).to receive(:current_user).and_return(alice)
+        TagFollowing.create!(tag: @tag, user: alice)
+      end
+
+      it "redirects to stream if the user has getting started set to true and has already added tags" do
+        expect(@controller.send(:after_sign_in_path_for, alice)).to eq(stream_path)
+      end
+    end
+
+    context "getting started true and user image present on user" do
+      before do
+        alice.update_attribute(:getting_started, true)
+        # Just set the image url...
+        alice.profile.image_url = "something not nil"
+        allow(@controller).to receive(:current_user).and_return(alice)
+      end
+
+      it "redirects to stream if the user has getting started set to true and has already added a photo" do
+        expect(@controller.send(:after_sign_in_path_for, alice)).to eq(stream_path)
       end
     end
   end


### PR DESCRIPTION
Only redirect users with getting_started active to the getting_started page if they have not made changes there (avatar, tags). The display of getting-started-hints on the stream is unaffected by this.

Solves #6416.
