### PR TITLE
Added avatar image fallback for notifications

### DIFF
--- a/app/assets/javascripts/app/views/notification_dropdown_view.js
+++ b/app/assets/javascripts/app/views/notification_dropdown_view.js
@@ -101,6 +101,7 @@ app.views.NotificationDropdown = app.views.Base.extend({
         if($.inArray(notification, notifications) === -1){
           var node = self.dropdownNotifications.append(notification.note_html);
           $(node).find(".unread-toggle .entypo-eye").tooltip("destroy").tooltip();
+          $(node).find(self.avatars.selector).error(self.avatars.fallback);
         }
       });
     });


### PR DESCRIPTION
Added avatar image fallback for notifications (since the default fallback from the base-view is not applied).

I already did so before, but somehow this was not merged or never completed... don't know why.
(see: #5669 and my PR for the base-view, to see that this method works: #5638 )

This will fix #6149.
