### PR TITLE
Add DatabaseSizeControl sidetiq job

### DIFF
--- a/app/workers/database_size_control.rb
+++ b/app/workers/database_size_control.rb
@@ -1,0 +1,41 @@
+
+module Workers
+  class DatabaseSizeControl < Base
+    include Sidetiq::Schedulable
+
+    sidekiq_options queue: :maintenance
+
+    recurrence { daily }
+
+    def perform
+      return unless AppConfig.settings.maintenance.database_size_control.enable?
+      remove_signatures
+    end
+
+    def remove_signatures
+      return unless AppConfig.settings.maintenance.database_size_control.remove_old_participations_after?
+      remove_before_date = Time.zone.today -
+        (AppConfig.settings.maintenance.database_size_control.remove_old_participations_after.to_i).days
+      remove_like_sigs(remove_before_date)
+      remove_participation_sigs(remove_before_date)
+    end
+
+    def remove_participation_sigs(remove_before_date)
+      removals = Participation.where(
+        "created_at < ? and (author_signature is not null or parent_author_signature is not null)",
+        remove_before_date).update_all(
+          author_signature: nil, parent_author_signature: nil
+        )
+      logger.info "DatabaseSizeControl: nullified #{removals} signatures from the participations table"
+    end
+
+    def remove_like_sigs(remove_before_date)
+      removals = Like.where(
+        "created_at < ? and (author_signature is not null or parent_author_signature is not null)",
+        remove_before_date).update_all(
+          author_signature: nil, parent_author_signature: nil
+        )
+      logger.info "DatabaseSizeControl: nullified #{removals} signatures from the likes table"
+    end
+  end
+end

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -154,7 +154,10 @@ defaults:
         enable: false
         after_days: 730
         warn_days: 30
-        limit_removals_to_per_day: 100
+        limit_removals_to_per_day: 100  
+      database_size_control:
+        enable: false
+        remove_old_participations_after: 365
     source_url:
     default_color_theme: "original"
   services:

--- a/config/diaspora.yml.example
+++ b/config/diaspora.yml.example
@@ -587,6 +587,20 @@ configuration: ## Section
         ## Limit queuing for removal per day.
         #limit_removals_to_per_day: 100
 
+      ## Database size control allows purging selected old data from the database
+      ## automatically.
+      database_size_control:
+
+        # Enable first database size control
+        #enable: true
+
+        # Like and Participations contain signatures that allow the like or participation
+        # to be retracted later. Unfortunately, these signatures make up most of the data
+        # in a regular pod. Removing the signatures will not remove the likes or participations,
+        # it will just make it impossible for remote users to remove them. Local users will still
+        # be able to remove their likes even after the signatures are removed.
+        #remove_old_participations_after: 365
+
     ## Source code URL
     ## URL to the source code your pod is currently running.
     ## If not set your pod will provide a downloadable archive.

--- a/lib/tasks/maintenance.rake
+++ b/lib/tasks/maintenance.rake
@@ -36,7 +36,7 @@ RUBY
       puts "Could not install logrotate configs. Perhaps you should try running this task as root and ensuring logrotate is installed:\n#{logrotate_conf}"
     end
   end
-  
+
   desc "Queue users for removal"
   task :queue_users_for_removal => :environment do
     # Queue users for removal due to inactivity
@@ -44,5 +44,10 @@ RUBY
     # must still be enabled, this only bypasses
     # scheduling to run the queuing immediately
     Workers::QueueUsersForRemoval.perform_async
+  end
+
+  desc "Database size control"
+  task :database_size_control => :environment do
+    Workers::DatabaseSizeControl.perform_async
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -56,6 +56,8 @@ FactoryGirl.define do
   factory :like do
     association :author, :factory => :person
     association :target, :factory => :status_message
+    author_signature "author_signature"
+    parent_author_signature "parent_author_signature"
   end
 
   factory :user do

--- a/spec/workers/database_size_control_spec.rb
+++ b/spec/workers/database_size_control_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+
+describe Workers::DatabaseSizeControl do
+  describe "database size control is active" do
+    before do
+      AppConfig.settings.maintenance.database_size_control.enable = true
+      AppConfig.settings.maintenance.database_size_control.remove_old_participations_after = 1
+    end
+
+    it "#removes signatures from likes older than set time" do
+      like = FactoryGirl.create(
+        :like, created_at: 2.days.ago, author_signature: "foobar", parent_author_signature: "barfoo"
+      )
+      like2 = FactoryGirl.create(
+        :like, created_at: Time.zone.today, author_signature: "foobar", parent_author_signature: "barfoo"
+      )
+      Workers::DatabaseSizeControl.new.perform
+      like = Like.find(like.id)
+      like2 = Like.find(like2.id)
+      expect(like.author_signature).to be_nil
+      expect(like2.author_signature).to eq("foobar")
+      expect(like.parent_author_signature).to be_nil
+      expect(like2.parent_author_signature).to eq("barfoo")
+    end
+  end
+end
+
+describe Workers::DatabaseSizeControl do
+  describe "database size control is inactive" do
+    before do
+      AppConfig.settings.maintenance.database_size_control.enable = false
+      AppConfig.settings.maintenance.database_size_control.remove_old_participations_after = 1
+    end
+
+    it "#does not remove any signatures" do
+      like = FactoryGirl.create(
+        :like, created_at: 2.days.ago, author_signature: "foobar", parent_author_signature: "barfoo"
+      )
+      Workers::DatabaseSizeControl.new.perform
+      like = Like.find(like.id)
+      expect(like.author_signature).to eq("foobar")
+      expect(like.parent_author_signature).to eq("barfoo")
+    end
+  end
+end


### PR DESCRIPTION
Cleans initially author signatures from old Like and Participations tables. These signatures take a huge amount of space in the database and their only function is to allow retraction of likes and participations. Allow podmins to define a set of days that these are kept, by default the cleaning is off with a default of 365 days.

Closes #4920

TODO:
- [ ] Do default terms need a if to print out some text regarding cleaning of data if enabled?
