### PR TITLE
Remove old stream instance when reloading the stream

### DIFF
--- a/app/assets/javascripts/app/router.js
+++ b/app/assets/javascripts/app/router.js
@@ -104,6 +104,10 @@ app.Router = Backbone.Router.extend({
   //below here is oldness
 
   stream : function() {
+    if(app.page) {
+      app.page.unbindInfScroll();
+      app.page.remove();
+    }
     app.stream = new app.models.Stream();
     app.stream.fetch();
     app.page = new app.views.Stream({model : app.stream});


### PR DESCRIPTION
Otherwise there would be multiple instances after some reloads which are all listening to scroll events and all instances except for the current one will try to load more posts every time which makes the page really slow and is bad for the UX.
