### PR TITLE
Improve federation regarding reshares and root post author

### DIFF
--- a/app/models/reshare.rb
+++ b/app/models/reshare.rb
@@ -59,6 +59,7 @@ class Reshare < Post
   def receive(recipient, sender)
     local_reshare = Reshare.where(:guid => self.guid).first
     if local_reshare && local_reshare.root.author_id == recipient.person.id
+      recipient.participate! self
       return unless recipient.has_contact_for?(sender)
     end
     super(recipient, sender)

--- a/lib/federated/generator.rb
+++ b/lib/federated/generator.rb
@@ -12,9 +12,18 @@ module Federated
       relayable = build(options)
       if relayable.save!
         logger.info "user:#{@user.id} dispatching #{relayable.class}:#{relayable.guid}"
+        add_root_author(relayable)
         Postzord::Dispatcher.defer_build_and_post(@user, relayable, @dispatcher_opts)
         relayable
       end
+    end
+
+    def add_root_author(relayable)
+      return unless relayable.parent.respond_to?(:root) && relayable.parent.root
+      # Comment post is a reshare, include original author in subscribers
+      root_post = relayable.parent.root
+      @dispatcher_opts[:additional_subscribers] ||= []
+      @dispatcher_opts[:additional_subscribers] << root_post.author
     end
 
     def build(options={})

--- a/spec/lib/diaspora/federated/generator_spec.rb
+++ b/spec/lib/diaspora/federated/generator_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+describe "adds root author on reshare" do
+  before do
+    @generator = Federated::Generator.new(double("user", id: 1), double)
+    @root_author = double("root_author")
+    root = double("root", author: @root_author)
+    parent = double("parent", root: root)
+    @relayable = double("relayable", parent: parent, class: "foo", guid: "123")
+  end
+
+  it "adds root to additional subscribers" do
+    @generator.add_root_author(@relayable)
+    additional_subscribers = @generator.instance_variable_get(:@dispatcher_opts)[:additional_subscribers]
+    expect(additional_subscribers).to include(@root_author)
+  end
+
+  it "calls add_root_author" do
+    allow(Postzord::Dispatcher).to receive(:defer_build_and_post).and_return(true)
+    allow(@generator).to receive(:build).and_return(@relayable)
+    allow(@relayable).to receive(:save!).and_return(true)
+    expect(@generator).to receive(:add_root_author)
+    @generator.create!
+  end
+end

--- a/spec/models/reshare_spec.rb
+++ b/spec/models/reshare_spec.rb
@@ -51,6 +51,7 @@ describe Reshare, type: :model do
       receive_reshare
       expect(@root.resharers).to include(@reshare.author)
     end
+
     it "does not error if the root author has a contact for the resharer" do
       bob.share_with @reshare.author, bob.aspects.first
       expect {
@@ -58,6 +59,12 @@ describe Reshare, type: :model do
           receive_reshare # This doesn't ever terminate on my machine before it was fixed.
         end
       }.not_to raise_error
+    end
+
+    it "participates root author in the reshare" do
+      receive_reshare
+      participations = Participation.where(target_id: @reshare.id, author_id: @root.author_id)
+      expect(participations.count).to eq(1)
     end
   end
 


### PR DESCRIPTION
When author of the root post receives a reshare to it, no participation is added to the root author on the reshare. This causes any comments on the reshare on remote pods not to be sent to the author. Adding a participation should subscribe to the reshare and thus bring added comments back to the author.

Did some live testing with develop production pods to make sure of this case. Basically:
- User A posts a post on pod A
- User B, who follows user A, reshares it on pod B
- User C, who follows user B, comments on the reshare of B on pod C

Expected:
- Pod A should receive the reshare and the comment
- Pod B should receive the reshare and the comment
- Pod C should receive the reshare and the comment (has authored it)

What happens:
- Pod A receives only the reshare, not the comment
- Pod B receives the reshare and the comment
- Pod C receives the reshare and the comment (has authored it)
