### PR TITLE
Fetch notification counts

### DIFF
--- a/app/assets/javascripts/app/router.js
+++ b/app/assets/javascripts/app/router.js
@@ -188,6 +188,14 @@ app.Router = Backbone.Router.extend({
     $("#main_stream").html(app.page.render().el);
     $("#selected_aspect_contacts .content").html(streamFacesView.render().el);
     this._hideInactiveStreamLists();
+    this._ensureUpdateHeaderCounts();
+  },
+
+  _ensureUpdateHeaderCounts: function() {
+    // Update header counts if they are not polled automatically
+    if (gon.appConfig.settings.notifications.polling_interval === 0) {
+      app.header.notificationDropdown.updateHeaderCounts();
+    }
   }
 });
 // @license-end

--- a/app/assets/javascripts/app/views/notification_dropdown_view.js
+++ b/app/assets/javascripts/app/views/notification_dropdown_view.js
@@ -17,7 +17,9 @@ app.views.NotificationDropdown = app.views.Base.extend({
     this.ajaxLoader = this.dropdown.find(".ajax-loader");
     this.perfectScrollbarInitialized = false;
     this.updateHeaderCounts();
-    setInterval(this.updateHeaderCounts, 30000);
+    if (gon.appConfig.settings.notifications.polling_interval > 0) {
+      setInterval(this.updateHeaderCounts, gon.appConfig.settings.notifications.polling_interval*1000);
+    }
   },
 
   toggleDropdown: function(evt){
@@ -35,6 +37,7 @@ app.views.NotificationDropdown = app.views.Base.extend({
   showDropdown: function(){
     this.resetParams();
     this.ajaxLoader.show();
+    this.updateHeaderCounts();
     this.dropdown.addClass("dropdown-open");
     this.updateScrollbar();
     this.dropdownNotifications.addClass("loading");
@@ -107,7 +110,6 @@ app.views.NotificationDropdown = app.views.Base.extend({
         }
       });
     });
-    this.updateHeaderCounts();
 
     this.hideAjaxLoader();
 

--- a/app/assets/javascripts/app/views/notification_dropdown_view.js
+++ b/app/assets/javascripts/app/views/notification_dropdown_view.js
@@ -16,6 +16,8 @@ app.views.NotificationDropdown = app.views.Base.extend({
     this.dropdownNotifications = this.dropdown.find(".notifications");
     this.ajaxLoader = this.dropdown.find(".ajax-loader");
     this.perfectScrollbarInitialized = false;
+    this.updateHeaderCounts();
+    setInterval(this.updateHeaderCounts, 30000);
   },
 
   toggleDropdown: function(evt){
@@ -105,6 +107,7 @@ app.views.NotificationDropdown = app.views.Base.extend({
         }
       });
     });
+    this.updateHeaderCounts();
 
     this.hideAjaxLoader();
 
@@ -131,6 +134,22 @@ app.views.NotificationDropdown = app.views.Base.extend({
       this.dropdownNotifications.perfectScrollbar("destroy");
       this.perfectScrollbarInitialized = false;
     }
+  },
+
+  updateHeaderCounts: function() {
+    $.getJSON(Routes.notificationsCounts(), function(data) {
+      var headerBadge = $(".notifications-link .badge"),
+        markAllReadLink = $("a#mark_all_read_link");
+      if (data.notifications > 0) {
+        headerBadge.html(parseInt(data.notifications));
+        headerBadge.removeClass("hidden");
+        markAllReadLink.removeClass("enabled");
+      } else {
+        headerBadge.addClass("hidden");
+        headerBadge.html(0);
+        markAllReadLink.removeClass("disabled");
+      }
+    });
   }
 });
 // @license-end

--- a/app/assets/templates/header_tpl.jst.hbs
+++ b/app/assets/templates/header_tpl.jst.hbs
@@ -9,7 +9,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a href="/stream" class="navbar-brand" data-stream-title="{{t "my_stream"}}">
+          <a href="/stream" rel="backbone" class="navbar-brand" data-stream-title="{{t "my_stream"}}">
             {{ podname }}
           </a>
           <ul class="nav nav-badges visible-sm visible-xs">
@@ -34,8 +34,8 @@
 
         <div class="collapse navbar-collapse" id="navbar-collapse">
           <ul class="nav navbar-nav navbar-left">
-            <li><a href="/stream">{{t "my_stream"}}</a></li>
-            <li><a href="/activity">{{t "my_activity"}}</a></li>
+            <li><a href="/stream" rel="backbone">{{t "my_stream"}}</a></li>
+            <li><a href="/activity" rel="backbone">{{t "my_activity"}}</a></li>
             <li class="visible-sm visible-xs"><a href="/mobile/toggle">{{t "header.toggle_mobile"}}</a></li>
           </ul>
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -150,7 +150,10 @@ class ApplicationController < ActionController::Base
   def gon_set_appconfig
     gon.push(appConfig: {
                chat:     {enabled: AppConfig.chat.enabled?},
-               settings: {podname: AppConfig.settings.pod_name},
+               settings: {
+                 podname: AppConfig.settings.pod_name,
+                 notifications: AppConfig.settings.notifications
+               },
                map:      {mapbox: AppConfig.map.mapbox}
              })
   end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -5,6 +5,8 @@
 class NotificationsController < ApplicationController
   before_action :authenticate_user!
 
+  respond_to :json, only: :counts
+
   def update
     note = Notification.where(:recipient_id => current_user.id, :id => params[:id]).first
     if note
@@ -78,4 +80,9 @@ class NotificationsController < ApplicationController
 
   end
 
+  def counts
+    render json: {
+      notifications: current_user.unread_notifications.count
+    }
+  end
 end

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -157,6 +157,8 @@ defaults:
         limit_removals_to_per_day: 100
     source_url:
     default_color_theme: "original"
+    notifications:
+      polling_interval: 30
   services:
     facebook:
       enable: false

--- a/config/diaspora.yml.example
+++ b/config/diaspora.yml.example
@@ -599,6 +599,13 @@ configuration: ## Section
     ## ("original" for the theme in "app/assets/stylesheets/color_themes/original/", for
     ## example).
     #default_color_theme: "original"
+
+    ## Notifications
+    notifications:  ## Section
+      ## Interval which clients should poll for unread notification counts, in seconds
+      ## Set to 0 for no background polling
+      #polling_interval: 30
+
   ## Posting from Diaspora to external services (all are disabled by default).
   services: ## Section
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,7 @@ Diaspora::Application.routes.draw do
     end
   end
 
+  get "notifications/counts" => "notifications#counts"
 
   resources :tags, :only => [:index]
 

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -181,4 +181,19 @@ describe NotificationsController, :type => :controller do
       expect(response).not_to be_redirect
     end
   end
+
+  describe "counts" do
+    it "succeeds" do
+      get :counts
+      expect(response).to be_success
+    end
+
+    it "returns unread notifications count" do
+      post = FactoryGirl.create(:status_message)
+      FactoryGirl.create(:notification, recipient: alice, target: post)
+      FactoryGirl.create(:notification, recipient: alice, target: post, unread: false)
+      get :counts
+      expect(response.body).to eq('{"notifications":1}')
+    end
+  end
 end


### PR DESCRIPTION
Add route for polling unread notification counts. Add polling to JS every 30 seconds to refresh the count.

Fixes #6473 and #5780 
Also partly addresses #3890

TODO's
- [ ] Jasmine tests
- [ ] Waiting for additional input from @svbergerem re code placement
- [ ] Also support conversation counts
- [ ] Make polling inactive when tab is not visible

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/diaspora/diaspora/6493)

<!-- Reviewable:end -->
