### PR TITLE
Remove the lines from inlined_jobs.rb which never get called.

### DIFF
--- a/spec/support/inlined_jobs.rb
+++ b/spec/support/inlined_jobs.rb
@@ -4,7 +4,5 @@ module HelperMethods
     result = yield Sidekiq::Worker
     Sidekiq::Worker.drain_all
     result
-  rescue NoMethodError
-    yield Sidekiq::Worker if block_given? # Never error out on our own
   end
 end


### PR DESCRIPTION
Tests result doesn't change with removing of this lines.

With this lines if the test fails with NoMethodError calls given block for the second time which won't help and will confuse a tester.
