### PR TITLE
Don't set key for logfile on Heroku

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,7 +1,9 @@
 <% require_relative 'config/load_config' %>
 ---
 :verbose: false
-:logfile: "<%= AppConfig.sidekiq_log unless AppConfig.heroku? %>"
+<% unless AppConfig.heroku? %>
+:logfile: "<%= AppConfig.sidekiq_log %>"
+<% end %>
 :concurrency: <%= AppConfig.environment.sidekiq.concurrency.to_i %>
 :queues:
   - socket_webfinger


### PR DESCRIPTION
This fixes the issue reported in #5947. Sidekiq will only log to stdout when this key evals to false, so this can't be forced with an empty string. This change eliminates the key altogether when running on Heroku.
