### PR TITLE
A prototype for the federation message generation automated tests.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,8 @@ gem "unicorn", "4.9.0", require: false
 
 # Federation
 
-gem "diaspora_federation-rails", "0.0.8"
+gem 'diaspora_federation-rails', :git => "https://github.com/SuperTux88/diaspora_federation.git", :branch => "salmon"
+
 
 # API and JSON
 
@@ -282,6 +283,8 @@ group :test do
   gem "timecop",            "0.8.0"
   gem "webmock",            "1.21.0", require: false
   gem "shoulda-matchers",   "2.8.0", require: false
+
+  gem "federation-testbed", :git => "https://github.com/cmrd-senya/federation-testbed.git", :branch => "shape-into-gem"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,26 @@
+GIT
+  remote: https://github.com/SuperTux88/diaspora_federation.git
+  revision: cc63cfe285a55212b40ddffc43279db0afbf83f8
+  branch: salmon
+  specs:
+    diaspora_federation (0.0.8)
+      faraday (~> 0.9.0)
+      faraday_middleware (~> 0.10.0)
+      nokogiri (~> 1.6, >= 1.6.6)
+      typhoeus (~> 0.7)
+      valid (~> 1.0)
+    diaspora_federation-rails (0.0.8)
+      diaspora_federation (= 0.0.8)
+      rails (~> 4.2)
+
+GIT
+  remote: https://github.com/cmrd-senya/federation-testbed.git
+  revision: f712789aa6da3e8ff440cd9d4f72fdad9e42d676
+  branch: shape-into-gem
+  specs:
+    federation-testbed (0.1.0)
+      rest-client
+
 GEM
   remote: https://rubygems.org/
   remote: https://rails-assets.org/
@@ -154,15 +177,6 @@ GEM
       eventmachine (~> 1.0.8)
       http_parser.rb (~> 0.6)
       nokogiri (~> 1.6)
-    diaspora_federation (0.0.8)
-      faraday (~> 0.9.0)
-      faraday_middleware (~> 0.10.0)
-      nokogiri (~> 1.6, >= 1.6.6)
-      typhoeus (~> 0.7)
-      valid (~> 1.0)
-    diaspora_federation-rails (0.0.8)
-      diaspora_federation (= 0.0.8)
-      rails (~> 4.2)
     diff-lcs (1.2.5)
     docile (1.1.5)
     domain_name (0.5.24)
@@ -458,6 +472,7 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.2)
+    netrc (0.10.3)
     nio4r (1.1.1)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
@@ -644,6 +659,10 @@ GEM
     request_store (1.2.0)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     roxml (3.1.6)
       activesupport (>= 2.3.0)
       nokogiri (>= 1.3.3)
@@ -783,7 +802,7 @@ GEM
       raindrops (~> 0.7)
     uuid (2.3.8)
       macaddr (~> 1.0)
-    valid (1.0.2)
+    valid (1.1.0)
     warden (1.2.3)
       rack (>= 1.0)
     webmock (1.21.0)
@@ -818,13 +837,14 @@ DEPENDENCIES
   devise-token_authenticatable (~> 0.4.0)
   devise_lastseenable (= 0.0.6)
   diaspora-vines (~> 0.2.0.develop)
-  diaspora_federation-rails (= 0.0.8)
+  diaspora_federation-rails!
   entypo-rails (= 3.0.0.pre.rc2)
   eye (= 0.7)
   factory_girl_rails (= 4.5.0)
   faraday (= 0.9.1)
   faraday-cookie_jar (= 0.0.6)
   faraday_middleware (= 0.10.0)
+  federation-testbed!
   fixture_builder (= 0.4.1)
   fog (= 1.34.0)
   fuubar (= 2.0.0)

--- a/app/models/pod.rb
+++ b/app/models/pod.rb
@@ -25,7 +25,9 @@ class Pod < ActiveRecord::Base
 
   class << self
     def find_or_create_by(opts) # Rename this method to not override an AR method
-      u = URI.parse(opts.fetch(:url))
+      url = opts.fetch(:url)
+      return if url.nil?
+      u = URI.parse(url)
       find_or_initialize_by(host: u.host).tap do |pod|
         unless pod.persisted?
           pod.ssl = (u.scheme == "https")

--- a/spec/federation_messages/federation_messages_spec.rb
+++ b/spec/federation_messages/federation_messages_spec.rb
@@ -1,0 +1,42 @@
+require "spec_helper"
+require "federation-testbed"
+
+describe "Generation and dispatch of federation messages" do
+  before :all do
+    @testbed_pod = FactoryGirl.build(:pod).host
+    FederationTestbed.config.configure(
+      "testbed_config" => {"host" => @testbed_pod, "method" => "http"},
+      "test_target"    => {
+        "method" => "http",
+        "host"   => "localhost:3000",
+        "user"   => "alice"
+      }
+    )
+    u = FederationTestbed::User.new
+    u.id = alice.diaspora_handle
+    u.public_key = alice.public_key
+    u.private_key = nil
+    FederationTestbed.test_data.push(u)
+    rack_app = FederationTestbed::App.new
+    stub_request(:get, Addressable::Template.new(@testbed_pod + "/.well-known/host-meta")).to_rack(rack_app)
+    stub_request(:get, Addressable::Template.new(@testbed_pod + "/webfinger?q=acct:test@" + @testbed_pod))
+      .to_rack(rack_app)
+    stub_request(:get, Addressable::Template.new(@testbed_pod + "/hcard/users/test@" + @testbed_pod))
+      .to_rack(rack_app)
+    stub_request(:post, Addressable::Template.new(@testbed_pod + "/receive/users/{guid}")).to_rack(rack_app)
+  end
+  before do
+    allow_any_instance_of(Postzord::Dispatcher::Private).to receive(:deliver_to_remote).and_call_original
+    allow_any_instance_of(Postzord::Dispatcher::Public).to receive(:deliver_to_remote).and_call_original
+  end
+  after :all do
+  end
+
+  describe "user share request" do
+    it "works" do
+      friend = Person.find_or_fetch_by_identifier("test@" + @testbed_pod)
+      expect(friend).not_to be_nil
+      expect(alice.share_with(friend, alice.aspects.first)).not_to be_falsy
+    end
+  end
+end


### PR DESCRIPTION
This is a prototype made in purpose to try and implement an automated
way of testing federation. This patch contains a test for an outgoing
federation message.

The test case loads [federation-testbed](https://github.com/cmrd-senya/federation-testbed/tree/shape-into-gem) as a gem. It uses an embedded
Sinatra web application of the testbed and stubs outgoing federated
calls to it. The testbed application process queries as if it was a real
Diaspora pod and fails a test in case when the received message
is inconsistent.

This is an early version used to highlight difficulties and issues
of the approach and implementation. Development versions of the
involved gems are used.

refs #5114 #6479

**For some reason `bin/rake spec` gets broken with this. Help wanted!**

While the newly added test runs fine if run alone with `bin/rspec spec/federation_messages/federation_messages_spec.rb`, the whole thing gets broken - running `bin/rake spec` produces [weird output](https://gist.github.com/cmrd-senya/cf18acdc42b0c5849874#file-rake-spec-log-L64). The highlighted line points to some bundler message. So that is probably just some problem cause by using git versions of gems. I am pretty sure, that it's not my fault!
