### PR TITLE
Consolidate amount of sidekiq queues from 13 to 5

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -30,6 +30,16 @@ bind to an UNIX socket at `unix:tmp/diaspora.sock`. Please change your local
 
 With the port to Bootstrap 3, app/views/terms/default.haml has a new structure. If you have created a customised app/views/terms/terms.haml or app/views/terms/terms.erb file, you will need to edit those files to base your customisations on the new default.haml file.
 
+## Sidekiq queue changes
+
+We've decreased the amount of sidekiq queues from 13 to 5 in PR [#6530](https://github.com/diaspora/diaspora/pull/6530).
+The new queues are organized according to priority for the jobs they will process. When upgrading please make sure to 
+empty the sidekiq queues before shutting down the server for an update.
+
+If you run your sidekiq with a custom queue configuration, please make sure to update that for the new queues.
+
+The new queues are: `urgent, high, medium, low, default`.
+
 ## Refactor
 * Improve bookmarklet [#5904](https://github.com/diaspora/diaspora/pull/5904)
 * Update listen configuration to listen on unix sockets by default [#5974](https://github.com/diaspora/diaspora/pull/5974)
@@ -59,6 +69,7 @@ With the port to Bootstrap 3, app/views/terms/default.haml has a new structure. 
 * Replace mobile background with color [#6415](https://github.com/diaspora/diaspora/pull/6415)
 * Port flash messages to backbone [#6395](https://github.com/diaspora/diaspora/6395)
 * Change login/registration/forgot password button color [#6504](https://github.com/diaspora/diaspora/pull/6504)
+* Consolidate sidekiq queues [#6530](https://github.com/diaspora/diaspora/pull/6530)
 
 ## Bug fixes
 * Destroy Participation when removing interactions with a post [#5852](https://github.com/diaspora/diaspora/pull/5852)

--- a/app/workers/clean_cached_files.rb
+++ b/app/workers/clean_cached_files.rb
@@ -2,7 +2,7 @@ module Workers
   class CleanCachedFiles < Base
     include Sidetiq::Schedulable
 
-    sidekiq_options queue: :maintenance
+    sidekiq_options queue: :low
 
     recurrence { daily }
 

--- a/app/workers/deferred_dispatch.rb
+++ b/app/workers/deferred_dispatch.rb
@@ -4,7 +4,7 @@
 
 module Workers
   class DeferredDispatch < Base
-    sidekiq_options queue: :dispatch
+    sidekiq_options queue: :high
 
     def perform(user_id, object_class_name, object_id, opts)
       user = User.find(user_id)

--- a/app/workers/delete_account.rb
+++ b/app/workers/delete_account.rb
@@ -5,7 +5,7 @@
 
 module Workers
   class DeleteAccount < Base
-    sidekiq_options queue: :delete_account
+    sidekiq_options queue: :low
     
     def perform(account_deletion_id)
       account_deletion = AccountDeletion.find(account_deletion_id)

--- a/app/workers/delete_post_from_service.rb
+++ b/app/workers/delete_post_from_service.rb
@@ -4,7 +4,7 @@
 #
 module Workers
   class DeletePostFromService < Base
-    sidekiq_options queue: :http_service
+    sidekiq_options queue: :high
 
     def perform(service_id, post_id)
       service = Service.find_by_id(service_id)

--- a/app/workers/export_photos.rb
+++ b/app/workers/export_photos.rb
@@ -5,7 +5,7 @@
 
 module Workers
   class ExportPhotos < Base
-    sidekiq_options queue: :export
+    sidekiq_options queue: :low
 
     def perform(user_id)
       @user = User.find(user_id)

--- a/app/workers/export_user.rb
+++ b/app/workers/export_user.rb
@@ -5,7 +5,7 @@
 
 module Workers
   class ExportUser < Base
-    sidekiq_options queue: :export
+    sidekiq_options queue: :low
 
     def perform(user_id)
       @user = User.find(user_id)

--- a/app/workers/fetch_profile_photo.rb
+++ b/app/workers/fetch_profile_photo.rb
@@ -5,7 +5,7 @@
 
 module Workers
   class FetchProfilePhoto < Base
-    sidekiq_options queue: :photos
+    sidekiq_options queue: :medium
 
     def perform(user_id, service_id, fallback_image_url = nil)
       service = Service.find(service_id)

--- a/app/workers/fetch_public_posts.rb
+++ b/app/workers/fetch_public_posts.rb
@@ -4,7 +4,7 @@
 
 module Workers
   class FetchPublicPosts < Base
-    sidekiq_options queue: :http_service
+    sidekiq_options queue: :medium
 
     def perform(diaspora_id)
       Diaspora::Fetcher::Public.new.fetch!(diaspora_id)

--- a/app/workers/fetch_webfinger.rb
+++ b/app/workers/fetch_webfinger.rb
@@ -4,7 +4,7 @@
 
 module Workers
   class FetchWebfinger < Base
-    sidekiq_options queue: :socket_webfinger
+    sidekiq_options queue: :urgent
 
     def perform(account)
       person = Person.find_or_fetch_by_identifier(account)

--- a/app/workers/gather_o_embed_data.rb
+++ b/app/workers/gather_o_embed_data.rb
@@ -5,7 +5,7 @@
 
 module Workers
   class GatherOEmbedData < Base
-    sidekiq_options queue: :http_service
+    sidekiq_options queue: :medium
 
     def perform(post_id, url, retry_count=1)
       post = Post.find(post_id)

--- a/app/workers/gather_open_graph_data.rb
+++ b/app/workers/gather_open_graph_data.rb
@@ -5,7 +5,7 @@
 
 module Workers
   class GatherOpenGraphData < Base
-    sidekiq_options queue: :http_service
+    sidekiq_options queue: :medium
 
     def perform(post_id, url, retry_count=1)
       post = Post.find(post_id)

--- a/app/workers/http_multi.rb
+++ b/app/workers/http_multi.rb
@@ -4,7 +4,7 @@
 
 module Workers
   class HttpMulti < Base
-    sidekiq_options queue: :http
+    sidekiq_options queue: :medium
 
     MAX_RETRIES = 3
     ABANDON_ON_CODES=[:peer_failed_verification, # Certificate does not match URL

--- a/app/workers/mail/also_commented.rb
+++ b/app/workers/mail/also_commented.rb
@@ -1,7 +1,7 @@
 module Workers
   module Mail
     class AlsoCommented < Base
-      sidekiq_options queue: :mail
+      sidekiq_options queue: :low
 
       def perform(recipient_id, sender_id, comment_id)
         if email = Notifier.also_commented(recipient_id, sender_id, comment_id)

--- a/app/workers/mail/comment_on_post.rb
+++ b/app/workers/mail/comment_on_post.rb
@@ -1,7 +1,7 @@
 module Workers
   module Mail
     class CommentOnPost < Base
-      sidekiq_options queue: :mail
+      sidekiq_options queue: :low
 
       def perform(recipient_id, sender_id, comment_id)
         Notifier.comment_on_post(recipient_id, sender_id, comment_id).deliver_now

--- a/app/workers/mail/confirm_email.rb
+++ b/app/workers/mail/confirm_email.rb
@@ -1,7 +1,7 @@
 module Workers
   module Mail
     class ConfirmEmail < Base
-      sidekiq_options queue: :mail
+      sidekiq_options queue: :low
       
       def perform(user_id)
         Notifier.confirm_email(user_id).deliver_now

--- a/app/workers/mail/invite_email.rb
+++ b/app/workers/mail/invite_email.rb
@@ -5,7 +5,7 @@
 module Workers
   module Mail
     class InviteEmail < Base
-      sidekiq_options queue: :mail
+      sidekiq_options queue: :low
 
       def perform(emails, inviter_id, options={})
         EmailInviter.new(emails, User.find(inviter_id), options).send!

--- a/app/workers/mail/liked.rb
+++ b/app/workers/mail/liked.rb
@@ -1,7 +1,7 @@
 module Workers
   module Mail
     class Liked < Base
-      sidekiq_options queue: :mail
+      sidekiq_options queue: :low
 
       def perform(recipient_id, sender_id, like_id)
         Notifier.liked(recipient_id, sender_id, like_id).deliver_now

--- a/app/workers/mail/mentioned.rb
+++ b/app/workers/mail/mentioned.rb
@@ -6,7 +6,7 @@
 module Workers
   module Mail
     class Mentioned < Base
-      sidekiq_options queue: :mail
+      sidekiq_options queue: :low
       
       def perform(recipient_id, actor_id, target_id)
         Notifier.mentioned( recipient_id, actor_id, target_id).deliver_now

--- a/app/workers/mail/private_message.rb
+++ b/app/workers/mail/private_message.rb
@@ -6,7 +6,7 @@
 module Workers
   module Mail
     class PrivateMessage < Base
-      sidekiq_options queue: :mail
+      sidekiq_options queue: :low
       
       def perform(recipient_id, actor_id, target_id)
         Notifier.private_message( recipient_id, actor_id, target_id).deliver_now

--- a/app/workers/mail/report_worker.rb
+++ b/app/workers/mail/report_worker.rb
@@ -1,7 +1,7 @@
 module Workers
   module Mail
     class ReportWorker < Base
-      sidekiq_options queue: :mail
+      sidekiq_options queue: :low
 
       def perform(type, id)
         ReportMailer.new_report(type, id).each(&:deliver_now)

--- a/app/workers/mail/reshared.rb
+++ b/app/workers/mail/reshared.rb
@@ -1,7 +1,7 @@
 module Workers
   module Mail
     class Reshared < Base
-      sidekiq_options queue: :mail
+      sidekiq_options queue: :low
       
       def perform(recipient_id, sender_id, reshare_id)
         Notifier.reshared(recipient_id, sender_id, reshare_id).deliver_now

--- a/app/workers/mail/started_sharing.rb
+++ b/app/workers/mail/started_sharing.rb
@@ -6,7 +6,7 @@
 module Workers
   module Mail
     class StartedSharing < Base
-      sidekiq_options queue: :mail
+      sidekiq_options queue: :low
       
       def perform(recipient_id, sender_id, target_id)
         Notifier.started_sharing(recipient_id, sender_id).deliver_now

--- a/app/workers/notify_local_users.rb
+++ b/app/workers/notify_local_users.rb
@@ -4,7 +4,7 @@
 
 module Workers
   class NotifyLocalUsers < Base
-    sidekiq_options queue: :receive_local
+    sidekiq_options queue: :high
 
     def perform(user_ids, object_klass, object_id, person_id)
 

--- a/app/workers/post_to_service.rb
+++ b/app/workers/post_to_service.rb
@@ -4,7 +4,7 @@
 #
 module Workers
   class PostToService < Base
-    sidekiq_options queue: :http_service
+    sidekiq_options queue: :medium
 
     def perform(service_id, post_id, url)
       service = Service.find_by_id(service_id)

--- a/app/workers/process_photo.rb
+++ b/app/workers/process_photo.rb
@@ -5,7 +5,7 @@
 
 module Workers
   class ProcessPhoto < Base
-    sidekiq_options queue: :photos
+    sidekiq_options queue: :low
 
     def perform(id)
       photo = Photo.find(id)

--- a/app/workers/publish_to_hub.rb
+++ b/app/workers/publish_to_hub.rb
@@ -4,7 +4,7 @@
 
 module Workers
   class PublishToHub < Base
-    sidekiq_options queue: :http_service
+    sidekiq_options queue: :medium
 
     def perform(sender_atom_url)
       Pubsubhubbub.new(AppConfig.environment.pubsub_server.get).publish(sender_atom_url)

--- a/app/workers/queue_users_for_removal.rb
+++ b/app/workers/queue_users_for_removal.rb
@@ -6,7 +6,7 @@ module Workers
   class QueueUsersForRemoval < Base
     include Sidetiq::Schedulable
     
-    sidekiq_options queue: :maintenance
+    sidekiq_options queue: :low
     
     recurrence { daily }
     

--- a/app/workers/receive.rb
+++ b/app/workers/receive.rb
@@ -5,7 +5,7 @@
 
 module Workers
   class Receive < Base
-    sidekiq_options queue: :receive
+    sidekiq_options queue: :urgent
 
     def perform(user_id, xml, salmon_author_id)
       suppress_annoying_errors do

--- a/app/workers/receive_encrypted_salmon.rb
+++ b/app/workers/receive_encrypted_salmon.rb
@@ -5,7 +5,7 @@
 
 module Workers
   class ReceiveEncryptedSalmon < Base
-    sidekiq_options queue: :receive_salmon
+    sidekiq_options queue: :urgent
 
     def perform(user_id, xml)
       suppress_annoying_errors do

--- a/app/workers/receive_local_batch.rb
+++ b/app/workers/receive_local_batch.rb
@@ -4,7 +4,7 @@
 
 module Workers
   class ReceiveLocalBatch < Base
-    sidekiq_options queue: :receive
+    sidekiq_options queue: :urgent
 
     def perform(object_class_string, object_id, recipient_user_ids)
       object = object_class_string.constantize.find(object_id)

--- a/app/workers/receive_unencrypted_salmon.rb
+++ b/app/workers/receive_unencrypted_salmon.rb
@@ -4,7 +4,7 @@
 
 module Workers
   class ReceiveUnencryptedSalmon < Base
-    sidekiq_options queue: :receive
+    sidekiq_options queue: :urgent
 
     def perform(xml)
       suppress_annoying_errors do

--- a/app/workers/recurring_pod_check.rb
+++ b/app/workers/recurring_pod_check.rb
@@ -3,7 +3,7 @@ module Workers
   class RecurringPodCheck < Base
     include Sidetiq::Schedulable
 
-    sidekiq_options queue: :maintenance
+    sidekiq_options queue: :low
 
     recurrence { daily }
 

--- a/app/workers/remove_old_user.rb
+++ b/app/workers/remove_old_user.rb
@@ -4,7 +4,7 @@
 
 module Workers
   class RemoveOldUser < Base
-    sidekiq_options queue: :maintenance
+    sidekiq_options queue: :low
     
     def safe_remove_after
       # extra safety time to compare in addition to remove_after

--- a/app/workers/resend_invitation.rb
+++ b/app/workers/resend_invitation.rb
@@ -5,7 +5,7 @@
 
 module Workers
   class ResendInvitation < Base
-    sidekiq_options queue: :mail
+    sidekiq_options queue: :low
     
     def perform(invitation_id)
       inv = Invitation.find(invitation_id)

--- a/app/workers/reset_password.rb
+++ b/app/workers/reset_password.rb
@@ -1,6 +1,6 @@
 module Workers
   class ResetPassword < Base
-    sidekiq_options queue: :mail
+    sidekiq_options queue: :urgent
 
     def perform(user_id)
       User.find(user_id).send_reset_password_instructions!

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -6,16 +6,8 @@
 <% end %>
 :concurrency: <%= AppConfig.environment.sidekiq.concurrency.to_i %>
 :queues:
-  - socket_webfinger
-  - photos
-  - http_service
-  - dispatch
-  - mail
-  - delete_account
-  - receive_local
-  - receive
-  - receive_salmon
-  - http
-  - export
-  - maintenance
+  - urgent
+  - high
+  - medium
+  - low
   - default

--- a/spec/controllers/publics_controller_spec.rb
+++ b/spec/controllers/publics_controller_spec.rb
@@ -42,7 +42,7 @@ describe PublicsController, :type => :controller do
       post :receive, "guid" => @user.person.guid.to_s, "xml" => xml
     end
 
-    it 'unescapes the xml before sending it to receive_salmon' do
+    it "unescapes the xml before sending it to queue" do
       aspect = @user.aspects.create(:name => 'foo')
       post1 = @user.post(:status_message, :text => 'moms', :to => [aspect.id])
       xml2 = post1.to_diaspora_xml

--- a/spec/workers/receive_salmon_spec.rb
+++ b/spec/workers/receive_salmon_spec.rb
@@ -12,7 +12,7 @@ describe Workers::ReceiveEncryptedSalmon do
       end
     }
   end
-  it 'calls receive_salmon' do
+  it "calls receiver" do
     zord = double
 
     expect(zord).to receive(:perform!)


### PR DESCRIPTION
Sidekiq documentation says 'Sidekiq is not designed to work well with dozens of queues.'. Having the amount of queues we have at the moment brings no anyway.

Closes #5571

If this is accepted, should put a note in Changelog, in relevant version to be included in, for podmins to run their queues empty on update.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/diaspora/diaspora/6530)

<!-- Reviewable:end -->
