### PR TITLE
A prototype for the federation message generation automated tests.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,8 @@ gem "unicorn", "4.9.0", require: false
 
 # Federation
 
-gem "diaspora_federation-rails", "0.0.8"
+gem 'diaspora_federation-rails', :git => "https://github.com/SuperTux88/diaspora_federation.git", :branch => "salmon"
+
 
 # API and JSON
 
@@ -280,8 +281,10 @@ group :test do
 
   gem "factory_girl_rails", "4.5.0"
   gem "timecop",            "0.8.0"
-  gem "webmock",            "1.22.1", require: false
+  gem "webmock",            "1.22.3", require: false
   gem "shoulda-matchers",   "3.0.0"
+
+  gem "federation-testbed", :git => "https://github.com/cmrd-senya/federation-testbed.git", :branch => "shape-into-gem"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,26 @@
+GIT
+  remote: https://github.com/SuperTux88/diaspora_federation.git
+  revision: 5a4d742db21f604cb91c2a940a471ad638ae3778
+  branch: salmon
+  specs:
+    diaspora_federation (0.0.8)
+      faraday (~> 0.9.0)
+      faraday_middleware (~> 0.10.0)
+      nokogiri (~> 1.6, >= 1.6.6)
+      typhoeus (~> 0.7)
+      valid (~> 1.0)
+    diaspora_federation-rails (0.0.8)
+      diaspora_federation (= 0.0.8)
+      rails (~> 4.2)
+
+GIT
+  remote: https://github.com/cmrd-senya/federation-testbed.git
+  revision: 028f81667f6b98beb3fa15a60d144c1258d91c6e
+  branch: shape-into-gem
+  specs:
+    federation-testbed (0.1.0)
+      rest-client
+
 GEM
   remote: https://rubygems.org/
   remote: https://rails-assets.org/
@@ -154,15 +177,6 @@ GEM
       eventmachine (~> 1.0.8)
       http_parser.rb (~> 0.6)
       nokogiri (~> 1.6)
-    diaspora_federation (0.0.8)
-      faraday (~> 0.9.2)
-      faraday_middleware (~> 0.10.0)
-      nokogiri (~> 1.6, >= 1.6.6)
-      typhoeus (~> 0.7)
-      valid (~> 1.0)
-    diaspora_federation-rails (0.0.8)
-      diaspora_federation (= 0.0.8)
-      rails (~> 4.2)
     diff-lcs (1.2.5)
     docile (1.1.5)
     domain_name (0.5.25)
@@ -459,6 +473,7 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (3.0.1)
+    netrc (0.10.3)
     nio4r (1.1.1)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
@@ -645,6 +660,10 @@ GEM
     request_store (1.2.0)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     roxml (3.1.6)
       activesupport (>= 2.3.0)
       nokogiri (>= 1.3.3)
@@ -787,7 +806,7 @@ GEM
     valid (1.1.0)
     warden (1.2.3)
       rack (>= 1.0)
-    webmock (1.22.1)
+    webmock (1.22.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
@@ -820,13 +839,14 @@ DEPENDENCIES
   devise-token_authenticatable (~> 0.4.0)
   devise_lastseenable (= 0.0.6)
   diaspora-vines (~> 0.2.0.develop)
-  diaspora_federation-rails (= 0.0.8)
+  diaspora_federation-rails!
   entypo-rails (= 3.0.0.pre.rc2)
   eye (= 0.7)
   factory_girl_rails (= 4.5.0)
   faraday (= 0.9.2)
   faraday-cookie_jar (= 0.0.6)
   faraday_middleware (= 0.10.0)
+  federation-testbed!
   fixture_builder (= 0.4.1)
   fog (= 1.34.0)
   fuubar (= 2.0.0)
@@ -935,7 +955,7 @@ DEPENDENCIES
   uglifier (= 2.7.2)
   unicorn (= 4.9.0)
   uuid (= 2.3.8)
-  webmock (= 1.22.1)
+  webmock (= 1.22.3)
   will_paginate (= 3.0.7)
 
 BUNDLED WITH

--- a/spec/integration/federation/federation_messages_spec.rb
+++ b/spec/integration/federation/federation_messages_spec.rb
@@ -1,0 +1,48 @@
+require "spec_helper"
+require "federation-testbed"
+
+describe "Generation and dispatch of federation messages" do
+  before :all do
+    @testbed_pod = FactoryGirl.build(:pod).host
+    FederationTestbed.config.configure(
+      "testbed_config" => {"host" => @testbed_pod, "method" => "http"},
+      "test_target"    => {
+        "method" => "http",
+        "host"   => "localhost:3000",
+        "user"   => "alice"
+      }
+    )
+    user = FederationTestbed::User.new
+    user.id = alice.diaspora_handle
+    user.public_key = alice.public_key
+    user.private_key = nil
+    FederationTestbed.test_data.push(user)
+    @rack_app = FederationTestbed::App.new!
+    stub_request(:get, Addressable::Template.new("#{@testbed_pod}/.well-known/host-meta"))
+      .to_rack(@rack_app)
+    stub_request(:get, Addressable::Template.new("#{@testbed_pod}/webfinger?q=acct:test@#{@testbed_pod}"))
+      .to_rack(@rack_app)
+    stub_request(:get, Addressable::Template.new("#{@testbed_pod}/hcard/users/test@#{@testbed_pod}"))
+      .to_rack(@rack_app)
+    stub_request(:post, Addressable::Template.new("#{@testbed_pod}/receive/users/{guid}"))
+      .to_rack(@rack_app)
+  end
+
+  before do
+    allow_any_instance_of(Postzord::Dispatcher::Private).to receive(:deliver_to_remote).and_call_original
+    allow_any_instance_of(Postzord::Dispatcher::Public).to receive(:deliver_to_remote).and_call_original
+    @rack_app.pulled_entities.clear
+  end
+
+  describe "user share request" do
+    it "works" do
+      friend = Person.find_or_fetch_by_identifier("test@#{@testbed_pod}")
+      expect(friend).not_to be_nil
+      expect(alice.share_with(friend, alice.aspects.first)).not_to be_falsy
+      expect(@rack_app.pulled_entities.length).to eq(2)
+      expect(@rack_app.pulled_entities[0].sender_id).to eq(alice.diaspora_handle)
+      expect(@rack_app.pulled_entities[0].recipient_id).to eq(friend.diaspora_handle)
+      expect(@rack_app.pulled_entities[1].diaspora_id).to eq(alice.diaspora_handle) # profile is pushed after sharing is requested
+    end
+  end
+end


### PR DESCRIPTION
This is a prototype made in purpose to try and implement an automated
way of testing federation. This patch contains a test for an outgoing
federation message.

The test case loads federation-testbed as a gem. It uses an embedded
Sinatra web application of the testbed and stubs outgoing federated
calls to it. The testbed application process queries as if it were real
Diaspora pod and will fail a test in case when the received message
is inconsistent.

This is an early version used to highlight difficulties and issues
of the approach and implementation. Development versions of the
involved gems are used.

refs #5114 #6479
