### PR TITLE
Catch Diaspora::NotMine on Post Controller

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -21,6 +21,10 @@ class PostsController < ApplicationController
     end
   end
 
+  rescue_from Diaspora::NotMine do
+    render text: "You are not allowed to do that", status: 403
+  end
+
   def show
     post_service = PostService.new(id: params[:id], user: current_user)
     post_service.mark_user_notifications

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -135,5 +135,15 @@ describe PostsController, type: :controller do
       message = alice.post(:status_message, text: "hey", to: alice.aspects.first.id)
       delete :destroy, format: :js, id: message.id
     end
+
+    context "when Diaspora::NotMine is raised by retract post" do
+      it "will respond with a 403" do
+        expect(post_service_double).to receive(:retract_post).and_raise(Diaspora::NotMine)
+        message = alice.post(:status_message, text: "hey", to: alice.aspects.first.id)
+        delete :destroy, format: :js, id: message.id
+        expect(response.body).to eq("You are not allowed to do that")
+        expect(response.status).to eq(403)
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #6532 

@noplanman Thanks for the catch! The `posts_controller.rb` was indeed missing a `rescue_from` clause.
