### PR TITLE
Do not add participation for comment if comment validation failed

### DIFF
--- a/app/models/user/social_actions.rb
+++ b/app/models/user/social_actions.rb
@@ -1,7 +1,8 @@
 module User::SocialActions
   def comment!(target, text, opts={})
+    comment = Comment::Generator.new(self, target, text).create!(opts)
     update_or_create_participation!(target)
-    Comment::Generator.new(self, target, text).create!(opts)
+    comment
   end
 
   def participate!(target, opts={})
@@ -9,19 +10,21 @@ module User::SocialActions
   end
 
   def like!(target, opts={})
+    like = Like::Generator.new(self, target).create!(opts)
     update_or_create_participation!(target)
-    Like::Generator.new(self, target).create!(opts)
+    like
   end
 
   def participate_in_poll!(target, answer, opts={})
+    poll_participation = PollParticipation::Generator.new(self, target, answer).create!(opts)
     update_or_create_participation!(target)
-    PollParticipation::Generator.new(self, target, answer).create!(opts)
+    poll_participation
   end
 
   def reshare!(target, opts={})
-    update_or_create_participation!(target)
     reshare = build_post(:reshare, :root_guid => target.guid)
     reshare.save!
+    update_or_create_participation!(target)
     Postzord::Dispatcher.defer_build_and_post(self, reshare)
     reshare
   end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -77,6 +77,15 @@ describe Comment, :type => :model do
       participations = Participation.where(target_id: comment_alice.commentable_id, author_id: comment_alice.author_id)
       expect(participations.count).to eq(1)
     end
+
+    it "does not create a participation if comment validation failed" do
+      begin
+        alice.comment!(status_bob, " ")
+      rescue ActiveRecord::RecordInvalid
+      end
+      participations = Participation.where(target_id: status_bob, author_id: alice.person.id)
+      expect(participations.count).to eq(0)
+    end
   end
 
   describe "counter cache" do


### PR DESCRIPTION
Previously the server created a participation for a comment before validating the comment itself. Thus if a client sent an invalid comment to the server (e.g. consists only of spaces) a participation would be created while the comment was refused. This pull request changes the order of the operations so that comment is validated before the participation gets created.

I also noticed that the other social actions had the same odd behavior so i changed them too.
