### PR TITLE
Fix_notifications_timestamp_issue #4826

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -64,6 +64,8 @@ private
       begin
         n.actors = n.actors | [actor]
         n.unread = true
+        # Explicitly touch the notification to update updated_at whenever new actor is inserted in notification.
+        n.touch
         n.save!
       rescue ActiveRecord::RecordNotUnique
         nil

--- a/app/views/notifications/_notification.haml
+++ b/app/views/notifications/_notification.haml
@@ -10,4 +10,4 @@
   .media-body
     = notification_message_for(note)
     %div
-      = timeago(note.created_at)
+      = timeago(note.updated_at)

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -97,8 +97,10 @@ describe Notification, :type => :model do
           p = FactoryGirl.build(:status_message, :author => @user.person)
           person2 = FactoryGirl.build(:person)
           notification = Notification.notify(@user, FactoryGirl.build(:like, :author => @person, :target => p), @person)
+          earlier_updated_at = notification.updated_at
           notification2 =  Notification.notify(@user, FactoryGirl.build(:like, :author => person2, :target => p), person2)
           expect(notification.id).to eq(notification2.id)
+          expect(earlier_updated_at).to_not eq(notification.reload.updated_at)
         end
       end
 
@@ -107,8 +109,10 @@ describe Notification, :type => :model do
           p = FactoryGirl.build(:status_message, :author => @user.person)
           person2 = FactoryGirl.build(:person)
           notification = Notification.notify(@user, FactoryGirl.build(:comment, :author => @person, :post => p), @person)
+          earlier_updated_at = notification.updated_at
           notification2 =  Notification.notify(@user, FactoryGirl.build(:comment, :author => person2, :post => p), person2)
           expect(notification.id).to eq(notification2.id)
+          expect(earlier_updated_at).to_not eq(notification.reload.updated_at)
         end
       end
 


### PR DESCRIPTION
- Showing updated_at instead of created_at to show latest time.
  For e.g there is a 'like' notification and another likes the same post then time shown should be the time when second person liked the post.
