### PR TITLE
Remove parent author signature for relayables from the DB

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -21,11 +21,6 @@ class Message < ActiveRecord::Base
                    # inside, which would cause an infinite recursion
     #sign comment as commenter
     self.author_signature = self.sign_with_key(self.author.owner.encryption_key) if self.author.owner
-
-    if self.author.owns?(self.parent)
-      #sign comment as post owner
-      self.parent_author_signature = self.sign_with_key(self.parent.author.owner.encryption_key) if self.parent.author.owner
-    end
     self.save!
     self
   end

--- a/db/migrate/20151210213023_remove_signatures_from_relayables.rb
+++ b/db/migrate/20151210213023_remove_signatures_from_relayables.rb
@@ -1,0 +1,9 @@
+class RemoveSignaturesFromRelayables < ActiveRecord::Migration
+  def change
+    remove_column :comments, :parent_author_signature, :text
+    remove_column :poll_participations, :parent_author_signature, :text
+    remove_column :messages, :parent_author_signature, :text
+    remove_column :participations, :parent_author_signature, :text
+    remove_column :likes, :parent_author_signature, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151003142048) do
+ActiveRecord::Schema.define(version: 20151210213023) do
 
   create_table "account_deletions", force: :cascade do |t|
     t.string   "diaspora_handle", limit: 255
@@ -92,7 +92,6 @@ ActiveRecord::Schema.define(version: 20151003142048) do
     t.integer  "author_id",               limit: 4,                      null: false
     t.string   "guid",                    limit: 255,                    null: false
     t.text     "author_signature",        limit: 65535
-    t.text     "parent_author_signature", limit: 65535
     t.datetime "created_at",                                             null: false
     t.datetime "updated_at",                                             null: false
     t.integer  "likes_count",             limit: 4,     default: 0,      null: false
@@ -168,7 +167,6 @@ ActiveRecord::Schema.define(version: 20151003142048) do
     t.integer  "author_id",               limit: 4
     t.string   "guid",                    limit: 255
     t.text     "author_signature",        limit: 65535
-    t.text     "parent_author_signature", limit: 65535
     t.datetime "created_at",                                           null: false
     t.datetime "updated_at",                                           null: false
     t.string   "target_type",             limit: 60,                   null: false
@@ -205,7 +203,6 @@ ActiveRecord::Schema.define(version: 20151003142048) do
     t.datetime "created_at",                            null: false
     t.datetime "updated_at",                            null: false
     t.text     "author_signature",        limit: 65535
-    t.text     "parent_author_signature", limit: 65535
   end
 
   add_index "messages", ["author_id"], name: "index_messages_on_author_id", using: :btree
@@ -257,7 +254,6 @@ ActiveRecord::Schema.define(version: 20151003142048) do
     t.string   "target_type",             limit: 60,                null: false
     t.integer  "author_id",               limit: 4
     t.text     "author_signature",        limit: 65535
-    t.text     "parent_author_signature", limit: 65535
     t.datetime "created_at",                                        null: false
     t.datetime "updated_at",                                        null: false
     t.integer  "count",                   limit: 4,     default: 1, null: false
@@ -338,7 +334,6 @@ ActiveRecord::Schema.define(version: 20151003142048) do
     t.integer  "poll_id",                 limit: 4,     null: false
     t.string   "guid",                    limit: 255
     t.text     "author_signature",        limit: 65535
-    t.text     "parent_author_signature", limit: 65535
     t.datetime "created_at"
     t.datetime "updated_at"
   end

--- a/spec/shared_behaviors/relayable.rb
+++ b/spec/shared_behaviors/relayable.rb
@@ -61,11 +61,6 @@ shared_examples_for "it is relayable" do
         expect(@object_by_parent_author.verify_parent_author_signature).to be true
       end
 
-      it 'does not sign as the parent author is not parent' do
-        @object_by_recipient.author_signature = @object_by_recipient.send(:sign_with_key, @local_leia.encryption_key)
-        expect(@object_by_recipient.verify_parent_author_signature).to be false
-      end
-
       it 'should verify a object made on a remote post by a different contact' do
         @object_by_recipient.author_signature = @object_by_recipient.send(:sign_with_key, @local_leia.encryption_key)
         @object_by_recipient.parent_author_signature = @object_by_recipient.send(:sign_with_key, @local_luke.encryption_key)
@@ -88,12 +83,6 @@ shared_examples_for "it is relayable" do
         expect {
           @dup_object_by_parent_author.receive(@local_leia, @local_luke.person)
         }.to_not change { @dup_object_by_parent_author.class.count }
-      end
-
-      it 'does not process if post_creator_signature is invalid' do
-        @object_by_parent_author.delete # remove object from db so we set a creator sig
-        @dup_object_by_parent_author.parent_author_signature = "dsfadsfdsa"
-        expect(@dup_object_by_parent_author.receive(@local_leia, @local_luke.person)).to eq(nil)
       end
 
       it 'signs when the person receiving is the parent author' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -73,6 +73,8 @@ RSpec.configure do |config|
   config.include Devise::TestHelpers, :type => :controller
   config.mock_with :rspec
 
+  config.example_status_persistence_file_path = "tmp/rspec-persistance.txt"
+
   config.render_views
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!


### PR DESCRIPTION
Remove author and parent author signatures for relayables from the DB since they are considered redundant.

This not strictly closes #4920, but makes it less tense.
