### PR TITLE
Bump omniauth-facebook to latest version (v3.0.0)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -143,7 +143,7 @@ gem "open_graph_reader", "0.6.1"
 # Services
 
 gem "omniauth",           "1.2.2"
-gem "omniauth-facebook",  "2.0.1"
+gem "omniauth-facebook",  "3.0.0"
 gem "omniauth-tumblr",    "1.1"
 gem "omniauth-twitter",   "1.2.1"
 gem "twitter",            "5.15.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -477,7 +477,7 @@ GEM
     omniauth (1.2.2)
       hashie (>= 1.2, < 4)
       rack (~> 1.0)
-    omniauth-facebook (2.0.1)
+    omniauth-facebook (3.0.0)
       omniauth-oauth2 (~> 1.2)
     omniauth-oauth (1.1.0)
       oauth
@@ -860,7 +860,7 @@ DEPENDENCIES
   mysql2 (= 0.3.20)
   nokogiri (= 1.6.6.4)
   omniauth (= 1.2.2)
-  omniauth-facebook (= 2.0.1)
+  omniauth-facebook (= 3.0.0)
   omniauth-tumblr (= 1.1)
   omniauth-twitter (= 1.2.1)
   omniauth-wordpress (= 0.2.2)


### PR DESCRIPTION
I was able to post to Facebook with the latest version of omniauth-facebook (v3.0.0)
