### PR TITLE
New feature: Subscribe to receive email notifications on new posts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -301,4 +301,7 @@ group :development, :test do
 
   # silence assets
   gem "quiet_assets", "1.1.0"
+  
+  # Test notification emails by opening emails in the browser
+  gem "letter_opener"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -431,6 +431,10 @@ GEM
       activesupport (>= 3.0.0)
     kgio (2.10.0)
     leaflet-rails (0.7.4)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    letter_opener (1.4.1)
+      launchy (~> 2.2)
     listen (3.0.5)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
@@ -868,6 +872,7 @@ DEPENDENCIES
   json (= 1.8.3)
   json-schema (= 2.5.2)
   leaflet-rails (= 0.7.4)
+  letter_opener
   logging-rails (= 0.5.0)
   markerb (= 1.1.0)
   messagebus_ruby_api (= 1.0.3)

--- a/app/controllers/status_messages_controller.rb
+++ b/app/controllers/status_messages_controller.rb
@@ -77,7 +77,7 @@ class StatusMessagesController < ApplicationController
     return unless comes_from_others_profile_page?
     flash[:notice] = successful_mention_message
   end
-  
+
   def handle_subscriptions
     @status_message.subscriber_users.each do |subscriber|
       recipient_id = subscriber.id

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,18 +1,17 @@
 class SubscriptionsController < ApplicationController
-  
   def index
     @subscriptions = current_user.subscriptions
   end
-  
+
   def create
-    @subscription = current_user.subscriptions.create channel_type: params[:channel_type], channel_id: params[:channel_id]
+    @subscription = current_user.subscriptions.create(
+      channel_type: params[:channel_type], channel_id: params[:channel_id])
     redirect_to :back
   end
-  
+
   def destroy
     @subscription = Subscription.find params[:id]
     @subscription.destroy
     redirect_to :back
   end
-  
 end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,0 +1,18 @@
+class SubscriptionsController < ApplicationController
+  
+  def index
+    @subscriptions = current_user.subscriptions
+  end
+  
+  def create
+    @subscription = current_user.subscriptions.create channel_type: params[:channel_type], channel_id: params[:channel_id]
+    redirect_to :back
+  end
+  
+  def destroy
+    @subscription = Subscription.find params[:id]
+    @subscription.destroy
+    redirect_to :back
+  end
+  
+end

--- a/app/mailers/notification_mailers/posted.rb
+++ b/app/mailers/notification_mailers/posted.rb
@@ -1,0 +1,12 @@
+module NotificationMailers
+  class Posted < NotificationMailers::Base
+    attr_accessor :post
+    delegate :author_name, to: :post, prefix: true
+
+    def set_headers(target_id)
+      @post = Post.find_by_id(target_id)
+
+      @headers[:subject] = I18n.t('notifier.posted.subject', :name => @sender.name)
+    end
+  end
+end

--- a/app/mailers/notification_mailers/posted.rb
+++ b/app/mailers/notification_mailers/posted.rb
@@ -6,7 +6,7 @@ module NotificationMailers
     def set_headers(target_id)
       @post = Post.find_by_id(target_id)
 
-      @headers[:subject] = I18n.t('notifier.posted.subject', :name => @sender.name)
+      @headers[:subject] = I18n.t("notifier.posted.subject", name: @sender.name)
     end
   end
 end

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -70,6 +70,10 @@ class Notifier < ActionMailer::Base
   def mentioned(recipient_id, sender_id, target_id)
     send_notification(:mentioned, recipient_id, sender_id, target_id)
   end
+  
+  def posted(recipient_id, sender_id, target_id)
+    send_notification(:posted, recipient_id, sender_id, target_id)
+  end
 
   def comment_on_post(recipient_id, sender_id, comment_id)
     send_notification(:comment_on_post, recipient_id, sender_id, comment_id)

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -70,7 +70,7 @@ class Notifier < ActionMailer::Base
   def mentioned(recipient_id, sender_id, target_id)
     send_notification(:mentioned, recipient_id, sender_id, target_id)
   end
-  
+
   def posted(recipient_id, sender_id, target_id)
     send_notification(:posted, recipient_id, sender_id, target_id)
   end

--- a/app/models/acts_as_taggable_on-tag.rb
+++ b/app/models/acts_as_taggable_on-tag.rb
@@ -1,6 +1,5 @@
 module ActsAsTaggableOn
   class Tag
-    
     has_many :subscriptions, as: :channel
 
     self.include_root_in_json = false

--- a/app/models/acts_as_taggable_on-tag.rb
+++ b/app/models/acts_as_taggable_on-tag.rb
@@ -1,5 +1,7 @@
 module ActsAsTaggableOn
   class Tag
+    
+    has_many :subscriptions, as: :channel
 
     self.include_root_in_json = false
 

--- a/app/models/aspect.rb
+++ b/app/models/aspect.rb
@@ -15,6 +15,8 @@ class Aspect < ActiveRecord::Base
   validates :name, :presence => true, :length => { :maximum => 20 }
 
   validates_uniqueness_of :name, :scope => :user_id, :case_sensitive => false
+  
+  has_many :subscriptions, as: :channel
 
   before_validation do
     name.strip!

--- a/app/models/aspect.rb
+++ b/app/models/aspect.rb
@@ -15,7 +15,7 @@ class Aspect < ActiveRecord::Base
   validates :name, :presence => true, :length => { :maximum => 20 }
 
   validates_uniqueness_of :name, :scope => :user_id, :case_sensitive => false
-  
+
   has_many :subscriptions, as: :channel
 
   before_validation do

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -63,12 +63,11 @@ class Contact < ActiveRecord::Base
   def receive_shareable(shareable)
     ShareVisibility.create!(:shareable_id => shareable.id, :shareable_type => shareable.class.base_class.to_s, :contact_id => self.id)
   end
-  
+
   def incoming_aspects
-    Aspect.where(
-          :user_id => self.person.owner_id,
-          :contacts_visible => true).joins(:contacts).where(
-            :contacts => {:person_id => self.user.person_id}).select('aspects.id')
+    Aspect.where(user_id: person.owner_id, contacts_visible: true)
+    .joins(:contacts).where(contacts: {person_id: user.person_id})
+    .select("aspects.id")
   end
 
   def incoming_aspect_ids

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -63,14 +63,20 @@ class Contact < ActiveRecord::Base
   def receive_shareable(shareable)
     ShareVisibility.create!(:shareable_id => shareable.id, :shareable_type => shareable.class.base_class.to_s, :contact_id => self.id)
   end
+  
+  def incoming_aspects
+    Aspect.where(
+          :user_id => self.person.owner_id,
+          :contacts_visible => true).joins(:contacts).where(
+            :contacts => {:person_id => self.user.person_id}).select('aspects.id')
+  end
+
+  def incoming_aspect_ids
+    incoming_aspects.map(&:id)
+  end
 
   def contacts
     people = Person.arel_table
-    incoming_aspects = Aspect.where(
-      :user_id => self.person.owner_id,
-      :contacts_visible => true).joins(:contacts).where(
-        :contacts => {:person_id => self.user.person_id}).select('aspects.id')
-    incoming_aspect_ids = incoming_aspects.map{|a| a.id}
     similar_contacts = Person.joins(:contacts => :aspect_memberships).where(
       :aspect_memberships => {:aspect_id => incoming_aspect_ids}).where(people[:id].not_eq(self.user.person.id)).select('DISTINCT people.*')
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -121,6 +121,14 @@ class Post < ActiveRecord::Base
     return unless user
     likes.where(:author_id => user.person.id).first
   end
+  
+  def subscriptions
+    Subscription.by_post self
+  end
+  
+  def subscriber_users  # "subscribers" is already taken :(
+    subscriptions.map(&:subscriber).uniq
+  end
 
   #############
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -121,12 +121,12 @@ class Post < ActiveRecord::Base
     return unless user
     likes.where(:author_id => user.person.id).first
   end
-  
+
   def subscriptions
     Subscription.by_post self
   end
-  
-  def subscriber_users  # "subscribers" is already taken :(
+
+  def subscriber_users # "subscribers" is already taken :(
     subscriptions.map(&:subscriber).uniq
   end
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -11,21 +11,20 @@
 # * `Tag`: Receive notifications whenever a post is created with that tag.
 #
 class Subscription < ActiveRecord::Base
-  
-  belongs_to :subscriber, class_name: 'User'
+  belongs_to :subscriber, class_name: "User"
   belongs_to :channel, polymorphic: true
-  
+
   # When a new post is created, it's convenient to get all subscriptions
   # that should be triggered by the new post. This includes:
-  # 
+  #
   # - Person-type channels, considering the author of the post.
   # - Aspect-type channels, considering the author could be member of the aspect.
   # - Tag-type channels, considering the post could have the tag.
   #
   def self.by_post(post)
-    (self.by_person(post.author) +
-    self.by_aspects(Aspect.includes(:contacts).where(contacts: {person: post.author})) +
-    self.by_tags(post.tags)).select { |subscription|
+    (by_person(post.author) +
+    by_aspects(Aspect.includes(:contacts).where(contacts: {person: post.author})) +
+    by_tags(post.tags)).select {|subscription|
       # Check that the post is actually visible to the subscriber:
       post.share_visibilities.includes(:contact)
       .where(contacts: {user_id: subscription.subscriber_id})
@@ -34,23 +33,22 @@ class Subscription < ActiveRecord::Base
   end
 
   def self.by_person(person)
-    self.where(channel_type: 'Person', channel_id: person.id)
+    where(channel_type: "Person", channel_id: person.id)
   end
-  
+
   def self.by_aspects(aspects)
-    aspects.collect { |aspect| self.by_aspect(aspect) }.flatten
+    aspects.map {|aspect| by_aspect(aspect) }.flatten
   end
-  
+
   def self.by_aspect(aspect)
-    self.where(channel_type: 'Aspect', channel_id: aspect.id)
+    where(channel_type: "Aspect", channel_id: aspect.id)
   end
-  
+
   def self.by_tags(tags)
-    tags.collect { |tag| self.by_tag(tag) }.flatten
+    tags.map {|tag| by_tag(tag) }.flatten
   end
-  
+
   def self.by_tag(tag)
-    self.where(channel_type: 'ActsAsTaggableOn::Tag', channel_id: tag.id)
+    where(channel_type: "ActsAsTaggableOn::Tag", channel_id: tag.id)
   end
-  
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,0 +1,56 @@
+# A user can subscribe to certain channels in order to receive email notifications
+# when a post is created in that channel. The subscribing user is called subscriber.
+#
+# ## Channel
+#
+# The channel is polymorphic such that the subscriber can subscribe to several types
+# of objects.
+#
+# * `Person`: Receive notifications whenever the person creates a post.
+# * `Aspect`: Receive notifications whenever anyone of the aspect's members creates a post.
+# * `Tag`: Receive notifications whenever a post is created with that tag.
+#
+class Subscription < ActiveRecord::Base
+  
+  belongs_to :subscriber, class_name: 'User'
+  belongs_to :channel, polymorphic: true
+  
+  # When a new post is created, it's convenient to get all subscriptions
+  # that should be triggered by the new post. This includes:
+  # 
+  # - Person-type channels, considering the author of the post.
+  # - Aspect-type channels, considering the author could be member of the aspect.
+  # - Tag-type channels, considering the post could have the tag.
+  #
+  def self.by_post(post)
+    (self.by_person(post.author) +
+    self.by_aspects(Aspect.includes(:contacts).where(contacts: {person: post.author})) +
+    self.by_tags(post.tags)).select { |subscription|
+      # Check that the post is actually visible to the subscriber:
+      post.share_visibilities.includes(:contact)
+      .where(contacts: {user_id: subscription.subscriber_id})
+      .any?
+    }
+  end
+
+  def self.by_person(person)
+    self.where(channel_type: 'Person', channel_id: person.id)
+  end
+  
+  def self.by_aspects(aspects)
+    aspects.collect { |aspect| self.by_aspect(aspect) }.flatten
+  end
+  
+  def self.by_aspect(aspect)
+    self.where(channel_type: 'Aspect', channel_id: aspect.id)
+  end
+  
+  def self.by_tags(tags)
+    tags.collect { |tag| self.by_tag(tag) }.flatten
+  end
+  
+  def self.by_tag(tag)
+    self.where(channel_type: 'ActsAsTaggableOn::Tag', channel_id: tag.id)
+  end
+  
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,9 +55,9 @@ class User < ActiveRecord::Base
   belongs_to :invited_by, :class_name => 'User'
 
   has_many :aspect_memberships, :through => :aspects
-  
+
   has_many :subscriptions, foreign_key: :subscriber_id
-  
+
   has_many :contacts
   has_many :contact_people, :through => :contacts, :source => :person
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,7 +55,9 @@ class User < ActiveRecord::Base
   belongs_to :invited_by, :class_name => 'User'
 
   has_many :aspect_memberships, :through => :aspects
-
+  
+  has_many :subscriptions, foreign_key: :subscriber_id
+  
   has_many :contacts
   has_many :contact_people, :through => :contacts, :source => :person
 

--- a/app/views/notifier/posted.markerb
+++ b/app/views/notifier/posted.markerb
@@ -1,0 +1,9 @@
+<% if @notification.post.public? %>
+<%= post_message(@notification.post, :process_newlines => true) %>
+<% else %>
+<%= t('notifier.posted.limited_post') %>
+<% end %>
+
+[<%= t('notifier.comment_on_post.reply', :name => @notification.post_author_name) %>][1]
+
+[1]: <%= post_url(@notification.post) %>

--- a/app/views/subscriptions/_channel_switch.html.haml
+++ b/app/views/subscriptions/_channel_switch.html.haml
@@ -1,0 +1,18 @@
+- # locals:
+- channel || raise('no channel given.')
+
+.stream_element.media
+  .pull-right
+    - subscription = channel.subscriptions.where(subscriber: current_user).first
+    - if subscription
+      = link_to subscription_path(subscription), method: :delete, class: 'btn btn-small green' do
+        = t '.subscribed'
+    - else
+      = link_to subscriptions_path(channel_type: channel.class.name, channel_id: channel.id), method: :post, class: 'btn btn-small' do
+        = t '.subscribe'
+  .media-body
+    - case channel
+      - when ActsAsTaggableOn::Tag
+        %p= link_to "##{channel.name}", tag_path(name: channel.name)
+      - else
+        %p= channel.name

--- a/app/views/subscriptions/_channel_switch.html.haml
+++ b/app/views/subscriptions/_channel_switch.html.haml
@@ -1,15 +1,16 @@
-- # locals:
-- channel || raise('no channel given.')
+-# locals:
+- channel || raise("no channel given.")
 
 .stream_element.media
   .pull-right
     - subscription = channel.subscriptions.where(subscriber: current_user).first
     - if subscription
-      = link_to subscription_path(subscription), method: :delete, class: 'btn btn-small btn-success' do
-        = t '.subscribed'
+      = link_to subscription_path(subscription), method: :delete, class: "btn btn-small btn-success" do
+        = t ".subscribed"
     - else
-      = link_to subscriptions_path(channel_type: channel.class.name, channel_id: channel.id), method: :post, class: 'btn btn-small btn-default' do
-        = t '.subscribe'
+      = link_to(subscriptions_path(channel_type: channel.class.name, channel_id: channel.id),
+                method: :post, class: "btn btn-small btn-default") do
+        = t ".subscribe"
   .media-body
     - case channel
       - when ActsAsTaggableOn::Tag

--- a/app/views/subscriptions/_channel_switch.html.haml
+++ b/app/views/subscriptions/_channel_switch.html.haml
@@ -5,10 +5,10 @@
   .pull-right
     - subscription = channel.subscriptions.where(subscriber: current_user).first
     - if subscription
-      = link_to subscription_path(subscription), method: :delete, class: 'btn btn-small green' do
+      = link_to subscription_path(subscription), method: :delete, class: 'btn btn-small btn-success' do
         = t '.subscribed'
     - else
-      = link_to subscriptions_path(channel_type: channel.class.name, channel_id: channel.id), method: :post, class: 'btn btn-small' do
+      = link_to subscriptions_path(channel_type: channel.class.name, channel_id: channel.id), method: :post, class: 'btn btn-small btn-default' do
         = t '.subscribe'
   .media-body
     - case channel

--- a/app/views/subscriptions/index.html.haml
+++ b/app/views/subscriptions/index.html.haml
@@ -2,14 +2,16 @@
   = t('.title')
 
 - content_for :content do
-  #container.container-fluid
+  .container-fluid#container
     %h1= t('.title')
     %p= t('.explanation')
 
-    %h2= t('.aspects')
-    - current_user.aspects.each do |aspect|
-      = render partial: 'subscriptions/channel_switch', locals: {channel: aspect}
-    
-    %h2= t('.tags')
-    - current_user.followed_tags.each do |tag|
-      = render partial: 'subscriptions/channel_switch', locals: {channel: tag}
+    .col-md-6
+      %h2= t('.aspects')
+      - current_user.aspects.each do |aspect|
+        = render partial: 'subscriptions/channel_switch', locals: {channel: aspect}
+
+    .col-md-6
+      %h2= t('.tags')
+      - current_user.followed_tags.each do |tag|
+        = render partial: 'subscriptions/channel_switch', locals: {channel: tag}

--- a/app/views/subscriptions/index.html.haml
+++ b/app/views/subscriptions/index.html.haml
@@ -1,0 +1,15 @@
+- content_for :page_title do
+  = t('.title')
+
+- content_for :content do
+  #container.container-fluid
+    %h1= t('.title')
+    %p= t('.explanation')
+
+    %h2= t('.aspects')
+    - current_user.aspects.each do |aspect|
+      = render partial: 'subscriptions/channel_switch', locals: {channel: aspect}
+    
+    %h2= t('.tags')
+    - current_user.followed_tags.each do |tag|
+      = render partial: 'subscriptions/channel_switch', locals: {channel: tag}

--- a/app/views/subscriptions/index.html.haml
+++ b/app/views/subscriptions/index.html.haml
@@ -1,17 +1,17 @@
 - content_for :page_title do
-  = t('.title')
+  = t(".title")
 
 - content_for :content do
   .container-fluid#container
-    %h1= t('.title')
-    %p= t('.explanation')
+    %h1= t(".title")
+    %p= t(".explanation")
 
     .col-md-6
-      %h2= t('.aspects')
+      %h2= t(".aspects")
       - current_user.aspects.each do |aspect|
-        = render partial: 'subscriptions/channel_switch', locals: {channel: aspect}
+        = render partial: "subscriptions/channel_switch", locals: {channel: aspect}
 
     .col-md-6
-      %h2= t('.tags')
+      %h2= t(".tags")
       - current_user.followed_tags.each do |tag|
-        = render partial: 'subscriptions/channel_switch', locals: {channel: tag}
+        = render partial: "subscriptions/channel_switch", locals: {channel: tag}

--- a/app/workers/mail/posted.rb
+++ b/app/workers/mail/posted.rb
@@ -6,7 +6,7 @@ module Workers
   module Mail
     class Posted < Base
       sidekiq_options queue: :mail
-      
+
       def perform(recipient_id, actor_id, target_id)
         Notifier.posted(recipient_id, actor_id, target_id).deliver_now
       end

--- a/app/workers/mail/posted.rb
+++ b/app/workers/mail/posted.rb
@@ -1,0 +1,15 @@
+#   Copyright (c) 2010-2011, Diaspora Inc.  This file is
+#   licensed under the Affero General Public License version 3 or later.  See
+#   the COPYRIGHT file.
+
+module Workers
+  module Mail
+    class Posted < Base
+      sidekiq_options queue: :mail
+      
+      def perform(recipient_id, actor_id, target_id)
+        Notifier.posted(recipient_id, actor_id, target_id).deliver_now
+      end
+    end
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,6 +15,12 @@ Diaspora::Application.configure do
 
   # Don't care if the mailer can't send
   config.action_mailer.raise_delivery_errors = false
+  
+  # Use letter_opener to show emails in the browser
+  if ENV['LETTER_OPENER'].present?
+    config.action_mailer.delivery_method = :letter_opener
+    config.action_mailer.raise_delivery_errors = true
+  end
 
   # Raise an error on page load if there are pending migrations
   config.active_record.migration_error = :page_load
@@ -24,7 +30,6 @@ Diaspora::Application.configure do
 
   # Only use best-standards-support built into browsers
   config.action_dispatch.best_standards_support = :builtin
-
 
   # Do not compress assets
   config.assets.compress = false

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,9 +15,9 @@ Diaspora::Application.configure do
 
   # Don't care if the mailer can't send
   config.action_mailer.raise_delivery_errors = false
-  
+
   # Use letter_opener to show emails in the browser
-  if ENV['LETTER_OPENER'].present?
+  if ENV["LETTER_OPENER"].present?
     config.action_mailer.delivery_method = :letter_opener
     config.action_mailer.raise_delivery_errors = true
   end

--- a/config/initializers/mailer_config.rb
+++ b/config/initializers/mailer_config.rb
@@ -4,9 +4,9 @@
 require Rails.root.join('lib', 'messagebus', 'mailer')
 
 Diaspora::Application.configure do
-  config.action_mailer.perform_deliveries = AppConfig.mail.enable? || ENV['LETTER_OPENER'].present?
+  config.action_mailer.perform_deliveries = AppConfig.mail.enable? || ENV["LETTER_OPENER"].present?
 
-  unless Rails.env == 'test' || ENV['LETTER_OPENER'].present? || !AppConfig.mail.enable?
+  unless Rails.env == "test" || ENV["LETTER_OPENER"].present? || !AppConfig.mail.enable?
     if AppConfig.mail.method == 'messagebus'
 
       if AppConfig.mail.message_bus_api_key.present?

--- a/config/initializers/mailer_config.rb
+++ b/config/initializers/mailer_config.rb
@@ -4,9 +4,9 @@
 require Rails.root.join('lib', 'messagebus', 'mailer')
 
 Diaspora::Application.configure do
-  config.action_mailer.perform_deliveries = AppConfig.mail.enable?
+  config.action_mailer.perform_deliveries = AppConfig.mail.enable? || ENV['LETTER_OPENER'].present?
 
-  unless Rails.env == 'test' || !AppConfig.mail.enable?
+  unless Rails.env == 'test' || ENV['LETTER_OPENER'].present? || !AppConfig.mail.enable?
     if AppConfig.mail.method == 'messagebus'
 
       if AppConfig.mail.message_bus_api_key.present?

--- a/config/locales/diaspora/de.yml
+++ b/config/locales/diaspora/de.yml
@@ -1312,6 +1312,15 @@ de:
     tags:
       contacts_title: "Personen, die diesen Tag nutzen"
       title: "Getaggte Beiträge: %{tags}"
+  subscriptions:
+    index:
+      title: "E-Mail-Abonnements"
+      explanation: "Auf dieser Seite kannst Du einstellen, für welche Kanäle Du E-Mail-Benachrichtigungen empfangen möchtest, sobald dort ein neuer Beitrag erstellt wird."
+      aspects: "Aspekte"
+      tags: "#Hashtags, denen Du folgst"
+    channel_switch:
+      subscribe: 'Abonnieren'
+      subscribed: 'Du erhältst E-Mail-Benachrichtigungen'
   tag_followings:
     create:
       failure: "Fehler beim Folgen von: #%{name}. Folgst du #%{name} bereits?"

--- a/config/locales/diaspora/de.yml
+++ b/config/locales/diaspora/de.yml
@@ -825,6 +825,9 @@ de:
       limited_post: "Du wurdest in einem begrenzten Beitrag erwähnt."
       mentioned: "hat dich in einem Beitrag erwähnt:"
       subject: "%{name} hat dich auf diaspora* erwähnt"
+    posted:
+      limited_post: "Ein begrenzter Beitrag wurde in einem Kanal veröffentlicht, den Du abonniert hast."
+      subject: "%{name} hat einen neuen Beitrag geschrieben"
     private_message:
       reply_to_or_view: "Antworte oder sieh dir diese Unterhaltung an >"
     remove_old_user:

--- a/config/locales/diaspora/de_formal.yml
+++ b/config/locales/diaspora/de_formal.yml
@@ -1295,6 +1295,15 @@ de_formal:
     tags:
       contacts_title: "Menschen, die diese Tags nutzen"
       title: "Getaggte Beiträge: %{tags}"
+  subscriptions:
+    index:
+      title: "E-Mail-Abonnements"
+      explanation: "Auf dieser Seite können Sie einstellen, für welche Kanäle Sie E-Mail-Benachrichtigungen empfangen möchten, sobald dort ein neuer Beitrag erstellt wird."
+      aspects: "Aspekte"
+      tags: "#Hashtags, denen Sie folgen"
+    channel_switch:
+      subscribe: 'Abonnieren'
+      subscribed: 'Sie erhalten E-Mail-Benachrichtigungen'
   tag_followings:
     create:
       failure: "Fehler beim Folgen von: #%{name}"

--- a/config/locales/diaspora/de_formal.yml
+++ b/config/locales/diaspora/de_formal.yml
@@ -820,6 +820,9 @@ de_formal:
       limited_post: "Sie wurden in einem begrenzten Beitrag erwähnt."
       mentioned: "hat Sie in einem Beitrag erwähnt:"
       subject: "%{name} hat Sie auf diaspora* erwähnt"
+    posted:
+      limited_post: "Ein begrenzter Beitrag wurde in einem Kanal veröffentlicht, den Sie abonniert haben."
+      subject: "%{name} hat einen neuen Beitrag geschrieben"
     private_message:
       reply_to_or_view: "Antworten Sie oder sehen Sie sich diese Unterhaltung an >"
     remove_old_user:

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -1280,6 +1280,15 @@ en:
       none: "The empty tag does not exist!"
     name_too_long: "Please make your tag name fewer than %{count} characters. Right now it is %{current_length} characters"
 
+  subscriptions:
+    index:
+      title: "Email subscriptions"
+      explanation: "On this page you may choose the channels you would like to receive email notifications for new posts."
+      aspects: "Aspects"
+      tags: "#Hashtags you are following"
+    channel_switch:
+      subscribe: 'Subscribe'
+      subscribed: 'You receive email notifications'
   tag_followings:
     create:
       success: "Hooray!  You’re now following #%{name}."

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -770,6 +770,9 @@ en:
         subject: "%{name} has mentioned you on diaspora*"
         mentioned: "mentioned you in a post:"
         limited_post: "You were mentioned in a limited post."
+    posted:
+      limited_post: "A new post has been published in a channel you've subscribed to."
+      subject: "%{name} has created a new post"
     private_message:
         reply_to_or_view: "Reply to or view this conversation >"
     liked:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -234,6 +234,9 @@ Diaspora::Application.routes.draw do
   if AppConfig.settings.terms.enable?
     get 'terms' => 'terms#index'
   end
+  
+  # Subscriptions
+  resources :subscriptions
 
   # Relay
   get ".well-known/x-social-relay" => "social_relay#well_known"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -234,7 +234,7 @@ Diaspora::Application.routes.draw do
   if AppConfig.settings.terms.enable?
     get 'terms' => 'terms#index'
   end
-  
+
   # Subscriptions
   resources :subscriptions
 

--- a/db/migrate/20151231140208_create_subscriptions.rb
+++ b/db/migrate/20151231140208_create_subscriptions.rb
@@ -1,0 +1,11 @@
+class CreateSubscriptions < ActiveRecord::Migration
+  def change
+    create_table :subscriptions do |t|
+      t.integer :subscriber_id
+      t.integer :channel_id
+      t.string :channel_type
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -495,6 +495,14 @@ ActiveRecord::Schema.define(version: 20151003142048) do
 
   add_index "simple_captcha_data", ["key"], name: "idx_key", using: :btree
 
+  create_table "subscriptions", force: :cascade do |t|
+    t.integer  "subscriber_id", limit: 4
+    t.integer  "channel_id",    limit: 4
+    t.string   "channel_type",  limit: 255
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+  end
+
   create_table "tag_followings", force: :cascade do |t|
     t.integer  "tag_id",     limit: 4, null: false
     t.integer  "user_id",    limit: 4, null: false

--- a/lib/account_deleter.rb
+++ b/lib/account_deleter.rb
@@ -46,15 +46,17 @@ class AccountDeleter
 
   #user deletions
   def normal_ar_user_associates_to_delete
-    [:tag_followings, :invitations_to_me, :services, :aspects, :subscriptions, :user_preferences, :notifications, :blocks]
+    %i(tag_followings invitations_to_me services aspects subscriptions
+       user_preferences notifications blocks)
   end
 
   def special_ar_user_associations
-    [:invitations_from_me, :person, :profile, :contacts, :auto_follow_back_aspect]
+    %i(invitations_from_me person profile contacts auto_follow_back_aspect)
   end
 
   def ignored_ar_user_associations
-    [:followed_tags, :invited_by, :contact_people, :aspect_memberships, :ignored_people, :conversation_visibilities, :conversations, :reports]
+    %i(followed_tags invited_by contact_people aspect_memberships ignored_people
+       conversation_visibilities conversations reports)
   end
 
   def delete_standard_user_associations

--- a/lib/account_deleter.rb
+++ b/lib/account_deleter.rb
@@ -46,7 +46,7 @@ class AccountDeleter
 
   #user deletions
   def normal_ar_user_associates_to_delete
-    [:tag_followings, :invitations_to_me, :services, :aspects, :user_preferences, :notifications, :blocks]
+    [:tag_followings, :invitations_to_me, :services, :aspects, :subscriptions, :user_preferences, :notifications, :blocks]
   end
 
   def special_ar_user_associations

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -11,36 +11,56 @@ describe Subscription do
     @contact = @user.contacts.create! person_id: @author.person.id, receiving: true, sharing: true
     @aspect = @user.aspects.create! name: "Family"
     @aspect_membership = @aspect.aspect_memberships.create! contact_id: @contact.id
-    @share_visibility = @post.share_visibilities.create! contact_id: @contact.id
   end
   
   describe ".by_post" do
     subject { Subscription.by_post(@post) }
     
-    describe "when the user subscribed to the post author" do
-      before { @subscription = @user.subscriptions.create channel: @post.author }
+    describe "when the post is visible for the user" do
+      before do
+        @share_visibility = @post.share_visibilities.create! contact_id: @contact.id
+      end
+    
+      describe "when the user subscribed to the post author" do
+        before { @subscription = @user.subscriptions.create! channel: @post.author }
+        
+        it "should include the subscription of the user" do
+          expect(subject).to include @user.subscriptions.first
+          expect(@user.subscriptions.first).to eq @subscription
+        end
+      end
       
-      it "should include the subscription of the user" do
-        expect(subject).to include @user.subscriptions.first
-        expect(@user.subscriptions.first).to eq @subscription
+      describe "when the user subscribed to an aspect the author is member of" do
+        before { @subscription = @user.subscriptions.create! channel: @aspect }
+        
+        it "should include the subscription of the user" do
+          expect(subject).to include @user.subscriptions.first
+          expect(@user.subscriptions.first).to eq @subscription
+        end
+      end
+      
+      describe "when the user subscribed to a tag of the post" do
+        before { @subscription = @user.subscriptions.create! channel: @tag }
+        
+        it "should include the subscription of the user" do
+          expect(subject).to include @user.subscriptions.first
+          expect(@user.subscriptions.first).to eq @subscription
+        end
       end
     end
     
-    describe "when the user subscribed to an aspect the author is member of" do
-      before { @subscription = @user.subscriptions.create channel: @aspect }
-      
-      it "should include the subscription of the user" do
-        expect(subject).to include @user.subscriptions.first
-        expect(@user.subscriptions.first).to eq @subscription
+    describe "when the post is not visible to the user" do
+      before do
+        @post.share_visibilities.destroy_all
+        
+        @user.subscriptions.create! channel: @post.author
+        @user.subscriptions.create! channel: @aspect
+        @user.subscriptions.create! channel: @tag
       end
-    end
-    
-    describe "when the user subscribed to a tag of the post" do
-      before { @subscription = @user.subscriptions.create channel: @tag }
       
-      it "should include the subscription of the user" do
-        expect(subject).to include @user.subscriptions.first
-        expect(@user.subscriptions.first).to eq @subscription
+      it "should not include the user's subscriptions (since the user is not allowed to see the post)" do
+        expect(subject).not_to include @user.subscriptions
+        expect(subject).to eq []
       end
     end
   end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe Subscription do
+  before do
+    @user = create :user  # This will be the subscriber.
+
+    @author = create :user
+    @post = Post.create! author: @author.person, type: "StatusMessage", text: "Currently #coding for #diaspora."
+    @tag = @post.tags.first
+    
+    @contact = @user.contacts.create! person_id: @author.person.id, receiving: true, sharing: true
+    @aspect = @user.aspects.create! name: "Family"
+    @aspect_membership = @aspect.aspect_memberships.create! contact_id: @contact.id
+    @share_visibility = @post.share_visibilities.create! contact_id: @contact.id
+  end
+  
+  describe ".by_post" do
+    subject { Subscription.by_post(@post) }
+    
+    describe "when the user subscribed to the post author" do
+      before { @subscription = @user.subscriptions.create channel: @post.author }
+      
+      it "should include the subscription of the user" do
+        expect(subject).to include @user.subscriptions.first
+        expect(@user.subscriptions.first).to eq @subscription
+      end
+    end
+    
+    describe "when the user subscribed to an aspect the author is member of" do
+      before { @subscription = @user.subscriptions.create channel: @aspect }
+      
+      it "should include the subscription of the user" do
+        expect(subject).to include @user.subscriptions.first
+        expect(@user.subscriptions.first).to eq @subscription
+      end
+    end
+    
+    describe "when the user subscribed to a tag of the post" do
+      before { @subscription = @user.subscriptions.create channel: @tag }
+      
+      it "should include the subscription of the user" do
+        expect(subject).to include @user.subscriptions.first
+        expect(@user.subscriptions.first).to eq @subscription
+      end
+    end
+  end
+end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1,63 +1,63 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Subscription do
   before do
-    @user = create :user  # This will be the subscriber.
+    @user = create :user # This will be the subscriber.
 
     @author = create :user
     @post = Post.create! author: @author.person, type: "StatusMessage", text: "Currently #coding for #diaspora."
     @tag = @post.tags.first
-    
+
     @contact = @user.contacts.create! person_id: @author.person.id, receiving: true, sharing: true
     @aspect = @user.aspects.create! name: "Family"
     @aspect_membership = @aspect.aspect_memberships.create! contact_id: @contact.id
   end
-  
+
   describe ".by_post" do
     subject { Subscription.by_post(@post) }
-    
+
     describe "when the post is visible for the user" do
       before do
         @share_visibility = @post.share_visibilities.create! contact_id: @contact.id
       end
-    
+
       describe "when the user subscribed to the post author" do
         before { @subscription = @user.subscriptions.create! channel: @post.author }
-        
+
         it "should include the subscription of the user" do
           expect(subject).to include @user.subscriptions.first
           expect(@user.subscriptions.first).to eq @subscription
         end
       end
-      
+
       describe "when the user subscribed to an aspect the author is member of" do
         before { @subscription = @user.subscriptions.create! channel: @aspect }
-        
+
         it "should include the subscription of the user" do
           expect(subject).to include @user.subscriptions.first
           expect(@user.subscriptions.first).to eq @subscription
         end
       end
-      
+
       describe "when the user subscribed to a tag of the post" do
         before { @subscription = @user.subscriptions.create! channel: @tag }
-        
+
         it "should include the subscription of the user" do
           expect(subject).to include @user.subscriptions.first
           expect(@user.subscriptions.first).to eq @subscription
         end
       end
     end
-    
+
     describe "when the post is not visible to the user" do
       before do
         @post.share_visibilities.destroy_all
-        
+
         @user.subscriptions.create! channel: @post.author
         @user.subscriptions.create! channel: @aspect
         @user.subscriptions.create! channel: @tag
       end
-      
+
       it "should not include the user's subscriptions (since the user is not allowed to see the post)" do
         expect(subject).not_to include @user.subscriptions
         expect(subject).to eq []


### PR DESCRIPTION
New users, family members and friends in particular, do not access diaspora\* on a regular basis. Instead, they expect to be notified via email when something interesting happens, i.e. when there are new posts of their family members or friends.

The idea behind this pull request is: A user can subscribe to certain channels in order to receive email notifications when a post is created in that channel. The channel is polymorphic such that the subscriber can subscribe to several types of objects:
- `Person`: Receive notifications whenever the person creates a post.
- `Aspect`: Receive notifications whenever anyone of the aspect's members creates a post.
- `Tag`: Receive notifications whenever a post is created with that tag.
## User interface

It is open to discussion how the users should subscribe to the channels in order to receive email notifications. 

One possibility would be to provide a subscription dropdown (like github's "watch" dropdown) where the user can subscribe to channels and choose a subscription level: (1) No subscription, (2) show in stream, (3) receive notification emails. If the channel is a person or an aspect, one also might expect to control from this menu whether to share with this person or aspect.

![img_1461](https://cloud.githubusercontent.com/assets/1679688/12072654/76d2f4fc-b0eb-11e5-9a5b-71f534097439.PNG)

But, for the moment, this pull requests only provides an `subscriptions#index` view from where the user can choose the channels for which he wants to receive email notifications.

<img width="1018" alt="bildschirmfoto 2016-01-02 um 00 51 54" src="https://cloud.githubusercontent.com/assets/1679688/12072657/7e04c8d6-b0eb-11e5-84a2-c85f18945135.png">

As long as this feature is work in progress, this view can't be accessed through any menu item, yet. Just visit https://localhost:3000/subscriptions to access `subscriptions#index`.

Also, we have to discuss what the default setting for (a) the four default aspects, (b) custom aspects, and (c) followed tags should be. For the moment, there are no default subscriptions, i.e. the users have to enable subscriptions manually.
## Letter opener

In order to try out email notifications in _development_, the [letter_opener gem](https://github.com/ryanb/letter_opener) has been added. This gem allows to view delivered emails in the browser in development. In order to keep the default behaviour of diaspora\* unchanged, you need to activate the letter_opener behaviour by setting the `LETTER_OPENER` environment variable when starting the rails server.

```
export LETTER_OPENER=true; bundle exec rails server
```
## Branching model

In order to be able to merge the feature into my pod's _production_ branch (for beta testing) without merging other code from the _upstream/develop_ branch, I've based the feature branch on _master_ rather than _develop_.

I think, git is smart enough to correctly merge the appropriate changes into the _develop_ branch. But is there anything I could do to make the merge easier without merging other _develop_ code into my _production_ branch?
## Next steps

In order to proceed, I will need some pointers for most of the following next steps.
- [ ] **Authorization**: The `SubscriptionsController` does not handle any authorization, yet. How is this done in diaspora_? Apparently, there is no *cancan_ gem.
- [ ] **Connecting to the federation**: Currently, this pull request only considers the local pod. What is the proper way to extend the code to properly talk to the other pods? I suspect, each pod should be responsible for notifying its local users. Then, the notification should be triggered when posts are created from outside. Where is the proper place to do this?
- [ ] **UI**:
  - [ ] **javascript**: Currently, `subscriptions#index` uses regular forms to toggle the subscriptions on/off. I'm not familiar with diaspora*'s client-side framework. But, for production use, the ui should give immediate feedback to a click on the 'subscribe' button.
  - [ ] **subscription dropdown** for Aspects, Tags, People, or some other way to handle subscriptions through the ui.
  - [ ] **menu item to access subscriptions#index**: Where would the user expect to find the subscriptions#index?
- [ ] **Translation in other languages**: Who is responsible to provide i18n for new features? Currently, this pull request provides `en`, `de` and `de_formal`.
- [ ] ~~**GPG emails**: It would be great if we could send more information about the new post via email, e.g. the first image and a couple of lines from the post's content. To respect privacy, this could be done by encrypting the email with the recipient's public key. Is there any mechanism to do this in diaspora*, yet?~~ _[jhass: No and adding such is completely out of scope of this PR. Please don't include anything into that direction here.]_
## Issues
- [ ] Sometimes, the wrong name appears as sender in notification emails about a new post.
- [ ] Sometimes, the multiple notification emails are sent.
- [ ] The `subscriptions#index` has no mobile view, yet.
