### PR TITLE
Wait for ajax to complete before checking for posts in the stream

### DIFF
--- a/features/step_definitions/posts_steps.rb
+++ b/features/step_definitions/posts_steps.rb
@@ -15,6 +15,7 @@ Then /^I should not see an uploaded image within the photo drop zone$/ do
 end
 
 Then /^I should not see any posts in my stream$/ do
+  page.assert_selector("#paginate .loader", visible: :hidden)
   page.assert_selector(".stream_element", count: 0)
 end
 


### PR DESCRIPTION
Previously cukes using the line "Then I should not see any posts in my stream" would always succeed. Because the assert_selector's condition is already fulfilled while the stream is loading the command doesn't wait for the stream to load on its own leading to immediate success of the condition (wether the stream is empty or not).

This PR introduces a loop waiting for all ajax requests to complete (and thus the stream to load) before checking if any posts are in the stream.
