### PR TITLE
Show posts of ignored users on their profile page

### DIFF
--- a/app/assets/javascripts/app/pages/profile.js
+++ b/app/assets/javascripts/app/pages/profile.js
@@ -75,13 +75,6 @@ app.pages.Profile = app.views.Base.extend({
     if(!this.model.has("profile")){
       return false;
     }
-    if( this.model.isBlocked() ) {
-      $("#main_stream").empty().html(
-        '<div class="dull">'+
-        Diaspora.I18n.t("profile.ignoring", {name: this.model.get("name")}) +
-        "</div>");
-      return false;
-    }
 
     // a collection is set, this means we want to view photos
     var route = this.streamCollection ? "personPhotos" : "personStream";

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -103,11 +103,17 @@ class Post < ActiveRecord::Base
     excluding_blocks(user).excluding_hidden_shareables(user)
   end
 
-  def self.for_a_stream(max_time, order, user=nil)
+  def self.for_a_stream(max_time, order, user=nil, ignore_blocks=false)
     scope = self.for_visible_shareable_sql(max_time, order).
       includes_for_a_stream
 
-    scope = scope.excluding_hidden_content(user) if user.present?
+    if user.present?
+      if ignore_blocks
+        scope = scope.excluding_hidden_shareables(user)
+      else
+        scope = scope.excluding_hidden_content(user)
+      end
+    end
 
     scope
   end

--- a/app/views/people/show.mobile.haml
+++ b/app/views/people/show.mobile.haml
@@ -27,7 +27,5 @@
       - else
         #main_stream
           .dull
-          - if @block.present?
-            = t(".ignoring", name: @person.first_name)
-          - elsif user_signed_in? && (current_user.person != @person)
+          - if user_signed_in? && (current_user.person != @person)
             = t(".has_not_shared_with_you_yet", name: @person.first_name)

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -914,7 +914,6 @@ en:
       start_sharing: "Start sharing"
       message: "Message"
       mention: "Mention"
-      ignoring: "You are ignoring all posts from %{name}."
       closed_account: "This account has been closed."
     sub_header:
       you_have_no_tags: "You have no tags!"

--- a/config/locales/javascript/javascript.en.yml
+++ b/config/locales/javascript/javascript.en.yml
@@ -194,7 +194,6 @@ en:
       edit: "Edit"
       add_some: "Add some"
       you_have_no_tags: "You have no tags!"
-      ignoring: "You are ignoring all posts from <%= name %>."
       bio: "Bio"
       location: "Location"
       gender: "Gender"

--- a/features/desktop/blocks_user.feature
+++ b/features/desktop/blocks_user.feature
@@ -7,6 +7,7 @@ Feature: Blocking a user from the stream
       | Alice Smith | alice@alice.alice |
     And a user with email "bob@bob.bob" is connected with "alice@alice.alice"
     And Alice has a post mentioning Bob
+    And "alice@alice.alice" has a public post with text "All your base are belong to us!"
     And I sign in as "bob@bob.bob"
 
   Scenario: Blocking a user
@@ -19,4 +20,6 @@ Feature: Blocking a user from the stream
     When I am on "alice@alice.alice"'s page
     When I click on the profile block button
     And I confirm the alert
+    Then "All your base are belong to us!" should be post 1
+    When I go to the home page
     Then I should not see any posts in my stream

--- a/lib/stream/person.rb
+++ b/lib/stream/person.rb
@@ -15,4 +15,11 @@ class Stream::Person < Stream::Base
   def posts
     @posts ||= user.present? ? user.posts_from(@person) : @person.posts.where(:public => true)
   end
+
+  # @return [Array<Post>]
+  def stream_posts
+    posts.for_a_stream(max_time, order, user, true).tap do |posts|
+      like_posts_for_stream!(posts) # some sql person could probably do this with joins.
+    end
+  end
 end


### PR DESCRIPTION
Currently the profile page of ignored users shows the text "You are ignoring all posts from %user". This gives the user no possibility to view the post of an ignored user except logging out.

This PR displays the posts of a user on the profile page even if he is ignored giving users the possibility to view the posts of a ignored user if they wish to do so.
