### PR TITLE
Removal of pre-filling message box - Do not merge. Not complete

### DIFF
--- a/app/assets/stylesheets/getting-started.scss
+++ b/app/assets/stylesheets/getting-started.scss
@@ -54,7 +54,6 @@
     color: $white;
     margin: 0;
     text-overflow: ellipsis;
-    white-space: nowrap;
   }
 
   #gs-skip-x {

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -243,7 +243,7 @@ en:
       people_sharing_with_you: "People sharing with you"
 
       welcome_to_diaspora: "Welcome to diaspora*, %{name}!"
-      introduce_yourself: "This is your stream.  Jump in and introduce yourself."
+      introduce_yourself: "This is your stream.  Why not let everyone know by creating a post with the #newhere tag to get started"
 
       new_here:
         title: "Welcome new users"

--- a/features/desktop/signs_up.feature
+++ b/features/desktop/signs_up.feature
@@ -39,23 +39,6 @@ Feature: new user registration
     Then I should be on the stream page
     And I close the publisher
 
-  Scenario: new user without any tags posts first status message
-    When I follow "awesome_button"
-    And I confirm the alert
-    Then I should be on the stream page
-    When I submit the publisher
-    Then "Hey everyone, I’m #newhere." should be post 1
-
-  Scenario: new user with some tags posts first status message
-    When I fill in the following:
-      | profile_first_name | some name        |
-    And I fill in "tags" with "#rockstar"
-    And I press the first ".as-result-item" within "#as-results-tags"
-    And I follow "awesome_button"
-    Then I should be on the stream page
-    When I submit the publisher
-    Then "Hey everyone, I’m #newhere. I’m interested in #rockstar." should be post 1
-
   Scenario: closing a popover clears getting started
     When I follow "awesome_button"
     And I confirm the alert


### PR DESCRIPTION
Upon requesting facebook integration for 'publish_actions' (As set out in the [dispora wiki](https://wiki.diasporafoundation.org/Integrating_other_social_networks) ) we actually break one of the rules which is pre-filling a message field. 

Facebook's policy example is here: https://developers.facebook.com/docs/apps/review/prefill
(While it basically says nothing)

How to produce this issue:
- Signup to a pod with a new account.
- Login with a new account
- Message box is now Pre-Filled with "Hello everyone, I'm #newhere"
- Example image:
  ![messagebox-example](https://diaspora.slowb.ro/uploads/images/scaled_full_fc06dd3b282af22ac67a.png)

My proposed fix is as follows:
- Replace the pre-filling of the post upon users first login, with an updated introduce_yourself h3.
- I removed the no-wrap so even on a smaller screen all text is viewable. 

![messagebox-1920x](https://diaspora.slowb.ro/uploads/images/scaled_full_83e81465009da1ad6f47.png)

![message](https://diaspora.slowb.ro/uploads/images/scaled_full_b21646380f61052659e3.png)

Thoughts?
