### PR TITLE
fix suppress_annoying_errors

### DIFF
--- a/app/workers/base.rb
+++ b/app/workers/base.rb
@@ -24,10 +24,10 @@ module Workers
       logger.warn "error on receive: #{e.class}"
     rescue ActiveRecord::RecordInvalid => e
       logger.warn "failed to save received object: #{e.record.errors.full_messages}"
-      raise e unless %w(
-        "already been taken"
+      raise e unless [
+        "already been taken",
         "is ignored by the post author"
-      ).any? {|reason| e.message.include? reason }
+      ].any? {|reason| e.message.include? reason }
     end
   end
 end

--- a/spec/integration/federation/receive_federation_messages_spec.rb
+++ b/spec/integration/federation/receive_federation_messages_spec.rb
@@ -46,7 +46,9 @@ describe "Receive federation messages feature" do
         post = FactoryGirl.create(:status_message, author: alice.person, public: false)
         reshare = FactoryGirl.build(
           :reshare_entity, root_diaspora_id: alice.diaspora_handle, root_guid: post.guid, diaspora_id: sender_id)
-        post_message(generate_xml(reshare, sender))
+        expect {
+          post_message(generate_xml(reshare, sender))
+        }.to raise_error ActiveRecord::RecordInvalid, "Validation failed: Only posts which are public may be reshared."
 
         expect(Reshare.exists?(root_guid: post.guid, diaspora_handle: sender_id)).to be_falsey
       end


### PR DESCRIPTION
%w splits at the spaces and creates `"already`, `been`, ...
