### PR TITLE
CSS: set "resize: vertical" as default for textarea

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -20,6 +20,10 @@ textarea {
 }
 // scss-lint:enable QualifyingElement
 
+textarea {
+  resize: vertical;
+}
+
 // Forms described here are only used on the public pages at the moment
 .block-form {
   margin: 20px auto;

--- a/app/assets/stylesheets/mobile/mobile.scss
+++ b/app/assets/stylesheets/mobile/mobile.scss
@@ -32,6 +32,10 @@ body {
   padding: 0;
 }
 
+textarea {
+  resize: vertical;
+}
+
 h3 {  margin-top: 0; }
 .clear { clear: both; }
 #main { padding: 56px 10px 0 10px; }


### PR DESCRIPTION
Hi there!

I think we should set default `resize` param to make textareas looks pretty, on the conversations pages, or `/profile/edit`...
