### PR TITLE
Fix blueimp gallery indicators

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -44,5 +44,6 @@
 //= require osmlocator
 //= require bootstrap-switch
 //= require blueimp-gallery
+//= require blueimp-gallery/blueimp-gallery-indicator
 //= require leaflet
 //= require api/authorization_page

--- a/app/assets/stylesheets/_application.scss
+++ b/app/assets/stylesheets/_application.scss
@@ -100,6 +100,7 @@
 
 /* gallery */
 @import 'blueimp-gallery';
+@import 'blueimp-gallery/blueimp-gallery-indicator';
 @import 'gallery';
 
 // settings


### PR DESCRIPTION
The blueimp gallery repo refactored the bower files and it looks like the indicators are no longer included. I don't know if this is a blueimp gallery issue or a rails-assets issue but this PR manually loads the missing files and fixes the gallery indicators (thumbnails).

Fixes a regression from #6665.
