### PR TITLE
Check for collapsible content_view again after images are loaded

### DIFF
--- a/app/assets/javascripts/app/views/content_view.js
+++ b/app/assets/javascripts/app/views/content_view.js
@@ -72,6 +72,21 @@ app.views.Content = app.views.Base.extend({
 
   postRenderTemplate : function(){
     _.defer(_.bind(this.collapseOversized, this));
+
+    // run collapseOversized again after all contained images are loaded
+    var self = this;
+    _.defer(function() {
+      self.$("img").each(function() {
+        this.addEventListener("load", function() {
+          // only fire if the top of the post is in viewport
+          var rect = self.el.getBoundingClientRect();
+          if(rect.top > 0) {
+            self.collapseOversized.call(self);
+          }
+        });
+      });
+    });
+
     var photoAttachments = this.$(".photo_attachments");
     if(photoAttachments.length > 0) {
       new app.views.Gallery({ el: photoAttachments });


### PR DESCRIPTION
I added a check for collapseOversized after each image in a post content have finished loading.
This was the main reason for posts with long / big images were not collapsed, since the checking code was run after the page was finished loading, but the images finished loading later.

I'm not certain how to write a test for this, since it's a countermeasure to some sort of timing problem. There are already tests for collapsing long posts, but they deal with text content only.

This will fix https://github.com/diaspora/diaspora/issues/3307
