### PR TITLE
Use Hamlit to render Haml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -175,7 +175,7 @@ gem "typhoeus",           "0.8.0"
 # Views
 
 gem "gon",                     "6.0.1"
-gem "haml",                    "4.0.7"
+gem "hamlit",                  "2.2.1"
 gem "mobile-fu",               "1.3.1"
 gem "will_paginate",           "3.1.0"
 gem "rails-timeago",           "2.11.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -390,6 +390,10 @@ GEM
       haml (~> 4.0)
       rubocop (>= 0.25.0)
       sysexits (~> 1.1)
+    hamlit (2.2.1)
+      temple (~> 0.7.6)
+      thor
+      tilt
     handlebars_assets (0.23.0)
       execjs (~> 2.0)
       multi_json (~> 1.0)
@@ -816,6 +820,7 @@ GEM
       json (>= 1.4.3)
     sysexits (1.2.0)
     systemu (2.6.5)
+    temple (0.7.6)
     terminal-table (1.5.2)
     test_after_commit (0.4.2)
       activerecord (>= 3.2)
@@ -927,8 +932,8 @@ DEPENDENCIES
   guard-jshintrb (= 1.1.1)
   guard-rspec (= 4.6.4)
   guard-rubocop (= 1.2.0)
-  haml (= 4.0.7)
   haml_lint (= 0.15.2)
+  hamlit (= 2.2.1)
   handlebars_assets (= 0.23.0)
   http_accept_language (= 2.0.5)
   i18n-inflector-rails (= 1.0.7)

--- a/config/initializers/haml.rb
+++ b/config/initializers/haml.rb
@@ -1,2 +1,2 @@
-Haml::Template.options[:format] = :html5
-Haml::Template.options[:escape_html] = true
+Hamlit::Engine.options[:format] = :html
+Hamlit::Engine.options[:escape_html] = true


### PR DESCRIPTION
[Hamlit](https://github.com/k0kubun/hamlit) is faster implementation of Haml language. I use it for production and some of OSS apps like [ManageIQ](https://github.com/manageiq/manageiq) uses it for performance.

This pull request changes Haml implementation to Hamlit. I confirmed that all tests except already failing ones passed on my local machine.
