### PR TITLE
Set maxwidth for container-fluid and unify settings UI

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -35,7 +35,7 @@ linters:
     enabled: true
 
   DisableLinterReason:
-    enabled: false
+    enabled: true
 
   DuplicateProperty:
     enabled: true

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -3,6 +3,13 @@ body {
   padding: none;
 }
 
+.container-fluid { max-width: $screen-lg-min; }
+
+.page-streams,
+.page-tags.action-show {
+  > .container-fluid { max-width: 100%; }
+}
+
 // Overflow
 h1,
 h2,

--- a/app/assets/stylesheets/conversations.scss
+++ b/app/assets/stylesheets/conversations.scss
@@ -191,11 +191,12 @@
   }
 }
 
-@media (max-width: 1354px) {
-  #left_pane #conversation_inbox .pagination ul > li > a {
-    padding: 4px 7px;
-  }
+// We need this to override the Bootstrap pagination style only for the conversations view
+// scss-lint:disable SelectorDepth
+.conversation-inbox .pagination > li > a {
+  padding: 4px 7px;
 }
+// scss-lint:enable SelectorDepth
 
 #new_conversation_pane {
   ul.as-selections { width: 100% !important; }

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -9,7 +9,6 @@
   }
 
   @media (max-width: $grid-float-breakpoint-max) {
-    .col-lg-10 { padding: 0; }
     .navbar-header > .nav li { display: inline-block !important; }
     .nav-badge {
       color: $navbar-inverse-link-color;

--- a/app/assets/templates/header_tpl.jst.hbs
+++ b/app/assets/templates/header_tpl.jst.hbs
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-inverse navbar-fixed-top">
   <div class="container-fluid">
     <div class="row">
-      <div class="col-lg-10 col-lg-offset-1">
+      <div class="col-md-12">
         <div class="navbar-header">
           <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target="#navbar-collapse">
             <span class="sr-only">{{t "header.toggle_navigation"}}</span>

--- a/app/views/api/openid_connect/user_applications/index.html.haml
+++ b/app/views/api/openid_connect/user_applications/index.html.haml
@@ -3,10 +3,9 @@
 
 .container-fluid.applications-page
   .row
-    .col-md-12
+    .col-md-3
       = render "shared/settings_nav"
-  .row
-    .col-md-12
+    .col-md-9
       %h3= t(".title")
       .row
         .col-md-12

--- a/app/views/api/openid_connect/user_applications/index.html.haml
+++ b/app/views/api/openid_connect/user_applications/index.html.haml
@@ -3,10 +3,10 @@
 
 .container-fluid.applications-page
   .row
-    .col-lg-10.col-lg-offset-1
+    .col-md-12
       = render "shared/settings_nav"
   .row
-    .col-lg-8.col-lg-offset-2
+    .col-md-12
       %h3= t(".title")
       .row
         .col-md-12

--- a/app/views/api/openid_connect/user_applications/index.mobile.haml
+++ b/app/views/api/openid_connect/user_applications/index.mobile.haml
@@ -1,6 +1,6 @@
 .container-fluid.settings_container.applications-page
   .row
-    .col-lg-10.col-lg-offset-1
+    .col-md-12
       - content_for :page_title do
         = t(".edit_applications")
       = render "shared/settings_nav"

--- a/app/views/conversations/index.haml
+++ b/app/views/conversations/index.haml
@@ -14,7 +14,7 @@
               = link_to t('.new_conversation'), conversations_path, class: 'btn btn-default'
             = t('.inbox')
 
-        #conversation_inbox
+        .conversation-inbox#conversation_inbox
           .stream.conversations
             - if @visibilities.count > 0
               = render partial: "conversations/conversation", collection: @visibilities, as: :visibility
@@ -34,9 +34,8 @@
       - else
         .stream_container.hidden
           #conversation_show
-        .row#conversation_new
-          .col-md-10.col-md-offset-1
-            .new-conversation
-              %h3.text-center
-                = t("conversations.index.new_conversation")
-              = render "conversations/new"
+        #conversation_new
+          .new-conversation
+            %h3.text-center
+              = t("conversations.index.new_conversation")
+            = render "conversations/new"

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -8,7 +8,7 @@
       %nav.navbar.navbar-inverse.navbar-fixed-top
         .container-fluid
           .row
-            .col-lg-10.col-lg-offset-1
+            .col-md-12
               .navbar-header
                 %button.navbar-toggle.collapsed{type: "button", data: {toggle: "collapse", target: "#navbar-collapse"}}
                   %span.sr-only

--- a/app/views/profiles/edit.haml
+++ b/app/views/profiles/edit.haml
@@ -4,11 +4,11 @@
 
 .container-fluid
   .row
-    .col-lg-10.col-lg-offset-1
+    .col-md-12
       = render "shared/settings_nav"
 
   .row
-    .col-lg-8.col-lg-offset-2
+    .col-md-12
       - content_for :submit_block do
         = link_to t("cancel"), local_or_remote_person_path(current_user.person), class: "btn btn-default"
         = submit_tag t(".update_profile"), class: "btn btn-primary pull-right", id: "update_profile"

--- a/app/views/profiles/edit.haml
+++ b/app/views/profiles/edit.haml
@@ -4,11 +4,9 @@
 
 .container-fluid
   .row
-    .col-md-12
+    .col-md-3
       = render "shared/settings_nav"
-
-  .row
-    .col-md-12
+    .col-md-9
       - content_for :submit_block do
         = link_to t("cancel"), local_or_remote_person_path(current_user.person), class: "btn btn-default"
         = submit_tag t(".update_profile"), class: "btn btn-primary pull-right", id: "update_profile"

--- a/app/views/profiles/edit.mobile.haml
+++ b/app/views/profiles/edit.mobile.haml
@@ -4,11 +4,11 @@
 
 .settings_container.container-fluid
   .row
-    .col-lg-10.col-lg-offset-1
+    .col-md-12
       = render "shared/settings_nav"
 
   .row
-    .col-lg-8.col-lg-offset-2
+    .col-md-12
       - content_for :submit_block do
         = link_to t("cancel"), local_or_remote_person_path(current_user.person), class: "btn btn-default"
         = submit_tag t(".update_profile"), class: "btn btn-primary pull-right", id: "update_profile"

--- a/app/views/services/index.html.haml
+++ b/app/views/services/index.html.haml
@@ -7,16 +7,16 @@
 
 .container-fluid
   .row
-    .col-lg-10.col-lg-offset-1
+    .col-md-12
       = render "shared/settings_nav"
 
   .row
-    .col-lg-8.col-lg-offset-2
+    .col-md-12
       %h3= t(".title")
   .row
-    .col-md-7.col-lg-5.col-lg-offset-2
+    .col-md-7
       = render "add_remove_services"
 
-    .col-md-5.col-lg-3
+    .col-md-5
       %p
         = t(".services_explanation")

--- a/app/views/services/index.html.haml
+++ b/app/views/services/index.html.haml
@@ -7,16 +7,15 @@
 
 .container-fluid
   .row
-    .col-md-12
+    .col-md-3
       = render "shared/settings_nav"
-
-  .row
-    .col-md-12
+    .col-md-9
       %h3= t(".title")
-  .row
-    .col-md-7
-      = render "add_remove_services"
+      .row
+        .col-md-12
+          = render "add_remove_services"
 
-    .col-md-5
-      %p
-        = t(".services_explanation")
+      .row
+        .col-md-12
+          %p
+            = t(".services_explanation")

--- a/app/views/services/index.mobile.haml
+++ b/app/views/services/index.mobile.haml
@@ -7,14 +7,14 @@
 
 .settings_container.services_page.container-fluid
   .row
-    .col-lg-10.col-lg-offset-1
+    .col-md-12
       = render "shared/settings_nav"
 
   .row
-    .col-lg-8.col-lg-offset-2
+    .col-md-12
       = render "add_remove_services"
 
   .row
-    .col-lg-8.col-lg-offset-2
+    .col-md-12
       .services_explanation
         = t(".services_explanation")

--- a/app/views/shared/_settings_nav.haml
+++ b/app/views/shared/_settings_nav.haml
@@ -1,10 +1,14 @@
 #section_header
   %h2
     = t("settings")
-  %ul.nav.nav-tabs#settings_nav
-    %li{class: current_page?(edit_profile_path) && "active"}= link_to t("profile"), edit_profile_path
-    %li{class: current_page?(edit_user_path) && "active"}= link_to t("account"), edit_user_path
-    %li{class: current_page?(privacy_settings_path) && "active"}= link_to t("privacy"), privacy_settings_path
-    %li{class: current_page?(services_path) && "active"}= link_to t("_services"), services_path
-    %li{class: current_page?(api_openid_connect_user_applications_path) && "active"}
-      = link_to t("_applications"), api_openid_connect_user_applications_path
+  .list-group#settings_nav
+    = link_to t("profile"), edit_profile_path,
+      class: current_page?(edit_profile_path) ? "list-group-item active" : "list-group-item"
+    = link_to t("account"), edit_user_path,
+      class: current_page?(edit_user_path) ? "list-group-item active" : "list-group-item"
+    = link_to t("privacy"), privacy_settings_path,
+      class: current_page?(privacy_settings_path) ? "list-group-item active" : "list-group-item"
+    = link_to t("_services"), services_path,
+      class: current_page?(services_path) ? "list-group-item active" : "list-group-item"
+    = link_to t("_applications"), api_openid_connect_user_applications_path,
+      class: current_page?(api_openid_connect_user_applications_path) ? "list-group-item active" : "list-group-item"

--- a/app/views/users/_edit.haml
+++ b/app/views/users/_edit.haml
@@ -6,11 +6,11 @@
   = t(".edit_account")
 
 .row
-  .col-lg-10.col-lg-offset-1
+  .col-md-12
     = render "shared/settings_nav"
 
 .row
-  .col-lg-8.col-lg-offset-2
+  .col-md-12
     .row
       .col-md-6
         %h3= t(".your_handle")
@@ -173,7 +173,7 @@
     %hr
 
     .row
-      .col-lg-7#account_data
+      .col-md-12#account_data
         .row
           .col-md-6
             %h3= t(".export_data")
@@ -208,7 +208,7 @@
                 = link_to t(".request_export_photos"), export_photos_user_path, method: :post,
                   class: "btn btn-default btn-block"
 
-      .col-lg-5
+      .col-md-12
         %h3
           = t(".close_account_text")
         .form-group

--- a/app/views/users/_edit.haml
+++ b/app/views/users/_edit.haml
@@ -7,10 +7,6 @@
 
 .row
   .col-md-12
-    = render "shared/settings_nav"
-
-.row
-  .col-md-12
     .row
       .col-md-6
         %h3= t(".your_handle")
@@ -173,42 +169,40 @@
     %hr
 
     .row
-      .col-md-12#account_data
-        .row
-          .col-md-6
-            %h3= t(".export_data")
-            .form-group
-              - if current_user.exporting
-                .export-in-progress= t(".export_in_progress")
-              - elsif current_user.export.present?
-                = link_to t(".request_export_update"), export_profile_user_path, method: :post,
-                  class: "btn btn-default btn-block"
-                .small-horizontal-spacer
-                = link_to t(".download_export"), download_profile_user_path,
-                  class: "btn btn-success btn-block"
-                .small-horizontal-spacer
-                %h6
-                  = t(".last_exported_at", timestamp: current_user.exported_at)
-              - else
-                = link_to t(".request_export"), export_profile_user_path, method: :post,
-                  class: "btn btn-default btn-block"
+      .col-md-6#account_data
+        %h3= t(".export_data")
+        .form-group
+          - if current_user.exporting
+            .export-in-progress= t(".export_in_progress")
+          - elsif current_user.export.present?
+            = link_to t(".request_export_update"), export_profile_user_path, method: :post,
+              class: "btn btn-default"
+            .small-horizontal-spacer
+            = link_to t(".download_export"), download_profile_user_path,
+              class: "btn btn-success"
+            .small-horizontal-spacer
+            %h6
+              = t(".last_exported_at", timestamp: current_user.exported_at)
+          - else
+            = link_to t(".request_export"), export_profile_user_path, method: :post,
+              class: "btn btn-default"
 
-            .form-group
-              - if current_user.exporting_photos
-                .export-in-progress= t(".export_photos_in_progress")
-              - elsif current_user.exported_photos_file.present?
-                = link_to t(".request_export_photos_update"), export_photos_user_path, method: :post,
-                  class: "btn btn-default btn-block"
-                .small-horizontal-spacer
-                = link_to t(".download_export_photos"), download_photos_user_path, class: "btn btn-success btn-block"
-                .small-horizontal-spacer
-                %h6
-                  = t(".last_exported_at", timestamp: current_user.exported_photos_at)
-              - else
-                = link_to t(".request_export_photos"), export_photos_user_path, method: :post,
-                  class: "btn btn-default btn-block"
+        .form-group
+          - if current_user.exporting_photos
+            .export-in-progress= t(".export_photos_in_progress")
+          - elsif current_user.exported_photos_file.present?
+            = link_to t(".request_export_photos_update"), export_photos_user_path, method: :post,
+              class: "btn btn-default"
+            .small-horizontal-spacer
+            = link_to t(".download_export_photos"), download_photos_user_path, class: "btn btn-success"
+            .small-horizontal-spacer
+            %h6
+              = t(".last_exported_at", timestamp: current_user.exported_photos_at)
+          - else
+            = link_to t(".request_export_photos"), export_photos_user_path, method: :post,
+              class: "btn btn-default"
 
-      .col-md-12
+      .col-md-6
         %h3
           = t(".close_account_text")
         .form-group

--- a/app/views/users/_privacy_settings.haml
+++ b/app/views/users/_privacy_settings.haml
@@ -1,34 +1,28 @@
 .row
   .col-md-12
-    = render "shared/settings_nav"
+    %h3
+      = t(".title")
+
+    = form_for current_user, url: user_path, html: {method: :put} do |f|
+      = f.error_messages
+
+      = f.fields_for :stream_preferences do
+        .checkbox#stream_prefs
+          = f.label :strip_exif do
+            = f.check_box :strip_exif
+            = t(".strip_exif")
+          = f.submit t("users.edit.change"), class: "btn btn-primary pull-right"
+%hr
 
 .row
   .col-md-12
-    .row
-      .col-md-12
-        %h3
-          = t(".title")
+    %h3
+      = t(".ignored_users")
 
-        = form_for current_user, url: user_path, html: {method: :put} do |f|
-          = f.error_messages
-
-          = f.fields_for :stream_preferences do
-            .checkbox#stream_prefs
-              = f.label :strip_exif do
-                = f.check_box :strip_exif
-                = t(".strip_exif")
-              = f.submit t("users.edit.change"), class: "btn btn-primary pull-right"
-    %hr
-
-    .row
-      .col-md-12
-        %h3
-          = t(".ignored_users")
-
-        - if @blocks.length.zero?
-          %p
-            = t(".no_user_ignored_message")
-        - else
-          #blocked_people
-            - @blocks.each do |block|
-              = render partial: "blocked_person", locals: {block: block, person: block.person}
+    - if @blocks.length.zero?
+      %p
+        = t(".no_user_ignored_message")
+    - else
+      #blocked_people
+        - @blocks.each do |block|
+          = render partial: "blocked_person", locals: {block: block, person: block.person}

--- a/app/views/users/_privacy_settings.haml
+++ b/app/views/users/_privacy_settings.haml
@@ -1,9 +1,9 @@
 .row
-  .col-lg-10.col-lg-offset-1
+  .col-md-12
     = render "shared/settings_nav"
 
 .row
-  .col-lg-8.col-lg-offset-2
+  .col-md-12
     .row
       .col-md-12
         %h3

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,2 +1,6 @@
 .container-fluid
-  = render "edit"
+  .row
+    .col-md-3
+      = render "shared/settings_nav"
+    .col-md-9
+      = render "edit"

--- a/app/views/users/edit.mobile.haml
+++ b/app/views/users/edit.mobile.haml
@@ -1,2 +1,8 @@
 .settings_container.container-fluid
-  = render "edit"
+  .row
+    .col-md-12
+      = render "shared/settings_nav"
+
+  .row
+    .col-md-12
+      = render "edit"

--- a/app/views/users/privacy_settings.html.haml
+++ b/app/views/users/privacy_settings.html.haml
@@ -6,4 +6,8 @@
   = t('.title')
 
 .container-fluid
-  = render "privacy_settings"
+  .row
+    .col-md-3
+      = render "shared/settings_nav"
+    .col-md-9
+      = render "privacy_settings"

--- a/app/views/users/privacy_settings.mobile.haml
+++ b/app/views/users/privacy_settings.mobile.haml
@@ -6,4 +6,10 @@
   = t(".title")
 
 .settings_container.container-fluid
-  = render "privacy_settings"
+  .row
+    .col-md-12
+      = render "shared/settings_nav"
+
+  .row
+    .col-md-12
+      = render "privacy_settings"


### PR DESCRIPTION
This PR sets the max-width for `.container-fluid` to 1200px which makes sure that streams, settings etc. don't look bad on wide screens. The max-width is still the same for the different stream pages and the tags view since they would need some redesign first and this is done in #6535. The width of the profile page however changes with this PR.

Since the settings pages were now really too wide I used the same `list-group` that we already have on the contacts and conversations page. This only affects the desktop settings pages.

I split these changes into two commits. There is a third commit since scss-lint didn't enforce comments before temporary linter changes. I can move that to another PR or just push the commit to the develop branch if anyone has a problem with the commit being part of this PR.
### settings page

![settings page](https://i.imgur.com/cV99zbk.png)
### conversations page

![conversations page](http://i.imgur.com/CGW6wpi.png)
### profile page

![profile page](http://i.imgur.com/zTrhHrB.png)
