### PR TITLE
Remove stream-title data attribute

### DIFF
--- a/app/assets/javascripts/app/app.js
+++ b/app/assets/javascripts/app/app.js
@@ -103,12 +103,7 @@ var app = {
 
       evt.preventDefault();
       var link = $(this);
-      if(link.data("stream-title") && link.data("stream-title").length) {
-        $(".stream_title").text(link.data("stream-title"));
-      } else {
-        $(".stream_title").text(link.text());
-      }
-
+      $(".stream_title").text(link.text());
       $("html, body").animate({scrollTop: 0});
 
       // app.router.navigate doesn't tell us if it changed the page,

--- a/app/assets/templates/header_tpl.jst.hbs
+++ b/app/assets/templates/header_tpl.jst.hbs
@@ -9,7 +9,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a href="/stream" class="navbar-brand" data-stream-title="{{t "my_stream"}}">
+          <a href="/stream" class="navbar-brand">
             {{ podname }}
           </a>
           <ul class="nav nav-badges visible-sm visible-xs">


### PR DESCRIPTION
Following #6686 and https://github.com/diaspora/diaspora/commit/ac5a7746e28327dae898413913ed770841bc5e8d it looks like we don't need data-stream-title anymore, `.stream_title` now only _really_ refers to the stream title (the legend of avatars in the right side column was previously also changed by this code). The only place where we still set data-stream-title instead of using the text of the link was the pod name in the header, which launches a refresh of the page anyway (so the title of the stream is not loaded with JS).
