### PR TITLE
Speed up asset serving in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -265,6 +265,8 @@ group :development do
 
   # test coverage
   gem "simplecov", "0.11.2", require: false
+
+  gem "turbo_dev_assets", "0.0.2"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -832,6 +832,7 @@ GEM
       hitimes
     tins (1.6.0)
     trollop (2.1.2)
+    turbo_dev_assets (0.0.2)
     twitter (5.16.0)
       addressable (~> 2.3)
       buftok (~> 0.2.0)
@@ -1027,6 +1028,7 @@ DEPENDENCIES
   spring-commands-rspec (= 1.0.4)
   test_after_commit (= 0.4.2)
   timecop (= 0.8.0)
+  turbo_dev_assets (= 0.0.2)
   twitter (= 5.16.0)
   twitter-text (= 1.13.3)
   typhoeus (= 0.8.0)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,4 +37,7 @@ Diaspora::Application.configure do
 
   # Show the logging configuration on STDOUT
   config.show_log_configuration = true
+
+  # Speed up asset serving
+  config.middleware.insert 0, TurboDevAssets
 end


### PR DESCRIPTION
[Discourse uses the same code](https://github.com/discourse/discourse/blob/master/lib/middleware/turbo_dev.rb) and this is just the gem version of it.
