### PR TITLE
Remove #publisher_photo_upload from haml

### DIFF
--- a/app/views/photos/_new_profile_photo.haml
+++ b/app/views/photos/_new_profile_photo.haml
@@ -69,5 +69,3 @@
 
   %p
     #fileInfo
-
-  #publisher_photo_upload

--- a/app/views/publisher/_publisher.html.haml
+++ b/app/views/publisher/_publisher.html.haml
@@ -73,6 +73,4 @@
 
     = link_to "", contacts_path(aspect_ids: aspect_ids), class: "selected_contacts_link hidden"
 
-    #publisher_photo_upload
-
 = render "shared/public_explain"

--- a/app/views/publisher/_publisher.mobile.haml
+++ b/app/views/publisher/_publisher.mobile.haml
@@ -37,5 +37,3 @@
         id: "submit_new_message",
         data: {"disable-with" => t("shared.publisher.posting")}
     .clearfix
-
-    #publisher_photo_upload


### PR DESCRIPTION
It seems like #publisher_photo_upload is relict of blueprint.
It was removed from CSS in 0c7d319fdc31ea6de8c6f30ae7badf89c9d5aef8 and
probably was unused even before. So remove it from publishers.
