### PR TITLE
Include a private key to the user data export archive

### DIFF
--- a/app/serializers/export/user_serializer.rb
+++ b/app/serializers/export/user_serializer.rb
@@ -4,6 +4,7 @@ module Export
                :email,
                :language,
                :username,
+               :serialized_private_key,
                :disable_mail,
                :show_community_spotlight_in_stream,
                :auto_follow_back,


### PR DESCRIPTION
In order to allow a user to notify his contacts of his migration with a trustworthy signature the old private key must be available to the new pod where we import data.
