### PR TITLE
Cleanup aspect visibilities

### DIFF
--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -150,10 +150,12 @@ class PhotosController < ApplicationController
     @photo = current_user.build_post(:photo, params[:photo])
 
     if @photo.save
-      aspects = current_user.aspects_from_ids(params[:photo][:aspect_ids])
 
       unless @photo.pending
-        current_user.add_to_streams(@photo, aspects)
+        unless @photo.public?
+          aspects = current_user.aspects_from_ids(params[:photo][:aspect_ids])
+          current_user.add_to_streams(@photo, aspects)
+        end
         current_user.dispatch_post(@photo, :to => params[:photo][:aspect_ids])
       end
 

--- a/app/controllers/reshares_controller.rb
+++ b/app/controllers/reshares_controller.rb
@@ -11,7 +11,6 @@ class ResharesController < ApplicationController
     end
 
     if @reshare.save
-      current_user.add_to_streams(@reshare, current_user.aspects)
       current_user.dispatch_post(@reshare, :url => post_url(@reshare), :additional_subscribers => @reshare.root_author)
       render :json => ExtremePostPresenter.new(@reshare, current_user), :status => 201
     else

--- a/app/models/user/querying.rb
+++ b/app/models/user/querying.rb
@@ -134,7 +134,10 @@ module User::Querying
     query = opts[:klass].where(conditions)
 
     unless opts[:all_aspects?]
-      query = query.joins(:aspect_visibilities).where(aspect_visibilities: {aspect_id: opts[:by_members_of]})
+      query = query.with_aspects.where(
+        AspectVisibility.arel_table[:aspect_id].in(opts[:by_members_of])
+          .or(opts[:klass].arel_table[:public].eq(true))
+      )
     end
 
     ugly_select_clause(query, opts)

--- a/app/services/status_message_creation_service.rb
+++ b/app/services/status_message_creation_service.rb
@@ -34,9 +34,9 @@ class StatusMessageCreationService
   end
 
   def destination_aspect_ids(params, user)
-    if params[:status_message][:public] || params[:status_message][:aspect_ids].first == "all_aspects"
+    if params[:status_message][:aspect_ids].first == "all_aspects"
       user.aspect_ids
-    else
+    elsif !params[:status_message][:public]
       params[:aspect_ids]
     end
   end

--- a/db/migrate/20160302025129_cleanup_aspect_visibility.rb
+++ b/db/migrate/20160302025129_cleanup_aspect_visibility.rb
@@ -1,0 +1,27 @@
+class CleanupAspectVisibility < ActiveRecord::Migration
+  class AspectVisibility < ActiveRecord::Base
+  end
+
+  def up
+    AspectVisibility.joins("LEFT OUTER JOIN posts ON posts.id = aspect_visibilities.shareable_id")
+      .where(shareable_type: "Post").delete_all("posts.id is NULL")
+    AspectVisibility.joins("LEFT OUTER JOIN photos ON photos.id = aspect_visibilities.shareable_id")
+      .where(shareable_type: "Photo").delete_all("photos.id is NULL")
+    AspectVisibility.joins("INNER JOIN posts ON posts.id = aspect_visibilities.shareable_id")
+      .where(shareable_type: "Post").delete_all(posts: {public: true})
+    AspectVisibility.joins("INNER JOIN photos ON photos.id = aspect_visibilities.shareable_id")
+      .where(shareable_type: "Photo").delete_all(photos: {public: true})
+
+    remove_columns :aspect_visibilities, :created_at, :updated_at
+  end
+
+  def down
+    add_column :aspect_visibilities, :created_at, :datetime
+    add_column :aspect_visibilities, :updated_at, :datetime
+
+    User.all.each do |user|
+      user.posts.where(public: true).each {|post| user.add_to_streams(post, user.aspects) }
+      user.photos.where(public: true).each {|photo| user.add_to_streams(photo, user.aspects) }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160225232049) do
+ActiveRecord::Schema.define(version: 20160302025129) do
 
   create_table "account_deletions", force: :cascade do |t|
     t.string   "diaspora_handle", limit: 255
@@ -31,11 +31,9 @@ ActiveRecord::Schema.define(version: 20160225232049) do
   add_index "aspect_memberships", ["contact_id"], name: "index_aspect_memberships_on_contact_id", using: :btree
 
   create_table "aspect_visibilities", force: :cascade do |t|
-    t.integer  "shareable_id",   limit: 4,                    null: false
-    t.integer  "aspect_id",      limit: 4,                    null: false
-    t.datetime "created_at",                                  null: false
-    t.datetime "updated_at",                                  null: false
-    t.string   "shareable_type", limit: 255, default: "Post", null: false
+    t.integer "shareable_id",   limit: 4,                    null: false
+    t.integer "aspect_id",      limit: 4,                    null: false
+    t.string  "shareable_type", limit: 255, default: "Post", null: false
   end
 
   add_index "aspect_visibilities", ["aspect_id"], name: "index_aspect_visibilities_on_aspect_id", using: :btree

--- a/lib/diaspora/shareable.rb
+++ b/lib/diaspora/shareable.rb
@@ -8,7 +8,7 @@ module Diaspora
   module Shareable
     def self.included(model)
       model.instance_eval do
-        has_many :aspect_visibilities, as: :shareable, validate: false
+        has_many :aspect_visibilities, as: :shareable, validate: false, dependent: :delete_all
         has_many :aspects, through: :aspect_visibilities
 
         has_many :share_visibilities, as: :shareable, dependent: :delete_all

--- a/lib/diaspora/shareable.rb
+++ b/lib/diaspora/shareable.rb
@@ -24,6 +24,10 @@ module Diaspora
           joins("LEFT OUTER JOIN share_visibilities ON share_visibilities.shareable_id = #{table_name}.id")
         }
 
+        scope :with_aspects, -> {
+          joins("LEFT OUTER JOIN aspect_visibilities ON aspect_visibilities.shareable_id = #{table_name}.id")
+        }
+
         def self.owned_or_visible_by_user(user)
           with_visibility.where(
             visible_by_user(user).or(arel_table[:public].eq(true)

--- a/spec/controllers/reshares_controller_spec.rb
+++ b/spec/controllers/reshares_controller_spec.rb
@@ -33,11 +33,6 @@ describe ResharesController, :type => :controller do
         }.to change(Reshare, :count).by(1)
       end
 
-      it 'after save, calls add to streams' do
-        expect(bob).to receive(:add_to_streams)
-        post_request!
-      end
-
       it 'calls dispatch' do
         expect(bob).to receive(:dispatch_post).with(anything, hash_including(:additional_subscribers))
         post_request!


### PR DESCRIPTION
This is based on #6723, because I needed the new stream-query-refactorings.

This cleans up most of the `aspect_visibilities` table:
- with nerdpol.ch database:
  - before: 560k rows
  - after: 32k rows

The `aspect_visibilities` for public posts didn't work anyway, because after creating a new aspect, all old public posts were missing in this aspect-stream
