### PR TITLE
Fix birthday issues on leap days

### DIFF
--- a/app/helpers/people_helper.rb
+++ b/app/helpers/people_helper.rb
@@ -16,10 +16,10 @@ module PeopleHelper
   end
 
   def birthday_format(bday)
-    if bday.year == 1000
-      I18n.l bday, :format => I18n.t('date.formats.birthday')
+    if bday.year <= 1004
+      I18n.l bday, format: I18n.t("date.formats.birthday")
     else
-      I18n.l bday, :format => I18n.t('date.formats.birthday_with_year')
+      I18n.l bday, format: I18n.t("date.formats.birthday_with_year")
     end
   end
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -113,20 +113,20 @@ class Profile < ActiveRecord::Base
   end
 
   def date= params
-    if ['month', 'day'].all? { |key| params[key].present?  }
-      params['year'] = '1000' if params['year'].blank?
-      if Date.valid_civil?(params['year'].to_i, params['month'].to_i, params['day'].to_i)
-        self.birthday = Date.new(params['year'].to_i, params['month'].to_i, params['day'].to_i)
+    if %w(month day).all? {|key| params[key].present? }
+      params["year"] = "1004" if params["year"].blank?
+      if Date.valid_civil?(params["year"].to_i, params["month"].to_i, params["day"].to_i)
+        self.birthday = Date.new(params["year"].to_i, params["month"].to_i, params["day"].to_i)
       else
         @invalid_birthday_date = true
       end
-    elsif [ 'year', 'month', 'day'].all? { |key| params[key].blank? }
+    elsif %w(year month day).all? {|key| params[key].blank? }
       self.birthday = nil
     end
   end
 
   def formatted_birthday
-    birthday.to_s(:long).gsub(', 1000', '') if birthday.present?
+    birthday.to_s(:long).gsub(/, 100[0|4]/, "") if birthday.present?
   end
 
   def bio_message

--- a/spec/helpers/people_helper_spec.rb
+++ b/spec/helpers/people_helper_spec.rb
@@ -10,6 +10,18 @@ describe PeopleHelper, :type => :helper do
     @person = FactoryGirl.create(:person)
   end
 
+  describe "#birthday_format" do
+    it "contains the birth year if available" do
+      birthday = Date.new 2016, 3, 5
+      expect(birthday_format(birthday)).to include "2016"
+    end
+
+    it "does not contain the birth year if placeholder year is used" do
+      birthday = Date.new 1004, 3, 5
+      expect(birthday_format(birthday)).not_to include "1004"
+    end
+  end
+
   describe "#person_image_link" do
     it "returns an empty string if person is nil" do
       expect(person_image_link(nil)).to eq("")


### PR DESCRIPTION
Our cukes broke on Tuesday because our [placeholder birth year fails](http://schub.io/blog/2016/03/05/the-leap-day-the-profiles-died.html) on leap days. I've changed the default year to `1004` which passed the validation.

This also fixes the profile update for people who are born on leap days!

I'm happy if someone has a nice idea on how to write a test that fails on lap days without having to add a lot of stuff (like a library to change the date for tests), but I had no idea...
