### PR TITLE
fix pod table migration if someone deleted a user (owner) manually

### DIFF
--- a/db/migrate/20160124234712_extend_pods.rb
+++ b/db/migrate/20160124234712_extend_pods.rb
@@ -46,9 +46,9 @@ class ExtendPods < ActiveRecord::Migration
     add_column :people, :pod_id, :integer
     add_index :people, :url, length: 190
     add_foreign_key :people, :pods, name: :people_pod_id_fk, on_delete: :cascade
-    Person.where(owner: nil).group_by {|person| person[:url] }.each do |url, _|
+    Person.where(owner: nil).distinct(:url).pluck(:url).each do |url|
       pod = Pod.find_or_create_by(url: url)
-      Person.where(url: url).update_all(pod_id: pod.id)
+      Person.where(url: url, owner_id: nil).update_all(pod_id: pod.id) if pod.persisted?
     end
 
     # cleanup unused pods

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -369,7 +369,7 @@ FactoryGirl.define do
   factory(:federation_person_from_webfinger, class: DiasporaFederation::Entities::Person) do
     sequence(:guid) { UUID.generate :compact }
     sequence(:diaspora_id) {|n| "bob-person-#{n}#{r_str}@example.net" }
-    url AppConfig.pod_uri.to_s
+    url "https://example.net/"
     exported_key OpenSSL::PKey::RSA.generate(1024).public_key.export
     profile {
       DiasporaFederation::Entities::Profile.new(

--- a/spec/lib/postzord/receiver/public_spec.rb
+++ b/spec/lib/postzord/receiver/public_spec.rb
@@ -21,7 +21,7 @@ describe Postzord::Receiver::Public do
       xml = Salmon::Slap.create_by_user_and_activity(bob, comment.to_diaspora_xml).xml_for(nil)
       person = bob.person
       person.owner = nil
-      person.pod = Pod.find_or_create_by(url: AppConfig.pod_uri)
+      person.pod = Pod.find_or_create_by(url: "https://example.org/")
       person.save
       bob.destroy
       comment.destroy

--- a/spec/models/pod_spec.rb
+++ b/spec/models/pod_spec.rb
@@ -25,17 +25,45 @@ describe Pod, type: :model do
     end
 
     it "updates ssl boolean if upgraded to https" do
-      pod = Pod.find_or_create_by(url: "http://joindiaspora.com/")
+      pod = Pod.find_or_create_by(url: "http://example.org/")
       expect(pod.ssl).to be false
-      pod = Pod.find_or_create_by(url: "https://joindiaspora.com/")
+      pod = Pod.find_or_create_by(url: "https://example.org/")
       expect(pod.ssl).to be true
     end
 
     it "does not update ssl boolean if downgraded to http" do
-      pod = Pod.find_or_create_by(url: "https://joindiaspora.com/")
+      pod = Pod.find_or_create_by(url: "https://example.org/")
       expect(pod.ssl).to be true
-      pod = Pod.find_or_create_by(url: "http://joindiaspora.com/")
+      pod = Pod.find_or_create_by(url: "http://example.org/")
       expect(pod.ssl).to be true
+    end
+
+    context "validation" do
+      it "is valid" do
+        pod = Pod.find_or_create_by(url: "https://example.org/")
+        expect(pod).to be_valid
+      end
+
+      it "doesn't allow own pod" do
+        pod = Pod.find_or_create_by(url: AppConfig.url_to("/"))
+        expect(pod).not_to be_valid
+      end
+
+      it "doesn't allow own pod with default port" do
+        uri = URI.parse("https://example.org/")
+        allow(AppConfig).to receive(:pod_uri).and_return(uri)
+
+        pod = Pod.find_or_create_by(url: AppConfig.url_to("/"))
+        expect(pod).not_to be_valid
+      end
+
+      it "doesn't allow own pod with other scheme" do
+        uri = URI.parse("https://example.org/")
+        allow(AppConfig).to receive(:pod_uri).and_return(uri)
+
+        pod = Pod.find_or_create_by(url: "http://example.org/")
+        expect(pod).not_to be_valid
+      end
     end
   end
 


### PR DESCRIPTION
@jpope777 deleted a user manually in the database, so the owner of the person was nil and the migration created a `Pod` for his own pod and linked this with all other users. This is now fixed.

Follow up for #6727 
