### PR TITLE
Remove diaspora_handle from shareables

### DIFF
--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -86,7 +86,6 @@ class Photo < ActiveRecord::Base
     photo.author = params[:author]
     photo.public = params[:public] if params[:public]
     photo.pending = params[:pending] if params[:pending]
-    photo.diaspora_handle = photo.author.diaspora_handle
 
     photo.random_string = SecureRandom.hex(10)
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -137,7 +137,6 @@ class Post < ActiveRecord::Base
     new_post.author = params[:author]
     new_post.public = params[:public] if params[:public]
     new_post.pending = params[:pending] if params[:pending]
-    new_post.diaspora_handle = new_post.author.diaspora_handle
     new_post
   end
 

--- a/db/migrate/20160307142216_cleanup_handles.rb
+++ b/db/migrate/20160307142216_cleanup_handles.rb
@@ -1,0 +1,7 @@
+class CleanupHandles < ActiveRecord::Migration
+  def change
+    remove_column :photos, :tmp_old_id, :integer
+    remove_column :photos, :diaspora_handle, :string
+    remove_column :posts, :diaspora_handle, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160302025129) do
+ActiveRecord::Schema.define(version: 20160307142216) do
 
   create_table "account_deletions", force: :cascade do |t|
     t.string   "diaspora_handle", limit: 255
@@ -341,10 +341,8 @@ ActiveRecord::Schema.define(version: 20160302025129) do
   add_index "people", ["pod_id"], name: "people_pod_id_fk", using: :btree
 
   create_table "photos", force: :cascade do |t|
-    t.integer  "tmp_old_id",          limit: 4
     t.integer  "author_id",           limit: 4,                     null: false
     t.boolean  "public",                            default: false, null: false
-    t.string   "diaspora_handle",     limit: 255
     t.string   "guid",                limit: 255,                   null: false
     t.boolean  "pending",                           default: false, null: false
     t.text     "text",                limit: 65535
@@ -418,7 +416,6 @@ ActiveRecord::Schema.define(version: 20160302025129) do
   create_table "posts", force: :cascade do |t|
     t.integer  "author_id",             limit: 4,                     null: false
     t.boolean  "public",                              default: false, null: false
-    t.string   "diaspora_handle",       limit: 255
     t.string   "guid",                  limit: 255,                   null: false
     t.boolean  "pending",                             default: false, null: false
     t.string   "type",                  limit: 40,                    null: false

--- a/lib/diaspora/federated/shareable.rb
+++ b/lib/diaspora/federated/shareable.rb
@@ -24,12 +24,11 @@ module Diaspora
       module InstanceMethods
         include Diaspora::Logging
         def diaspora_handle
-          read_attribute(:diaspora_handle) || author.diaspora_handle
+          author.diaspora_handle
         end
 
         def diaspora_handle=(author_handle)
           self.author = Person.where(diaspora_handle: author_handle).first
-          write_attribute(:diaspora_handle, author_handle)
         end
 
         # @param [User] user The user that is receiving this shareable.

--- a/spec/integration/federation/receive_federation_messages_spec.rb
+++ b/spec/integration/federation/receive_federation_messages_spec.rb
@@ -39,7 +39,8 @@ describe "Receive federation messages feature" do
           :reshare_entity, root_diaspora_id: alice.diaspora_handle, root_guid: post.guid, diaspora_id: sender_id)
         post_message(generate_xml(reshare, sender))
 
-        expect(Reshare.exists?(root_guid: post.guid, diaspora_handle: sender_id)).to be_truthy
+        expect(Reshare.exists?(root_guid: post.guid)).to be_truthy
+        expect(Reshare.where(root_guid: post.guid).last.diaspora_handle).to eq(sender_id)
       end
 
       it "reshare of private post fails" do
@@ -50,7 +51,7 @@ describe "Receive federation messages feature" do
           post_message(generate_xml(reshare, sender))
         }.to raise_error ActiveRecord::RecordInvalid, "Validation failed: Only posts which are public may be reshared."
 
-        expect(Reshare.exists?(root_guid: post.guid, diaspora_handle: sender_id)).to be_falsey
+        expect(Reshare.exists?(root_guid: post.guid)).to be_falsey
       end
     end
 


### PR DESCRIPTION
We can determine diaspora_handle from a relation with people for the
shareables (posts, photos). So we don't need to store diaspora_handle in
the DB. Also remove tmp_old_id from photos which is not refenrenced anywhere.
