### PR TITLE
https oembed

### DIFF
--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -20,7 +20,7 @@ module PostsHelper
   def post_iframe_url(post_id, opts={})
     opts[:width] ||= 516
     opts[:height] ||= 315
-    host = AppConfig.pod_uri.authority
-   "<iframe src='#{Rails.application.routes.url_helpers.post_url(post_id, :host => host)}' width='#{opts[:width]}px' height='#{opts[:height]}px' frameBorder='0'></iframe>".html_safe
+    "<iframe src='#{AppConfig.url_to(Rails.application.routes.url_helpers.post_path(post_id))}' " \
+      "width='#{opts[:width]}px' height='#{opts[:height]}px' frameBorder='0'></iframe>".html_safe
   end
 end

--- a/app/presenters/o_embed_presenter.rb
+++ b/app/presenters/o_embed_presenter.rb
@@ -38,7 +38,7 @@ class OEmbedPresenter
   end
 
   def post_author_url
-   Rails.application.routes.url_helpers.person_url(@post.author, :host => AppConfig.pod_uri.host)
+    AppConfig.url_to(Rails.application.routes.url_helpers.person_path(@post.author))
   end
 
   def iframe_html

--- a/spec/helpers/jsxc_helper_spec.rb
+++ b/spec/helpers/jsxc_helper_spec.rb
@@ -2,20 +2,19 @@ require 'spec_helper'
 
 describe JsxcHelper, :type => :helper do
   before do
-    AppConfig.chat.server.bosh.proxy = false
     AppConfig.chat.server.bosh.port = 1234
-    AppConfig.chat.server.bosh.bind = '/bind'
-    AppConfig.environment.url = "https://localhost/"
-    AppConfig.instance_variable_set(:@pod_uri, nil)
+    AppConfig.chat.server.bosh.bind = "/bind"
   end
 
   describe "#get_bosh_endpoint" do
     it "using http scheme and default values" do
+      AppConfig.chat.server.bosh.proxy = false
       expect(helper.get_bosh_endpoint).to include %Q(http://localhost:1234/bind)
     end
 
     it "using https scheme and no port" do
       AppConfig.chat.server.bosh.proxy = true
+      allow(AppConfig).to receive(:pod_uri).and_return(Addressable::URI.parse("https://localhost/"))
       expect(helper.get_bosh_endpoint).to include %Q(https://localhost/bind)
     end
   end


### PR DESCRIPTION
Use `AppConfig.url_to` instead of `_url` which didn't generate the pod-url with https if the pod has https.

Also fixed the `jsxc_helper_spec.rb`. It changed the `AppConfig.environment.url` permanently for all following specs. Mock it temporarily now.
