### PR TITLE
Toggle action isn't idempotent, so it can't be PUT-action

### DIFF
--- a/app/views/contacts/_header.html.haml
+++ b/app/views/contacts/_header.html.haml
@@ -4,14 +4,14 @@
       - if @aspect.contacts.size > 0 && @aspect.contacts.size < 20
         = start_a_conversation_link(@aspect, @aspect.contacts.size)
 
-      = link_to aspect_toggle_contact_visibility_path(@aspect), id: "contacts_visibility_toggle", class: "contacts_button", method: :put, remote: true do
+      = link_to aspect_toggle_contact_visibility_path(@aspect), id: "contacts_visibility_toggle", class: "contacts_button", method: :patch, remote: true do
         -if @aspect.contacts_visible?
           %i.entypo-lock-open.contacts-header-icon{title: t("aspects.edit.aspect_list_is_visible")}
         -else
           %i.entypo-lock.contacts-header-icon{title: t("aspects.edit.aspect_list_is_not_visible")}
 
       -if AppConfig.chat.enabled?
-        = link_to aspect_toggle_chat_privilege_path(@aspect), id: "chat_privilege_toggle", class: "contacts_button", method: :put, remote: true do
+        = link_to aspect_toggle_chat_privilege_path(@aspect), id: "chat_privilege_toggle", class: "contacts_button", method: :patch, remote: true do
           -if @aspect.chat_enabled?
             %i.entypo-chat.enabled.contacts-header-icon{title: t("aspects.edit.aspect_chat_is_enabled")}
           -else

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,8 +58,8 @@ Diaspora::Application.routes.draw do
   get "aspects" => "streams#aspects", :as => "aspects_stream"
 
   resources :aspects do
-    put :toggle_contact_visibility
-    put :toggle_chat_privilege
+    patch :toggle_contact_visibility
+    patch :toggle_chat_privilege
     collection do
       put "order" => :update_order
     end


### PR DESCRIPTION
It looks that toggle actions have wrong HTTP-method semantics. PUT method is for idempotent actions, but toggle performed twice is not equal to toggle performed once. POST method should be more appropriate.
