### PR TITLE
Fix back to top not appearing on Webkit browsers + redesign

### DIFF
--- a/app/assets/javascripts/app/views/back_to_top_view.js
+++ b/app/assets/javascripts/app/views/back_to_top_view.js
@@ -16,7 +16,7 @@ app.views.BackToTop = Backbone.View.extend({
   },
 
   toggleVisibility: function() {
-    if($("html, body").scrollTop() > 1000) {
+    if($(document).scrollTop() > 1000) {
       $("#back-to-top").addClass("visible");
     } else {
       $("#back-to-top").removeClass("visible");

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -65,22 +65,25 @@ pre { word-wrap: break-word; }
 
 .back-to-top {
   background-color: $border-dark-grey;
-  border-radius: 10px;
+  border-radius: 4px;
   bottom: 20px;
   color: $white;
   display: block;
-  font-size: 2.9em;
-  line-height: 1.5;
+  font-size: 3.5em;
+  height: 50px;
+  line-height: 50px;
   opacity: 0;
-  padding: 0 12px;
   position: fixed;
   right: 54px;
+  transition: opacity ease 400ms;
+  width: 50px;
   z-index: 49;
 
   &:hover,
   &.visible:hover {
     color: $white;
     opacity: .85;
+    text-decoration: none;
   }
 
   &.visible { opacity: .5; }

--- a/app/views/people/contacts.haml
+++ b/app/views/people/contacts.haml
@@ -17,8 +17,7 @@
             = render partial: 'people/person', locals: hash
         = will_paginate @contacts_of_contact, renderer: WillPaginate::ActionView::BootstrapLinkRenderer
 
-      %a.back-to-top#back-to-top{title: "#{t('layouts.application.back_to_top')}", href: "#"}
-        &#8679;
+      %a.entypo-chevron-up.back-to-top#back-to-top{title: "#{t('layouts.application.back_to_top')}", href: "#"}
 
 -if user_signed_in? && @person
   #new_status_message_pane

--- a/app/views/people/index.html.haml
+++ b/app/views/people/index.html.haml
@@ -37,8 +37,7 @@
 
           = will_paginate(@people)
 
-        %a.back-to-top#back-to-top{title: "#{t('layouts.application.back_to_top')}", href: "#"}
-          &#8679;
+        %a.entypo-chevron-up.back-to-top#back-to-top{title: "#{t('layouts.application.back_to_top')}", href: "#"}
 
     .col-md-4
       - if AppConfig.settings.invitations.open?

--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -27,8 +27,7 @@
           %span.loader.hidden
             .spinner
 
-      %a.back-to-top#back-to-top{title: "#{t('layouts.application.back_to_top')}", href: "#"}
-        &#8679;
+      %a.entypo-chevron-up.back-to-top#back-to-top{title: "#{t('layouts.application.back_to_top')}", href: "#"}
 
 -if user_signed_in? && @person
   #new_status_message_pane

--- a/app/views/streams/main_stream.html.haml
+++ b/app/views/streams/main_stream.html.haml
@@ -158,5 +158,4 @@
       .stream_container#aspect_stream_container
         = render "aspects/aspect_stream", stream: @stream
 
-      %a.back-to-top#back-to-top{title: "#{t('layouts.application.back_to_top')}", href: "#"}
-        &#8679;
+      %a.entypo-chevron-up.back-to-top#back-to-top{title: "#{t('layouts.application.back_to_top')}", href: "#"}

--- a/app/views/tags/show.haml
+++ b/app/views/tags/show.haml
@@ -34,5 +34,4 @@
           %span.loader.hidden
             .spinner
 
-      %a.back-to-top#back-to-top{title: "#{t('layouts.application.back_to_top')}", href: "#"}
-        &#8679;
+      %a.entypo-chevron-up.back-to-top#back-to-top{title: "#{t('layouts.application.back_to_top')}", href: "#"}


### PR DESCRIPTION
The `$("html, body").scrollTop()` was always returning 0 on Webkit browsers.

I changed the arrow based on #5729 while touching that, so this should supersedes #6713. I simply replaced the character by the CSS arrow designed by @SansPseudoFix 
