### PR TITLE
Extend the generated fixtures set and refactor AccountDeletion

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -37,8 +37,13 @@ class Person < ActiveRecord::Base
   has_many :posts, :foreign_key => :author_id, :dependent => :destroy # This person's own posts
   has_many :photos, :foreign_key => :author_id, :dependent => :destroy # This person's own photos
   has_many :comments, :foreign_key => :author_id, :dependent => :destroy # This person's own comments
+  has_many :likes, foreign_key: :author_id, dependent: :destroy # This person's own likes
   has_many :participations, :foreign_key => :author_id, :dependent => :destroy
+  has_many :poll_participations, foreign_key: :author_id, dependent: :destroy
   has_many :conversation_visibilities
+  has_many :messages, foreign_key: :author_id
+  has_many :conversations, foreign_key: :author_id
+  has_many :blocks
 
   has_many :roles
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,6 +49,7 @@ class User < ActiveRecord::Base
            :first_name, :last_name, :gender, :participations, to: :person
   delegate :id, :guid, to: :person, prefix: true
 
+  has_many :invitation_codes
   has_many :aspects, -> { order('order_id ASC') }
 
   belongs_to  :auto_follow_back_aspect, :class_name => 'Aspect'

--- a/lib/account_deleter.rb
+++ b/lib/account_deleter.rb
@@ -18,7 +18,7 @@ class AccountDeleter
   attr_accessor :person, :user
 
   def initialize(diaspora_handle)
-    self.person = Person.where(:diaspora_handle => diaspora_handle).first
+    self.person = Person.by_account_identifier(diaspora_handle)
     self.user = self.person.owner
   end
 
@@ -45,7 +45,7 @@ class AccountDeleter
   #user deletions
   def normal_ar_user_associates_to_delete
     %i(tag_followings services aspects user_preferences
-       notifications blocks authorizations o_auth_applications pairwise_pseudonymous_identifiers)
+       notifications blocks authorizations o_auth_applications pairwise_pseudonymous_identifiers invitation_codes)
   end
 
   def special_ar_user_associations
@@ -101,7 +101,8 @@ class AccountDeleter
   end
 
   def ignored_or_special_ar_person_associations
-    %i(comments contacts notification_actors notifications owner profile conversation_visibilities pod)
+    %i(comments likes contacts notification_actors notifications owner profile conversation_visibilities pod
+       messages conversations poll_participations blocks)
   end
 
   def mark_account_deletion_complete

--- a/spec/controllers/admins_controller_spec.rb
+++ b/spec/controllers/admins_controller_spec.rb
@@ -18,6 +18,7 @@ describe AdminsController, :type => :controller do
 
     context "admin signed in" do
       before do
+        Report.destroy_all
         Role.add_admin(@user.person)
         @post = bob.post(:status_message, text: "hello", to: bob.aspects.first.id)
         @post_report = alice.reports.create(

--- a/spec/controllers/conversations_controller_spec.rb
+++ b/spec/controllers/conversations_controller_spec.rb
@@ -144,14 +144,14 @@ describe ConversationsController, :type => :controller do
         it "responds with the conversation id as JSON" do
           post :create, @hash
           expect(response).to be_success
-          expect(JSON.parse(response.body)["id"]).to eq(Conversation.first.id)
+          expect(JSON.parse(response.body)["id"]).to eq(Conversation.last.id)
         end
 
         it "sets the author to the current_user" do
           @hash[:author] = FactoryGirl.create(:user)
           post :create, @hash
-          expect(Message.first.author).to eq(alice.person)
-          expect(Conversation.first.author).to eq(alice.person)
+          expect(Message.last.author).to eq(alice.person)
+          expect(Conversation.last.author).to eq(alice.person)
         end
 
         it "dispatches the conversation" do
@@ -183,7 +183,7 @@ describe ConversationsController, :type => :controller do
         it "responds with the conversation id as JSON" do
           post :create, @hash
           expect(response).to be_success
-          expect(JSON.parse(response.body)["id"]).to eq(Conversation.first.id)
+          expect(JSON.parse(response.body)["id"]).to eq(Conversation.last.id)
         end
       end
 
@@ -314,14 +314,14 @@ describe ConversationsController, :type => :controller do
         it "responds with the conversation id as JSON" do
           post :create, @hash
           expect(response).to be_success
-          expect(JSON.parse(response.body)["id"]).to eq(Conversation.first.id)
+          expect(JSON.parse(response.body)["id"]).to eq(Conversation.last.id)
         end
 
         it "sets the author to the current_user" do
           @hash[:author] = FactoryGirl.create(:user)
           post :create, @hash
-          expect(Message.first.author).to eq(alice.person)
-          expect(Conversation.first.author).to eq(alice.person)
+          expect(Message.last.author).to eq(alice.person)
+          expect(Conversation.last.author).to eq(alice.person)
         end
 
         it "dispatches the conversation" do
@@ -353,7 +353,7 @@ describe ConversationsController, :type => :controller do
         it "responds with the conversation id as JSON" do
           post :create, @hash
           expect(response).to be_success
-          expect(JSON.parse(response.body)["id"]).to eq(Conversation.first.id)
+          expect(JSON.parse(response.body)["id"]).to eq(Conversation.last.id)
         end
       end
 

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -167,20 +167,21 @@ describe NotificationsController, :type => :controller do
   describe "#read_all" do
     it 'marks all notifications as read' do
       request.env["HTTP_REFERER"] = "I wish I were spelled right"
-      FactoryGirl.create(:notification, :recipient => alice, :target => @post)
-      FactoryGirl.create(:notification, :recipient => alice, :target => @post)
+      FactoryGirl.create(:notification, recipient: alice, target: @post)
+      FactoryGirl.create(:notification, recipient: alice, target: @post)
 
-      expect(Notification.where(:unread => true).count).to eq(2)
+      expect(Notification.where(unread: true, recipient: alice).count).to eq(2)
       get :read_all
-      expect(Notification.where(:unread => true).count).to eq(0)
+      expect(Notification.where(unread: true, recipient: alice).count).to eq(0)
     end
     it 'marks all notifications in the current filter as read' do
       request.env["HTTP_REFERER"] = "I wish I were spelled right"
-      FactoryGirl.create(:notification, :recipient => alice, :target => @post)
-      FactoryGirl.create(:notification, :recipient => alice, :type => "Notifications::StartedSharing")
-      expect(Notification.where(:unread => true).count).to eq(2)
-      get :read_all, "type" => "started_sharing"
-      expect(Notification.where(:unread => true).count).to eq(1)
+      FactoryGirl.create(:notification, recipient: alice, target: @post)
+      FactoryGirl.create(:notification, recipient: alice, type: "Notifications::StartedSharing")
+
+      expect(Notification.where(unread: true, recipient: alice).count).to eq(2)
+      get :read_all, type: "started_sharing"
+      expect(Notification.where(unread: true, recipient: alice).count).to eq(1)
     end
     it "should redirect back in the html version if it has > 0 notifications" do
       FactoryGirl.create(:notification, :recipient => alice, :type => "Notifications::StartedSharing")

--- a/spec/controllers/status_messages_controller_spec.rb
+++ b/spec/controllers/status_messages_controller_spec.rb
@@ -185,7 +185,7 @@ describe StatusMessagesController, :type => :controller do
       status_message_hash.merge!(:aspect_ids => ['public'])
       status_message_hash[:status_message].merge!(:provider_display_name => "mobile")
       post :create, status_message_hash
-      expect(StatusMessage.first.provider_display_name).to eq('mobile')
+      expect(StatusMessage.last.provider_display_name).to eq("mobile")
     end
 
     it "has no participation" do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -339,6 +339,21 @@ FactoryGirl.define do
     additional_data { {"new_property" => "some text"} }
   end
 
+  factory :report do
+    sequence(:text) {|n| "#{n} offensive content" }
+    association :user
+  end
+
+  factory :report_on_post, parent: :report do
+    association :item, factory: :status_message
+    item_type "Post"
+  end
+
+  factory :role do
+    association :person
+    name "moderator"
+  end
+
   factory(:poll_participation_signature) do
     author_signature "some signature"
     association :signature_order, order: "guid parent_guid author poll_answer_guid new_property"
@@ -352,7 +367,7 @@ FactoryGirl.define do
   factory(:status, :parent => :status_message)
 
   factory :o_auth_application, class: Api::OpenidConnect::OAuthApplication do
-    client_name "Diaspora Test Client"
+    sequence(:client_name) {|n| "Diaspora Test Client #{n}#{r_str}" }
     redirect_uris %w(http://localhost:3000/)
   end
 

--- a/spec/helper_methods.rb
+++ b/spec/helper_methods.rb
@@ -27,12 +27,12 @@ module HelperMethods
     File.open(fixture_name)
   end
 
-  def create_conversation_with_message(sender, recipient_person, subject, text)
+  def create_conversation_with_message(sender_person, recipient_person, subject, text)
     create_hash = {
-      :author => sender.person,
-      :participant_ids => [sender.person.id, recipient_person.id],
-      :subject => subject,
-      :messages_attributes => [ {:author => sender.person, :text => text} ]
+      author:              sender_person,
+      participant_ids:     [sender_person.id, recipient_person.id],
+      subject:             subject,
+      messages_attributes: [{author: sender_person, text: text}]
     }
 
     Conversation.create!(create_hash)

--- a/spec/helpers/report_helper_spec.rb
+++ b/spec/helpers/report_helper_spec.rb
@@ -1,5 +1,7 @@
 describe ReportHelper, type: :helper do
   before do
+    Report.destroy_all
+
     @user = bob
     @post = @user.post(:status_message, text: "hello", to: @user.aspects.first.id)
     @comment = @user.comment!(@post, "welcome")

--- a/spec/integration/account_deletion_spec.rb
+++ b/spec/integration/account_deletion_spec.rb
@@ -35,6 +35,14 @@ describe "deleteing your account", type: :request do
       expect(user.contacts).to be_empty
     end
 
+    it "deletes all invitation codes" do
+      expect(bob.invitation_codes).to be_empty
+    end
+
+    it "deletes all tag followings" do
+      expect(bob.tag_followings).to be_empty
+    end
+
     it "clears the account fields" do
       user.send(:clearable_fields).each do |field|
         expect(user.reload[field]).to be_blank

--- a/spec/integration/account_deletion_spec.rb
+++ b/spec/integration/account_deletion_spec.rb
@@ -1,128 +1,61 @@
 describe "deleteing your account", type: :request do
   context "user" do
     before do
-      @person = bob.person
-      @alices_post = alice.post(:status_message,
-                                text: "@{bob Grimn; #{bob.person.diaspora_handle}} you are silly",
-                                to:   alice.aspects.find_by_name("generic"))
-
-      # bob's own content
-      bob.post(:status_message, text: "asldkfjs", to: bob.aspects.first)
-      FactoryGirl.create(:photo, author: bob.person)
-
-      @aspect_vis = AspectVisibility.where(aspect_id: bob.aspects.map(&:id))
-
-      # objects on post
-      bob.like!(@alices_post)
-      bob.comment!(@alices_post, "here are some thoughts on your post")
-
-      # conversations
-      create_conversation_with_message(alice, bob.person, "Subject", "Hey bob")
-
-      # join tables
-      @users_sv = ShareVisibility.where(user_id: bob.id).load
-      @persons_sv = ShareVisibility.where(shareable_id: bob.posts.map(&:id), shareable_type: "Post").load
-
-      # user associated objects
-      @prefs = []
-      %w(mentioned liked reshared).each do |pref|
-        @prefs << bob.user_preferences.create!(email_type: pref)
-      end
-
-      # notifications
-      @notifications = []
-      3.times do
-        @notifications << FactoryGirl.create(:notification, recipient: bob)
-      end
-
-      # services
-      @services = []
-      3.times do
-        @services << FactoryGirl.create(:service, user: bob)
-      end
-
-      # block
-      @block = bob.blocks.create!(person: eve.person)
-
-      AccountDeleter.new(bob.person.diaspora_handle).perform!
-      bob.reload
+      AccountDeleter.new(user.person.diaspora_handle).perform!
+      user.reload
     end
 
+    let(:user) { carol }
+
     it "deletes all of the user's preferences" do
-      expect(UserPreference.where(id: @prefs.map(&:id))).to be_empty
+      expect(UserPreference.where(user_id: user.id)).to be_empty
     end
 
     it "deletes all of the user's notifications" do
-      expect(Notification.where(id: @notifications.map(&:id))).to be_empty
+      expect(Notification.where(recipient_id: user.id)).to be_empty
     end
 
     it "deletes all of the users's blocked users" do
-      expect(Block.where(id: @block.id)).to be_empty
+      expect(Block.where(user_id: user.id)).to be_empty
     end
 
     it "deletes all of the user's services" do
-      expect(Service.where(id: @services.map(&:id))).to be_empty
+      expect(Service.where(user_id: user.id)).to be_empty
     end
 
-    it "deletes all of bobs share visiblites" do
-      expect(ShareVisibility.where(id: @users_sv.map(&:id))).to be_empty
-      expect(ShareVisibility.where(id: @persons_sv.map(&:id))).to be_empty
-    end
-
-    it "deletes all of bobs aspect visiblites" do
-      expect(AspectVisibility.where(id: @aspect_vis.map(&:id))).to be_empty
+    it "deletes all of user's share visiblites" do
+      expect(ShareVisibility.where(user_id: user.id)).to be_empty
     end
 
     it "deletes all aspects" do
-      expect(bob.aspects).to be_empty
+      expect(user.aspects).to be_empty
     end
 
     it "deletes all user contacts" do
-      expect(bob.contacts).to be_empty
+      expect(user.contacts).to be_empty
     end
 
     it "clears the account fields" do
-      bob.send(:clearable_fields).each do |field|
-        expect(bob.reload[field]).to be_blank
+      user.send(:clearable_fields).each do |field|
+        expect(user.reload[field]).to be_blank
       end
     end
 
-    it_should_behave_like "it removes the person associations"
+    it_should_behave_like "it removes the person associations" do
+      let(:person) { user.person }
+    end
   end
 
   context "remote person" do
     before do
       @person = remote_raphael
 
-      # contacts
-      @contacts = @person.contacts
-
-      # posts
-      @posts = (1..3).map do
-        FactoryGirl.create(:status_message, author: @person)
-      end
-
-      @persons_sv = @posts.each do |post|
-        @contacts.each do |contact|
-          ShareVisibility.create!(user_id: contact.user.id, shareable: post)
-        end
-      end
-
-      # photos
-      @photo = FactoryGirl.create(:photo, author: @person)
-
-      # mentions
-      @mentions = 3.times do
-        FactoryGirl.create(:mention, person: @person)
-      end
-
-      # conversations
-      create_conversation_with_message(alice, @person, "Subject", "Hey bob")
-
       AccountDeleter.new(@person.diaspora_handle).perform!
       @person.reload
     end
 
-    it_should_behave_like "it removes the person associations"
+    it_should_behave_like "it removes the person associations" do
+      let(:person) { @person }
+    end
   end
 end

--- a/spec/mailers/report_spec.rb
+++ b/spec/mailers/report_spec.rb
@@ -32,29 +32,28 @@ describe Report, type: :mailer do
     it "should be added to the delivery queue" do
       expect {
         ReportMailer.new_report(@post_report.id).each(&:deliver_now)
-      }.to change(ActionMailer::Base.deliveries, :size).by(2)
+      }.to change(ActionMailer::Base.deliveries, :size).by(Role.count)
     end
 
     it "should include correct recipient" do
       ReportMailer.new_report(@post_report.id).each(&:deliver_now)
-      expect(ActionMailer::Base.deliveries[0].to[0]).to include(@user.email)
-      expect(ActionMailer::Base.deliveries[1].to[0]).to include(@user2.email)
+      moderators_emails = ActionMailer::Base.deliveries.map(&:to).flatten
+      expect(moderators_emails).to include(@user.email)
+      expect(moderators_emails).to include(@user2.email)
     end
 
     it "should send mail in recipent's prefered language" do
       ReportMailer.new_report(@post_report.id).each(&:deliver_now)
-      expect(ActionMailer::Base.deliveries[0].subject).to match("Ein neuer post wurde als anstößig markiert")
-      expect(ActionMailer::Base.deliveries[1].subject).to match("A new post was marked as offensive")
-    end
-
-    it "should find correct post translation" do
-      ReportMailer.new_report(@post_report.id).each(&:deliver_now)
-      expect(ActionMailer::Base.deliveries[0].subject).not_to match("translation missing")
+      expect(ActionMailer::Base.deliveries.find {|msg| msg.to[0] == @user.email }.subject)
+        .to match("Ein neuer post wurde als anstößig markiert")
+      expect(ActionMailer::Base.deliveries.find {|msg| msg.to[0] == @user2.email }.subject)
+        .to match("A new post was marked as offensive")
     end
 
     it "should find correct comment translation" do
       ReportMailer.new_report(@comment_report.id).each(&:deliver_now)
-      expect(ActionMailer::Base.deliveries[0].subject).not_to match("translation missing")
+      expect(ActionMailer::Base.deliveries.find {|msg| msg.to[0] == @user.email }.subject)
+        .not_to match("translation missing")
     end
   end
 end

--- a/spec/misc_spec.rb
+++ b/spec/misc_spec.rb
@@ -12,6 +12,10 @@ describe 'making sure the spec runner works' do
   describe 'fixtures' do
     it 'loads fixtures' do
       expect(User.count).not_to eq(0)
+      expect(TagFollowing.count).not_to eq(0)
+      expect(Role.count).not_to eq(0)
+      expect(Report.count).not_to eq(0)
+      expect(Api::OpenidConnect::OAuthApplication.count).not_to eq(0)
     end
   end
 
@@ -78,7 +82,7 @@ describe 'making sure the spec runner works' do
 
   describe "#create_conversation_with_message" do
     it 'creates a conversation and a message' do
-      conversation = create_conversation_with_message(alice, bob.person, "Subject", "Hey Bob")
+      conversation = create_conversation_with_message(alice.person, bob.person, "Subject", "Hey Bob")
 
       expect(conversation.participants).to eq([alice.person, bob.person])
       expect(conversation.subject).to eq("Subject")

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -60,11 +60,14 @@ describe Notification, :type => :model do
     end
 
     it "creates a new notification if the notification is unread" do
-      @note.unread = false
-      @note.save
-      expect(Notification.count).to eq(1)
-      Notification.concatenate_or_create(@note.recipient, @note.target, eve.person)
-      expect(Notification.count).to eq(2)
+      expect {
+        @note.unread = false
+        @note.save
+      }.to change(Notification, :count).by(1)
+
+      expect {
+        Notification.concatenate_or_create(@note.recipient, @note.target, @note.actors.first)
+      }.to change(Notification, :count).by(1)
     end
 
     it "appends the actors to the already existing notification" do

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -91,7 +91,7 @@ describe Post, :type => :model do
       end
 
       it 'returns posts if you dont have any blocks' do
-        expect(Post.excluding_blocks(alice).count).to eq(2)
+        expect(Post.excluding_blocks(alice).count).to eq(Post.count)
       end
     end
 
@@ -119,6 +119,7 @@ describe Post, :type => :model do
 
     context 'having some posts' do
       before do
+        Post.destroy_all
         time_interval = 1000
         time_past = 1000000
         @posts = (1..5).map do |n|

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1098,7 +1098,7 @@ describe User, :type => :model do
     end
 
     it "returns total_users excluding closed accounts & users without usernames" do
-      expect(User.active.count).to eq 6     # 6 users from fixtures
+      expect(User.active.count).to eq 8 # 8 users from fixtures
     end
   end
 end

--- a/spec/shared_behaviors/account_deletion.rb
+++ b/spec/shared_behaviors/account_deletion.rb
@@ -19,6 +19,14 @@ shared_examples_for 'it removes the person associations' do
     expect(Photo.where(author_id: person.id)).to be_empty
   end
 
+  it "deletes all person's participations" do
+    expect(Participation.where(author_id: person.id)).to be_empty
+  end
+
+  it "deletes all person's roles" do
+    expect(Role.where(person_id: person.id)).to be_empty
+  end
+
   it 'sets the person object as closed and the profile is cleared' do
     expect(person.reload.closed_account).to be true
 

--- a/spec/shared_behaviors/account_deletion.rb
+++ b/spec/shared_behaviors/account_deletion.rb
@@ -4,30 +4,37 @@
 
 shared_examples_for 'it removes the person associations' do
   it "removes all of the person's posts" do
-    expect(Post.where(:author_id => @person.id).count).to eq(0)
+    expect(Post.where(author_id: person.id).count).to eq(0)
   end
 
   it 'deletes all person contacts' do
-    expect(Contact.where(:person_id => @person.id)).to be_empty
+    expect(Contact.where(person_id: person.id)).to be_empty
   end
 
   it 'deletes all mentions' do
-    expect(@person.mentions).to be_empty
+    expect(person.mentions).to be_empty
   end
 
   it "removes all of the person's photos" do
-    expect(Photo.where(:author_id => @person.id)).to be_empty
+    expect(Photo.where(author_id: person.id)).to be_empty
   end
 
   it 'sets the person object as closed and the profile is cleared' do
-    expect(@person.reload.closed_account).to  be true
+    expect(person.reload.closed_account).to be true
 
-    expect(@person.profile.reload.first_name).to  be_blank
-    expect(@person.profile.reload.last_name).to  be_blank
+    expect(person.profile.first_name).to be_blank
+    expect(person.profile.last_name).to be_blank
   end
 
-  it 'deletes only the converersation visibility for the deleted user' do
-    expect(ConversationVisibility.where(:person_id => alice.person.id)).not_to be_empty
-    expect(ConversationVisibility.where(:person_id => @person.id)).to be_empty
+  it "deletes all the converersation visibilities for the deleted user" do
+    expect(ConversationVisibility.where(person_id: person.id)).to be_empty
+  end
+
+  it "doesn't delete the conversations of the user" do
+    expect(Conversation.where(author: person)).not_to be_empty
+  end
+
+  it "doesn't delete the converersation visibilities for other participants in the user's conversations" do
+    expect(ConversationVisibility.where(conversation: Conversation.where(author: person))).not_to be_empty
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,10 @@ def bob
   @bob ||= User.find_by(username: "bob")
 end
 
+def carol
+  @carol ||= User.find_by(username: "carol")
+end
+
 def eve
   @eve ||= User.find_by(username: "eve")
 end

--- a/spec/support/fixture_builder.rb
+++ b/spec/support/fixture_builder.rb
@@ -18,8 +18,15 @@ FixtureBuilder.configure do |fbuilder|
     bobs_aspect = bob.aspects.where(:name => "generic").first
     FactoryGirl.create(:aspect, :name => "empty", :user => bob)
 
+    carol = FactoryGirl.create(:user_with_aspect, username: "carol")
+    carols_aspect = carol.aspects.where(name: "generic").first
+
+    debora = FactoryGirl.create(:user_with_aspect, username: "debora")
+    deboras_aspect = carol.aspects.where(name: "generic").first
+
     connect_users(bob, bobs_aspect, alice, alices_aspect)
     connect_users(bob, bobs_aspect, eve, eves_aspect)
+    connect_users(carol, carols_aspect, debora, deboras_aspect)
 
     # Set up friends - 2 local, 1 remote
     local_luke = FactoryGirl.create(:user_with_aspect, :username => "luke")
@@ -43,5 +50,90 @@ FixtureBuilder.configure do |fbuilder|
                            :aspects => [peters_aspect],
                            :sharing => false,
                            :receiving => true)
-   end
+
+    deboras_post = debora.post(:status_message,
+                               text: "@{carol; #{carol.person.diaspora_handle}} you are silly",
+                               to:   carols_aspect)
+
+    # objects on post
+    carol.like!(deboras_post)
+    carol.comment!(deboras_post, "here are some thoughts on your post")
+    deboras_post.reload
+
+    # conversations
+    create_conversation_with_message(carol.person, debora.person, "Subject", "Hey debora")
+
+    # poll participation
+    smwp = FactoryGirl.create(:status_message_with_poll)
+    carol.participate_in_poll!(smwp, smwp.poll.poll_answers[0])
+
+    # carol's own content
+    carol.post(:status_message, text: "asldkfjs", to: carol.aspects.first)
+
+    # user associated objects
+    %w(mentioned liked reshared).each do |pref|
+      carol.user_preferences.create!(email_type: pref)
+    end
+
+    # notifications
+    3.times do
+      FactoryGirl.create(:notification, recipient: carol)
+    end
+
+    NotificationActor.where(person_id: carol.person.id)
+
+    # notifications for person (notification actors for carol)
+    NotificationService.new.notify(
+      carol.post(:status_message, text: "@{eve; #{eve.person.diaspora_handle}}", to: carol.aspects.first),
+      [eve.id]
+    )
+
+    # tag followings
+    TagFollowing.create!(tag: ActsAsTaggableOn::Tag.create!(name: "partytimeexcellent2"), user: carol)
+
+    # services
+    3.times do
+      FactoryGirl.create(:service, user: carol)
+    end
+
+    # block
+    carol.blocks.create!(person: eve.person)
+    eve.blocks.create!(person: carol.person)
+
+    FactoryGirl.create(:report_on_post, user: carol)
+
+    FactoryGirl.create(:auth_with_read_and_write, user: carol)
+
+    FactoryGirl.create(:role, person: carol.person)
+
+    carol.invitation_code
+
+    [carol.person, remote_raphael].each do |person|
+      # posts
+      posts = (1..3).map do
+        FactoryGirl.create(:status_message, author: person)
+      end
+
+      posts.each do |post|
+        person.contacts.each do |contact|
+          ShareVisibility.create!(user_id: contact.user.id, shareable: post)
+        end
+      end
+
+      # photos
+      FactoryGirl.create(:photo, author: person)
+
+      # mentions
+      (1..3).map do
+        FactoryGirl.create(:mention, person: person)
+      end
+
+      # conversations
+      a_friend = person.contacts.first.user.person
+      create_conversation_with_message(a_friend, person, "Subject", "Hey carol")
+      create_conversation_with_message(person, a_friend, "Subject", "Hey carol")
+
+      person.reload
+    end
+  end
 end


### PR DESCRIPTION
This adds some more generation code to the fixtures builder. The AccountDeletion test is rewritten basing on the newly added fixtures. Some other tests  which depended on fixtures are fixed up to conform    the changes.

ref #6780 
