### PR TITLE
Fix up the meaning of the name parameter in mention

### DIFF
--- a/app/helpers/people_helper.rb
+++ b/app/helpers/people_helper.rb
@@ -28,7 +28,9 @@ module PeopleHelper
     opts[:class] << " self" if defined?(user_signed_in?) && user_signed_in? && current_user.person == person
     opts[:class] << " hovercardable" if defined?(user_signed_in?) && user_signed_in? && current_user.person != person
     remote_or_hovercard_link = Rails.application.routes.url_helpers.person_path(person).html_safe
-    "<a data-hovercard='#{remote_or_hovercard_link}' href='#{remote_or_hovercard_link}' class='#{opts[:class]}' #{ ("target=" + opts[:target]) if opts[:target]}>#{h(person.name)}</a>".html_safe
+    "<a data-hovercard='#{remote_or_hovercard_link}' href='#{remote_or_hovercard_link}' class='#{opts[:class]}'>"\
+      "#{html_escape_once(opts[:display_name] || person.name)}</a>"\
+      .html_safe
   end
 
   def person_image_tag(person, size = :thumb_small)
@@ -58,7 +60,7 @@ module PeopleHelper
     absolute = opts.delete(:absolute)
 
     if person.local?
-      username = person.diaspora_handle.split('@')[0]
+      username = person.username
       unless username.include?('.')
         opts.merge!(:username => username)
         if absolute

--- a/lib/diaspora/mentionable.rb
+++ b/lib/diaspora/mentionable.rb
@@ -14,8 +14,8 @@ module Diaspora::Mentionable
     mention = mention_str.match(REGEX)[2]
     del_pos = mention.rindex(/;/)
 
-    name   = mention[0..(del_pos-1)].strip
-    handle = mention[(del_pos+1)..-1].strip
+    name = mention[0..(del_pos - 1)].strip
+    handle = mention[(del_pos + 1)..-1].strip
 
     [name, handle]
   end
@@ -85,33 +85,33 @@ module Diaspora::Mentionable
   module MentionsInternal
     extend ::PeopleHelper
 
-    # output a formatted mention link as defined by the given options,
-    # use the fallback name if the person is unavailable
+    # output a formatted mention link as defined by the given arguments.
+    # if the display name is blank, falls back to the person's name.
     # @see Diaspora::Mentions#format
     #
     # @param [Person] AR Person
-    # @param [String] fallback name
+    # @param [String] display name
     # @param [Hash] formatting options
-    def self.mention_link(person, fallback_name, opts)
-      return fallback_name unless person.present?
+    def self.mention_link(person, display_name, opts)
+      return display_name unless person.present?
 
       if opts[:plain_text]
-        person.name
+        display_name.presence || person.name
       else
-        person_link(person, class: PERSON_HREF_CLASS)
+        person_link(person, class: PERSON_HREF_CLASS, display_name: display_name)
       end
     end
 
-    # output a markdown formatted link to the given person or the given fallback
-    # string, in case the person is not present
+    # output a markdown formatted link to the given person with the display name as the link text.
+    # if the display name is blank, falls back to the person's name.
     #
     # @param [Person] AR Person
-    # @param [String] fallback name
+    # @param [String] display name
     # @return [String] markdown person link
-    def self.profile_link(person, fallback_name)
-      return fallback_name unless person.present?
+    def self.profile_link(person, display_name)
+      return display_name unless person.present?
 
-      "[#{person.name}](#{local_or_remote_person_path(person)})"
+      "[#{display_name.presence || person.name}](#{local_or_remote_person_path(person)})"
     end
 
     # takes a user and an array of aspect ids or an array containing "all" as

--- a/spec/helpers/people_helper_spec.rb
+++ b/spec/helpers/people_helper_spec.rb
@@ -77,6 +77,11 @@ describe PeopleHelper, :type => :helper do
     it 'links by id for a local user' do
       expect(person_link(@user.person)).to include "href='#{person_path(@user.person)}'"
     end
+
+    it "recognizes the 'display_name' option" do
+      display_name = "string used as a name"
+      expect(person_link(@person, display_name: display_name)).to match(%r{<a [^>]+>#{display_name}</a>})
+    end
   end
 
   describe '#local_or_remote_person_path' do

--- a/spec/integration/mentioning_spec.rb
+++ b/spec/integration/mentioning_spec.rb
@@ -52,6 +52,7 @@ describe "mentioning", type: :request do
     expect(status_msg.public?).to be false
     expect(status_msg.text).to include(@user3.name)
     expect(status_msg.text).not_to include(@user3.diaspora_handle)
+    expect(status_msg.text).to include(user_profile_path(username: @user3.username))
 
     expect(stream_for(@user3).map(&:id)).not_to include(status_msg.id)
     expect(mention_stream_for(@user3).map(&:id)).not_to include(status_msg.id)

--- a/spec/lib/diaspora/federation/receive_spec.rb
+++ b/spec/lib/diaspora/federation/receive_spec.rb
@@ -360,7 +360,7 @@ describe Diaspora::Federation::Receive do
       expect(profile.location).to eq(profile_entity.location)
       expect(profile.searchable).to eq(profile_entity.searchable)
       expect(profile.nsfw).to eq(profile_entity.nsfw)
-      expect(profile.tag_string).to eq(profile_entity.tag_string)
+      expect(profile.tag_string.split(" ")).to match_array(profile_entity.tag_string.split(" "))
     end
   end
 


### PR DESCRIPTION
The desktop frontend now treats the "name" parameter of mention as
a string to display unconditionally. But the Diaspora::Mentionable
renders mentions the different way: "name" is treated as a fallback
string which is rendered only if the person's name is unavailable.
This reflects on the mobile version ATM. This patch makes it behave
the same way as the current desktop version does.

fix #6795 
