### PR TITLE
Add inviter diaspora-ID to invite email #6796

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -39,7 +39,7 @@ class InvitationsController < ApplicationController
       else
         params[:invitation_code]
       end
-
+    @inviter = user || InvitationCode.where(id: params[:invitation_code]).first.try(:user)
     if @invitation_code.present?
       render 'notifier/invite', :layout => false
     else

--- a/app/views/notifier/invite.markerb
+++ b/app/views/notifier/invite.markerb
@@ -1,1 +1,1 @@
-<%= t('.message', :invite_url => invite_code_url(@invitation_code), :diasporafoundation_url => 'https://diasporafoundation.org/') %>
+<%= t('.message', :invite_url => invite_code_url(@invitation_code), :diasporafoundation_url => 'https://diasporafoundation.org/', :diaspora_id => @inviter.try(:diaspora_handle)) %>

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -851,11 +851,13 @@ en:
       message: |-
         Hello!
 
-        You have been invited to join diaspora*!
+        You have been invited to join diaspora* by %{diaspora_id}!
 
         Click this link to get started
 
         [%{invite_url}][1]
+
+        Or you can add %{diaspora_id} to your contacts if you already have an account.
 
 
         Love,


### PR DESCRIPTION
The invite email should show the diaspora-ID of the person who has invited you to diaspora*. 

-- I am not sure how to add it for locales other than English.
