### PR TITLE
Mentions in comments backend changes

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -23,8 +23,8 @@ class NotificationsController < ApplicationController
 
   def index
     conditions = {:recipient_id => current_user.id}
-    if params[:type] && Notification.types.has_key?(params[:type])
-      conditions[:type] = Notification.types[params[:type]]
+    if params[:type] && types.has_key?(params[:type])
+      conditions[:type] = types[params[:type]]
     end
     if params[:show] == "unread" then conditions[:unread] = true end
     page = params[:page] || 1
@@ -44,7 +44,7 @@ class NotificationsController < ApplicationController
 
     @grouped_unread_notification_counts = {}
 
-    Notification.types.each_with_object(current_user.unread_notifications.group_by(&:type)) {|(name, type), notifications|
+    types.each_with_object(current_user.unread_notifications.group_by(&:type)) {|(name, type), notifications|
       @grouped_unread_notification_counts[name] = notifications.has_key?(type) ? notifications[type].count : 0
     }
 
@@ -65,7 +65,7 @@ class NotificationsController < ApplicationController
   end
 
   def read_all
-    current_type = Notification.types[params[:type]]
+    current_type = types[params[:type]]
     notifications = Notification.where(recipient_id: current_user.id, unread: true)
     notifications = notifications.where(type: current_type) if params[:type]
     notifications.update_all(unread: false)
@@ -93,4 +93,17 @@ class NotificationsController < ApplicationController
       }
     }.as_json
   end
+
+  def types
+    {
+      "also_commented"       => "Notifications::AlsoCommented",
+      "comment_on_post"      => "Notifications::CommentOnPost",
+      "liked"                => "Notifications::Liked",
+      "mentioned"            => "Notifications::MentionedInPost",
+      "mentioned_in_comment" => "Notifications::MentionedInComment",
+      "reshared"             => "Notifications::Reshared",
+      "started_sharing"      => "Notifications::StartedSharing"
+    }
+  end
+  helper_method :types
 end

--- a/app/controllers/status_messages_controller.rb
+++ b/app/controllers/status_messages_controller.rb
@@ -80,7 +80,10 @@ class StatusMessagesController < ApplicationController
 
   def handle_mention_feedback(status_message)
     return unless comes_from_others_profile_page?
-    flash[:notice] = t("status_messages.create.success", names: status_message.mentioned_people_names)
+    flash[:notice] = t(
+      "status_messages.create.success",
+      names: PersonPresenter.people_names(status_message.mentioned_people)
+    )
   end
 
   def comes_from_others_profile_page?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -150,16 +150,7 @@ class UsersController < ApplicationController
       :auto_follow_back_aspect_id,
       :getting_started,
       :post_default_public,
-      email_preferences: %i(
-        someone_reported
-        also_commented
-        mentioned
-        comment_on_post
-        private_message
-        started_sharing
-        liked
-        reshared
-      )
+      email_preferences: UserPreference::VALID_EMAIL_TYPES.map(&:to_sym)
     )
   end
   # rubocop:enable Metrics/MethodLength

--- a/app/mailers/notification_mailers/mentioned.rb
+++ b/app/mailers/notification_mailers/mentioned.rb
@@ -4,7 +4,7 @@ module NotificationMailers
     delegate :author_name, to: :post, prefix: true
 
     def set_headers(target_id)
-      @post = Mention.find_by_id(target_id).post
+      @post = Mention.find_by_id(target_id).mentions_container
 
       @headers[:subject] = I18n.t('notifier.mentioned.subject', :name => @sender.name)
       @headers[:in_reply_to] = @headers[:references] = "<#{@post.guid}@#{AppConfig.pod_uri.host}>"

--- a/app/mailers/notification_mailers/mentioned_in_comment.rb
+++ b/app/mailers/notification_mailers/mentioned_in_comment.rb
@@ -1,0 +1,11 @@
+module NotificationMailers
+  class MentionedInComment < NotificationMailers::Base
+    attr_reader :comment
+
+    def set_headers(target_id) # rubocop:disable Style/AccessorMethodName
+      @comment = Mention.find_by_id(target_id).mentions_container
+
+      @headers[:subject] = I18n.t("notifier.mentioned.subject", name: @sender.name)
+    end
+  end
+end

--- a/app/mailers/notification_mailers/started_sharing.rb
+++ b/app/mailers/notification_mailers/started_sharing.rb
@@ -1,7 +1,7 @@
 module NotificationMailers
   class StartedSharing < NotificationMailers::Base
-    def set_headers
-      @headers[:subject] = I18n.t('notifier.started_sharing.subject', :name => @sender.name)
+    def set_headers(*_args) # rubocop:disable Style/AccessorMethodName
+      @headers[:subject] = I18n.t("notifier.started_sharing.subject", name: @sender.name)
     end
   end
 end

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -55,53 +55,19 @@ class Notifier < ActionMailer::Base
     end
   end
 
-  def started_sharing(recipient_id, sender_id)
-    send_notification(:started_sharing, recipient_id, sender_id)
-  end
-
-  def liked(recipient_id, sender_id, like_id)
-    send_notification(:liked, recipient_id, sender_id, like_id)
-  end
-
-  def reshared(recipient_id, sender_id, reshare_id)
-    send_notification(:reshared, recipient_id, sender_id, reshare_id)
-  end
-
-  def mentioned(recipient_id, sender_id, target_id)
-    send_notification(:mentioned, recipient_id, sender_id, target_id)
-  end
-
-  def comment_on_post(recipient_id, sender_id, comment_id)
-    send_notification(:comment_on_post, recipient_id, sender_id, comment_id)
-  end
-
-  def also_commented(recipient_id, sender_id, comment_id)
-    send_notification(:also_commented, recipient_id, sender_id, comment_id)
-  end
-
-  def private_message(recipient_id, sender_id, message_id)
-    send_notification(:private_message, recipient_id, sender_id, message_id)
-  end
-
-  def confirm_email(recipient_id)
-    send_notification(:confirm_email, recipient_id)
-  end
-
-  def csrf_token_fail(recipient_id)
-    send_notification(:csrf_token_fail, recipient_id)
-  end
-
-  private
   def send_notification(type, *args)
     @notification = NotificationMailers.const_get(type.to_s.camelize).new(*args)
 
     with_recipient_locale do
       mail(@notification.headers) do |format|
+        self.action_name = type
         format.text
         format.html
       end
     end
   end
+
+  private
 
   def with_recipient_locale(&block)
     I18n.with_locale(@notification.recipient.language, &block)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -11,6 +11,7 @@ class Comment < ActiveRecord::Base
 
   include Diaspora::Taggable
   include Diaspora::Likeable
+  include Diaspora::MentionsContainer
 
   acts_as_taggable_on :tags
   extract_tags_from :text
@@ -49,12 +50,20 @@ class Comment < ActiveRecord::Base
     participation.unparticipate! if participation.present?
   end
 
-  def message
-    @message ||= Diaspora::MessageRenderer.new text
-  end
-
   def text= text
      self[:text] = text.to_s.strip #to_s if for nil, for whatever reason
+  end
+
+  def people_allowed_to_be_mentioned
+    if parent.public?
+      :all
+    else
+      [*parent.comments.pluck(:author_id), *parent.likes.pluck(:author_id), parent.author_id].uniq
+    end
+  end
+
+  def add_mention_subscribers?
+    super && parent.author.local?
   end
 
   class Generator < Diaspora::Federated::Generator
@@ -68,7 +77,7 @@ class Comment < ActiveRecord::Base
     end
 
     def relayable_options
-      {:post => @target, :text => @text}
+      {post: @target, text: @text}
     end
   end
 end

--- a/app/models/mention.rb
+++ b/app/models/mention.rb
@@ -3,10 +3,14 @@
 #   the COPYRIGHT file.
 
 class Mention < ActiveRecord::Base
-  belongs_to :post
+  belongs_to :mentions_container, polymorphic: true
   belongs_to :person
-  validates :post, presence: true
+  validates :mentions_container, presence: true
   validates :person, presence: true
+
+  scope :local, -> {
+    joins(:person).where.not(people: {owner_id: nil})
+  }
 
   after_destroy :delete_notification
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -51,15 +51,4 @@ class Notification < ActiveRecord::Base
   private_class_method def self.suppress_notification?(recipient, actor)
     recipient.blocks.where(person: actor).exists?
   end
-
-  def self.types
-    {
-      "also_commented" => "Notifications::AlsoCommented",
-      "comment_on_post" => "Notifications::CommentOnPost",
-      "liked" => "Notifications::Liked",
-      "mentioned" => "Notifications::Mentioned",
-      "reshared" => "Notifications::Reshared",
-      "started_sharing" => "Notifications::StartedSharing"
-    }
-  end
 end

--- a/app/models/notifications/also_commented.rb
+++ b/app/models/notifications/also_commented.rb
@@ -1,5 +1,7 @@
 module Notifications
   class AlsoCommented < Notification
+    include Notifications::Commented
+
     def mail_job
       Workers::Mail::AlsoCommented
     end
@@ -8,17 +10,13 @@ module Notifications
       "notifications.also_commented"
     end
 
-    def deleted_translation_key
-      "notifications.also_commented_deleted"
-    end
-
     def self.notify(comment, _recipient_user_ids)
       actor = comment.author
       commentable = comment.commentable
       recipient_ids = commentable.participants.local.where.not(id: [commentable.author_id, actor.id]).pluck(:owner_id)
 
       User.where(id: recipient_ids).find_each do |recipient|
-        next if recipient.is_shareable_hidden?(commentable)
+        next if recipient.is_shareable_hidden?(commentable) || mention_notification_exists?(comment, recipient.person)
 
         concatenate_or_create(recipient, commentable, actor).try(:email_the_user, comment, actor)
       end

--- a/app/models/notifications/comment_on_post.rb
+++ b/app/models/notifications/comment_on_post.rb
@@ -1,5 +1,7 @@
 module Notifications
   class CommentOnPost < Notification
+    include Notifications::Commented
+
     def mail_job
       Workers::Mail::CommentOnPost
     end
@@ -8,15 +10,12 @@ module Notifications
       "notifications.comment_on_post"
     end
 
-    def deleted_translation_key
-      "notifications.also_commented_deleted"
-    end
-
     def self.notify(comment, _recipient_user_ids)
       actor = comment.author
       commentable_author = comment.commentable.author
 
       return unless commentable_author.local? && actor != commentable_author
+      return if mention_notification_exists?(comment, commentable_author)
 
       concatenate_or_create(commentable_author.owner, comment.commentable, actor).email_the_user(comment, actor)
     end

--- a/app/models/notifications/commented.rb
+++ b/app/models/notifications/commented.rb
@@ -1,0 +1,15 @@
+module Notifications
+  module Commented
+    extend ActiveSupport::Concern
+
+    def deleted_translation_key
+      "notifications.also_commented_deleted"
+    end
+
+    module ClassMethods
+      def mention_notification_exists?(comment, recipient_person)
+        Notifications::MentionedInComment.exists?(target: comment.mentions.where(person: recipient_person))
+      end
+    end
+  end
+end

--- a/app/models/notifications/mentioned_in_comment.rb
+++ b/app/models/notifications/mentioned_in_comment.rb
@@ -1,0 +1,38 @@
+module Notifications
+  class MentionedInComment < Notification
+    include Notifications::Mentioned
+
+    def popup_translation_key
+      "notifications.mentioned_in_comment"
+    end
+
+    def deleted_translation_key
+      "notifications.mentioned_in_comment_deleted"
+    end
+
+    def self.filter_mentions(mentions, mentionable, _recipient_user_ids)
+      people = mentionable.people_allowed_to_be_mentioned
+      if people == :all
+        mentions
+      else
+        mentions.where(person_id: people)
+      end
+    end
+
+    def mail_job
+      if !recipient.user_preferences.exists?(email_type: "mentioned_in_comment")
+        Workers::Mail::MentionedInComment
+      elsif shareable.author.owner_id == recipient_id
+        Workers::Mail::CommentOnPost
+      elsif shareable.participants.local.where(owner_id: recipient_id)
+        Workers::Mail::AlsoCommented
+      end
+    end
+
+    private
+
+    def shareable
+      linked_object.parent
+    end
+  end
+end

--- a/app/models/notifications/mentioned_in_post.rb
+++ b/app/models/notifications/mentioned_in_post.rb
@@ -1,0 +1,22 @@
+module Notifications
+  class MentionedInPost < Notification
+    include Notifications::Mentioned
+
+    def mail_job
+      Workers::Mail::Mentioned
+    end
+
+    def popup_translation_key
+      "notifications.mentioned"
+    end
+
+    def deleted_translation_key
+      "notifications.mentioned_deleted"
+    end
+
+    def self.filter_mentions(mentions, mentionable, recipient_user_ids)
+      return mentions if mentionable.public
+      mentions.where(person: Person.where(owner_id: recipient_user_ids).ids)
+    end
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -12,15 +12,14 @@ class Post < ActiveRecord::Base
   include Diaspora::Likeable
   include Diaspora::Commentable
   include Diaspora::Shareable
+  include Diaspora::MentionsContainer
 
   has_many :participations, dependent: :delete_all, as: :target, inverse_of: :target
-  has_many :participants, class_name: "Person", through: :participations, source: :author
+  has_many :participants, through: :participations, source: :author
 
   attr_accessor :user_like
 
   has_many :reports, as: :item
-
-  has_many :mentions, dependent: :destroy
 
   has_many :reshares, class_name: "Reshare", foreign_key: :root_guid, primary_key: :guid
   has_many :resharers, class_name: "Person", through: :reshares, source: :author
@@ -60,7 +59,6 @@ class Post < ActiveRecord::Base
   end
 
   def root; end
-  def mentioned_people; []; end
   def photos; []; end
 
   #prevents error when trying to access @post.address in a post different than Reshare and StatusMessage types;

--- a/app/models/status_message.rb
+++ b/app/models/status_message.rb
@@ -23,13 +23,12 @@ class StatusMessage < Post
   attr_accessor :oembed_url
   attr_accessor :open_graph_url
 
-  after_create :create_mentions
   after_commit :queue_gather_oembed_data, :on => :create, :if => :contains_oembed_url_in_text?
   after_commit :queue_gather_open_graph_data, :on => :create, :if => :contains_open_graph_url_in_text?
 
   #scopes
   scope :where_person_is_mentioned, ->(person) {
-    joins(:mentions).where(:mentions => {:person_id => person.id})
+    owned_or_visible_by_user(person.owner).joins(:mentions).where(mentions: {person_id: person.id})
   }
 
   def self.guids_for_author(person)
@@ -50,36 +49,6 @@ class StatusMessage < Post
 
   def nsfw
     text.try(:match, /#nsfw/i) || super
-  end
-
-  def message
-    @message ||= Diaspora::MessageRenderer.new(text, mentioned_people: mentioned_people)
-  end
-
-  def mentioned_people
-    if self.persisted?
-      self.mentions.includes(:person => :profile).map{ |mention| mention.person }
-    else
-      Diaspora::Mentionable.people_from_string(text)
-    end
-  end
-
-  ## TODO ----
-  # don't put presentation logic in the model!
-  def mentioned_people_names
-    self.mentioned_people.map(&:name).join(', ')
-  end
-  ## ---- ----
-
-  def create_mentions
-    ppl = Diaspora::Mentionable.people_from_string(text)
-    ppl.each do |person|
-      self.mentions.find_or_create_by(person_id: person.id)
-    end
-  end
-
-  def mentions?(person)
-    mentioned_people.include? person
   end
 
   def comment_email_subject
@@ -124,6 +93,22 @@ class StatusMessage < Post
     super(recipient_user_ids)
 
     photos.each {|photo| photo.receive(recipient_user_ids) }
+  end
+
+  # Only includes those people, to whom we're going to send a federation entity
+  # (and doesn't define exhaustive list of people who can receive it)
+  def people_allowed_to_be_mentioned
+    @aspects_ppl ||=
+      if public?
+        :all
+      else
+        Contact.joins(:aspect_memberships).where(aspect_memberships: {aspect: aspects}).distinct.pluck(:person_id)
+      end
+  end
+
+  def filter_mentions
+    return if people_allowed_to_be_mentioned == :all
+    update(text: Diaspora::Mentionable.filter_people(text, people_allowed_to_be_mentioned))
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -333,6 +333,7 @@ class User < ActiveRecord::Base
 
   ######### Mailer #######################
   def mail(job, *args)
+    return unless job.present?
     pref = job.to_s.gsub('Workers::Mail::', '').underscore
     if(self.disable_mail == false && !self.user_preferences.exists?(:email_type => pref))
       job.perform_async(*args)

--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -5,13 +5,14 @@ class UserPreference < ActiveRecord::Base
 
   VALID_EMAIL_TYPES =
     ["someone_reported",
-   "mentioned",
-   "comment_on_post",
-   "private_message",
-   "started_sharing",
-   "also_commented",
-   "liked",
-   "reshared"]
+     "mentioned",
+     "mentioned_in_comment",
+     "comment_on_post",
+     "private_message",
+     "started_sharing",
+     "also_commented",
+     "liked",
+     "reshared"]
 
   def must_be_valid_email_type
     unless VALID_EMAIL_TYPES.include?(self.email_type)

--- a/app/presenters/person_presenter.rb
+++ b/app/presenters/person_presenter.rb
@@ -40,6 +40,10 @@ class PersonPresenter < BasePresenter
     }
   end
 
+  def self.people_names(people)
+    people.map(&:name).join(", ")
+  end
+
   protected
 
   def own_profile?

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -1,8 +1,8 @@
 class NotificationService
   NOTIFICATION_TYPES = {
-    Comment       => [Notifications::CommentOnPost, Notifications::AlsoCommented],
+    Comment       => [Notifications::MentionedInComment, Notifications::CommentOnPost, Notifications::AlsoCommented],
     Like          => [Notifications::Liked],
-    StatusMessage => [Notifications::Mentioned],
+    StatusMessage => [Notifications::MentionedInPost],
     Conversation  => [Notifications::PrivateMessage],
     Message       => [Notifications::PrivateMessage],
     Reshare       => [Notifications::Reshared],

--- a/app/services/status_message_creation_service.rb
+++ b/app/services/status_message_creation_service.rb
@@ -19,18 +19,7 @@ class StatusMessageCreationService
 
   def build_status_message(params)
     public = params[:public] || false
-    filter_mentions params
     user.build_post(:status_message, params[:status_message].merge(public: public))
-  end
-
-  def filter_mentions(params)
-    unless params[:public]
-      params[:status_message][:text] = Diaspora::Mentionable.filter_for_aspects(
-        params[:status_message][:text],
-        user,
-        *params[:aspect_ids]
-      )
-    end
   end
 
   def add_attachments(status_message, params)
@@ -75,6 +64,7 @@ class StatusMessageCreationService
 
   def dispatch(status_message, services)
     receiving_services = services ? Service.titles(services) : []
+    status_message.filter_mentions # this is only required until changes from #6818 are deployed on every pod
     user.dispatch_post(status_message,
                        url:           short_post_url(status_message.guid, host: AppConfig.environment.url),
                        service_types: receiving_services)

--- a/app/views/notifications/_notification.haml
+++ b/app/views/notifications/_notification.haml
@@ -1,5 +1,5 @@
-.media.stream-element{data: {guid: note.id, type: (Notification.types.key(note.type) || "")},
-                      class: (note.unread ? "unread" : "read")}
+.media.stream-element{data: {guid: note.id, type: (types.key(note.type) || "")},
+  class: (note.unread ? "unread" : "read")}
   .unread-toggle.pull-right
     %i.entypo-eye{title: (note.unread ? t("notifications.index.mark_read") : t("notifications.index.mark_unread"))}
   - if note.type == "Notifications::StartedSharing" && (!defined?(no_aspect_dropdown) || !no_aspect_dropdown)

--- a/app/views/notifications/_notification.mobile.haml
+++ b/app/views/notifications/_notification.mobile.haml
@@ -1,4 +1,5 @@
-.notification_element{:data=>{:guid => note.id, :type => (Notification.types.key(note.type) || '')}, :class => (note.unread ? "unread" : "read")}
+.notification_element{data: {guid: note.id, type: (types.key(note.type) || "")},
+  class: (note.unread ? "unread" : "read")}
   .pull-right.unread-toggle
     %i.entypo-eye{title: (note.unread ? t("notifications.index.mark_read") : t("notifications.index.mark_unread"))}
   = person_image_tag note.actors.first, :thumb_small

--- a/app/views/notifications/index.html.haml
+++ b/app/views/notifications/index.html.haml
@@ -23,7 +23,7 @@
                   %i.entypo-comment
                 - when "liked"
                   %i.entypo-heart
-                - when "mentioned"
+                - when "mentioned", "mentioned_in_comment"
                   %span.mentionIcon
                     @
                 - when "reshared"

--- a/app/views/notifier/mentioned.markerb
+++ b/app/views/notifier/mentioned.markerb
@@ -4,6 +4,6 @@
 <%= t('notifier.mentioned.limited_post') %>
 <% end %>
 
-[<%= t('notifier.comment_on_post.reply', :name => @notification.post_author_name) %>][1]
+[<%= t("notifier.comment_on_post.reply", name: @notification.post_author_name) %>][1]
 
 [1]: <%= post_url(@notification.post) %>

--- a/app/views/notifier/mentioned_in_comment.markerb
+++ b/app/views/notifier/mentioned_in_comment.markerb
@@ -1,0 +1,9 @@
+<% if @notification.comment.public? %>
+<%= @notification.comment.message.plain_text_without_markdown %>
+<% else %>
+<%= t("notifier.mentioned_in_comment.limited_post") %>
+<% end %>
+
+[<%= t("notifier.mentioned_in_comment.reply") %>][1]
+
+[1]: <%= post_url(@notification.comment.parent, anchor: @notification.comment.guid) %>

--- a/app/views/users/_edit.haml
+++ b/app/views/users/_edit.haml
@@ -142,6 +142,11 @@
                   = t(".mentioned")
                 .small-horizontal-spacer
 
+                = type.label :mentioned_in_comment, class: "checkbox-inline" do
+                  = type.check_box :mentioned_in_comment, {checked: @email_prefs["mentioned_in_comment"]}, false, true
+                  = t(".mentioned_in_comment")
+                .small-horizontal-spacer
+
                 = type.label :liked, class: "checkbox-inline" do
                   = type.check_box :liked, {checked: @email_prefs["liked"]}, false, true
                   = t(".liked")

--- a/app/workers/mail/also_commented.rb
+++ b/app/workers/mail/also_commented.rb
@@ -1,13 +1,6 @@
 module Workers
   module Mail
-    class AlsoCommented < Base
-      sidekiq_options queue: :low
-
-      def perform(recipient_id, sender_id, comment_id)
-        if email = Notifier.also_commented(recipient_id, sender_id, comment_id)
-          email.deliver_now
-        end
-      end
+    class AlsoCommented < NotifierBase
     end
   end
 end

--- a/app/workers/mail/comment_on_post.rb
+++ b/app/workers/mail/comment_on_post.rb
@@ -1,11 +1,6 @@
 module Workers
   module Mail
-    class CommentOnPost < Base
-      sidekiq_options queue: :low
-
-      def perform(recipient_id, sender_id, comment_id)
-        Notifier.comment_on_post(recipient_id, sender_id, comment_id).deliver_now
-      end
+    class CommentOnPost < NotifierBase
     end
   end
 end

--- a/app/workers/mail/confirm_email.rb
+++ b/app/workers/mail/confirm_email.rb
@@ -1,11 +1,6 @@
 module Workers
   module Mail
-    class ConfirmEmail < Base
-      sidekiq_options queue: :low
-      
-      def perform(user_id)
-        Notifier.confirm_email(user_id).deliver_now
-      end
+    class ConfirmEmail < NotifierBase
     end
   end
 end

--- a/app/workers/mail/csrf_token_fail.rb
+++ b/app/workers/mail/csrf_token_fail.rb
@@ -1,11 +1,6 @@
 module Workers
   module Mail
-    class CsrfTokenFail < Base
-      sidekiq_options queue: :low
-
-      def perform(user_id)
-        Notifier.csrf_token_fail(user_id).deliver_now
-      end
+    class CsrfTokenFail < NotifierBase
     end
   end
 end

--- a/app/workers/mail/liked.rb
+++ b/app/workers/mail/liked.rb
@@ -1,10 +1,8 @@
 module Workers
   module Mail
-    class Liked < Base
-      sidekiq_options queue: :low
-
-      def perform(recipient_id, sender_id, like_id)
-        Notifier.liked(recipient_id, sender_id, like_id).deliver_now
+    class Liked < NotifierBase
+      def perform(*args)
+        super
       rescue ActiveRecord::RecordNotFound => e
         logger.warn("failed to send liked notification mail: #{e.message}")
         raise e unless e.message.start_with?("Couldn't find Like with")

--- a/app/workers/mail/mentioned.rb
+++ b/app/workers/mail/mentioned.rb
@@ -5,12 +5,7 @@
 
 module Workers
   module Mail
-    class Mentioned < Base
-      sidekiq_options queue: :low
-      
-      def perform(recipient_id, actor_id, target_id)
-        Notifier.mentioned( recipient_id, actor_id, target_id).deliver_now
-      end
+    class Mentioned < NotifierBase
     end
   end
 end

--- a/app/workers/mail/mentioned_in_comment.rb
+++ b/app/workers/mail/mentioned_in_comment.rb
@@ -1,0 +1,6 @@
+module Workers
+  module Mail
+    class MentionedInComment < NotifierBase
+    end
+  end
+end

--- a/app/workers/mail/notifier_base.rb
+++ b/app/workers/mail/notifier_base.rb
@@ -1,0 +1,11 @@
+module Workers
+  module Mail
+    class NotifierBase < Base
+      sidekiq_options queue: :low
+
+      def perform(*args)
+        Notifier.send_notification(self.class.name.gsub("Workers::Mail::", "").underscore, *args).deliver_now
+      end
+    end
+  end
+end

--- a/app/workers/mail/private_message.rb
+++ b/app/workers/mail/private_message.rb
@@ -5,12 +5,7 @@
 
 module Workers
   module Mail
-    class PrivateMessage < Base
-      sidekiq_options queue: :low
-      
-      def perform(recipient_id, actor_id, target_id)
-        Notifier.private_message( recipient_id, actor_id, target_id).deliver_now
-      end
+    class PrivateMessage < NotifierBase
     end
   end
 end

--- a/app/workers/mail/reshared.rb
+++ b/app/workers/mail/reshared.rb
@@ -1,11 +1,6 @@
 module Workers
   module Mail
-    class Reshared < Base
-      sidekiq_options queue: :low
-      
-      def perform(recipient_id, sender_id, reshare_id)
-        Notifier.reshared(recipient_id, sender_id, reshare_id).deliver_now
-      end
+    class Reshared < NotifierBase
     end
   end
 end

--- a/app/workers/mail/started_sharing.rb
+++ b/app/workers/mail/started_sharing.rb
@@ -5,12 +5,7 @@
 
 module Workers
   module Mail
-    class StartedSharing < Base
-      sidekiq_options queue: :low
-      
-      def perform(recipient_id, sender_id, target_id)
-        Notifier.started_sharing(recipient_id, sender_id).deliver_now
-      end
+    class StartedSharing < NotifierBase
     end
   end
 end

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -615,9 +615,11 @@ en:
       one: "%{actors} also commented on %{post_author}’s post %{post_link}."
       other: "%{actors} also commented on %{post_author}’s post %{post_link}."
     mentioned:
-      zero: "%{actors} have mentioned you in the post %{post_link}."
       one: "%{actors} has mentioned you in the post %{post_link}."
       other: "%{actors} have mentioned you in the post %{post_link}."
+    mentioned_in_comment:
+      one: "%{actors} has mentioned you in a <a href='%{comment_path}'>comment</a> to the post %{post_link}."
+      other: "%{actors} have mentioned you in a <a href='%{comment_path}'>comment</a> to the post %{post_link}."
     liked:
       zero: "%{actors} have liked your post %{post_link}."
       one: "%{actors} has liked your post %{post_link}."
@@ -640,9 +642,11 @@ en:
       one: "%{actors} reshared your deleted post."
       other: "%{actors} reshared your deleted post."
     mentioned_deleted:
-      zero: "%{actors} mentioned you in a deleted post."
       one: "%{actors} mentioned you in a deleted post."
       other: "%{actors} mentioned you in a deleted post."
+    mentioned_in_comment_deleted:
+      one: "%{actors} mentioned you in a deleted comment."
+      other: "%{actors} mentioned you in a deleted comment."
     index:
       notifications: "Notifications"
       mark_all_as_read: "Mark all as read"
@@ -655,7 +659,8 @@ en:
       also_commented: "Also commented"
       comment_on_post: "Comment on post"
       liked: "Liked"
-      mentioned: "Mentioned"
+      mentioned: "Mentioned in post"
+      mentioned_in_comment: "Mentioned in comment"
       reshared: "Reshared"
       started_sharing: "Started sharing"
       no_notifications: "You don't have any notifications yet."
@@ -689,6 +694,9 @@ en:
     mentioned:
         subject: "%{name} has mentioned you on diaspora*"
         limited_post: "You were mentioned in a limited post."
+    mentioned_in_comment:
+        limited_post: "You were mentioned in a comment to a limited post."
+        reply: "Reply to or view this conversation >"
     private_message:
         subject: "There’s a new private message for you"
         reply_to_or_view: "Reply to or view this conversation >"
@@ -1167,6 +1175,7 @@ en:
       started_sharing: "someone starts sharing with you"
       someone_reported: "someone sends a report"
       mentioned: "you are mentioned in a post"
+      mentioned_in_comment: "you are mentioned in a comment"
       liked: "someone likes your post"
       reshared: "someone reshares your post"
       comment_on_post: "someone comments on your post"

--- a/db/migrate/20161107100840_polymorphic_mentions.rb
+++ b/db/migrate/20161107100840_polymorphic_mentions.rb
@@ -1,0 +1,38 @@
+class PolymorphicMentions < ActiveRecord::Migration
+  def change
+    remove_index :mentions, column: %i(post_id)
+    remove_index :mentions, column: %i(person_id post_id), unique: true
+    rename_column :mentions, :post_id, :mentions_container_id
+    add_column :mentions, :mentions_container_type, :string, null: false
+    add_index :mentions,
+              %i(mentions_container_id mentions_container_type),
+              name:   "index_mentions_on_mc_id_and_mc_type",
+              length: {mentions_container_type: 191}
+    add_index :mentions,
+              %i(person_id mentions_container_id mentions_container_type),
+              name:   "index_mentions_on_person_and_mc_id_and_mc_type",
+              length: {mentions_container_type: 191},
+              unique: true
+
+    reversible(&method(:up_down))
+  end
+
+  class Mention < ActiveRecord::Base
+  end
+
+  class Notification < ActiveRecord::Base
+  end
+
+  def up_down(change)
+    change.up do
+      Mention.update_all(mentions_container_type: "Post")
+      Notification.where(type: "Notifications::Mentioned").update_all(type: "Notifications::MentionedInPost")
+    end
+
+    change.down do
+      Notification.where(type: "Notifications::MentionedInPost").update_all(type: "Notifications::Mentioned")
+      Mention.where(mentions_container_type: "Comment").destroy_all
+      Notification.where(type: "Notifications::MentionedInComment").destroy_all
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161024231443) do
+ActiveRecord::Schema.define(version: 20161107100840) do
 
   create_table "account_deletions", force: :cascade do |t|
     t.string   "diaspora_handle", limit: 255
@@ -204,13 +204,14 @@ ActiveRecord::Schema.define(version: 20161024231443) do
   end
 
   create_table "mentions", force: :cascade do |t|
-    t.integer "post_id",   limit: 4, null: false
-    t.integer "person_id", limit: 4, null: false
+    t.integer "mentions_container_id",   limit: 4,   null: false
+    t.integer "person_id",               limit: 4,   null: false
+    t.string  "mentions_container_type", limit: 255, null: false
   end
 
-  add_index "mentions", ["person_id", "post_id"], name: "index_mentions_on_person_id_and_post_id", unique: true, using: :btree
+  add_index "mentions", ["mentions_container_id", "mentions_container_type"], name: "index_mentions_on_mc_id_and_mc_type", length: {"mentions_container_id"=>nil, "mentions_container_type"=>191}, using: :btree
+  add_index "mentions", ["person_id", "mentions_container_id", "mentions_container_type"], name: "index_mentions_on_person_and_mc_id_and_mc_type", unique: true, length: {"person_id"=>nil, "mentions_container_id"=>nil, "mentions_container_type"=>191}, using: :btree
   add_index "mentions", ["person_id"], name: "index_mentions_on_person_id", using: :btree
-  add_index "mentions", ["post_id"], name: "index_mentions_on_post_id", using: :btree
 
   create_table "messages", force: :cascade do |t|
     t.integer  "conversation_id",  limit: 4,     null: false

--- a/features/desktop/change_settings.feature
+++ b/features/desktop/change_settings.feature
@@ -22,6 +22,10 @@ Feature: Change settings
     And I press "change_email_preferences"
     Then I should see "Email notifications changed"
     And the "user_email_preferences_mentioned" checkbox should not be checked
+    When I uncheck "user_email_preferences_mentioned_in_comment"
+    And I press "change_email_preferences"
+    Then I should see "Email notifications changed"
+    And the "user_email_preferences_mentioned_in_comment" checkbox should not be checked
 
   Scenario: Change my preferred language
     When I select "polski" from "user_language"

--- a/features/desktop/notifications.feature
+++ b/features/desktop/notifications.feature
@@ -101,6 +101,26 @@ Feature: Notifications
     Then I should see "mentioned you in the post"
     And I should have 1 email delivery
 
+  Scenario: someone mentioned me in a comment
+    Given "alice@alice.alice" has a public post with text "check this out!"
+    And "bob@bob.bob" has commented mentioning "alice@alice.alice" on "check this out!"
+    When I sign in as "alice@alice.alice"
+    And I follow "Notifications" in the header
+    Then the notification dropdown should be visible
+    And I should see "mentioned you in a comment"
+    And I should have 1 email delivery
+
+  Scenario: I mark a notification as read
+    Given a user with email "bob@bob.bob" is connected with "alice@alice.alice"
+    And Alice has a post mentioning Bob
+    When I sign in as "bob@bob.bob"
+    And I follow "Notifications" in the header
+    Then the notification dropdown should be visible
+    And I wait for notifications to load
+    And I should see a ".unread .unread-toggle .entypo-eye"
+    When I click on selector ".unread .unread-toggle .entypo-eye"
+    Then I should see a ".read .unread-toggle"
+
   Scenario: filter notifications
     Given a user with email "bob@bob.bob" is connected with "alice@alice.alice"
     And Alice has a post mentioning Bob

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -21,6 +21,12 @@ Given /^"([^"]*)" has commented "([^"]*)" on "([^"]*)"$/ do |email, comment_text
   user.comment!(post, comment_text)
 end
 
+Given /^"([^"]*)" has commented mentioning "([^"]*)" on "([^"]*)"$/ do |email, mentionee_email, post_text|
+  user = User.find_by(email: email)
+  post = StatusMessage.find_by(text: post_text)
+  user.comment!(post, text_mentioning(User.find_by(email: mentionee_email)))
+end
+
 Given /^"([^"]*)" has commented a lot on "([^"]*)"$/ do |email, post_text|
   user = User.find_by(email: email)
   post = StatusMessage.find_by(text: post_text)

--- a/features/step_definitions/custom_web_steps.rb
+++ b/features/step_definitions/custom_web_steps.rb
@@ -176,7 +176,7 @@ end
 
 Then /^(?:|I )should see a "([^\"]*)"(?: within "([^\"]*)")?$/ do |selector, scope_selector|
   with_scope(scope_selector) do
-    current_scope.should have_css selector
+    expect(current_scope).to have_css(selector)
   end
 end
 

--- a/features/step_definitions/notifications_steps.rb
+++ b/features/step_definitions/notifications_steps.rb
@@ -3,7 +3,7 @@ When "I filter notifications by likes" do
 end
 
 When "I filter notifications by mentions" do
-  step %(I follow "Mentioned" within "#notifications_container .list-group")
+  step %(I follow "Mentioned in post" within "#notifications_container .list-group")
 end
 
 Then /^I should( not)? have activated notifications for the post( in the single post view)?$/ do |negate, spv|

--- a/lib/diaspora/mentions_container.rb
+++ b/lib/diaspora/mentions_container.rb
@@ -1,0 +1,38 @@
+module Diaspora
+  module MentionsContainer
+    extend ActiveSupport::Concern
+
+    included do
+      after_create :create_mentions
+      has_many :mentions, as: :mentions_container, dependent: :destroy
+    end
+
+    def mentioned_people
+      if persisted?
+        mentions.includes(person: :profile).map(&:person)
+      else
+        Diaspora::Mentionable.people_from_string(text)
+      end
+    end
+
+    def add_mention_subscribers?
+      public?
+    end
+
+    def subscribers
+      super.tap {|subscribers|
+        subscribers.concat(mentions.map(&:person).select(&:remote?)) if add_mention_subscribers?
+      }
+    end
+
+    def create_mentions
+      Diaspora::Mentionable.people_from_string(text).each do |person|
+        mentions.find_or_create_by(person_id: person.id)
+      end
+    end
+
+    def message
+      @message ||= Diaspora::MessageRenderer.new text, mentioned_people: mentioned_people
+    end
+  end
+end

--- a/lib/diaspora/message_renderer.rb
+++ b/lib/diaspora/message_renderer.rb
@@ -72,7 +72,7 @@ module Diaspora
         end
 
         if options[:disable_hovercards] || options[:link_all_mentions]
-          @message = Diaspora::Mentionable.filter_for_aspects message, nil
+          @message = Diaspora::Mentionable.filter_people message, []
         else
           make_mentions_plain_text
         end

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -77,12 +77,13 @@ describe NotificationsController, :type => :controller do
       timeago_content = note_html.css("time")[0]["data-time-ago"]
       expect(response_json["unread_count"]).to be(1)
       expect(response_json["unread_count_by_type"]).to eq(
-        "also_commented"  => 1,
-        "comment_on_post" => 0,
-        "liked"           => 0,
-        "mentioned"       => 0,
-        "reshared"        => 0,
-        "started_sharing" => 0
+        "also_commented"       => 1,
+        "comment_on_post"      => 0,
+        "liked"                => 0,
+        "mentioned"            => 0,
+        "mentioned_in_comment" => 0,
+        "reshared"             => 0,
+        "started_sharing"      => 0
       )
       expect(timeago_content).to include(@notification.updated_at.iso8601)
       expect(response.body).to match(/note_html/)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -184,20 +184,24 @@ describe UsersController, :type => :controller do
       end
     end
 
-    describe 'email settings' do
-      it 'lets the user turn off mail' do
-        par = {:id => @user.id, :user => {:email_preferences => {'mentioned' => 'true'}}}
-        expect{
-          put :update, par
-        }.to change(@user.user_preferences, :count).by(1)
-      end
+    describe "email settings" do
+      UserPreference::VALID_EMAIL_TYPES.each do |email_type|
+        context "for #{email_type}" do
+          it "lets the user turn off mail" do
+            par = {id: @user.id, user: {email_preferences: {email_type => "true"}}}
+            expect {
+              put :update, par
+            }.to change(@user.user_preferences, :count).by(1)
+          end
 
-      it 'lets the user get mail again' do
-        @user.user_preferences.create(:email_type => 'mentioned')
-        par = {:id => @user.id, :user => {:email_preferences => {'mentioned' => 'false'}}}
-        expect{
-          put :update, par
-        }.to change(@user.user_preferences, :count).by(-1)
+          it "lets the user get mail again" do
+            @user.user_preferences.create(email_type: email_type)
+            par = {id: @user.id, user: {email_preferences: {email_type => "false"}}}
+            expect {
+              put :update, par
+            }.to change(@user.user_preferences, :count).by(-1)
+          end
+        end
       end
     end
 

--- a/spec/integration/mentioning_spec.rb
+++ b/spec/integration/mentioning_spec.rb
@@ -1,10 +1,39 @@
 module MentioningSpecHelpers
-  def default_aspect
-    @user1.aspects.where(name: "generic").first
+  def notifications_about_mentioning(user, object)
+    table = object.class.table_name
+
+    if object.is_a?(StatusMessage)
+      klass = Notifications::MentionedInPost
+    elsif object.is_a?(Comment)
+      klass = Notifications::MentionedInComment
+    end
+
+    klass
+      .where(recipient_id: user.id)
+      .joins("LEFT OUTER JOIN mentions ON notifications.target_id = mentions.id AND "\
+             "notifications.target_type = 'Mention'")
+      .joins("LEFT OUTER JOIN #{table} ON mentions_container_id = #{table}.id AND "\
+             "mentions_container_type = '#{object.class.base_class}'").where(table.to_sym => {id: object.id})
   end
 
-  def text_mentioning(user)
-    "this is a text mentioning @{#{user.name}; #{user.diaspora_handle}} ... have fun testing!"
+  def mention_container_path(object)
+    object.is_a?(Post) ? post_path(object) : post_path(object.parent, anchor: object.guid)
+  end
+
+  def mentioning_mail_notification(user, object)
+    ActionMailer::Base.deliveries.select {|delivery|
+      delivery.to.include?(user.email) &&
+        delivery.subject.include?(I18n.t("notifier.mentioned.subject", name: "")) &&
+        delivery.body.parts[0].body.include?(mention_container_path(object))
+    }
+  end
+
+  def also_commented_mail_notification(user, post)
+    ActionMailer::Base.deliveries.select {|delivery|
+      delivery.to.include?(user.email) &&
+        delivery.subject.include?(I18n.t("notifier.also_commented.limited_subject")) &&
+        delivery.body.parts[0].body.include?(post_path(post))
+    }
   end
 
   def stream_for(user)
@@ -17,77 +46,336 @@ module MentioningSpecHelpers
     stream.posts
   end
 
-  def users_connected?(user1, user2)
-    user1.contacts.where(person_id: user2.person).count > 0
+  def post_status_message(mentioned_user, aspects=nil)
+    aspects = user1.aspects.first.id.to_s if aspects.nil?
+    sign_in user1
+    status_msg = nil
+    inlined_jobs do
+      post "/status_messages.json", status_message: {text: text_mentioning(mentioned_user)}, aspect_ids: aspects
+      status_msg = StatusMessage.find(JSON.parse(response.body)["id"])
+    end
+    status_msg
+  end
+
+  def receive_each(entity, recipients)
+    inlined_jobs do
+      recipients.each do |recipient|
+        DiasporaFederation.callbacks.trigger(:receive_entity, entity, entity.author, recipient.id)
+      end
+    end
+  end
+
+  def find_private_message(guid)
+    StatusMessage.find_by(guid: guid).tap do |status_msg|
+      expect(status_msg).not_to be_nil
+      expect(status_msg.public?).to be false
+    end
+  end
+
+  def receive_status_message_via_federation(text, *recipients)
+    entity = FactoryGirl.build(
+      :status_message_entity,
+      author: remote_raphael.diaspora_handle,
+      text:   text,
+      public: false
+    )
+
+    expect {
+      receive_each(entity, recipients)
+    }.to change(Post, :count).by(1).and change(ShareVisibility, :count).by(recipients.count)
+
+    find_private_message(entity.guid)
+  end
+
+  def receive_comment_via_federation(text, parent)
+    entity = build_relayable_federation_entity(
+      :comment,
+      parent_guid: parent.guid,
+      author:      remote_raphael.diaspora_handle,
+      parent:      Diaspora::Federation::Entities.related_entity(parent),
+      text:        text
+    )
+
+    receive_each(entity, [parent.author.owner])
+
+    Comment.find_by(guid: entity.guid)
   end
 end
-
 
 describe "mentioning", type: :request do
   include MentioningSpecHelpers
 
-  before do
-    @user1 = FactoryGirl.create :user_with_aspect
-    @user2 = FactoryGirl.create :user
-    @user3 = FactoryGirl.create :user
+  RSpec::Matchers.define :be_mentioned_in do |object|
+    include Rails.application.routes.url_helpers
 
-    @user1.share_with(@user2.person, default_aspect)
-    sign_in @user1
+    def user_notified?(user, object)
+      notifications_about_mentioning(user, object).any? && mentioning_mail_notification(user, object).any?
+    end
+
+    match do |user|
+      object.message.markdownified.include?(person_path(id: user.person.guid)) && user_notified?(user, object)
+    end
+
+    match_when_negated do |user|
+      !user_notified?(user, object)
+    end
   end
 
-  # see: https://github.com/diaspora/diaspora/issues/4160
-  it "doesn't mention people that aren't in the target aspect" do
-    expect(users_connected?(@user1, @user3)).to be false
+  RSpec::Matchers.define :be_in_streams_of do |user|
+    match do |status_message|
+      stream_for(user).map(&:id).include?(status_message.id) &&
+        mention_stream_for(user).map(&:id).include?(status_message.id)
+    end
 
+    match_when_negated do |status_message|
+      !stream_for(user).map(&:id).include?(status_message.id) &&
+        !mention_stream_for(user).map(&:id).include?(status_message.id)
+    end
+  end
+
+  let(:user1) { FactoryGirl.create(:user_with_aspect) }
+  let(:user2) { FactoryGirl.create(:user_with_aspect, friends: [user1, user3]) }
+  let(:user3) { FactoryGirl.create(:user_with_aspect) }
+
+  # see: https://github.com/diaspora/diaspora/issues/4160
+  it "only mentions people that are in the target aspect" do
     status_msg = nil
     expect {
-      post "/status_messages.json", status_message: {text: text_mentioning(@user3)}, aspect_ids: default_aspect.id.to_s
-      status_msg = StatusMessage.find(JSON.parse(response.body)["id"])
+      status_msg = post_status_message(user3)
     }.to change(Post, :count).by(1).and change(AspectVisibility, :count).by(1)
 
     expect(status_msg).not_to be_nil
     expect(status_msg.public?).to be false
-    expect(status_msg.text).to include(@user3.name)
-    expect(status_msg.text).not_to include(@user3.diaspora_handle)
-    expect(status_msg.text).to include(user_profile_path(username: @user3.username))
+    expect(status_msg.text).to include(user3.name)
 
-    expect(stream_for(@user3).map(&:id)).not_to include(status_msg.id)
-    expect(mention_stream_for(@user3).map(&:id)).not_to include(status_msg.id)
+    expect(user3).not_to be_mentioned_in(status_msg)
+    expect(status_msg).not_to be_in_streams_of(user3)
+  end
+
+  context "in private post via federation" do
+    let(:status_msg) {
+      receive_status_message_via_federation(text_mentioning(user2, user3), user3)
+    }
+
+    it "receiver is mentioned in status message" do
+      expect(user3).to be_mentioned_in(status_msg)
+    end
+
+    it "receiver can see status message in streams" do
+      expect(status_msg).to be_in_streams_of(user3)
+    end
+
+    it "non-receiver is not mentioned in status message" do
+      expect(user2).not_to be_mentioned_in(status_msg)
+    end
+
+    it "non-receiver can't see status message in streams" do
+      expect(status_msg).not_to be_in_streams_of(user2)
+    end
+  end
+
+  context "in private post via federation with multiple recipients" do
+    let(:status_msg) {
+      receive_status_message_via_federation(text_mentioning(user3, user2), user3, user2)
+    }
+
+    it "mentions all recipients in the status message" do
+      [user2, user3].each do |user|
+        expect(user).to be_mentioned_in(status_msg)
+      end
+    end
+
+    it "all recipients can see status message in streams" do
+      [user2, user3].each do |user|
+        expect(status_msg).to be_in_streams_of(user)
+      end
+    end
   end
 
   it "mentions people in public posts" do
-    expect(users_connected?(@user1, @user3)).to be false
-
     status_msg = nil
     expect {
-      post "/status_messages.json", status_message: {text: text_mentioning(@user3)}, aspect_ids: "public"
-      status_msg = StatusMessage.find(JSON.parse(response.body)["id"])
+      status_msg = post_status_message(user3, "public")
     }.to change(Post, :count).by(1)
 
     expect(status_msg).not_to be_nil
     expect(status_msg.public?).to be true
-    expect(status_msg.text).to include(@user3.name)
-    expect(status_msg.text).to include(@user3.diaspora_handle)
+    expect(status_msg.text).to include(user3.name)
+    expect(status_msg.text).to include(user3.diaspora_handle)
 
-    expect(stream_for(@user3).map(&:id)).to include(status_msg.id)
-    expect(mention_stream_for(@user3).map(&:id)).to include(status_msg.id)
+    expect(user3).to be_mentioned_in(status_msg)
+    expect(status_msg).to be_in_streams_of(user3)
   end
 
   it "mentions people that are in the target aspect" do
-    expect(users_connected?(@user1, @user2)).to be true
-
     status_msg = nil
     expect {
-      post "/status_messages.json", status_message: {text: text_mentioning(@user2)}, aspect_ids: default_aspect.id.to_s
-      status_msg = StatusMessage.find(JSON.parse(response.body)["id"])
+      status_msg = post_status_message(user2)
     }.to change(Post, :count).by(1).and change(AspectVisibility, :count).by(1)
 
     expect(status_msg).not_to be_nil
     expect(status_msg.public?).to be false
-    expect(status_msg.text).to include(@user2.name)
-    expect(status_msg.text).to include(@user2.diaspora_handle)
+    expect(status_msg.text).to include(user2.name)
+    expect(status_msg.text).to include(user2.diaspora_handle)
 
-    expect(stream_for(@user2).map(&:id)).to include(status_msg.id)
-    expect(mention_stream_for(@user2).map(&:id)).to include(status_msg.id)
+    expect(user2).to be_mentioned_in(status_msg)
+    expect(status_msg).to be_in_streams_of(user2)
+  end
+
+  context "in comments" do
+    let(:author) { FactoryGirl.create(:user_with_aspect) }
+
+    shared_context "commenter is author" do
+      let(:commenter) { author }
+    end
+
+    shared_context "commenter is author's friend" do
+      let(:commenter) { FactoryGirl.create(:user_with_aspect, friends: [author]) }
+    end
+
+    shared_context "commenter is not author's friend" do
+      let(:commenter) { FactoryGirl.create(:user) }
+    end
+
+    shared_context "mentioned user is author" do
+      let(:mentioned_user) { author }
+    end
+
+    shared_context "mentioned user is author's friend" do
+      let(:mentioned_user) { FactoryGirl.create(:user_with_aspect, friends: [author]) }
+    end
+
+    shared_context "mentioned user is not author's friend" do
+      let(:mentioned_user) { FactoryGirl.create(:user) }
+    end
+
+    context "with public post" do
+      let(:status_msg) { FactoryGirl.create(:status_message, author: author.person, public: true) }
+
+      [
+        ["commenter is author's friend", "mentioned user is not author's friend"],
+        ["commenter is author's friend", "mentioned user is author"],
+        ["commenter is not author's friend", "mentioned user is author's friend"],
+        ["commenter is not author's friend", "mentioned user is not author's friend"],
+        ["commenter is author", "mentioned user is author's friend"],
+        ["commenter is author", "mentioned user is not author's friend"]
+      ].each do |commenters_context, mentioned_context|
+        context "when #{commenters_context} and #{mentioned_context}" do
+          include_context commenters_context
+          include_context mentioned_context
+
+          let(:comment) {
+            inlined_jobs do
+              commenter.comment!(status_msg, text_mentioning(mentioned_user))
+            end
+          }
+
+          subject { mentioned_user }
+          it { is_expected.to be_mentioned_in(comment) }
+        end
+      end
+
+      context "when comment is received via federation" do
+        context "when mentioned user is remote" do
+          it "relays the comment to the mentioned user" do
+            mentioned_person = FactoryGirl.create(:person)
+            expect_any_instance_of(Diaspora::Federation::Dispatcher::Public)
+              .to receive(:deliver_to_remote).with([mentioned_person])
+
+            receive_comment_via_federation(text_mentioning(mentioned_person), status_msg)
+          end
+        end
+      end
+    end
+
+    context "with private post" do
+      [
+        ["commenter is author's friend", "mentioned user is author's friend"],
+        ["commenter is author", "mentioned user is author's friend"],
+        ["commenter is author's friend", "mentioned user is author"]
+      ].each do |commenters_context, mentioned_context|
+        context "when #{commenters_context} and #{mentioned_context}" do
+          include_context commenters_context
+          include_context mentioned_context
+
+          let(:parent) { FactoryGirl.create(:status_message_in_aspect, author: author.person) }
+          let(:comment) {
+            inlined_jobs do
+              commenter.comment!(parent, text_mentioning(mentioned_user))
+            end
+          }
+
+          before do
+            mentioned_user.like!(parent)
+          end
+
+          subject { mentioned_user }
+          it { is_expected.to be_mentioned_in(comment) }
+        end
+      end
+
+      context "when comment is received via federation" do
+        let(:parent) { FactoryGirl.create(:status_message_in_aspect, author: user2.person) }
+
+        before do
+          user3.like!(parent)
+          user1.like!(parent)
+        end
+
+        let(:comment_text) { text_mentioning(user2, user3, user1) }
+        let(:comment) { receive_comment_via_federation(comment_text, parent) }
+
+        it "mentions all the recepients" do
+          [user1, user2, user3].each do |user|
+            expect(user).to be_mentioned_in(comment)
+          end
+        end
+
+        context "with only post author mentioned" do
+          let(:post_author) { parent.author.owner }
+          let(:comment_text) { text_mentioning(post_author) }
+
+          it "makes only one notification for each recipient" do
+            expect {
+              comment
+            }.to change { Notifications::MentionedInComment.for(post_author).count }.by(1)
+              .and change { Notifications::AlsoCommented.for(user1).count }.by(1)
+              .and change { Notifications::AlsoCommented.for(user3).count }.by(1)
+
+            expect(mentioning_mail_notification(post_author, comment).count).to eq(1)
+
+            [user1, user3].each do |user|
+              expect(also_commented_mail_notification(user, parent).count).to eq(1)
+            end
+          end
+        end
+      end
+
+      context "commenter can't mention a non-participant" do
+        let(:status_msg) { FactoryGirl.create(:status_message_in_aspect, author: author.person) }
+
+        [
+          ["commenter is author's friend", "mentioned user is not author's friend"],
+          ["commenter is not author's friend", "mentioned user is author's friend"],
+          ["commenter is not author's friend", "mentioned user is not author's friend"],
+          ["commenter is author", "mentioned user is author's friend"],
+          ["commenter is author", "mentioned user is not author's friend"]
+        ].each do |commenters_context, mentioned_context|
+          context "when #{commenters_context} and #{mentioned_context}" do
+            include_context commenters_context
+            include_context mentioned_context
+
+            let(:comment) {
+              inlined_jobs do
+                commenter.comment!(status_msg, text_mentioning(mentioned_user))
+              end
+            }
+
+            subject { mentioned_user }
+            it { is_expected.not_to be_mentioned_in(comment) }
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/lib/diaspora/federation/receive_spec.rb
+++ b/spec/lib/diaspora/federation/receive_spec.rb
@@ -15,17 +15,15 @@ describe Diaspora::Federation::Receive do
   end
 
   describe ".comment" do
-    let(:comment_data) {
-      FactoryGirl.attributes_for(
-        :comment_entity,
-        author:           sender.diaspora_handle,
-        parent_guid:      post.guid,
-        author_signature: "aa"
-      )
-    }
     let(:comment_entity) {
-      DiasporaFederation::Entities::Comment.new(
-        comment_data, [:author, :guid, :parent_guid, :text, "new_property"], "new_property" => "data"
+      build_relayable_federation_entity(
+        :comment,
+        {
+          author:           sender.diaspora_handle,
+          parent_guid:      post.guid,
+          author_signature: "aa"
+        },
+        "new_property" => "data"
       )
     }
 
@@ -57,7 +55,7 @@ describe Diaspora::Federation::Receive do
       expect(comment.signature).not_to be_nil
       expect(comment.signature.author_signature).to eq("aa")
       expect(comment.signature.additional_data).to eq("new_property" => "data")
-      expect(comment.signature.order).to eq(%w(author guid parent_guid text new_property))
+      expect(comment.signature.order).to eq(comment_entity.xml_order.map(&:to_s))
     end
 
     let(:entity) { comment_entity }

--- a/spec/lib/diaspora/mentionable_spec.rb
+++ b/spec/lib/diaspora/mentionable_spec.rb
@@ -102,7 +102,7 @@ STR
     end
   end
 
-  describe "#filter_for_aspects" do
+  describe "#filter_people" do
     before do
       @user_a = FactoryGirl.create(:user_with_aspect, username: "user_a")
       @user_b = FactoryGirl.create(:user, username: "user_b")
@@ -122,8 +122,10 @@ STR
     end
 
     it "filters mention, if contact is not in a given aspect" do
-      aspect_id = @user_a.aspects.where(name: "generic").first.id
-      txt = Diaspora::Mentionable.filter_for_aspects(@test_txt_c, @user_a, aspect_id)
+      txt = Diaspora::Mentionable.filter_people(
+        @test_txt_c,
+        @user_a.aspects.where(name: "generic").first.contacts.map(&:person_id)
+      )
 
       expect(txt).to include("user C")
       expect(txt).to include(local_or_remote_person_path(@user_c.person))
@@ -132,18 +134,13 @@ STR
     end
 
     it "leaves mention, if contact is in a given aspect" do
-      aspect_id = @user_a.aspects.where(name: "generic").first.id
-      txt = Diaspora::Mentionable.filter_for_aspects(@test_txt_b, @user_a, aspect_id)
+      txt = Diaspora::Mentionable.filter_people(
+        @test_txt_b,
+        @user_a.aspects.where(name: "generic").first.contacts.map(&:person_id)
+      )
 
       expect(txt).to include("user B")
       expect(txt).to include(@mention_b)
-    end
-
-    it "recognizes 'all' as keyword for aspects" do
-      txt = Diaspora::Mentionable.filter_for_aspects(@test_txt_bc, @user_a, "all")
-
-      expect(txt).to include(@mention_b)
-      expect(txt).to include(@mention_c)
     end
   end
 end

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -64,7 +64,7 @@ describe Notifier, type: :mailer do
   end
 
   describe ".started_sharing" do
-    let!(:request_mail) { Notifier.started_sharing(bob.id, person.id) }
+    let!(:request_mail) { Notifier.send_notification("started_sharing", bob.id, person.id) }
 
     it "goes to the right person" do
       expect(request_mail.to).to eq([bob.email])
@@ -136,7 +136,7 @@ describe Notifier, type: :mailer do
     before do
       @post = FactoryGirl.create(:status_message, author: alice.person, public: true)
       @like = @post.likes.create!(author: bob.person)
-      @mail = Notifier.liked(alice.id, @like.author.id, @like.id)
+      @mail = Notifier.send_notification("liked", alice.id, @like.author.id, @like.id)
     end
 
     it "TO: goes to the right person" do
@@ -158,7 +158,7 @@ describe Notifier, type: :mailer do
     it "can handle a reshare" do
       reshare = FactoryGirl.create(:reshare)
       like = reshare.likes.create!(author: bob.person)
-      Notifier.liked(alice.id, like.author.id, like.id)
+      Notifier.send_notification("liked", alice.id, like.author.id, like.id)
     end
   end
 
@@ -166,7 +166,7 @@ describe Notifier, type: :mailer do
     before do
       @post = FactoryGirl.create(:status_message, author: alice.person, public: true)
       @reshare = FactoryGirl.create(:reshare, root: @post, author: bob.person)
-      @mail = Notifier.reshared(alice.id, @reshare.author.id, @reshare.id)
+      @mail = Notifier.send_notification("reshared", alice.id, @reshare.author.id, @reshare.id)
     end
 
     it "TO: goes to the right person" do
@@ -205,7 +205,7 @@ describe Notifier, type: :mailer do
 
       @cnv = Conversation.create(@create_hash)
 
-      @mail = Notifier.private_message(bob.id, @cnv.author.id, @cnv.messages.first.id)
+      @mail = Notifier.send_notification("private_message", bob.id, @cnv.author.id, @cnv.messages.first.id)
     end
 
     it "TO: goes to the right person" do
@@ -248,7 +248,7 @@ describe Notifier, type: :mailer do
     let(:comment) { eve.comment!(commented_post, "Totally is") }
 
     describe ".comment_on_post" do
-      let(:comment_mail) { Notifier.comment_on_post(bob.id, person.id, comment.id).deliver_now }
+      let(:comment_mail) { Notifier.send_notification("comment_on_post", bob.id, person.id, comment.id).deliver_now }
 
       it "TO: goes to the right person" do
         expect(comment_mail.to).to eq([bob.email])
@@ -289,7 +289,7 @@ describe Notifier, type: :mailer do
     end
 
     describe ".also_commented" do
-      let(:comment_mail) { Notifier.also_commented(bob.id, person.id, comment.id) }
+      let(:comment_mail) { Notifier.send_notification("also_commented", bob.id, person.id, comment.id) }
 
       it "TO: goes to the right person" do
         expect(comment_mail.to).to eq([bob.email])
@@ -344,7 +344,7 @@ describe Notifier, type: :mailer do
       let(:comment) { bob.comment!(limited_post, "Totally is") }
 
       describe ".also_commented" do
-        let(:mail) { Notifier.also_commented(alice.id, bob.person.id, comment.id) }
+        let(:mail) { Notifier.send_notification("also_commented", alice.id, bob.person.id, comment.id) }
 
         it "TO: goes to the right person" do
           expect(mail.to).to eq([alice.email])
@@ -369,7 +369,7 @@ describe Notifier, type: :mailer do
 
       describe ".comment_on_post" do
         let(:comment) { bob.comment!(limited_post, "Totally is") }
-        let(:mail) { Notifier.comment_on_post(alice.id, bob.person.id, comment.id) }
+        let(:mail) { Notifier.send_notification("comment_on_post", alice.id, bob.person.id, comment.id) }
 
         it "TO: goes to the right person" do
           expect(mail.to).to eq([alice.email])
@@ -400,7 +400,7 @@ describe Notifier, type: :mailer do
 
     describe ".liked" do
       let(:like) { bob.like!(limited_post) }
-      let(:mail) { Notifier.liked(alice.id, bob.person.id, like.id) }
+      let(:mail) { Notifier.send_notification("liked", alice.id, bob.person.id, like.id) }
 
       it "TO: goes to the right person" do
         expect(mail.to).to eq([alice.email])
@@ -436,7 +436,7 @@ describe Notifier, type: :mailer do
   describe ".confirm_email" do
     before do
       bob.update_attribute(:unconfirmed_email, "my@newemail.com")
-      @confirm_email = Notifier.confirm_email(bob.id)
+      @confirm_email = Notifier.send_notification("confirm_email", bob.id)
     end
 
     it "goes to the right person" do
@@ -461,7 +461,7 @@ describe Notifier, type: :mailer do
   end
 
   describe ".csrf_token_fail" do
-    let(:email) { Notifier.csrf_token_fail(alice.id) }
+    let(:email) { Notifier.send_notification("csrf_token_fail", alice.id) }
 
     it "goes to the right person" do
       expect(email.to).to eq([alice.email])
@@ -495,7 +495,7 @@ describe Notifier, type: :mailer do
     it "handles idn addresses" do
       bob.update_attribute(:email, "ŧoo@ŧexample.com")
       expect {
-        Notifier.started_sharing(bob.id, person.id)
+        Notifier.send_notification("started_sharing", bob.id, person.id)
       }.to_not raise_error
     end
   end

--- a/spec/models/mention_spec.rb
+++ b/spec/models/mention_spec.rb
@@ -6,9 +6,9 @@ describe Mention, type: :model do
   describe "after destroy" do
     it "destroys a notification" do
       sm = alice.post(:status_message, text: "hi", to: alice.aspects.first)
-      mention = Mention.create!(person: bob.person, post: sm)
+      mention = Mention.create!(person: bob.person, mentions_container: sm)
 
-      Notifications::Mentioned.notify(sm, [bob.id])
+      Notifications::MentionedInPost.notify(sm, [bob.id])
 
       expect {
         mention.destroy

--- a/spec/models/notifications/mentioned_in_post_spec.rb
+++ b/spec/models/notifications/mentioned_in_post_spec.rb
@@ -1,0 +1,72 @@
+describe Notifications::MentionedInPost, type: :model do
+  let(:sm) {
+    FactoryGirl.create(:status_message, author: alice.person, text: "hi @{bob; #{bob.diaspora_handle}}", public: true)
+  }
+  let(:mentioned_notification) { Notifications::MentionedInPost.new(recipient: bob) }
+
+  describe ".notify" do
+    it "calls create_notification with mention" do
+      expect(Notifications::MentionedInPost).to receive(:create_notification).with(
+        bob, sm.mentions.first, sm.author
+      ).and_return(mentioned_notification)
+
+      Notifications::MentionedInPost.notify(sm, [])
+    end
+
+    it "sends an email to the mentioned person" do
+      allow(Notifications::MentionedInPost).to receive(:create_notification).and_return(mentioned_notification)
+      expect(bob).to receive(:mail).with(Workers::Mail::Mentioned, bob.id, sm.author.id, sm.mentions.first.id)
+
+      Notifications::MentionedInPost.notify(sm, [])
+    end
+
+    it "does nothing if the mentioned person is not local" do
+      sm = FactoryGirl.create(
+        :status_message,
+        author: alice.person,
+        text:   "hi @{raphael; #{remote_raphael.diaspora_handle}}",
+        public: true
+      )
+      expect(Notifications::MentionedInPost).not_to receive(:create_notification)
+
+      Notifications::MentionedInPost.notify(sm, [])
+    end
+
+    it "does not notify if the author of the post is ignored" do
+      bob.blocks.create(person: sm.author)
+
+      expect_any_instance_of(Notifications::MentionedInPost).not_to receive(:email_the_user)
+
+      Notifications::MentionedInPost.notify(sm, [])
+
+      expect(Notifications::MentionedInPost.where(target: sm.mentions.first)).not_to exist
+    end
+
+    context "with private post" do
+      let(:private_sm) {
+        FactoryGirl.create(
+          :status_message,
+          author: remote_raphael,
+          text:   "hi @{bob; #{bob.diaspora_handle}}",
+          public: false
+        ).tap {|private_sm|
+          private_sm.receive([bob.id, alice.id])
+        }
+      }
+
+      it "calls create_notification if the mentioned person is a recipient of the post" do
+        expect(Notifications::MentionedInPost).to receive(:create_notification).with(
+          bob, private_sm.mentions.first, private_sm.author
+        ).and_return(mentioned_notification)
+
+        Notifications::MentionedInPost.notify(private_sm, [bob.id])
+      end
+
+      it "does not call create_notification if the mentioned person is not a recipient of the post" do
+        expect(Notifications::MentionedInPost).not_to receive(:create_notification)
+
+        Notifications::MentionedInPost.notify(private_sm, [alice.id])
+      end
+    end
+  end
+end

--- a/spec/models/notifications/mentioned_spec.rb
+++ b/spec/models/notifications/mentioned_spec.rb
@@ -1,70 +1,53 @@
-describe Notifications::Mentioned, type: :model do
-  let(:sm) {
-    FactoryGirl.create(:status_message, author: alice.person, text: "hi @{bob; #{bob.diaspora_handle}}", public: true)
-  }
-  let(:mentioned_notification) { Notifications::Mentioned.new(recipient: bob) }
+describe Notifications::Mentioned do
+  class TestNotification < Notification
+    include Notifications::Mentioned
+
+    def self.filter_mentions(mentions, *)
+      mentions
+    end
+  end
 
   describe ".notify" do
-    it "calls create_notification with mention" do
-      expect(Notifications::Mentioned).to receive(:create_notification).with(
-        bob, sm.mentions.first, sm.author
-      ).and_return(mentioned_notification)
+    let(:status_message) {
+      FactoryGirl.create(:status_message, text: text_mentioning(remote_raphael, alice, bob, eve), author: eve.person)
+    }
 
-      Notifications::Mentioned.notify(sm, [])
+    it "calls filter_mentions on self" do
+      expect(TestNotification).to receive(:filter_mentions).with(
+        Mention.where(mentions_container: status_message, person: [alice, bob].map(&:person)),
+        status_message,
+        [alice.id, bob.id]
+      ).and_return([])
+
+      TestNotification.notify(status_message, [alice.id, bob.id])
     end
 
-    it "sends an email to the mentioned person" do
-      allow(Notifications::Mentioned).to receive(:create_notification).and_return(mentioned_notification)
-      expect(bob).to receive(:mail).with(Workers::Mail::Mentioned, bob.id, sm.author.id, sm.mentions.first.id)
-
-      Notifications::Mentioned.notify(sm, [])
-    end
-
-    it "does nothing if the mentioned person is not local" do
-      sm = FactoryGirl.create(
-        :status_message,
-        author: alice.person,
-        text:   "hi @{raphael; #{remote_raphael.diaspora_handle}}",
-        public: true
-      )
-      expect(Notifications::Mentioned).not_to receive(:create_notification)
-
-      Notifications::Mentioned.notify(sm, [])
-    end
-
-    it "does not notify if the author of the post is ignored" do
-      bob.blocks.create(person: sm.author)
-
-      expect_any_instance_of(Notifications::Mentioned).not_to receive(:email_the_user)
-
-      Notifications::Mentioned.notify(sm, [])
-
-      expect(Notifications::Mentioned.where(target: sm.mentions.first)).not_to exist
-    end
-
-    context "with private post" do
-      let(:private_sm) {
-        FactoryGirl.create(
-          :status_message,
-          author: remote_raphael,
-          text:   "hi @{bob; #{bob.diaspora_handle}}",
-          public: false
+    it "creates notification for each mention" do
+      [alice, bob].each do |recipient|
+        expect(TestNotification).to receive(:create_notification).with(
+          recipient,
+          Mention.where(mentions_container: status_message, person: recipient.person_id).first,
+          status_message.author
         )
-      }
-
-      it "calls create_notification if the mentioned person is a recipient of the post" do
-        expect(Notifications::Mentioned).to receive(:create_notification).with(
-          bob, private_sm.mentions.first, private_sm.author
-        ).and_return(mentioned_notification)
-
-        Notifications::Mentioned.notify(private_sm, [bob.id])
       end
 
-      it "does not call create_notification if the mentioned person is not a recipient of the post" do
-        expect(Notifications::Mentioned).not_to receive(:create_notification)
+      TestNotification.notify(status_message, nil)
+    end
 
-        Notifications::Mentioned.notify(private_sm, [alice.id])
-      end
+    it "creates email notification for mention" do
+      status_message = FactoryGirl.create(:status_message, text: text_mentioning(alice), author: eve.person)
+      expect_any_instance_of(TestNotification).to receive(:email_the_user).with(
+        Mention.where(mentions_container: status_message, person: alice.person_id).first,
+        status_message.author
+      )
+
+      TestNotification.notify(status_message, nil)
+    end
+
+    it "doesn't create notification if it was filtered out by filter_mentions" do
+      expect(TestNotification).to receive(:filter_mentions).and_return([])
+      expect(TestNotification).not_to receive(:create_notification)
+      TestNotification.notify(status_message, nil)
     end
   end
 end

--- a/spec/models/photo_spec.rb
+++ b/spec/models/photo_spec.rb
@@ -203,12 +203,6 @@ describe Photo, :type => :model do
     end
   end
 
-  context "commenting" do
-    it "accepts comments if there is no parent status message" do
-      expect{ @user.comment!(@photo, "big willy style") }.to change(@photo.comments, :count).by(1)
-    end
-  end
-
   describe '#queue_processing_job' do
     it 'should queue a job to process the images' do
       expect(Workers::ProcessPhoto).to receive(:perform_async).with(@photo.id)

--- a/spec/models/status_message_spec.rb
+++ b/spec/models/status_message_spec.rb
@@ -14,11 +14,12 @@ describe StatusMessage, type: :model do
       it "returns status messages where the given person is mentioned" do
         @bob = bob.person
         @test_string = "@{Daniel; #{@bob.diaspora_handle}} can mention people like Raph"
+        post1 = FactoryGirl.create(:status_message, text: @test_string, public: true)
+        post2 = FactoryGirl.create(:status_message, text: @test_string, public: true)
         FactoryGirl.create(:status_message, text: @test_string)
-        FactoryGirl.create(:status_message, text: @test_string)
-        FactoryGirl.create(:status_message)
+        FactoryGirl.create(:status_message, public: true)
 
-        expect(StatusMessage.where_person_is_mentioned(bob).count).to eq(2)
+        expect(StatusMessage.where_person_is_mentioned(@bob).ids).to match_array([post1.id, post2.id])
       end
     end
 
@@ -81,14 +82,6 @@ describe StatusMessage, type: :model do
     end
   end
 
-  describe ".after_create" do
-    it "calls create_mentions" do
-      status = FactoryGirl.build(:status_message, text: "text @{Test; #{alice.diaspora_handle}}")
-      expect(status).to receive(:create_mentions).and_call_original
-      status.save
-    end
-  end
-
   context "emptiness" do
     it "needs either a message or at least one photo" do
       post = user.build_post(:status_message, text: nil)
@@ -131,57 +124,20 @@ describe StatusMessage, type: :model do
     expect(status_message).not_to be_valid
   end
 
-  describe "mentions" do
-    let(:people) { [alice, bob, eve].map(&:person) }
-    let(:test_string) {
-      "@{Raphael; #{people[0].diaspora_handle}} can mention people like Raphael @{Ilya; #{people[1].diaspora_handle}}
-    can mention people like Raphaellike Raphael @{Daniel; #{people[2].diaspora_handle}} can mention people like Raph"
-    }
-    let(:status_message) { create(:status_message, text: test_string) }
+  it_behaves_like "it is mentions container"
 
-    describe "#create_mentions" do
-      it "creates a mention for everyone mentioned in the message" do
-        status_message
-        expect(Diaspora::Mentionable).to receive(:people_from_string).and_return(people)
-        status_message.mentions.delete_all
-        status_message.create_mentions
-        expect(status_message.mentions(true).map(&:person).to_set).to eq(people.to_set)
-      end
+  describe "#people_allowed_to_be_mentioned" do
+    it "returns only aspects members for private posts" do
+      sm = FactoryGirl.build(:status_message_in_aspect)
+      sm.author.owner.share_with(alice.person, sm.author.owner.aspects.first)
+      sm.author.owner.share_with(eve.person, sm.author.owner.aspects.first)
+      sm.save!
 
-      it "does not barf if it gets called twice" do
-        status_message.create_mentions
-
-        expect {
-          status_message.create_mentions
-        }.to_not raise_error
-      end
+      expect(sm.people_allowed_to_be_mentioned).to match_array([alice.person_id, eve.person_id])
     end
 
-    describe "#mentioned_people" do
-      it "does not call create_mentions if there are no mentions in the db" do
-        status_message.mentions.delete_all
-        expect(status_message).not_to receive(:create_mentions)
-        status_message.mentioned_people
-      end
-
-      it "returns the mentioned people" do
-        expect(status_message.mentioned_people.to_set).to eq(people.to_set)
-      end
-
-      it "does not call create_mentions if there are mentions in the db" do
-        expect(status_message).not_to receive(:create_mentions)
-        status_message.mentioned_people
-      end
-    end
-
-    describe "#mentions?" do
-      it "returns true if the person was mentioned" do
-        expect(status_message.mentions?(people[0])).to be true
-      end
-
-      it "returns false if the person was not mentioned" do
-        expect(status_message.mentions?(FactoryGirl.build(:person))).to be false
-      end
+    it "returns :all for public posts" do
+      expect(FactoryGirl.create(:status_message, public: true).people_allowed_to_be_mentioned).to eq(:all)
     end
   end
 

--- a/spec/presenters/post_presenter_spec.rb
+++ b/spec/presenters/post_presenter_spec.rb
@@ -126,9 +126,9 @@ describe PostPresenter do
 
     it "does not raise if the root of a reshare does not exist anymore" do
       reshare = FactoryGirl.create(:reshare)
-      reshare.root = nil
+      reshare.update(root: nil)
 
-      expect(PostPresenter.new(reshare).send(:description)).to eq(nil)
+      expect(PostPresenter.new(Post.find(reshare.id)).send(:description)).to eq(nil)
     end
   end
 

--- a/spec/services/notification_service_spec.rb
+++ b/spec/services/notification_service_spec.rb
@@ -1,0 +1,74 @@
+describe NotificationService do
+  describe "notification interrelation" do
+    context "with mention in comment" do
+      let(:status_message) {
+        FactoryGirl.create(:status_message, public: true, author: alice.person).tap {|status_message|
+          eve.comment!(status_message, "whatever")
+        }
+      }
+
+      let(:comment) {
+        FactoryGirl.create(
+          :comment,
+          author: bob.person,
+          text:   text_mentioning(alice, eve),
+          post:   status_message
+        )
+      }
+
+      it "sends only mention notification" do
+        [alice, eve].each do |user|
+          expect(Workers::Mail::MentionedInComment).to receive(:perform_async).with(
+            user.id,
+            bob.person.id,
+            *comment.mentions.where(person: user.person).ids
+          )
+        end
+
+        expect {
+          NotificationService.new.notify(comment, [])
+        }.to change { Notification.where(recipient_id: alice).count }.by(1)
+          .and change { Notification.where(recipient_id: eve).count }.by(1)
+
+        [alice, eve].each do |user|
+          expect(
+            Notifications::MentionedInComment.where(target: comment.mentions, recipient_id: user.id)
+          ).to exist
+
+          expect(
+            Notifications::CommentOnPost.where(target: comment.parent, recipient_id: user.id)
+          ).not_to exist
+
+          expect(
+            Notifications::AlsoCommented.where(target: comment.parent, recipient_id: user.id)
+          ).not_to exist
+        end
+      end
+
+      context "with \"mentioned in comment\" email turned off" do
+        before do
+          alice.user_preferences.create(email_type: "mentioned_in_comment")
+          eve.user_preferences.create(email_type: "mentioned_in_comment")
+        end
+
+        it "calls appropriate mail worker instead" do
+          expect(Workers::Mail::MentionedInComment).not_to receive(:perform_async)
+
+          expect(Workers::Mail::CommentOnPost).to receive(:perform_async).with(
+            alice.id,
+            bob.person.id,
+            *comment.mentions.where(person: alice.person).ids
+          )
+
+          expect(Workers::Mail::AlsoCommented).to receive(:perform_async).with(
+            eve.id,
+            bob.person.id,
+            *comment.mentions.where(person: eve.person).ids
+          )
+
+          NotificationService.new.notify(comment, [])
+        end
+      end
+    end
+  end
+end

--- a/spec/shared_behaviors/mentions_container.rb
+++ b/spec/shared_behaviors/mentions_container.rb
@@ -1,0 +1,44 @@
+shared_examples_for "it is mentions container" do
+  let(:people) { [alice, bob, eve].map(&:person) }
+  let(:test_string) {
+    "@{Raphael; #{people[0].diaspora_handle}} can mention people like @{Ilya; #{people[1].diaspora_handle}}"\
+    "can mention people like @{Daniel; #{people[2].diaspora_handle}}"
+  }
+  let(:target) { FactoryGirl.build(described_class.to_s.underscore.to_sym, text: test_string, author: alice.person) }
+  let(:target_persisted) {
+    target.save!
+    target
+  }
+
+  describe ".after_create" do
+    it "calls create_mentions" do
+      expect(target).to receive(:create_mentions).and_call_original
+      target.save
+    end
+  end
+
+  describe "#create_mentions" do
+    it "creates a mention for everyone mentioned in the message" do
+      people.each do |person|
+        expect(target.mentions).to receive(:find_or_create_by).with(person_id: person.id)
+      end
+      target.create_mentions
+    end
+
+    it "does not barf if it gets called twice" do
+      expect {
+        target_persisted.create_mentions
+      }.to_not raise_error
+    end
+  end
+
+  describe "#mentioned_people" do
+    it "returns the mentioned people if non-persisted" do
+      expect(target.mentioned_people).to match_array(people)
+    end
+
+    it "returns the mentioned people if persisted" do
+      expect(target_persisted.mentioned_people).to match_array(people)
+    end
+  end
+end

--- a/spec/workers/mail/csrf_token_fail_spec.rb
+++ b/spec/workers/mail/csrf_token_fail_spec.rb
@@ -3,12 +3,12 @@
 #   the COPYRIGHT file.
 
 describe Workers::Mail::CsrfTokenFail do
-  describe "#perfom" do
+  describe "#perform" do
     it "should call .deliver on the notifier object" do
       user = alice
       mail_double = double
       expect(mail_double).to receive(:deliver_now)
-      expect(Notifier).to receive(:csrf_token_fail).with(user.id).and_return(mail_double)
+      expect(Notifier).to receive(:send_notification).with("csrf_token_fail", user.id).and_return(mail_double)
 
       Workers::Mail::CsrfTokenFail.new.perform(user.id)
     end

--- a/spec/workers/mail/liked_spec.rb
+++ b/spec/workers/mail/liked_spec.rb
@@ -1,12 +1,13 @@
 describe Workers::Mail::Liked do
-  describe "#perfom" do
+  describe "#perform" do
     it "should call .deliver_now on the notifier object" do
       sm = FactoryGirl.build(:status_message, author: bob.person, public: true)
       like = FactoryGirl.build(:like, author: alice.person, target: sm)
 
       mail_double = double
       expect(mail_double).to receive(:deliver_now)
-      expect(Notifier).to receive(:liked).with(bob.id, like.author.id, like.id).and_return(mail_double)
+      expect(Notifier).to receive(:send_notification)
+        .with("liked", bob.id, like.author.id, like.id).and_return(mail_double)
 
       Workers::Mail::Liked.new.perform(bob.id, like.author.id, like.id)
     end
@@ -15,7 +16,7 @@ describe Workers::Mail::Liked do
       sm = FactoryGirl.build(:status_message, author: bob.person, public: true)
       like = FactoryGirl.build(:like, author: alice.person, target: sm)
 
-      expect(Notifier).to receive(:liked).with(bob.id, like.author.id, like.id)
+      expect(Notifier).to receive(:send_notification).with("liked", bob.id, like.author.id, like.id)
         .and_raise(ActiveRecord::RecordNotFound.new("Couldn't find Like with 'id'=42"))
 
       Workers::Mail::Liked.new.perform(bob.id, like.author.id, like.id)
@@ -25,7 +26,7 @@ describe Workers::Mail::Liked do
       sm = FactoryGirl.build(:status_message, author: bob.person, public: true)
       like = FactoryGirl.build(:like, author: alice.person, target: sm)
 
-      expect(Notifier).to receive(:liked).with(bob.id, like.author.id, like.id)
+      expect(Notifier).to receive(:send_notification).with("liked", bob.id, like.author.id, like.id)
         .and_raise(ActiveRecord::RecordNotFound.new("Couldn't find Person with 'id'=42"))
 
       expect {

--- a/spec/workers/mail/mentioned_spec.rb
+++ b/spec/workers/mail/mentioned_spec.rb
@@ -7,11 +7,12 @@ describe Workers::Mail::Mentioned do
     it "should call .deliver on the notifier object" do
       user = alice
       sm = FactoryGirl.build(:status_message)
-      m = Mention.new(:person => user.person, :post=> sm)
+      m = Mention.new(person: user.person, mentions_container: sm)
 
       mail_double = double()
       expect(mail_double).to receive(:deliver_now)
-      expect(Notifier).to receive(:send_notification).with("mentioned", user.id, sm.author.id, m.id).and_return(mail_double)
+      expect(Notifier).to receive(:send_notification)
+        .with("mentioned", user.id, sm.author.id, m.id).and_return(mail_double)
 
       Workers::Mail::Mentioned.new.perform(user.id, sm.author.id, m.id)
     end

--- a/spec/workers/mail/mentioned_spec.rb
+++ b/spec/workers/mail/mentioned_spec.rb
@@ -3,15 +3,15 @@
 #   the COPYRIGHT file.
 
 describe Workers::Mail::Mentioned do
-  describe '#perfom' do
-    it 'should call .deliver on the notifier object' do
+  describe "#perform" do
+    it "should call .deliver on the notifier object" do
       user = alice
       sm = FactoryGirl.build(:status_message)
       m = Mention.new(:person => user.person, :post=> sm)
 
       mail_double = double()
       expect(mail_double).to receive(:deliver_now)
-      expect(Notifier).to receive(:mentioned).with(user.id, sm.author.id, m.id).and_return(mail_double)
+      expect(Notifier).to receive(:send_notification).with("mentioned", user.id, sm.author.id, m.id).and_return(mail_double)
 
       Workers::Mail::Mentioned.new.perform(user.id, sm.author.id, m.id)
     end

--- a/spec/workers/mail/private_message_spec.rb
+++ b/spec/workers/mail/private_message_spec.rb
@@ -3,8 +3,8 @@
 #   the COPYRIGHT file.
 
 describe Workers::Mail::PrivateMessage do
-  describe '#perfom_delegate' do
-    it 'should call .deliver on the notifier object' do
+  describe "#perform" do
+    it "should call .deliver on the notifier object" do
       user1 = alice
       user2 = bob
       participant_ids = [user1.contacts.first.person.id, user1.person.id]
@@ -17,9 +17,10 @@ describe Workers::Mail::PrivateMessage do
 
       mail_double = double()
       expect(mail_double).to receive(:deliver_now)
-      expect(Notifier).to receive(:mentioned).with(user2.id, user1.person.id, message.id).and_return(mail_double)
+      expect(Notifier).to receive(:send_notification)
+        .with("private_message", user2.id, user1.person.id, message.id).and_return(mail_double)
 
-      Workers::Mail::Mentioned.new.perform(user2.id, user1.person.id, message.id)
+      Workers::Mail::PrivateMessage.new.perform(user2.id, user1.person.id, message.id)
     end
   end
 end

--- a/spec/workers/mail/reshared_spec.rb
+++ b/spec/workers/mail/reshared_spec.rb
@@ -3,14 +3,15 @@
 #   the COPYRIGHT file.
 
 describe Workers::Mail::Reshared do
-  describe '#perfom' do
-    it 'should call .deliver on the notifier object' do
+  describe "#perform" do
+    it "should call .deliver on the notifier object" do
       sm = FactoryGirl.build(:status_message, :author => bob.person, :public => true)
       reshare = FactoryGirl.build(:reshare, :author => alice.person, :root=> sm)
 
       mail_double = double()
       expect(mail_double).to receive(:deliver_now)
-      expect(Notifier).to receive(:reshared).with(bob.id, reshare.author.id, reshare.id).and_return(mail_double)
+      expect(Notifier).to receive(:send_notification)
+        .with("reshared", bob.id, reshare.author.id, reshare.id).and_return(mail_double)
 
       Workers::Mail::Reshared.new.perform(bob.id, reshare.author.id, reshare.id)
     end


### PR DESCRIPTION
This is an early preliminary PR with backend-changes to support mentions in comments (#1851).

It introduces changes to the DB schema making Mention model polymorphic and allowing a mention to belong to a comment. It also creates module Diaspora::MentionsContainer which incapsulates the logic of an object that supports keeping mentions. Now it includes logic I picked from the StatusMessage model.

ATM the mentions in comments are supported to the extent of placing user profile links instead of mention code in the mobile version (it is so because the mobile version doesn't require javascript code changes).

Changes summary:
- Make Mention model polymorphic;
- Introduce Diaspora::MentionsContainer which incapsulates the logic of an object that supports keeping mentions;
- We don't filter mentions anymore, instead we send notification/show in streams only that mentions, which are visible to the recipient;
- Create Notifications::Mentioned module which incapsulates common logic of mentioned notification;
- Add Notifications::MentionedInComment and move old Notifications::Mentioned to Notifications::MentionedInPost;
- Update the UI code to render new type of notification;
- Hack comments notifications to avoid having double notification when mentioned in a comment;

Drive-by refactorings:
- Move Notification.types out of the model to the controller;
- Move `StatusMessage#mentioned_people_names` out of the model. Create a `PersonPresenter.people_names` method instead;
- DRY UserController to use UserPreference::VALID_EMAIL_TYPES in the `user_params` method;

TODO:
- [x] Implement notifications for mentioning in comments
- [x] Implement restrictions of mentioning some kind of people (see [comment](https://github.com/diaspora/diaspora/issues/1851#issuecomment-36557842))
- [x] Ensure comment is federated to new discussion participants
- [x] Ensure mentions in comment are filtered on federation receive
- [x] ~~Ensure the filtered out mentions are replaced with links properly~~
- [x] Don't send redundant second notification when mentioned in comment.
- [x] Ensure email notifications work properly
- ~~Implement frontend javascript changes for comments publisher~~
