### PR TITLE
Fix time ago when making a notification read/unread.

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -9,7 +9,7 @@ class Notification < ActiveRecord::Base
   belongs_to :target, :polymorphic => true
 
   attr_accessor :note_html
- 
+
   def self.for(recipient, opts={})
     self.where(opts.merge!(:recipient_id => recipient.id)).order('updated_at desc')
   end
@@ -29,7 +29,7 @@ class Notification < ActiveRecord::Base
                                       actor, note_type)
     end
     return_note.email_the_user(target, actor) if return_note
-    return_note 
+    return_note
   end
 
   def as_json(opts={})
@@ -41,7 +41,7 @@ class Notification < ActiveRecord::Base
   end
 
   def set_read_state( read_state )
-    self.update_attributes( :unread => !read_state )
+    update_column(:unread, !read_state)
   end
 
   def mail_job

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -31,6 +31,19 @@ describe NotificationsController, :type => :controller do
       get :update, "id" => note.id, :set_unread => "true", :format => :json
     end
 
+    it "marks a notification as unread without timestamping" do
+      note = Timecop.travel(1.hour.ago) do
+        FactoryGirl.create(:notification, recipient: alice, unread: false)
+      end
+
+      get :update, "id" => note.id, :set_unread => "true", :format => :json
+      expect(response).to be_success
+
+      updated_note = Notification.find(note.id)
+      expect(updated_note.unread).to eq(true)
+      expect(updated_note.updated_at.iso8601).to eq(note.updated_at.iso8601)
+    end
+
     it 'only lets you read your own notifications' do
       user2 = bob
 

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -41,15 +41,17 @@ describe Notification, :type => :model do
   describe 'set_read_state method' do
     it "should set an unread notification to read" do
       @note.unread = true
+      @note.save
       @note.set_read_state( true )
       expect(@note.unread).to eq(false)
     end
+
     it "should set an read notification to unread" do
       @note.unread = false
+      @note.save
       @note.set_read_state( false )
       expect(@note.unread).to eq(true)
     end
-
   end
 
 


### PR DESCRIPTION
Marking a notification as unread resets the timeago stamp causing
the times to look wrong. It can be reproduced by marking an old
notification as unread. Using the update_colum instead of
update_attribute will not touch the updated_at attribute, and
thus will not affect the updated time ago in the view.

Fixes #6798.
