### PR TITLE
Fix message content overflow in conversations

### DIFF
--- a/app/assets/stylesheets/post-content.scss
+++ b/app/assets/stylesheets/post-content.scss
@@ -1,3 +1,4 @@
+.message-content,
 .post-content {
   img { max-width: 100%; }
   .photo_attachments {

--- a/app/views/conversations/_message.haml
+++ b/app/views/conversations/_message.haml
@@ -11,4 +11,5 @@
       = timeago(message.created_at)
 
       %div{ :class => direction_for(message.text) }
-        = message.message.markdownified
+        .message-content
+          = message.message.markdownified


### PR DESCRIPTION
Fixes everything mentioned in the first comment of #6823. The codeblocks issue mentioned by @denschub in the comments over there looks to me like a Bootstrap upstream issue related to https://github.com/twbs/bootstrap/issues/15958. I'm pretty sure I already linked a related Bootstrap issue somewhere else but I'm currently unable to find it.
