### PR TITLE
Fix like and reshare from the profile page

### DIFF
--- a/app/views/people/show.mobile.haml
+++ b/app/views/people/show.mobile.haml
@@ -19,7 +19,7 @@
 - if @post_type == :photos
   = render "photos/index", photos: @posts
 - else
-  #main_stream
+  .stream#main_stream
     - if @stream.stream_posts.length > 0
       = render "shared/stream", posts: @stream.stream_posts
       = render "shared/stream_more_button"

--- a/features/mobile/reactions.feature
+++ b/features/mobile/reactions.feature
@@ -15,7 +15,16 @@ Feature: reactions mobile post
 
   Scenario: like on a mobile post
     When I should see "No reactions" within ".show-comments"
-    And I click on selector "span.show-comments"
+    And I click on selector "a.like-action.inactive"
+    Then I should see a "a.like-action.active"
+    When I go to the stream page
+    And I should see "1 reaction" within ".show-comments"
+    And I click on selector "a.show-comments"
+    Then I should see "1" within ".like-count"
+
+  Scenario: liking from the profile view
+    When I am on "alice@alice.alice"'s page
+    Then I should see "No reactions" within ".show-comments"
     And I click on selector "a.like-action.inactive"
     Then I should see a "a.like-action.active"
     When I go to the stream page


### PR DESCRIPTION
Fix class assignment in the mobile view of the profile page. Add a cuke testing the "liking from the profile view" feature.

fix #6841
