### PR TITLE
6853 fix usernames overflow

### DIFF
--- a/app/assets/stylesheets/tag.scss
+++ b/app/assets/stylesheets/tag.scss
@@ -33,9 +33,7 @@ h1.tag {
       .side_stream #people_stream {
         .name { display: block; }
         .name, .diaspora_handle {
-          overflow: hidden;
-          text-overflow: ellipsis;
-          white-space: nowrap;
+          word-break: break-all;
         }
       }
     }


### PR DESCRIPTION
As far as I can see: 

```
overflow: hidden;
text-overflow: ellipsis;
white-space: nowrap;
```

is no more needed, but tell me if I'm wrong.

New behavior:

![6853-overflow](https://cloud.githubusercontent.com/assets/6507951/15855667/0b6c4866-2cb1-11e6-842e-6ec513540ebc.png)

I'm just concerned about tags background with small width:

![6853-overflow-min](https://cloud.githubusercontent.com/assets/6507951/15855692/2c807d1a-2cb1-11e6-8f27-6199d8fba14a.png)

Maybe a little bit ugly, no?

_Super Overflow_ strikes again! (should fix #6853 )
