### PR TITLE
remove REDISTOGO_URL deprecation

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -193,8 +193,6 @@ defaults:
       scope: tags
       include_user_tags: false
       pod_tags:
-  # List valid environment variables
-  redistogo_url:
 
 development:
   environment:
@@ -243,6 +241,7 @@ integration1:
 integration2:
   environment:
     url: 'http://localhost:34658/'
+    redis: 'redis://localhost:6380'
     single_process_mode: true
     assets:
       serve: true

--- a/config/diaspora.yml.example
+++ b/config/diaspora.yml.example
@@ -669,8 +669,8 @@ configuration: ## Section
 ## to have them different in different environments.
 production: ## Section
   environment: ## Section
-    #redis_url: 'redis://production.example.org:6379'
+    #redis: 'redis://production.example.org:6379'
 
 development: ## Section
   environment: ## Section
-    #redis_url: 'redis://production.example.org:6379'
+    #redis: 'redis://production.example.org:6379'

--- a/lib/configuration_methods.rb
+++ b/lib/configuration_methods.rb
@@ -102,25 +102,14 @@ module Configuration
     end
 
     def get_redis_options
-      if redistogo_url.present?
-        warn "WARNING: using the REDISTOGO_URL environment variable is deprecated, please use REDIS_URL now."
-        ENV['REDIS_URL'] = redistogo_url
+      redis_url = ENV["REDIS_URL"] || environment.redis.get
+
+      return {} unless redis_url.present?
+
+      unless redis_url.start_with?("redis://", "unix:///")
+        warn "WARNING: Your redis url (#{redis_url}) doesn't start with redis:// or unix:///"
       end
-
-      redis_options = {}
-
-      redis_url = ENV['REDIS_URL'] || environment.redis.get
-
-      if ENV['RAILS_ENV']== 'integration2'
-        redis_options[:url] = "redis://localhost:6380"
-      elsif redis_url.present?
-        unless redis_url.start_with?("redis://") || redis_url.start_with?("unix:///")
-          warn "WARNING: Your redis url (#{redis_url}) doesn't start with redis:// or unix:///"
-        end
-        redis_options[:url] = redis_url
-      end
-
-      redis_options
+      {url: redis_url}
     end
 
     def sidekiq_log

--- a/spec/lib/configuration_methods_spec.rb
+++ b/spec/lib/configuration_methods_spec.rb
@@ -152,19 +152,8 @@ describe Configuration::Methods do
   end
 
   describe "#get_redis_options" do
-    context "with REDISTOGO_URL set" do
-      before do
-        ENV["REDISTOGO_URL"] = "redis://myserver"
-      end
-
-      it "uses that" do
-        expect(@settings.get_redis_options[:url]).to match "myserver"
-      end
-    end
-
     context "with REDIS_URL set" do
       before do
-        ENV["REDISTOGO_URL"] = nil
         ENV["REDIS_URL"] = "redis://yourserver"
       end
 
@@ -175,7 +164,6 @@ describe Configuration::Methods do
 
     context "with redis set" do
       before do
-        ENV["REDISTOGO_URL"] = nil
         ENV["REDIS_URL"] = nil
         @settings.environment.redis = "redis://ourserver"
       end
@@ -187,7 +175,6 @@ describe Configuration::Methods do
 
     context "with a unix socket set" do
       before do
-        ENV["REDISTOGO_URL"] = nil
         ENV["REDIS_URL"] = nil
         @settings.environment.redis = "unix:///tmp/redis.sock"
       end


### PR DESCRIPTION
I think we can remove this deprecation-handling after more than 3,5 years.
