### PR TITLE
Eslint drop max nested callbacks and add "=" marker to spaced comment

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -79,7 +79,7 @@
     "max-depth": 0,
     "max-len": [1, {"code": 120, "ignoreUrls": true}],
     "max-lines": 0,
-    "max-nested-callbacks": [2, {"max": 3}],
+    "max-nested-callbacks": 0,
     "max-params": 0,
     "max-statements": 0,
     "max-statements-per-line": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -242,7 +242,7 @@
     "space-in-parens": [2, "never"],
     "space-infix-ops": [2, {"int32Hint": true}],
     "space-unary-ops": [2, {"words": true, "nonwords": false}],
-    "spaced-comment": [2, "always"],
+    "spaced-comment": [2, "always", {"markers": ["="]}],
     "strict": 0,
     "template-curly-spacing": 0,
     "unicode-bom": 0,


### PR DESCRIPTION
- We need more nested callbacks in spec files
- We need a `=` at the beginning of a comment (`//= require leaflet`)
