### PR TITLE
fix spec for ApplicationHelper#changelog_url

### DIFF
--- a/lib/configuration_methods.rb
+++ b/lib/configuration_methods.rb
@@ -89,13 +89,11 @@ module Configuration
       get_git_info if git_available?
       @git_revision
     end
-    attr_writer :git_revision
 
     def git_update
       get_git_info if git_available?
       @git_update
     end
-    attr_writer :git_update
 
     def rails_asset_id
       (git_revision || version)[0..8]

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -88,17 +88,16 @@ describe ApplicationHelper, :type => :helper do
     end
   end
 
-  describe '#changelog_url' do
-    it 'defaults to master branch changleog' do
-      AppConfig.git_revision = nil
-      expect(changelog_url).to eq('https://github.com/diaspora/diaspora/blob/master/Changelog.md')
+  describe "#changelog_url" do
+    it "defaults to master branch changleog" do
+      expect(AppConfig).to receive(:git_revision).and_return(nil)
+      expect(changelog_url).to eq("https://github.com/diaspora/diaspora/blob/master/Changelog.md")
     end
 
-    it 'displays the changelog for the current git revision if set' do
-      AppConfig.git_revision = '123'
-      expect(changelog_url).to eq('https://github.com/diaspora/diaspora/blob/123/Changelog.md')
+    it "displays the changelog for the current git revision if set" do
+      expect(AppConfig).to receive(:git_revision).twice.and_return("123")
+      expect(changelog_url).to eq("https://github.com/diaspora/diaspora/blob/123/Changelog.md")
     end
-
   end
 
   describe '#pod_name' do
@@ -108,7 +107,6 @@ describe ApplicationHelper, :type => :helper do
 
     it 'displays the supplied pod_name if it is set' do
       AppConfig.settings.pod_name = "Catspora"
-      # require 'pry'; binding.pry
       expect(pod_name).to match "Catspora"
     end
   end


### PR DESCRIPTION
This failed locally and on my [jenkins](https://jenkins.coding4.coffee/job/diaspora-2.2-other/556/testReport/junit/%28root%29/ApplicationHelper_changelog_url/ApplicationHelper_changelog_url_defaults_to_master_branch_changleog/)
