### PR TITLE
Update status message text after prefilling mentions

### DIFF
--- a/app/assets/javascripts/app/views/publisher_view.js
+++ b/app/assets/javascripts/app/views/publisher_view.js
@@ -135,6 +135,10 @@ app.views.Publisher = Backbone.View.extend({
     });
     this.viewPollCreator.on("change", this.checkSubmitAvailability, this);
     this.viewPollCreator.render();
+
+    if (this.prefillMention) {
+      this.handleTextchange();
+    }
   },
 
   // set the selected aspects in the dropdown by their ids

--- a/spec/javascripts/app/views/publisher_view_spec.js
+++ b/spec/javascripts/app/views/publisher_view_spec.js
@@ -47,6 +47,21 @@ describe("app.views.Publisher", function() {
       this.view = new app.views.Publisher();
     });
 
+    describe("#initSubviews", function() {
+      it("calls handleTextchange if the publisher is prefilled with mentions", function() {
+        spyOn(this.view, "handleTextchange");
+        this.view.prefillMention = "user@example.org";
+        this.view.initSubviews();
+        expect(this.view.handleTextchange).toHaveBeenCalled();
+      });
+
+      it("doesn't call handleTextchange if there are no prefilled mentions", function() {
+        spyOn(this.view, "handleTextchange");
+        this.view.initSubviews();
+        expect(this.view.handleTextchange).not.toHaveBeenCalled();
+      });
+    });
+
     describe("#open", function() {
       it("removes the 'closed' class from the publisher element", function() {
         expect($(this.view.el)).toHaveClass("closed");


### PR DESCRIPTION
Before the hidden field `#status_message_text` hasn't been updated after prefilling mentions. This only happend after the user added some more text.
