### PR TITLE
Fix guard setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -261,7 +261,6 @@ group :development do
 
   # Debugging
   gem "pry"
-  gem "pry-debundle"
   gem "pry-byebug"
 
   # test coverage

--- a/Gemfile
+++ b/Gemfile
@@ -234,10 +234,10 @@ end
 
 group :development do
   # Automatic test runs
-  gem "guard-cucumber", "2.1.2"
-  gem "guard-rspec",    "4.7.2", require: false
-  gem "guard-rubocop",  "1.2.0"
   gem "guard",          "2.14.0", require: false
+  gem "guard-cucumber", "2.1.2", require: false
+  gem "guard-rspec",    "4.7.2", require: false
+  gem "guard-rubocop",  "1.2.0", require: false
   gem "rb-fsevent",     "0.9.7", require: false
   gem "rb-inotify",     "0.9.7", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -604,8 +604,6 @@ GEM
     pry-byebug (3.4.0)
       byebug (~> 9.0)
       pry (~> 0.10)
-    pry-debundle (0.8)
-      pry
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.4)
@@ -989,7 +987,6 @@ DEPENDENCIES
   pronto-scss (= 0.6.0)
   pry
   pry-byebug
-  pry-debundle
   quiet_assets (= 1.1.0)
   rack-cors (= 0.4.0)
   rack-google-analytics (= 1.2.0)

--- a/Guardfile
+++ b/Guardfile
@@ -37,9 +37,3 @@ guard :rubocop, all_on_start: false, keep_failed: false do
   watch(/(?:app|config|db|lib|features|spec)\/.+\.rb$/)
   watch(/(config.ru|Gemfile|Guardfile|Rakefile)$/)
 end
-
-guard :jshintrb do
-  watch(/^app\/assets\/javascripts\/.+\.js$/)
-  watch(/^lib\/assets\/javascripts\/.+\.js$/)
-  watch(/^spec\/javascripts\/.+\.js$/)
-end

--- a/Guardfile
+++ b/Guardfile
@@ -22,8 +22,7 @@ guard :rspec, cmd: "bin/spring rspec", all_on_start: false, all_after_pass: fals
 end
 
 guard(:cucumber,
-      command_prefix: "bin/spring",
-      bundler:        false,
+      cmd:            "bin/spring cucumber",
       all_on_start:   false,
       all_after_pass: false) do
   watch(/^features\/.+\.feature$/)


### PR DESCRIPTION
I just pushed a small fixup (7fb6ffbb4dca257acfb617ec85c1124c9c006e73) that prevents guard-rspec from requiring rspec all the time in development since I discovered a warning in my Rails console. During that, I noticed that our guard setup is... somewhat broken.

With this PR, I
- removed pry-debundle since its very unmaintained and [broken with bundler 1.12](https://github.com/ConradIrwin/pry-debundle/issues/12). If everyone actually used it, there is a way to install it locally.
- removed the jshint guard config which was missed in #6860.
- fixed the guard-cocumber configuration (there were some deprecated values in there)
- told bundler to not require any of the guard-\* gems as a follow-up for 7fb6ffbb4dca257acfb617ec85c1124c9c006e73. guard will require those gems itself, so there is no need for us to do so (especially not if we're in a rails console or the development runserver...)
