### PR TITLE
Throw exception if no templateName gets provided

### DIFF
--- a/app/assets/javascripts/app/pages/profile.js
+++ b/app/assets/javascripts/app/pages/profile.js
@@ -1,6 +1,8 @@
 // @license magnet:?xt=urn:btih:0b31508aeb0634b347b8270c7bee4d411b5d4109&dn=agpl-3.0.txt AGPL-v3-or-Later
 
 app.pages.Profile = app.views.Base.extend({
+  templateName: false,
+
   events: {
     "click #block_user_button": "blockPerson",
     "click #unblock_user_button": "unblockPerson"

--- a/app/assets/javascripts/app/views.js
+++ b/app/assets/javascripts/app/views.js
@@ -38,9 +38,17 @@ app.views.Base = Backbone.View.extend({
   renderTemplate : function(){
     var presenter = _.isFunction(this.presenter) ? this.presenter() : this.presenter;
     this.template = HandlebarsTemplates[this.templateName+"_tpl"];
-    if(!this.template) {
-      console.log(this.templateName ? ("no template for " + this.templateName) : "no templateName specified");
+
+    if (this.templateName === false) {
       return;
+    }
+
+    if (!this.templateName) {
+      throw new Error("No templateName set, set to false to ignore.");
+    }
+
+    if (!this.template) {
+      throw new Error("Invalid templateName provided: " + this.templateName);
     }
 
     this.$el

--- a/spec/javascripts/app/views_spec.js
+++ b/spec/javascripts/app/views_spec.js
@@ -10,6 +10,30 @@ describe("app.views.Base", function(){
       this.view.render();
     });
 
+    it("throws an exception if no templateName was provided", function() {
+      expect(function() {
+        new app.views.Base().render();
+      }).toThrow(new Error("No templateName set, set to false to ignore."));
+    });
+
+    it("does not throw an exception if templateName is set to false", function() {
+      var ViewClass = app.views.Base.extend({
+        templateName: false
+      });
+
+      new ViewClass().render();
+    });
+
+    it("throws an exception if an invalid templateName was provided", function() {
+      expect(function() {
+        var ViewClass = app.views.Base.extend({
+          templateName: "noiamnotavalidtemplate"
+        });
+
+        new ViewClass().render();
+      }).toThrow(new Error("Invalid templateName provided: noiamnotavalidtemplate"));
+    });
+
     it("renders the template with the presenter", function(){
       expect($(this.view.el).text().trim()).toBe("model attributes are in the default presenter");
     });


### PR DESCRIPTION
but allow setting templateName to false explicitly...

During cucumber debugging, we noticed some strange console loggings. Turns out the profile page had no `templateName` specified, causing the messages. I've refactored the base view to throw if no `templateName` is specified. In the rare case no template is needed, setting it to `false` will mute the exception.
