### PR TITLE
fix sender for messages for old pods

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -15,9 +15,17 @@ class MessagesController < ApplicationController
     message = current_user.build_message(conversation, opts)
 
     if message.save
-      logger.info "event=create type=comment user=#{current_user.diaspora_handle} status=success " \
+      logger.info "event=create type=message user=#{current_user.diaspora_handle} status=success " \
                   "message=#{message.id} chars=#{params[:message][:text].length}"
       Diaspora::Federation::Dispatcher.defer_dispatch(current_user, message)
+
+      # TODO: can be removed when messages are not relayed anymore
+      conversation_owner = conversation.author.owner
+      if conversation_owner && conversation_owner != current_user
+        remote_subs = conversation.participants.remote.ids
+        opts = {subscriber_ids: remote_subs}
+        Diaspora::Federation::Dispatcher.defer_dispatch(conversation_owner, message, opts) unless remote_subs.empty?
+      end
     else
       flash[:error] = I18n.t('conversations.new_conversation.fail')
     end

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -39,6 +39,11 @@ describe MessagesController, :type => :controller do
           expect(response.status).to eq(302)
           expect(response).to redirect_to(conversations_path(:conversation_id => @conversation))
         end
+
+        it "dispatches the message" do
+          expect(Diaspora::Federation::Dispatcher).to receive(:defer_dispatch).with(alice, instance_of(Message))
+          post :create, @message_params
+        end
       end
 
       context "with an empty message" do
@@ -93,6 +98,24 @@ describe MessagesController, :type => :controller do
 
         post :create, @message_params
         expect(old_message.reload.text).to eq('hello')
+      end
+
+      it "dispatches the message" do
+        expect(Diaspora::Federation::Dispatcher).to receive(:defer_dispatch).with(alice, instance_of(Message))
+        post :create, @message_params
+      end
+
+      it "dispatches the message twice if the conversation author is local and it has remote users" do
+        @conversation_params[:participant_ids] = [bob.person.id, alice.person.id, remote_raphael.id]
+        conversation = Conversation.create!(@conversation_params)
+        @message_params[:conversation_id] = conversation.id
+
+        expect(Diaspora::Federation::Dispatcher).to receive(:defer_dispatch).with(alice, instance_of(Message))
+        expect(Diaspora::Federation::Dispatcher).to receive(:defer_dispatch).with(
+          bob, instance_of(Message), subscriber_ids: [remote_raphael.id]
+        )
+
+        post :create, @message_params
       end
     end
 


### PR DESCRIPTION
same problem as #6886

Send a second message to remote recipients with conversation-author
as salmon author if the conversation-author is local.

The first dispatch will fail on old pods. New pods will ignore the
second message, if the guid already exist.
