### PR TITLE
Fix up nodeinfo tests

### DIFF
--- a/spec/presenters/node_info_presenter_spec.rb
+++ b/spec/presenters/node_info_presenter_spec.rb
@@ -31,7 +31,7 @@ describe NodeInfoPresenter do
         },
         "services"          => {
           "inbound"  => [],
-          "outbound" => ["facebook"]
+          "outbound" => AppConfig.configured_services.map(&:to_s)
         },
         "openRegistrations" => AppConfig.settings.enable_registrations?,
         "usage"             => {

--- a/spec/presenters/statistics_presenter_spec.rb
+++ b/spec/presenters/statistics_presenter_spec.rb
@@ -25,7 +25,7 @@ describe StatisticsPresenter do
         "network"            => "Diaspora",
         "version"            => AppConfig.version_string,
         "registrations_open" => AppConfig.settings.enable_registrations?,
-        "services"           => ["facebook"]
+        "services"           => AppConfig.configured_services.map(&:to_s)
       )
     end
 
@@ -104,7 +104,7 @@ describe StatisticsPresenter do
           "active_users_monthly"  => User.monthly_actives.count,
           "local_posts"           => @presenter.local_posts,
           "local_comments"        => @presenter.local_comments,
-          "services"              => ["facebook"]
+          "services"              => AppConfig.configured_services.map(&:to_s)
         )
       end
     end


### PR DESCRIPTION
Tests for nodeinfo failed if services config are non-default. Fix it to pick the data for comparation from application settings.
