### PR TITLE
Add cuke for deleting conversations

### DIFF
--- a/app/views/conversations/create.js.erb
+++ b/app/views/conversations/create.js.erb
@@ -2,9 +2,11 @@ var response = <%= raw @response.to_json %>;
 <% if session[:mobile_view] %>
   window.location.href = "<%= conversations_path(conversation_id: @conversation.id) %>";
 <% else %>
-  app.flashMessages._flash(response.message, response.success);
   if(response.success){
+    app.flashMessages.success(response.message);
     $("#new_conversation").removeClass('form_do_not_clear').clearForm();
     window.location.href = "<%= conversations_path(conversation_id: @conversation.id) %>";
+  } else {
+    app.flashMessages.error(response.message);
   }
 <% end %>

--- a/features/desktop/conversations.feature
+++ b/features/desktop/conversations.feature
@@ -43,3 +43,18 @@ Feature: private conversations
     When I sign in as "alice@alice.alice"
     Then I should have 2 unread private messages
     And I should have 2 email delivery
+
+  Scenario: delete a conversation
+    When I sign in as "bob@bob.bob"
+    And I send a message with subject "Greetings" and text "hello, alice!" to "Alice Awesome"
+    Then I should see "Greetings" within "#conversation_inbox"
+    When I click on selector ".hide_conversation"
+    Then I should not see "Greetings" within "#conversation_inbox"
+    When I sign in as "alice@alice.alice"
+    Then I should have 1 unread private message
+    And I should have 1 email delivery
+    When I reply with "hey, how you doing?"
+    Then I should see "hey, how you doing?" within ".stream_container"
+    When I sign in as "bob@bob.bob"
+    Then I should have 1 email delivery
+    And I should have no unread private messages

--- a/features/step_definitions/conversations_steps.rb
+++ b/features/step_definitions/conversations_steps.rb
@@ -8,6 +8,10 @@ Then /^I should have (\d+) unread private messages?$/ do |n_unread|
   expect(find("header #conversations-link .badge")).to have_content(n_unread)
 end
 
+Then /^I should have no unread private messages$/ do
+  expect(page).to have_no_css "header #conversations-link .badge"
+end
+
 Then /^I send a message with subject "([^"]*)" and text "([^"]*)" to "([^"]*)"$/ do |subject, text, person|
   step %(I am on the conversations page)
   within("#conversation_new", match: :first) do


### PR DESCRIPTION
This adds a test for #6632 which fails when running on the old federation code. So it looks like #6632 also has been fixed by #6873.

While testing this I found out that the color of the flash message for new conversations is wrong, so I fixed that in another commit.
