### PR TITLE
Improve /tag page performance.

### DIFF
--- a/lib/stream/tag.rb
+++ b/lib/stream/tag.rb
@@ -29,7 +29,16 @@ class Stream::Tag < Stream::Base
   end
 
   def posts
-    @posts ||= construct_post_query
+    @posts ||= if user
+                 StatusMessage.user_tag_stream(user, tag.id)
+               else
+                 StatusMessage.public_tag_stream(tag.id)
+               end
+  end
+
+  def stream_posts
+    return [] unless tag
+    super
   end
 
   def tag_name=(tag_name)
@@ -41,14 +50,5 @@ class Stream::Tag < Stream::Base
   # @return [Hash]
   def publisher_opts
     {:open => true}
-  end
-
-  def construct_post_query
-    posts = if user.present?
-              StatusMessage.owned_or_visible_by_user(user)
-            else
-              StatusMessage.all_public
-            end
-    posts.tagged_with(tag_name, :any => true)
   end
 end

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -107,6 +107,18 @@ describe TagsController, :type => :controller do
           get :show, :name => 'foo', :format => :mobile
           expect(response).to be_success
         end
+
+        it "returns the post with the correct age" do
+          post2 = eve.post(
+            :status_message,
+            text:       "#what #yes #hellyes #foo tagged second post",
+            public:     true,
+            created_at: @post.created_at - 1.day
+          )
+          get :show, name: "what", max_time: @post.created_at, format: :json
+          expect(JSON.parse(response.body).size).to be(1)
+          expect(JSON.parse(response.body).first["guid"]).to eq(post2.guid)
+        end
       end
     end
   end

--- a/spec/lib/stream/tag_spec.rb
+++ b/spec/lib/stream/tag_spec.rb
@@ -85,6 +85,25 @@ describe Stream::Tag do
     it_should_behave_like 'it is a stream'
   end
 
+  describe '#stream_posts' do
+    it "returns an empty array if the tag does not exist" do
+      stream = Stream::Tag.new(FactoryGirl.create(:user), "test")
+      expect(stream.stream_posts).to eq([])
+    end
+
+    it "returns an empty array if there are no visible posts for the tag" do
+      alice.post(:status_message, text: "#what", public: false, to: "all")
+      stream = Stream::Tag.new(nil, "what")
+      expect(stream.stream_posts).to eq([])
+    end
+
+    it "returns the post containing the tag" do
+      post = alice.post(:status_message, text: "#what", public: true)
+      stream = Stream::Tag.new(FactoryGirl.create(:user), "what")
+      expect(stream.stream_posts).to eq([post])
+    end
+  end
+
   describe '#tag_name=' do
     it 'downcases the tag' do
       stream = Stream::Tag.new(nil, "WHAT")

--- a/spec/lib/stream/tag_spec.rb
+++ b/spec/lib/stream/tag_spec.rb
@@ -80,7 +80,7 @@ describe Stream::Tag do
 
   describe 'shared behaviors' do
     before do
-      @stream = Stream::Tag.new(FactoryGirl.create(:user), "test")
+      @stream = Stream::Tag.new(FactoryGirl.create(:user), FactoryGirl.create(:tag).name)
     end
     it_should_behave_like 'it is a stream'
   end


### PR DESCRIPTION
Fixes #6152.

In addition, this concerns #6852. Currently, there is a hack in place to make the page work even if the requested tag does not exist. More discussion is necessary in #6852 to establish the desired behaviour on what to do if the result set is empty.

I also noticed there is no test to check if additional posts are loaded correctly when scrolling down. This should be fixed as well.

Work in progress:
- [x] Simple speed fix (#6152)
- [x] Correct behaviour on empty list (#6852)
- [x] Tests for load on scroll-down
