### PR TITLE
Remove unused translations from diaspora.yml, add missing ones

### DIFF
--- a/app/controllers/aspect_memberships_controller.rb
+++ b/app/controllers/aspect_memberships_controller.rb
@@ -62,7 +62,7 @@ class AspectMembershipsController < ApplicationController
         format.all { redirect_to :back }
       end
     else
-      flash.now[:error] = I18n.t("contacts.create.failure")
+      flash.now[:error] = I18n.t("aspects.add_to_aspect.failure")
       render nothing: true, status: 409
     end
   end

--- a/app/views/aspects/_aspect_listings.haml
+++ b/app/views/aspects/_aspect_listings.haml
@@ -4,3 +4,4 @@
 
 = link_to t('streams.aspects.title'), aspects_path, :class => 'hoverable', :rel => 'backbone', :data => {:stream => 'aspects'}
 %ul#aspects_list
+  -# JS

--- a/app/views/tags/show.haml
+++ b/app/views/tags/show.haml
@@ -3,10 +3,7 @@
 -#   the COPYRIGHT file.
 
 - content_for :page_title do
-  - if @stream.tag_name
-    = @stream.display_tag_name
-  - else
-    = t('.whatup', pod: @pod_url)
+  = @stream.display_tag_name
 
 .container-fluid#tags_show
   .row

--- a/app/views/users/_edit.haml
+++ b/app/views/users/_edit.haml
@@ -46,7 +46,8 @@
               = f.password_field :password, placeholder: t(".character_minimum_expl"),
                 class: "form-control"
           .form-group
-            = f.label :password_confirmation, t("password_confirmation"), class: "col-sm-6 control-label"
+            = f.label :password_confirmation, t("registrations.new.password_confirmation"),
+              class: "col-sm-6 control-label"
             .col-sm-6
               = f.password_field :password_confirmation, placeholder: t(".character_minimum_expl"),
                 class: "form-control"

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -10,37 +10,26 @@ en:
   profile: "Profile"
   account: "Account"
   privacy: "Privacy"
-  privacy_policy: "Privacy policy"
-  terms_and_conditions: "Terms and conditions"
   _services: "Services"
   _applications: "Applications"
-  _photos: "Photos"
   _help: "Help"
   ok: "OK"
   cancel: "Cancel"
   delete: "Delete"
-  hide: "Hide"
-  ignore: "Ignore"
   username: "Username"
   email: "Email"
-  password: "Password"
-  password_confirmation: "Password confirmation"
   are_you_sure: "Are you sure?"
   are_you_sure_delete_account: "Are you sure you want to close your account? This can’t be undone!"
   fill_me_out: "Fill me out"
-  back: "Back"
   public: "Public"
   limited: "Limited"
   search: "Search"
   nsfw: "NSFW"
   find_people: "Find people or #tags"
-  _home: "Home"
   more: "More"
-  _comments: "Comments"
   all_aspects: "All aspects"
   no_results: "No results found"
   _contacts: "Contacts"
-  welcome: "Welcome!"
   _terms: "Terms"
   _statistics: "Statistics"
 
@@ -84,7 +73,6 @@ en:
               already_participated: "You’ve already participated in this poll!"
   error_messages:
     helper:
-      invalid_fields: "Invalid fields"
       correct_the_following_errors_and_try_again: "Correct the following errors and try again."
     need_javascript: "This website requires JavaScript to function properly. If you disabled JavaScript, please enable it and refresh this page."
 
@@ -133,6 +121,7 @@ en:
       account_closed: "Account closed"
       nsfw: "#nsfw"
       unknown: "Unknown"
+      invite_token: "Invite token"
       'yes': "Yes"
       'no': "No"
     weekly_user_stats:
@@ -171,14 +160,8 @@ en:
     pods:
       pod_network: "Pod network"
   aspects:
-    contacts_visible: "Contacts in this aspect will be able to see each other."
-    contacts_not_visible: "Contacts in this aspect will not be able to see each other."
     edit:
-      grant_contacts_chat_privilege: "Grant contacts in this aspect chat privilege?"
-      make_aspect_list_visible: "Make contacts in this aspect visible to each other?"
-      remove_aspect: "Delete this aspect"
       confirm_remove_aspect: "Are you sure you want to delete this aspect?"
-      set_visibility: "Set visibility"
       rename: "Rename"
       aspect_list_is_visible: "Contacts in this aspect are able to see each other."
       aspect_list_is_not_visible: "Contacts in this aspect are not able to see each other."
@@ -191,16 +174,7 @@ en:
       or_spotlight:  "Or you can share with %{link}"
       community_spotlight: "Community spotlight"
     aspect_listings:
-      select_all: "Select all"
-      deselect_all: "Deselect all"
-      edit_aspect: "Edit %{name}"
       add_an_aspect: "+ Add an aspect"
-    new:
-      name: "Name (only visible to you)"
-      create: "Create"
-    create:
-      success: "Your new aspect %{name} was created"
-      failure: "Aspect creation failed."
     destroy:
       success: "%{name} was successfully removed."
       success_auto_follow_back: "%{name} was successfully removed. You used this aspect to automatically follow back users. Check your user settings to select a new auto follow back aspect."
@@ -219,7 +193,6 @@ en:
     index:
       donate: "Donate"
       keep_pod_running: "Keep %{pod} running fast and buy servers their coffee fix with a monthly donation!"
-      keep_diaspora_running: "Keep diaspora* development fast with a monthly donation!"
       welcome_to_diaspora: "Welcome to diaspora*, %{name}!"
       introduce_yourself: "This is your stream.  Jump in and introduce yourself."
 
@@ -240,8 +213,6 @@ en:
         tag_feature: "feature"
         tutorials_and_wiki: "%{faq}, %{tutorial} & %{wiki}: help for your first steps."
         tutorial_link_text: "Tutorials"
-        email_feedback: "%{link} your feedback, if you prefer"
-        email_link: "Email"
         any_problem: "Got a problem?"
         contact_podmin: "Contact the administrator of your pod!"
         mail_podmin: "Podmin email"
@@ -264,14 +235,10 @@ en:
 
   bookmarklet:
     heading: "Bookmarklet"
-    post_success: "Posted! Closing!"
     post_something: "Post to diaspora*"
     explanation: "Post to diaspora* from anywhere by bookmarking this link => %{link}."
 
   comments:
-    zero: "No comments"
-    one: "1 comment"
-    other: "%{count} comments"
     new_comment:
       comment: "Comment"
       commenting: "Commenting..."
@@ -282,10 +249,6 @@ en:
     other: "%{count} reactions"
 
   contacts:
-    create:
-      failure: "Failed to create contact"
-    sharing:
-      people_sharing: "People sharing with you:"
     index:
       start_a_conversation: "Start a conversation"
       add_a_new_aspect: "Add a new aspect"
@@ -298,7 +261,6 @@ en:
       all_contacts: "All contacts"
       only_sharing_with_me: "Only sharing with me"
       add_contact: "Add contact"
-      remove_contact: "Remove contact"
       user_search: "Contact search"
     spotlight:
       community_spotlight: "Community spotlight"
@@ -308,7 +270,6 @@ en:
     index:
       conversations_inbox: "Conversations – Inbox"
       new_conversation: "New conversation"
-      create_a_new_conversation: "Start a new conversation"
       no_messages: "No messages"
       inbox: "Inbox"
     show:
@@ -602,11 +563,8 @@ en:
       language: "Language"
       invite_someone_to_join: "Invite someone to join diaspora*!"
       comma_separated_plz: "You can enter multiple email addresses separated by commas."
-      to: "To"
-      personal_message: "Personal message"
       send_an_invitation: "Send an invitation"
       sending_invitation: "Sending invitation..."
-      send_invitation: "Send invitation"
       paste_link: "Share this link with your friends to invite them to diaspora*, or email them the link directly."
       codes_left:
         zero:  "No invites left on this code"
@@ -620,13 +578,8 @@ en:
     header:
       profile: "Profile"
       settings: "Settings"
-      help: "Help"
       logout: "Log out"
-      login: "Log in"
       code: "Code"
-      admin: "Admin"
-      view_all: "View all"
-      recent_notifications: "Recent notifications"
       toggle_navigation: "Toggle navigation"
     application:
       powered_by: "Powered by diaspora*"
@@ -634,16 +587,8 @@ en:
       statistics_link: "Pod statistics"
       toggle: "Toggle mobile"
       public_feed: "Public diaspora* feed for %{name}"
-      your_aspects: "Your aspects"
       back_to_top: "Back to top"
       source_package: "Download the source code package"
-
-  likes:
-    likes:
-      people_like_this:
-        zero: "No likes"
-        one: "%{count} like"
-        other: "%{count} likes"
 
   notifications:
     started_sharing:
@@ -712,11 +657,6 @@ en:
         one: "and one more"
         other: "and %{count} others"
       and: "and"
-    helper:
-      new_notifications:
-        zero: "No new notifications"
-        one: "1 new notification"
-        other: "%{count} new notifications"
 
   notifier:
     a_post_you_shared: "a post."
@@ -741,7 +681,6 @@ en:
         limited_subject: "There's a new comment on a post you commented"
     mentioned:
         subject: "%{name} has mentioned you on diaspora*"
-        mentioned: "mentioned you in a post:"
         limited_post: "You were mentioned in a limited post."
     private_message:
         reply_to_or_view: "Reply to or view this conversation >"
@@ -819,7 +758,6 @@ en:
         Sorry,
 
         The diaspora* email robot!
-    accept_invite: "Accept your diaspora* invite!"
     invited_you: "%{name} invited you to diaspora*"
     invite:
       message: |-
@@ -916,9 +854,6 @@ en:
         could_not_authorize: "The application could not be authorized"
 
   people:
-    zero: "No people"
-    one: "1 person"
-    other: "%{count} people"
     person:
       thats_you: "That’s you!"
     index:
@@ -930,15 +865,9 @@ en:
       no_one_found: "...and no one was found."
       searching: "Searching, please be patient..."
       looking_for: "Looking for posts tagged %{tag_link}?"
-    webfinger:
-      fail: "Sorry, we couldn’t find %{handle}."
     show:
       has_not_shared_with_you_yet: "%{name} has not shared any posts with you yet!"
-      return_to_aspects: "Return to your aspects page"
-      to_accept_or_ignore: "to accept or ignore it."
       does_not_exist: "Person does not exist!"
-      message: "Message"
-      mention: "Mention"
       closed_account: "This account has been closed."
     profile_sidebar:
       bio: "Bio"
@@ -951,12 +880,6 @@ en:
   photos:
     show:
       show_original_post: "Show original post"
-    photo:
-      view_all: "View all of %{name}’s photos"
-    new:
-      new_photo: "New photo"
-      back_to_list: "Back to list"
-      post_it: "Post it!"
     create:
       runtime_error: "Photo upload failed.  Are you sure that your seatbelt is fastened?"
       integrity_error: "Photo upload failed.  Are you sure that was an image?"
@@ -981,9 +904,6 @@ en:
       title: "A post from %{name}"
     show:
       location: "Posted from: %{location}"
-      destroy: "Delete"
-      permalink: "Permalink"
-      not_found: "Sorry, we couldn’t find that post."
       forbidden: "You are not allowed to do that"
       photos_by:
         zero: "No photos by %{author}"
@@ -1003,9 +923,7 @@ en:
     confirm_deletion: "Are you sure to delete the item?"
     not_found: "<u>The post/comment was not found. It seems that it was deleted by the user!</u>"
     status:
-      marked: "The report was marked as reviewed"
       destroyed: "The post was destroyed"
-      created: "A report was created"
       failed: "Something went wrong"
 
   profiles:
@@ -1032,7 +950,6 @@ en:
       your_photo: "Your photo"
       update_profile: "Update profile"
       allow_search: "Allow for people to search for you within diaspora*"
-      edit_profile: "Edit profile"
       nsfw_explanation: "NSFW (“not safe for work”) is diaspora*’s self-governing community standard for content which may not be suitable to view while at work. If you plan to share such material frequently, please check this option so that everything you share will be hidden from people’s streams unless they choose to view them."
       nsfw_explanation2: "If you choose not to select this option, please add the #nsfw tag each time you share such material."
       nsfw_check: "Mark everything I share as NSFW"
@@ -1062,14 +979,8 @@ en:
   reshares:
     reshare:
       reshared_via: "Reshared via"
-      reshare:
-        zero: "Reshare"
-        one: "1 reshare"
-        other: "%{count} reshares"
       reshare_confirmation: "Reshare %{author}’s post?"
       deleted: "Original post deleted by author."
-    create:
-      failure: "There was an error resharing this post."
     comment_email_subject: "%{resharer}’s reshare of %{author}’s post"
   services:
     provider:
@@ -1108,7 +1019,6 @@ en:
 
   shared:
     aspect_dropdown:
-      add_to_aspect: "Add contact"
       mobile_row_checked: "%{name} (remove)"
       mobile_row_unchecked: "%{name} (add)"
       toggle:
@@ -1120,11 +1030,9 @@ en:
       posting: "Posting..."
       share: "Share"
       preview: "Preview"
-      all: "All"
       upload_photos: "Upload photos"
       get_location: "Get your location"
       remove_location: "Remove location"
-      all_contacts: "All contacts"
       whats_on_your_mind: "What’s on your mind?"
       discard_post: "Discard post"
       new_user_prefill:
@@ -1133,19 +1041,12 @@ en:
         i_like: "I’m interested in %{tags}. "
         invited_by: "Thanks for the invite, "
       poll:
-        remove_poll_answer: "Remove option"
-        add_poll_answer: "Add option"
         add_a_poll: "Add a poll"
-        question: "Question"
-        option: "Option 1"
     invitations:
       invites: "Invites"
-      invitations_left: "%{count} left"
       invite_your_friends: "Invite your friends"
       by_email: "By email"
       share_this: "Share this link via email, blog, or social networks!"
-    reshare:
-      reshare: "Reshare"
     public_explain:
       control_your_audience: "Control your audience"
       new_user_welcome_message: "Use #hashtags to classify your posts and find people who share your interests.  Call out awesome people with @Mentions"
@@ -1159,27 +1060,14 @@ en:
     stream_element:
       via: "Via %{link}"
       via_mobile: "Via mobile"
-      ignore_user: "Ignore %{name}"
-      ignore_user_description: "Ignore and remove user from all aspects?"
-      hide_and_mute: "Hide and mute post"
-      like: "Like"
-      unlike: "Unlike"
-      show: "Show"
   status_messages:
     new:
       mentioning: "Mentioning: %{person}"
     create:
       success: "Successfully mentioned: %{names}"
-    destroy:
-      failure: "Failed to delete post"
     too_long: "Please make your status message fewer than %{count} characters. Right now it is %{current_length} characters"
 
   stream_helper:
-    show_comments:
-      zero: "No more comments"
-      one: "Show one more comment"
-      other: "Show %{count} more comments"
-    hide_comments: "Hide all comments"
     no_more_posts: "You have reached the end of the stream."
     no_posts_yet: "There are no posts yet."
 
@@ -1190,19 +1078,11 @@ en:
         one: "1 person tagged with %{tag}"
         other: "%{count} people tagged with %{tag}"
       follow: "Follow #%{tag}"
-      following: "Following #%{tag}"
       stop_following: "Stop following #%{tag}"
       none: "The empty tag does not exist!"
     name_too_long: "Please make your tag name fewer than %{count} characters. Right now it is %{current_length} characters"
 
   tag_followings:
-    create:
-      success: "Hooray!  You’re now following #%{name}."
-      failure: "Failed to follow #%{name}.  Are you already following it?"
-      none: "You cannot follow a blank tag!"
-    destroy:
-      success: "Alas! You aren’t following #%{name} any more."
-      failure: "Failed to stop following #%{name}. Maybe you already stopped following it?"
     manage:
       title: "Manage followed tags"
       no_tags: "You aren't following any tags."
@@ -1261,7 +1141,6 @@ en:
       stream_preferences: "Stream preferences"
       show_community_spotlight: "Show “community spotlight” in stream"
       show_getting_started: "Show “getting started” hints"
-      getting_started: "New user preferences"
       following: "Sharing settings"
       auto_follow_back: "Automatically share with users who start sharing with you"
       auto_follow_aspect: "Aspect for users you automatically share with:"
@@ -1283,7 +1162,6 @@ en:
       download_export_photos: "Download my photos"
       request_export_photos: "Request my photos"
       request_export_photos_update: "Refresh my photos"
-      download_photos: "Download my photos"
       export_photos_in_progress: "We are currently processing your photos. Please check back in a few moments."
 
       close_account:


### PR DESCRIPTION
To extract the used translations from our code I used the following script (bash):

``` bash
(
  grep -Ro "\($\|\W\|\s\)t \?\((\| \) \?\"\.\w*\"" app/views | sed "s/app\/views\///;s/\..*:\W\?t \?\((\| \) \?\"//;s/\//./g;s/\._/./g;s/\"//"
  grep -Ro "\($\|\W\|\s\)t \?\((\| \) \?'\.\w*'" app/views | sed "s/app\/views\///;s/\..*:\W\?t \?\((\| \) \?'//;s/\//./g;s/\._/./g;s/'//"
  grep -Ro "\($\|\W\|\s\)t \?\((\| \) \?\"\w[^\"]*\"" app/views | sed "s/.*:\W\?t \?\((\| \) \?\"//;s/\"//"
  grep -Ro "\($\|\W\|\s\)t \?\((\| \) \?'\w[^']*'" app/views | sed "s/.*:\W\?t \?\((\| \) \?'//;s/'//"
  grep -Ro "\($\|\W\|\s\)t \?\((\| \) \?\"\w[^\"]*\"" lib app/{controllers,helpers,mailers,models,presenters,serializers,services,uploaders,workers} | sed "s/.*:\W\?t \?\((\| \) \?\"//;s/\"//"
  grep -Ro "\($\|\W\|\s\)t\((\| \) \?'\w[^']*'" lib app/{controllers,helpers,mailers,models,presenters,serializers,services,uploaders,workers} | sed "s/.*:\W\?t \?\((\| \) \?'//;s/'//"
) | sort | uniq
```

The script is not perfect but good enough to work with if you check the strings a second time before you remove them from the translations.

To extract them from the YAML file I used (python)

``` python
from yaml import safe_load

def get_keys(data, prefix=''):
  for key, value in data.items():
    if isinstance(value, str):
      yield prefix + key 
    elif isinstance(value, dict):
      keys = get_keys(value, prefix + key + '.')
      for key2 in keys:
        yield key2
    else:
      raise RuntimeError("%s%s is neither str nor dict" % (prefix, key))

f = open('config/locales/diaspora/en.yml','r')
data = safe_load(f)
keys = sorted(list(get_keys(data['en'])))
for key in keys:
  print(key)
```

(thank you @gandaro for the snippet you sent me)

and afterwards modified that with

``` bash
sed "s/\.\(one\|zero\|other\)$//" | sort | uniq
```

Translations for `api.openid_connect.*` remained untouched on purpose.
