### PR TITLE
 [Fix] #6850 Don't include subjects of private message

### DIFF
--- a/app/mailers/notification_mailers/private_message.rb
+++ b/app/mailers/notification_mailers/private_message.rb
@@ -8,8 +8,7 @@ module NotificationMailers
       @participants = @conversation.participants
 
       @headers[:from] = "\"#{@message.author_name} (diaspora*)\" <#{AppConfig.mail.sender_address}>"
-      @headers[:subject] = @conversation.subject.strip
-      @headers[:subject] = "Re: #{@headers[:subject]}" if @conversation.messages.size > 1
+      @headers[:subject] = I18n.t("notifier.private_message.subject")
     end
   end
 end

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -683,6 +683,7 @@ en:
         subject: "%{name} has mentioned you on diaspora*"
         limited_post: "You were mentioned in a limited post."
     private_message:
+        subject: "There’s a new private message for you"
         reply_to_or_view: "Reply to or view this conversation >"
     liked:
         liked: "%{name} liked your post"

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -212,15 +212,12 @@ describe Notifier, type: :mailer do
       expect(@mail["From"].to_s).to eq("\"#{@cnv.author.name} (diaspora*)\" <#{AppConfig.mail.sender_address}>")
     end
 
-    it "SUBJECT: has a snippet of the post contents" do
-      expect(@mail.subject).to eq(@cnv.subject)
+    it "should use a generic subject" do
+      expect(@mail.subject).to eq(I18n.translate("notifier.private_message.subject"))
     end
 
-    it "SUBJECT: has 'Re:' if not the first message in a conversation" do
-      @cnv.messages << Message.new(text: "yo", author: eve.person)
-      @mail = Notifier.private_message(bob.id, @cnv.author.id, @cnv.messages.last.id)
-
-      expect(@mail.subject).to eq("Re: #{@cnv.subject}")
+    it "SUBJECT: should not has a snippet of the private message contents" do
+      expect(@mail.subject).not_to eq(@cnv.subject)
     end
 
     it "BODY: does not contain the message text" do


### PR DESCRIPTION
#6850  Don't include subjects of private messages in email notifications
