### PR TITLE
Remove unused methods

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -54,14 +54,6 @@ class Post < ActiveRecord::Base
     joins(:likes).where(:likes => {:author_id => person.id})
   }
 
-  def self.visible_from_author(author, current_user=nil)
-    if current_user.present?
-      current_user.posts_from(author)
-    else
-      author.posts.all_public
-    end
-  end
-
   def post_type
     self.class.name
   end

--- a/app/models/status_message.rb
+++ b/app/models/status_message.rb
@@ -149,10 +149,5 @@ class StatusMessage < Post
   def self.tag_stream(tag_ids)
     joins(:taggings).where('taggings.tag_id IN (?)', tag_ids)
   end
-
-  def after_parse
-    # Make sure already received photos don't invalidate the model
-    self.photos = photos.select(&:valid?)
-  end
 end
 


### PR DESCRIPTION
While examining results of the analysis by the new fancy [coveralls](https://coveralls.io/github/diaspora/diaspora) tool, I noticed a couple ([1](https://coveralls.io/builds/6927615/source?filename=app%2Fmodels%2Fpost.rb#L56), [2](https://coveralls.io/builds/6927615/source?filename=app%2Fmodels%2Fstatus_message.rb#L128))  of methods that are marked as uncovered and that aren't referenced anywhere in the source cod. I suppose that these are just some methods left from the old code refactorings, so they could be safely deleted. Therefore, this PR should increase the test coverage rate.
