### PR TITLE
Escape HTML in mentions box

### DIFF
--- a/app/assets/javascripts/app/views/publisher/mention_view.js
+++ b/app/assets/javascripts/app/views/publisher/mention_view.js
@@ -91,7 +91,7 @@ app.views.PublisherMention = app.views.SearchBase.extend({
    */
   updateMessageTexts: function() {
     var fakeMessageText = this.inputBox.val(),
-        mentionBoxText = fakeMessageText,
+        mentionBoxText = _.escape(fakeMessageText),
         messageText = fakeMessageText;
 
     this.mentionedPeople.forEach(function(person) {

--- a/features/desktop/mentions.feature
+++ b/features/desktop/mentions.feature
@@ -29,3 +29,28 @@ Feature: Mentions
     Then I should see "Bob Jones" within ".stream_element"
     When I follow "Bob Jones"
     Then I should see "Bob Jones"
+
+  Scenario: A user tries to mention another user multiple times
+    Given following users exist:
+      | username     | email             |
+      | Bob Jones    | bob@bob.bob       |
+      | Alice Smith  | alice@alice.alice |
+    And a user with email "bob@bob.bob" is connected with "alice@alice.alice"
+    When I sign in as "alice@alice.alice"
+    And I expand the publisher
+    And I append "@Bob" to the publisher
+    Then I should see "Bob Jones" within ".tt-suggestion"
+    When I click on the first user in the mentions dropdown list
+    When I press the "A" key in the publisher
+    And I append "@Bob" to the publisher
+    Then I should not see the mentions dropdown list
+    When I press "Share"
+    Then I should see "Bob Jones" within ".stream_element"
+
+    When I expand the publisher
+    And I append "@Bob" to the publisher
+    And I click on the first user in the mentions dropdown list
+    And I press "Share"
+    Then I should see "Bob Jones" within ".stream_element"
+    When I follow "Bob Jones"
+    Then I should see "Bob Jones"

--- a/features/desktop/posts_from_main_page.feature
+++ b/features/desktop/posts_from_main_page.feature
@@ -196,6 +196,12 @@ Feature: posting from the main page
       And I select only "NotPostingThingsHere" aspect
       Then I should not see "I am eating a yogurt" and "And cornflakes also"
 
+    Scenario: Write html in the publisher
+      When I expand the publisher
+      Then I should not see any alert after I write the status message "<script>alert();</script>"
+      When I submit the publisher
+      Then "<script>alert();</script>" should be post 1
+
     # (NOTE) make this a jasmine spec
     Scenario: reject deletion one of my posts
       When I expand the publisher

--- a/features/step_definitions/mention_steps.rb
+++ b/features/step_definitions/mention_steps.rb
@@ -22,3 +22,7 @@ end
 And /^I click on the first user in the mentions dropdown list$/ do
   find(".tt-menu .tt-suggestion", match: :first).click
 end
+
+Then /^I should not see the mentions dropdown list$/ do
+  expect(page).to have_no_css ".tt-menu"
+end

--- a/spec/javascripts/app/views/publisher_mention_view_spec.js
+++ b/spec/javascripts/app/views/publisher_mention_view_spec.js
@@ -197,6 +197,13 @@ describe("app.views.PublisherMention", function() {
       expect(this.view.mentionsBox.find(".mentions").html())
         .toBe("@user1 Text before <strong><span>user1</span></strong>\ntext after");
     });
+
+    it("properly escapes the user input", function() {
+      this.view.inputBox.val("<img src=\"/default.png\"> @user1 Text before \u200Buser1\ntext after");
+      this.view.updateMessageTexts();
+      expect(this.view.mentionsBox.find(".mentions").html())
+        .toBe("&lt;img src=\"/default.png\"&gt; @user1 Text before <strong><span>user1</span></strong>\ntext after");
+    });
   });
 
   describe("updateTypeaheadInput", function() {


### PR DESCRIPTION
We didn't escape that before when the user wrote HTML in the publisher. (only on develop)
