### PR TITLE
Add 'no posts yet' message to empty streams

### DIFF
--- a/app/assets/javascripts/app/views/infinite_stream_view.js
+++ b/app/assets/javascripts/app/views/infinite_stream_view.js
@@ -16,6 +16,7 @@ app.views.InfScroll = app.views.Base.extend({
     this.showLoader();
     this.bind("loadMore", this.fetchAndshowLoader, this);
     this.stream.bind("fetched", this.finishedLoading, this);
+    this.stream.bind("allItemsLoaded", this.showNoPostsInfo, this);
     this.stream.bind("allItemsLoaded", this.unbindInfScroll, this);
 
     this.collection.bind("add", this.addPostView, this);
@@ -47,6 +48,13 @@ app.views.InfScroll = app.views.Base.extend({
         this.prependedPosts.insertBefore(el, this.prependedPosts.firstChild);
     } else {
         this.appendedPosts.appendChild(el);
+    }
+  },
+
+  showNoPostsInfo: function() {
+    if (this.postViews.length === 0) {
+      var noPostsInfo = new app.views.NoPostsInfo();
+      this.$el.append(noPostsInfo.render().el);
     }
   },
 

--- a/app/assets/javascripts/app/views/no_posts_info_view.js
+++ b/app/assets/javascripts/app/views/no_posts_info_view.js
@@ -1,0 +1,3 @@
+app.views.NoPostsInfo = app.views.Base.extend({
+  templateName: "no_posts_info"
+});

--- a/app/assets/stylesheets/stream_element.scss
+++ b/app/assets/stylesheets/stream_element.scss
@@ -189,4 +189,9 @@
   .leaflet-control-zoom {
     display: block;
   }
+
+  .no-posts-info {
+    margin-bottom: 10px;
+    margin-top: 10px;
+  }
 }

--- a/app/assets/templates/no_posts_info_tpl.jst.hbs
+++ b/app/assets/templates/no_posts_info_tpl.jst.hbs
@@ -1,0 +1,5 @@
+<div class="stream_element">
+  <div class="no-posts-info text-center">
+    <strong>{{ t "stream.no_posts_yet" }}</strong>
+  </div>
+</div>

--- a/config/locales/javascript/javascript.en.yml
+++ b/config/locales/javascript/javascript.en.yml
@@ -236,6 +236,7 @@ en:
       disable_post_notifications: "Disable notifications for this post"
       permalink: "Permalink"
       via: "via <%= provider %>"
+      no_posts_yet: "There are no posts yet."
 
       likes:
         zero: "<%= count %> Likes"

--- a/features/desktop/follows_tags.feature
+++ b/features/desktop/follows_tags.feature
@@ -41,3 +41,7 @@ Feature: posting
     When I go to the followed tags stream page
     And I unfollow the "boss" tag
     Then I should not see "#tag-following-boss" within "#tags_list"
+
+  Scenario: Go to a tags page with no posts
+    When I go to the tag page for "NoPosts"
+    Then I should not see any posts in my stream

--- a/features/desktop/signs_up.feature
+++ b/features/desktop/signs_up.feature
@@ -15,6 +15,7 @@ Feature: new user registration
     Then I should be on the stream page
     And I close the publisher
     And I should not see "awesome_button"
+    And I should not see any posts in my stream
 
   Scenario: new user tries to XSS itself
     When I fill in the following:

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -7,7 +7,7 @@ Then /^the first comment field should be open/ do
 end
 
 Then /^the first comment field should be closed$/ do
-  page.should have_css(".stream_element")
+  page.should have_css(".stream_element .media")
   page.should_not have_selector("#main_stream .stream_element .new_comment", match: :first)
 end
 

--- a/features/step_definitions/posts_steps.rb
+++ b/features/step_definitions/posts_steps.rb
@@ -15,8 +15,9 @@ Then /^I should not see an uploaded image within the photo drop zone$/ do
 end
 
 Then /^I should not see any posts in my stream$/ do
-  page.assert_selector("#paginate .loader", visible: :hidden)
-  page.assert_selector(".stream_element", count: 0)
+  expect(page).not_to have_selector("#paginate .loader")
+  expect(page).not_to have_selector(".stream_element .media")
+  expect(page).to have_selector(".stream_element .no-posts-info")
 end
 
 Then /^I should not see any picture in my stream$/ do

--- a/features/support/publishing_cuke_helpers.rb
+++ b/features/support/publishing_cuke_helpers.rb
@@ -113,10 +113,6 @@ module PublishingCukeHelpers
     end
   end
 
-  def stream_posts
-    all('.stream_element')
-  end
-
   def comment_on_show_page(comment_text)
     within("#single-post-interactions") do
       make_comment(comment_text)

--- a/spec/javascripts/app/views/no_posts_info_view_spec.js
+++ b/spec/javascripts/app/views/no_posts_info_view_spec.js
@@ -1,0 +1,11 @@
+describe("app.views.NoPostsInfo", function() {
+  describe("render", function() {
+    beforeEach(function() {
+      this.view = new app.views.NoPostsInfo();
+    });
+
+    it("renders the no posts info message", function() {
+      expect(this.view.render().$el.text().trim()).toBe(Diaspora.I18n.t("stream.no_posts_yet"));
+    });
+  });
+});


### PR DESCRIPTION
Fixes #6852 and #5748.

![stream](https://cloud.githubusercontent.com/assets/3798614/17620479/dffebb54-608c-11e6-8d16-878aa609b700.png)
![tags](https://cloud.githubusercontent.com/assets/3798614/17620478/dffe1352-608c-11e6-83d6-e2318073ce18.png)
![profile](https://cloud.githubusercontent.com/assets/3798614/17620480/e00335da-608c-11e6-902f-3ec98bd20a11.png)
