### PR TITLE
Allow hovercards of remote people when not logged in

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -7,6 +7,7 @@ class PeopleController < ApplicationController
 
   before_action :authenticate_user!, except: %i(show stream hovercard)
   before_action :find_person, only: %i(show stream hovercard)
+  before_action :authenticate_if_remote_profile!, only: %i(show stream)
 
   respond_to :html
   respond_to :json, :only => [:index, :show]
@@ -163,8 +164,6 @@ class PeopleController < ApplicationController
         })
       end
 
-    # view this profile on the home pod, if you don't want to sign in...
-    authenticate_user! if remote_profile_with_no_user_session?
     raise ActiveRecord::RecordNotFound if @person.nil?
     raise Diaspora::AccountClosed if @person.closed_account?
   end
@@ -189,8 +188,9 @@ class PeopleController < ApplicationController
     !query.try(:match, /^(\w)*@([a-zA-Z0-9]|[-]|[.]|[:])*$/).nil?
   end
 
-  def remote_profile_with_no_user_session?
-    @person.try(:remote?) && !user_signed_in?
+  # view this profile on the home pod, if you don't want to sign in...
+  def authenticate_if_remote_profile!
+    authenticate_user! if @person.try(:remote?)
   end
 
   def mark_corresponding_notifications_read

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -462,6 +462,24 @@ describe PeopleController, :type => :controller do
       get :hovercard, person_id: @hover_test.guid, format: "json"
       expect(JSON.parse(response.body)["contact"]).not_to be_falsy
     end
+
+    context "with no user signed in" do
+      before do
+        sign_out :user
+      end
+
+      it "succeeds with local person" do
+        get :hovercard, person_id: bob.person.guid, format: :json
+        expect(response.status).to eq(200)
+        expect(JSON.parse(response.body)["diaspora_id"]).to eq(bob.diaspora_handle)
+      end
+
+      it "succeeds with remote person" do
+        get :hovercard, person_id: remote_raphael.guid, format: :json
+        expect(response.status).to eq(200)
+        expect(JSON.parse(response.body)["diaspora_id"]).to eq(remote_raphael.diaspora_handle)
+      end
+    end
   end
 
   describe '#refresh_search ' do


### PR DESCRIPTION
In #6603 hovercards were activated for logged out users, but they only
worked for local people. Hovercards on remote-people are important to
get the diaspora-id to search the person on the local pod, if you don't
know who it is.
