### PR TITLE
Capitalisation of colour themes

### DIFF
--- a/config/color_themes.yml
+++ b/config/color_themes.yml
@@ -1,6 +1,6 @@
 available:
-  original: "Original Dark"
-  original_white: "Original White Background"
-  dark_green: "Dark Green"
+  original: "Original dark"
+  original_white: "Original white background"
+  dark_green: "Dark green"
   magenta: "Magenta"
-  egyptian_blue: "Egyptian Blue"
+  egyptian_blue: "Egyptian blue"

--- a/config/initializers/color_themes.rb
+++ b/config/initializers/color_themes.rb
@@ -10,10 +10,10 @@ if color_themes_file.exist?
     if color_themes["available"].length > 0
       color_themes["available"]
     else
-      {"original" => "Original Dark"}
+      {"original" => "Original dark"}
     end
 else
-  AVAILABLE_COLOR_THEMES = {"original" => "Original Dark"}
+  AVAILABLE_COLOR_THEMES = {"original" => "Original dark"}
 end
 # Get all codes from available themes into a separate variable, so that they can be called easier.
 AVAILABLE_COLOR_THEME_CODES = AVAILABLE_COLOR_THEMES.keys


### PR DESCRIPTION
Just noticed that the themes don't follow Diaspora's capitalisation guideline. Now fixed.

Please note: Homebrew is currently kaput on my machine (going to try to fix this tomorrow) so I can't test this PR. As it's only changing capitalisation of strings, I hope it won't break anything but I'd be grateful if you'd confirm this before merging.

ps: shouldn't these theme names be localised?
