### PR TITLE
only create mentions after creating statusmessages

### DIFF
--- a/app/models/status_message.rb
+++ b/app/models/status_message.rb
@@ -58,7 +58,6 @@ class StatusMessage < Post
 
   def mentioned_people
     if self.persisted?
-      create_mentions if self.mentions.empty?
       self.mentions.includes(:person => :profile).map{ |mention| mention.person }
     else
       Diaspora::Mentionable.people_from_string(text)

--- a/spec/models/status_message_spec.rb
+++ b/spec/models/status_message_spec.rb
@@ -160,15 +160,16 @@ describe StatusMessage, type: :model do
     end
 
     describe "#mentioned_people" do
-      it "calls create_mentions if there are no mentions in the db" do
+      it "does not call create_mentions if there are no mentions in the db" do
         status_message.mentions.delete_all
-        expect(status_message).to receive(:create_mentions)
+        expect(status_message).not_to receive(:create_mentions)
         status_message.mentioned_people
       end
+
       it "returns the mentioned people" do
-        status_message.mentions.delete_all
         expect(status_message.mentioned_people.to_set).to eq(people.to_set)
       end
+
       it "does not call create_mentions if there are mentions in the db" do
         expect(status_message).not_to receive(:create_mentions)
         status_message.mentioned_people


### PR DESCRIPTION
otherwise it will try to fetch a mentioned person from an unhealthy pod every time the post loads, if it is the only mention in this post.

(@cmrd-senya: this will conflict with #6818, but you can simply overwrite this change there, because your refactoring already fixed this, this is only a quickfix now)
