### PR TITLE
6840 : meta tags update

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -69,27 +69,26 @@ class PeopleController < ApplicationController
   # renders the persons user profile page
   def show
     mark_corresponding_notifications_read if user_signed_in?
-
-    @person_json = PersonPresenter.new(@person, current_user).as_json
+    @presenter = PersonPresenter.new(@person, current_user)
 
     respond_to do |format|
       format.all do
         if user_signed_in?
           @contact = current_user.contact_for(@person)
         end
-        gon.preloads[:person] = @person_json
+        gon.preloads[:person] = @presenter.as_json
         gon.preloads[:photos_count] = Photo.visible(current_user, @person).count(:all)
         gon.preloads[:contacts_count] = Contact.contact_contacts_for(current_user, @person).count(:all)
-        respond_with @person, layout: "with_header"
+        respond_with @presenter, layout: "with_header"
       end
 
       format.mobile do
         @post_type = :all
         person_stream
-        respond_with @person
+        respond_with @presenter
       end
 
-      format.json { render json: @person_json }
+      format.json { render json: @presenter.as_json }
     end
   end
 

--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -20,13 +20,14 @@ class PhotosController < ApplicationController
     @post_type = :photos
     @person = Person.find_by_guid(params[:person_id])
     authenticate_user! if @person.try(:remote?) && !user_signed_in?
+    @presenter = PersonPresenter.new(@person, current_user);
 
     if @person
       @contact = current_user.contact_for(@person) if user_signed_in?
       @posts = Photo.visible(current_user, @person, :all, max_time)
       respond_to do |format|
         format.all do
-          gon.preloads[:person] = PersonPresenter.new(@person, current_user).as_json
+          gon.preloads[:person] = @presenter.as_json
           gon.preloads[:photos_count] = Photo.visible(current_user, @person).count(:all)
           gon.preloads[:contacts_count] = Contact.contact_contacts_for(current_user, @person).count(:all)
           render "people/show", layout: "with_header"

--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -20,7 +20,7 @@ class PhotosController < ApplicationController
     @post_type = :photos
     @person = Person.find_by_guid(params[:person_id])
     authenticate_user! if @person.try(:remote?) && !user_signed_in?
-    @presenter = PersonPresenter.new(@person, current_user);
+    @presenter = PersonPresenter.new(@person, current_user)
 
     if @person
       @contact = current_user.contact_for(@person) if user_signed_in?

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -19,14 +19,15 @@ class PostsController < ApplicationController
   def show
     post = post_service.find!(params[:id])
     post_service.mark_user_notifications(post.id)
+    presenter = PostPresenter.new(post, current_user)
     respond_to do |format|
-      format.html {
-        gon.post = PostPresenter.new(post, current_user)
-        render locals: {post: post}
-      }
-      format.mobile { render locals: {post: post} }
+      format.html do
+        gon.post = presenter
+        render locals: {post: presenter}
+      end
+      format.mobile { render locals: {post: presenter} }
       format.xml { render xml: DiasporaFederation::Salmon::XmlPayload.pack(Diaspora::Federation::Entities.post(post)) }
-      format.json { render json: PostPresenter.new(post, current_user) }
+      format.json { render json: presenter }
     end
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -25,7 +25,7 @@ class PostsController < ApplicationController
         gon.post = presenter
         render locals: {post: presenter}
       end
-      format.mobile { render locals: {post: presenter} }
+      format.mobile { render locals: {post: post} }
       format.xml { render xml: DiasporaFederation::Salmon::XmlPayload.pack(Diaspora::Federation::Entities.post(post)) }
       format.json { render json: presenter }
     end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -37,9 +37,10 @@ class TagsController < ApplicationController
     if user_signed_in?
       gon.preloads[:tagFollowings] = tags
     end
-    @stream = Stream::Tag.new(current_user, params[:name], :max_time => max_time, :page => params[:page])
+    stream = Stream::Tag.new(current_user, params[:name], :max_time => max_time, :page => params[:page])
+    @stream = TagPresenter.new(stream)
     respond_with do |format|
-      format.json { render :json => @stream.stream_posts.map { |p| LastThreeCommentsDecorator.new(PostPresenter.new(p, current_user)) }}
+      format.json { render :json => stream.stream_posts.map { |p| LastThreeCommentsDecorator.new(PostPresenter.new(p, current_user)) }}
     end
   end
 

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -38,7 +38,7 @@ class TagsController < ApplicationController
       gon.preloads[:tagFollowings] = tags
     end
     stream = Stream::Tag.new(current_user, params[:name], max_time: max_time, page: params[:page])
-    @stream = TagPresenter.new(stream)
+    @stream = StreamTagPresenter.new(stream)
     respond_with do |format|
       format.json do
         posts = stream.stream_posts.map do |p|

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -37,10 +37,15 @@ class TagsController < ApplicationController
     if user_signed_in?
       gon.preloads[:tagFollowings] = tags
     end
-    stream = Stream::Tag.new(current_user, params[:name], :max_time => max_time, :page => params[:page])
+    stream = Stream::Tag.new(current_user, params[:name], max_time: max_time, page: params[:page])
     @stream = TagPresenter.new(stream)
     respond_with do |format|
-      format.json { render :json => stream.stream_posts.map { |p| LastThreeCommentsDecorator.new(PostPresenter.new(p, current_user)) }}
+      format.json do
+        posts = stream.stream_posts.map do |p|
+          LastThreeCommentsDecorator.new(PostPresenter.new(p, current_user))
+        end
+        render json: posts
+      end
     end
   end
 

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -38,7 +38,7 @@ class TagsController < ApplicationController
       gon.preloads[:tagFollowings] = tags
     end
     stream = Stream::Tag.new(current_user, params[:name], max_time: max_time, page: params[:page])
-    @stream = StreamTagPresenter.new(stream)
+    @stream = TagStreamPresenter.new(stream)
     respond_with do |format|
       format.json do
         posts = stream.stream_posts.map do |p|

--- a/app/helpers/meta_data_helper.rb
+++ b/app/helpers/meta_data_helper.rb
@@ -1,0 +1,31 @@
+module MetaDataHelper
+  include ActionView::Helpers::AssetUrlHelper
+  include ActionView::Helpers::TagHelper;
+
+  def site_url
+    AppConfig.environment.url
+  end
+
+  def default_image_url
+    AppConfig.url_to asset_url('assets/branding/logos/asterisk.png')
+  end
+
+  def default_author_name
+    AppConfig.settings.pod_name
+  end
+
+  def metas_tags(attributes_list)
+    attributes_list.map {|attributes| meta_tag attributes}.join("\n")
+  end
+
+  def meta_tag(attributes)
+    return "" if attributes.empty?
+    unless attributes[:content].respond_to?(:to_ary)
+      return tag(:meta, attributes)
+    end
+    items = attributes.delete(:content)
+    items.inject("") do |string, item|
+      %{#{string}#{meta_tag attributes.merge({ content: item })}\n}
+    end.chop
+  end
+end

--- a/app/helpers/meta_data_helper.rb
+++ b/app/helpers/meta_data_helper.rb
@@ -28,12 +28,12 @@ module MetaDataHelper
 
   def general_metas
     {
-      description:    {name: "description", content: default_description},
-      og_description: {property: "description", content: default_description},
+      description:    {name:     "description",  content: default_description},
+      og_description: {property: "description",  content: default_description},
       og_site_name:   {property: "og:site_name", content: default_title},
-      og_url:         {property: "og:url", content: site_url},
-      og_image:       {property: "og:image", content: default_image_url},
-      og_type:        {property: "og:type", content: "website"}
+      og_url:         {property: "og:url",       content: site_url},
+      og_image:       {property: "og:image",     content: default_image_url},
+      og_type:        {property: "og:type",      content: "website"}
     }
   end
 
@@ -42,15 +42,12 @@ module MetaDataHelper
     attributes_list.map {|_, attributes| meta_tag attributes }.join("\n").html_safe
   end
 
+  # recursively calls itself if attribute[:content] is an array
+  # (metas such as og:image or og:tag can be present multiple times with different values)
   def meta_tag(attributes)
     return "" if attributes.empty?
     return tag(:meta, attributes) unless attributes[:content].respond_to?(:to_ary)
-
-    # recursively calls meta_tag if attribute[:content] is an array
-    # (metas such as og:image can be present multiple times with different values)
     items = attributes.delete(:content)
-    items.inject("") do |string, item|
-      string + meta_tag(attributes.merge(content: item)) + "\n"
-    end
+    items.map {|item| meta_tag(attributes.merge(content: item)) }.join("\n")
   end
 end

--- a/app/helpers/meta_data_helper.rb
+++ b/app/helpers/meta_data_helper.rb
@@ -11,7 +11,7 @@ module MetaDataHelper
   end
 
   def default_image_url
-    asset_url("assets/branding/logos/asterisk.png")
+    asset_url "assets/branding/logos/asterisk.png"
   end
 
   def default_author_name

--- a/app/helpers/meta_data_helper.rb
+++ b/app/helpers/meta_data_helper.rb
@@ -14,8 +14,22 @@ module MetaDataHelper
     AppConfig.settings.pod_name
   end
 
+  def default_description
+    AppConfig.settings.default_metas.description
+  end
+
   def default_title
-    AppConfig.settings.pod_name
+    AppConfig.settings.default_metas.title
+  end
+
+  def general_metas
+    {
+      description:    { name:     'description'  , content: default_description },
+      og_description: { property: 'description'  , content: default_description },
+      og_title:       { property: 'og:title'     , content: default_title       },
+      og_website:     { property: 'og:url'       , content: site_url            },
+      og_image:       { property: 'og:image'     , content: default_image_url   },
+    }
   end
 
   def metas_tags(attributes_list)

--- a/app/helpers/meta_data_helper.rb
+++ b/app/helpers/meta_data_helper.rb
@@ -14,8 +14,12 @@ module MetaDataHelper
     AppConfig.settings.pod_name
   end
 
+  def default_title
+    AppConfig.settings.pod_name
+  end
+
   def metas_tags(attributes_list)
-    attributes_list.map {|attributes| meta_tag attributes}.join("\n")
+    attributes_list.map {|name,attributes| meta_tag attributes}.join("\n")
   end
 
   def meta_tag(attributes)

--- a/app/helpers/meta_data_helper.rb
+++ b/app/helpers/meta_data_helper.rb
@@ -2,6 +2,10 @@ module MetaDataHelper
   include ActionView::Helpers::AssetUrlHelper
   include ActionView::Helpers::TagHelper;
 
+  def og_prefix
+    'og: http://ogp.me/ns# article: http://ogp.me/ns/article# profile: http://ogp.me/ns/profile#'
+  end
+
   def site_url
     AppConfig.environment.url
   end
@@ -26,13 +30,15 @@ module MetaDataHelper
     {
       description:    { name:     'description'  , content: default_description },
       og_description: { property: 'description'  , content: default_description },
-      og_title:       { property: 'og:title'     , content: default_title       },
-      og_website:     { property: 'og:url'       , content: site_url            },
+      og_site_name:   { property: 'og:site_name' , content: default_title       },
+      og_url:         { property: 'og:url'       , content: site_url            },
       og_image:       { property: 'og:image'     , content: default_image_url   },
+      og_type:        { property: 'og:type'      , content: 'website'           },
     }
   end
 
-  def metas_tags(attributes_list)
+  def metas_tags(attributes_list = {}, with_general_metas = true)
+    attributes_list = general_metas.merge(attributes_list) if with_general_metas
     attributes_list.map {|name,attributes| meta_tag attributes}.join("\n")
   end
 

--- a/app/helpers/meta_data_helper.rb
+++ b/app/helpers/meta_data_helper.rb
@@ -1,6 +1,6 @@
 module MetaDataHelper
   include ActionView::Helpers::AssetUrlHelper
-  include ActionView::Helpers::TagHelper;
+  include ActionView::Helpers::TagHelper
 
   def og_prefix
     'og: http://ogp.me/ns# article: http://ogp.me/ns/article# profile: http://ogp.me/ns/profile#'
@@ -11,7 +11,7 @@ module MetaDataHelper
   end
 
   def default_image_url
-    AppConfig.url_to asset_url('assets/branding/logos/asterisk.png')
+    asset_url("assets/branding/logos/asterisk.png")
   end
 
   def default_author_name
@@ -28,28 +28,29 @@ module MetaDataHelper
 
   def general_metas
     {
-      description:    { name:     'description'  , content: default_description },
-      og_description: { property: 'description'  , content: default_description },
-      og_site_name:   { property: 'og:site_name' , content: default_title       },
-      og_url:         { property: 'og:url'       , content: site_url            },
-      og_image:       { property: 'og:image'     , content: default_image_url   },
-      og_type:        { property: 'og:type'      , content: 'website'           },
+      description:    {name: "description", content: default_description},
+      og_description: {property: "description", content: default_description},
+      og_site_name:   {property: "og:site_name", content: default_title},
+      og_url:         {property: "og:url", content: site_url},
+      og_image:       {property: "og:image", content: default_image_url},
+      og_type:        {property: "og:type", content: "website"}
     }
   end
 
-  def metas_tags(attributes_list = {}, with_general_metas = true)
+  def metas_tags(attributes_list={}, with_general_metas=true)
     attributes_list = general_metas.merge(attributes_list) if with_general_metas
-    attributes_list.map {|name,attributes| meta_tag attributes}.join("\n")
+    attributes_list.map {|_, attributes| meta_tag attributes }.join("\n").html_safe
   end
 
   def meta_tag(attributes)
     return "" if attributes.empty?
-    unless attributes[:content].respond_to?(:to_ary)
-      return tag(:meta, attributes)
-    end
+    return tag(:meta, attributes) unless attributes[:content].respond_to?(:to_ary)
+
+    # recursively calls meta_tag if attribute[:content] is an array
+    # (metas such as og:image can be present multiple times with different values)
     items = attributes.delete(:content)
     items.inject("") do |string, item|
-      %{#{string}#{meta_tag attributes.merge({ content: item })}\n}
-    end.chop
+      string + meta_tag(attributes.merge(content: item)) + "\n"
+    end
   end
 end

--- a/app/helpers/open_graph_helper.rb
+++ b/app/helpers/open_graph_helper.rb
@@ -1,79 +1,4 @@
 module OpenGraphHelper
-  def og_title(title)
-    meta_tag_with_property('og:title', title)
-  end
-
-  def og_type(post)
-    meta_tag_with_property('og:type', 'article')
-  end
-
-  def og_url(url)
-    meta_tag_with_property('og:url', url)
-  end
-
-  def og_image(post=nil)
-    tags = []
-    tags = post.photos.map{|x| meta_tag_with_property('og:image', x.url(:thumb_large))} if post
-    tags << meta_tag_with_property('og:image', default_image_url) if tags.empty?
-    tags.join(' ')
-  end
-
-  def og_description(description)
-    meta_tag_with_property('og:description', description)
-  end
-
-  def og_type(type='website')
-    meta_tag_with_property('og:type', type)
-  end
-
-  def og_namespace
-    AppConfig.services.facebook.open_graph_namespace
-  end
-
-  def og_site_name
-    meta_tag_with_property('og:site_name', AppConfig.settings.pod_name)
-  end
-
-  def og_common_tags
-    [og_site_name]
-  end
-
-  def og_general_tags
-    [
-      *og_common_tags,
-      og_type,
-      og_title('diaspora* social network'),
-      og_image,
-      og_url(AppConfig.environment.url),
-      og_description('diaspora* is the online social world where you are in control.')
-    ].join("\n").html_safe
-  end
-
-  def og_page_post_tags(post)
-    tags = og_common_tags
-
-    if post.message
-      tags.concat [
-        *tags,
-        og_type("#{og_namespace}:frame"),
-        og_title(post_page_title(post, :length => 140)),
-        og_url(post_url(post)),
-        og_image(post),
-        og_description(post.message.plain_text_without_markdown truncate: 1000)
-      ]
-    end
-
-    tags.join("\n").html_safe
-  end
-
-  def og_prefix
-    "og: http://ogp.me/ns# #{og_namespace}: https://diasporafoundation.org/ns/joindiaspora#"
-  end
-
-  def meta_tag_with_property(name, content)
-    tag(:meta, :property => name, :content => content)
-  end
-
   def og_html(cache)
     "<a href=\"#{cache.url}\" target=\"_blank\">" +
     "  <div>" +
@@ -90,15 +15,5 @@ module OpenGraphHelper
 
   def oembed_image_tag(cache, prefix)
     image_tag(cache.data["#{prefix}url"], cache.options_hash(prefix))
-  end
-  private
-
-  # This method compensates for hosting assets off of s3
-  def default_image_url
-    if image_path("branding/logos/asterisk.png").include?("http")
-      image_path("branding/logos/asterisk.png")
-    else
-      "#{root_url.chop}#{image_path('branding/logos/asterisk.png')}"
-    end
   end
 end

--- a/app/presenters/base_presenter.rb
+++ b/app/presenters/base_presenter.rb
@@ -22,13 +22,15 @@ class BasePresenter
     @presentable.public_send(method, *args)
   end
 
-  def default_url_options
-    { host: AppConfig.pod_uri.host, port: AppConfig.pod_uri.port }
-  end
-
   class NilPresenter
     def method_missing(method, *args)
       nil
     end
+  end
+
+  private
+
+  def default_url_options
+    { host: AppConfig.pod_uri.host, port: AppConfig.pod_uri.port }
   end
 end

--- a/app/presenters/base_presenter.rb
+++ b/app/presenters/base_presenter.rb
@@ -1,5 +1,6 @@
 class BasePresenter
   attr_reader :current_user
+  include Rails.application.routes.url_helpers
 
   class << self
     def new(*args)
@@ -19,6 +20,10 @@ class BasePresenter
 
   def method_missing(method, *args)
     @presentable.public_send(method, *args)
+  end
+
+  def default_url_options
+    { host: AppConfig.pod_uri.host, port: AppConfig.pod_uri.port }
   end
 
   class NilPresenter

--- a/app/presenters/base_presenter.rb
+++ b/app/presenters/base_presenter.rb
@@ -31,6 +31,6 @@ class BasePresenter
   private
 
   def default_url_options
-    { host: AppConfig.pod_uri.host, port: AppConfig.pod_uri.port }
+    {host: AppConfig.pod_uri.host, port: AppConfig.pod_uri.port}
   end
 end

--- a/app/presenters/person_presenter.rb
+++ b/app/presenters/person_presenter.rb
@@ -122,7 +122,7 @@ class PersonPresenter < BasePresenter
   end
 
   def description
-    # display bio if allowed?
+    "" # FIXME: display bio if allowed?
   end
 
 

--- a/app/presenters/person_presenter.rb
+++ b/app/presenters/person_presenter.rb
@@ -32,6 +32,7 @@ class PersonPresenter < BasePresenter
       og_title: { property: 'og:title', content: title                },
       og_url:   { property: 'og:url'  , content: url                  },
       og_image: { property: 'og:image', content: image_url            },
+      og_type:  { property: 'og:type' , content: 'profile'            },
 
       og_profile_username: { property: 'og:profile:username'  , content: name       },
       og_profile_firstname:{ property: 'og:profile:first_name', content: first_name },

--- a/app/presenters/person_presenter.rb
+++ b/app/presenters/person_presenter.rb
@@ -9,7 +9,6 @@ class PersonPresenter < BasePresenter
     }
   end
 
-
   def full_hash
     base_hash_with_contact.merge(
       relationship:      relationship,
@@ -30,7 +29,6 @@ class PersonPresenter < BasePresenter
   def metas_attributes
     [
       { name:     'keywords'             , content: comma_separated_tags },
-      { name:     'description'          , content: description          },
       { property: 'og:title'             , content: title                },
       { property: 'og:url'               , content: url                  },
       { property: 'og:image'             , content: image_url            },
@@ -120,10 +118,4 @@ class PersonPresenter < BasePresenter
       return AppConfig.url_to @presentable.image_url if @presentable.image_url[0] == '/'
       @presentable.image_url
   end
-
-  def description
-    "" # FIXME: display bio if allowed?
-  end
-
-
 end

--- a/app/presenters/person_presenter.rb
+++ b/app/presenters/person_presenter.rb
@@ -27,11 +27,13 @@ class PersonPresenter < BasePresenter
 
   def metas_attributes
     {
-      keywords:             {name:     "keywords", content: comma_separated_tags},
-      og_title:             {property: "og:title", content: title},
-      og_url:               {property: "og:url",   content: url},
-      og_image:             {property: "og:image", content: image_url},
-      og_type:              {property: "og:type",  content: "profile"},
+      keywords:             {name:     "keywords",    content: comma_separated_tags},
+      description:          {name:     "description", content: description},
+      og_title:             {property: "og:title",    content: title},
+      og_description:       {property: "og:title",    content: description},
+      og_url:               {property: "og:url",      content: url},
+      og_image:             {property: "og:image",    content: image_url},
+      og_type:              {property: "og:type",     content: "profile"},
       og_profile_username:  {property: "og:profile:username",   content: name},
       og_profile_firstname: {property: "og:profile:first_name", content: first_name},
       og_profile_lastname:  {property: "og:profile:last_name",  content: last_name}
@@ -112,6 +114,10 @@ class PersonPresenter < BasePresenter
 
   def url
     url_for(@presentable)
+  end
+
+  def description
+    public_details? ? bio : ""
   end
 
   def image_url

--- a/app/presenters/person_presenter.rb
+++ b/app/presenters/person_presenter.rb
@@ -1,5 +1,4 @@
 class PersonPresenter < BasePresenter
-
   def base_hash
     {
       id:          id,
@@ -28,15 +27,14 @@ class PersonPresenter < BasePresenter
 
   def metas_attributes
     {
-      keywords: { name:     'keywords', content: comma_separated_tags },
-      og_title: { property: 'og:title', content: title                },
-      og_url:   { property: 'og:url'  , content: url                  },
-      og_image: { property: 'og:image', content: image_url            },
-      og_type:  { property: 'og:type' , content: 'profile'            },
-
-      og_profile_username: { property: 'og:profile:username'  , content: name       },
-      og_profile_firstname:{ property: 'og:profile:first_name', content: first_name },
-      og_profile_lastname: { property: 'og:profile:last_name' , content: last_name  }
+      keywords: {name:     "keywords", content: comma_separated_tags},
+      og_title: {property: "og:title", content: title},
+      og_url:   {property: "og:url",   content: url},
+      og_image: {property: "og:image", content: image_url},
+      og_type:  {property: "og:type",  content: "profile"},
+      og_profile_username:  {property: "og:profile:username",   content: name},
+      og_profile_lastname:  {property: "og:profile:last_name",  content: last_name},
+      og_profile_firstname: {property: "og:profile:first_name", content: first_name}
     }
   end
 
@@ -109,7 +107,7 @@ class PersonPresenter < BasePresenter
   end
 
   def comma_separated_tags
-    profile.tags.collect(&:name).join(', ') if profile.tags
+    profile.tags.map(&:name).join(", ") if profile.tags
   end
 
   def url
@@ -117,7 +115,7 @@ class PersonPresenter < BasePresenter
   end
 
   def image_url
-      return AppConfig.url_to @presentable.image_url if @presentable.image_url[0] == '/'
-      @presentable.image_url
+    return AppConfig.url_to @presentable.image_url if @presentable.image_url[0] == "/"
+    @presentable.image_url
   end
 end

--- a/app/presenters/person_presenter.rb
+++ b/app/presenters/person_presenter.rb
@@ -1,4 +1,5 @@
 class PersonPresenter < BasePresenter
+
   def base_hash
     {
       id:          id,
@@ -7,6 +8,7 @@ class PersonPresenter < BasePresenter
       diaspora_id: diaspora_handle
     }
   end
+
 
   def full_hash
     base_hash_with_contact.merge(
@@ -23,6 +25,19 @@ class PersonPresenter < BasePresenter
 
   def hovercard
     base_hash_with_contact.merge(profile: ProfilePresenter.new(profile).for_hovercard)
+  end
+
+  def metas_attributes
+    [
+      { name:     'keywords'             , content: comma_separated_tags },
+      { name:     'description'          , content: description          },
+      { property: 'og:title'             , content: title                },
+      { property: 'og:url'               , content: url                  },
+      { property: 'og:image'             , content: image_url            },
+      { property: 'og:profile:username'  , content: name                 },
+      { property: 'og:profile:first_name', content: first_name           },
+      { property: 'og:profile:last_name' , content: last_name            }
+    ]
   end
 
   protected
@@ -88,4 +103,27 @@ class PersonPresenter < BasePresenter
   def is_blocked?
     current_user_person_block.present?
   end
+
+  def title
+    name
+  end
+
+  def comma_separated_tags
+    profile.tags.collect(&:name).join(', ') if profile.tags
+  end
+
+  def url
+    url_for(@presentable)
+  end
+
+  def image_url
+      return AppConfig.url_to @presentable.image_url if @presentable.image_url[0] == '/'
+      @presentable.image_url
+  end
+
+  def description
+    # display bio if allowed?
+  end
+
+
 end

--- a/app/presenters/person_presenter.rb
+++ b/app/presenters/person_presenter.rb
@@ -27,15 +27,16 @@ class PersonPresenter < BasePresenter
   end
 
   def metas_attributes
-    [
-      { name:     'keywords'             , content: comma_separated_tags },
-      { property: 'og:title'             , content: title                },
-      { property: 'og:url'               , content: url                  },
-      { property: 'og:image'             , content: image_url            },
-      { property: 'og:profile:username'  , content: name                 },
-      { property: 'og:profile:first_name', content: first_name           },
-      { property: 'og:profile:last_name' , content: last_name            }
-    ]
+    {
+      keywords: { name:     'keywords', content: comma_separated_tags },
+      og_title: { property: 'og:title', content: title                },
+      og_url:   { property: 'og:url'  , content: url                  },
+      og_image: { property: 'og:image', content: image_url            },
+
+      og_profile_username: { property: 'og:profile:username'  , content: name       },
+      og_profile_firstname:{ property: 'og:profile:first_name', content: first_name },
+      og_profile_lastname: { property: 'og:profile:last_name' , content: last_name  }
+    }
   end
 
   protected

--- a/app/presenters/person_presenter.rb
+++ b/app/presenters/person_presenter.rb
@@ -27,14 +27,14 @@ class PersonPresenter < BasePresenter
 
   def metas_attributes
     {
-      keywords: {name:     "keywords", content: comma_separated_tags},
-      og_title: {property: "og:title", content: title},
-      og_url:   {property: "og:url",   content: url},
-      og_image: {property: "og:image", content: image_url},
-      og_type:  {property: "og:type",  content: "profile"},
+      keywords:             {name:     "keywords", content: comma_separated_tags},
+      og_title:             {property: "og:title", content: title},
+      og_url:               {property: "og:url",   content: url},
+      og_image:             {property: "og:image", content: image_url},
+      og_type:              {property: "og:type",  content: "profile"},
       og_profile_username:  {property: "og:profile:username",   content: name},
-      og_profile_lastname:  {property: "og:profile:last_name",  content: last_name},
-      og_profile_firstname: {property: "og:profile:first_name", content: first_name}
+      og_profile_firstname: {property: "og:profile:first_name", content: first_name},
+      og_profile_lastname:  {property: "og:profile:last_name",  content: last_name}
     }
   end
 

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -15,11 +15,12 @@ class PostPresenter < BasePresenter
 
   def metas_attributes
     {
-      keywords:    { name:     'keywords',    content: comma_separated_tags },
-      description: { name:     'description', content: description          },
-      og_url:      { property: 'og:url',      content: url                  },
-      og_title:    { property: 'og:title',    content: title                },
-      og_image:    { property: 'og:image',    content: images               },
+      keywords:       { name:     'keywords',       content: comma_separated_tags },
+      description:    { name:     'description',    content: description          },
+      og_url:         { property: 'og:url',         content: url                  },
+      og_title:       { property: 'og:title',       content: title                },
+      og_image:       { property: 'og:image',       content: images               },
+      og_description: { property: 'og:description', content: description          },
 
       og_article_published_time: { property: 'og:article:published_time', content: published_time_iso8601 },
       og_article_modified_time:  { property: 'og:article:modified_time',  content: modified_time_iso8601  },

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -22,8 +22,7 @@ class PostPresenter < BasePresenter
       og_title:       {property: "og:title",       content: title},
       og_image:       {property: "og:image",       content: images},
       og_description: {property: "og:description", content: description},
-      og_article_tag:
-        {property: "og:article:tag", content: tags},
+      og_article_tag: {property: "og:article:tag", content: tags},
       og_article_author:
         {property: "og:article:author", content: author_name},
       og_article_modified:

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -14,17 +14,18 @@ class PostPresenter < BasePresenter
   end
 
   def metas_attributes
-    [
-      { name:     'keywords',                  content: comma_separated_tags   },
-      { name:     'description',               content: description            },
-      { property: 'og:url',                    content: url                    },
-      { property: 'og:title',                  content: title                  },
-      { property: 'og:image',                  content: images                 },
-      { property: 'og:article:published_time', content: published_time_iso8601 },
-      { property: 'og:article:modified_time',  content: modified_time_iso8601  },
-      { property: 'og:article:author',         content: author_name            },
-      { property: 'og:article:tag',            content: tags                   }
-    ]
+    {
+      keywords:    { name:     'keywords',    content: comma_separated_tags },
+      description: { name:     'description', content: description          },
+      og_url:      { property: 'og:url',      content: url                  },
+      og_title:    { property: 'og:title',    content: title                },
+      og_image:    { property: 'og:image',    content: images               },
+
+      og_article_published_time: { property: 'og:article:published_time', content: published_time_iso8601 },
+      og_article_modified_time:  { property: 'og:article:modified_time',  content: modified_time_iso8601  },
+      og_article_author:         { property: 'og:article:author',         content: author_name            },
+      og_article_tag:            { property: 'og:article:tag',            content: tags                   }
+    }
   end
 
   def page_title

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -16,19 +16,16 @@ class PostPresenter < BasePresenter
 
   def metas_attributes
     {
-      keywords:       {name:     "keywords",       content: comma_separated_tags},
-      description:    {name:     "description",    content: description},
-      og_url:         {property: "og:url",         content: url},
-      og_title:       {property: "og:title",       content: title},
-      og_image:       {property: "og:image",       content: images},
-      og_description: {property: "og:description", content: description},
-      og_article_tag: {property: "og:article:tag", content: tags},
-      og_article_author:
-        {property: "og:article:author", content: author_name},
-      og_article_modified:
-        {property: "og:article:modified_time", content: modified_time_iso8601},
-      og_article_published:
-        {property: "og:article:published_time", content: published_time_iso8601}
+      keywords:             {name:     "keywords",       content: comma_separated_tags},
+      description:          {name:     "description",    content: description},
+      og_url:               {property: "og:url",         content: url},
+      og_title:             {property: "og:title",       content: title},
+      og_image:             {property: "og:image",       content:  images},
+      og_description:       {property: "og:description", content: description},
+      og_article_tag:       {property: "og:article:tag", content: tags},
+      og_article_author:    {property: "og:article:author",         content: author_name},
+      og_article_modified:  {property: "og:article:modified_time",  content: modified_time_iso8601},
+      og_article_published: {property: "og:article:published_time", content: published_time_iso8601}
     }
   end
 

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -27,8 +27,6 @@ class PostPresenter < BasePresenter
     ]
   end
 
-  # FIXME : extract post_page_title from PostHelper
-  # FIXME : for posts w/ no message, title in as_json is different from content in <title>
   def page_title
     post_page_title @post
   end

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -10,22 +10,26 @@ class PostPresenter < BasePresenter
   end
 
   def as_json(_options={})
-    @post.as_json(only: directly_retrieved_attributes).merge(non_directly_retrieved_attributes)
+    @post.as_json(only: directly_retrieved_attributes)
+         .merge(non_directly_retrieved_attributes)
   end
 
   def metas_attributes
     {
-      keywords:       { name:     'keywords',       content: comma_separated_tags },
-      description:    { name:     'description',    content: description          },
-      og_url:         { property: 'og:url',         content: url                  },
-      og_title:       { property: 'og:title',       content: title                },
-      og_image:       { property: 'og:image',       content: images               },
-      og_description: { property: 'og:description', content: description          },
-
-      og_article_published_time: { property: 'og:article:published_time', content: published_time_iso8601 },
-      og_article_modified_time:  { property: 'og:article:modified_time',  content: modified_time_iso8601  },
-      og_article_author:         { property: 'og:article:author',         content: author_name            },
-      og_article_tag:            { property: 'og:article:tag',            content: tags                   }
+      keywords:       {name:     "keywords",       content: comma_separated_tags},
+      description:    {name:     "description",    content: description},
+      og_url:         {property: "og:url",         content: url},
+      og_title:       {property: "og:title",       content: title},
+      og_image:       {property: "og:image",       content: images},
+      og_description: {property: "og:description", content: description},
+      og_article_tag:
+        {property: "og:article:tag", content: tags},
+      og_article_author:
+        {property: "og:article:author", content: author_name},
+      og_article_modified:
+        {property: "og:article:modified_time", content: modified_time_iso8601},
+      og_article_published:
+        {property: "og:article:published_time", content: published_time_iso8601}
     }
   end
 
@@ -126,9 +130,8 @@ class PostPresenter < BasePresenter
   end
 
   def images
-    photos.any? ? photos.collect(&:url) : default_image_url
+    photos.any? ? photos.map(&:url) : default_image_url
   end
-
 
   def published_time_iso8601
     created_at.to_time.iso8601
@@ -139,13 +142,13 @@ class PostPresenter < BasePresenter
   end
 
   def tags
-    tags = @post.is_a?(Reshare) ? @post.root.tags: @post.tags
-    return tags.collect(&:name) if tags
+    tags = @post.is_a?(Reshare) ? @post.root.tags : @post.tags
+    return tags.map(&:name) if tags
     []
   end
 
   def comma_separated_tags
-    tags.join(', ')
+    tags.join(", ")
   end
 
   def url

--- a/app/presenters/stream_tag_presenter.rb
+++ b/app/presenters/stream_tag_presenter.rb
@@ -2,7 +2,7 @@
 #   licensed under the Affero General Public License version 3 or later.  See
 #   the COPYRIGHT file.
 
-class TagPresenter < BasePresenter
+class StreamTagPresenter < BasePresenter
   def title
     @presentable.display_tag_name
   end

--- a/app/presenters/stream_tag_presenter.rb
+++ b/app/presenters/stream_tag_presenter.rb
@@ -11,9 +11,9 @@ class StreamTagPresenter < BasePresenter
     {
       keywords:       {name:     "keywords",       content: tag_name},
       description:    {name:     "description",    content: description},
-      og_description: {property: "og:description", content: description},
+      og_url:         {property: "og:url",         content: url},
       og_title:       {property: "og:title",       content: title},
-      og_url:         {property: "og:url",         content: url}
+      og_description: {property: "og:description", content: description}
     }
   end
 

--- a/app/presenters/tag_presenter.rb
+++ b/app/presenters/tag_presenter.rb
@@ -13,7 +13,7 @@ class TagPresenter < BasePresenter
       description:    { name:     'description'   ,  content: description },
       og_description: { property: 'og:description',  content: description },
       og_title:       { property: 'og:title'      ,  content: title       },
-      og_url:         { property: 'og:url'        ,  content: url         }
+      og_url:         { property: 'og:url'        ,  content: url         },
     }
   end
 

--- a/app/presenters/tag_presenter.rb
+++ b/app/presenters/tag_presenter.rb
@@ -9,17 +9,18 @@ class TagPresenter < BasePresenter
 
   def metas_attributes
     [
-      { name:     'keywords'    , content: tag_name    },
-      { name:     'description' , content: description },
-      { property: 'og:title'    , content: title       },
-      { property: 'og:url'      , content: url         }
+      { name:     'keywords'      ,  content: tag_name    },
+      { name:     'description'   ,  content: description },
+      { property: 'og:description',  content: description },
+      { property: 'og:title'      ,  content: title       },
+      { property: 'og:url'        ,  content: url         }
     ]
   end
 
   private
 
   def description
-    I18n.t("tags.show.description", {"tag": tag_name})
+    I18n.t("streams.tags.title", {"tags": tag_name})
   end
 
   def url

--- a/app/presenters/tag_presenter.rb
+++ b/app/presenters/tag_presenter.rb
@@ -1,0 +1,28 @@
+#   Copyright (c) 2016, Diaspora Inc.  This file is
+#   licensed under the Affero General Public License version 3 or later.  See
+#   the COPYRIGHT file.
+
+class TagPresenter < BasePresenter
+  def title
+    @presentable.display_tag_name
+  end
+
+  def metas_attributes
+    [
+      { name:     'keywords'    , content: tag_name    },
+      { name:     'description' , content: description },
+      { property: 'og:title'    , content: title       },
+      { property: 'og:url'      , content: url         }
+    ]
+  end
+
+  private
+
+  def description
+    I18n.t("tags.show.description", {"tag": tag_name})
+  end
+
+  def url
+    tag_url tag_name
+  end
+end

--- a/app/presenters/tag_presenter.rb
+++ b/app/presenters/tag_presenter.rb
@@ -8,13 +8,13 @@ class TagPresenter < BasePresenter
   end
 
   def metas_attributes
-    [
-      { name:     'keywords'      ,  content: tag_name    },
-      { name:     'description'   ,  content: description },
-      { property: 'og:description',  content: description },
-      { property: 'og:title'      ,  content: title       },
-      { property: 'og:url'        ,  content: url         }
-    ]
+    {
+      keywords:       { name:     'keywords'      ,  content: tag_name    },
+      description:    { name:     'description'   ,  content: description },
+      og_description: { property: 'og:description',  content: description },
+      og_title:       { property: 'og:title'      ,  content: title       },
+      og_url:         { property: 'og:url'        ,  content: url         }
+    }
   end
 
   private

--- a/app/presenters/tag_presenter.rb
+++ b/app/presenters/tag_presenter.rb
@@ -9,18 +9,18 @@ class TagPresenter < BasePresenter
 
   def metas_attributes
     {
-      keywords:       { name:     'keywords'      ,  content: tag_name    },
-      description:    { name:     'description'   ,  content: description },
-      og_description: { property: 'og:description',  content: description },
-      og_title:       { property: 'og:title'      ,  content: title       },
-      og_url:         { property: 'og:url'        ,  content: url         },
+      keywords:       {name:     "keywords",       content: tag_name},
+      description:    {name:     "description",    content: description},
+      og_description: {property: "og:description", content: description},
+      og_title:       {property: "og:title",       content: title},
+      og_url:         {property: "og:url",         content: url}
     }
   end
 
   private
 
   def description
-    I18n.t("streams.tags.title", {"tags": tag_name})
+    I18n.t("streams.tags.title", tags: tag_name)
   end
 
   def url

--- a/app/presenters/tag_stream_presenter.rb
+++ b/app/presenters/tag_stream_presenter.rb
@@ -1,8 +1,4 @@
-#   Copyright (c) 2016, Diaspora Inc.  This file is
-#   licensed under the Affero General Public License version 3 or later.  See
-#   the COPYRIGHT file.
-
-class StreamTagPresenter < BasePresenter
+class TagStreamPresenter < BasePresenter
   def title
     @presentable.display_tag_name
   end

--- a/app/views/layouts/_open_graph.haml
+++ b/app/views/layouts/_open_graph.haml
@@ -1,5 +1,0 @@
-- if @post.present?
-  %link{:rel => 'alternate', :type => "application/json+oembed", :href => "#{oembed_url(:url => post_url(@post))}"}
-  = og_page_post_tags(@post)
-- else
-  = og_general_tags

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,19 +4,16 @@
 
 !!!
 %html{lang:  I18n.locale.to_s, dir:  (rtl?) ? 'rtl' : 'ltr'}
-  %head{prefix:  og_prefix}
+  %head
     %title
       = page_title yield(:page_title)
 
     %meta{charset:  'utf-8'}/
     %meta{"http-equiv" => "Content-Type", :content=>"text/html; charset=utf-8"}/
-    %meta{name:  "description", content:  "diaspora*"}/
-    %meta{name:  "author", content:  "diaspora* contributors"}/
     %meta{name:  "viewport", content:  "width=device-width, initial-scale=1"}/
+    = yield :meta_data
 
     %link{rel:  'shortcut icon', href:  "#{image_path('favicon.png')}" }
-
-    = render 'layouts/open_graph'
 
     = chartbeat_head_block
     = include_mixpanel

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,14 +4,14 @@
 
 !!!
 %html{lang:  I18n.locale.to_s, dir:  (rtl?) ? 'rtl' : 'ltr'}
-  %head
+  %head{prefix: og_prefix}
     %title
       = page_title yield(:page_title)
 
     %meta{charset:  'utf-8'}/
     %meta{"http-equiv" => "Content-Type", :content=>"text/html; charset=utf-8"}/
     %meta{name:  "viewport", content:  "width=device-width, initial-scale=1"}/
-    = yield :meta_data
+    = content_for?(:meta_data) ? yield(:meta_data) : metas_tags
 
     %link{rel:  'shortcut icon', href:  "#{image_path('favicon.png')}" }
 

--- a/app/views/layouts/application.mobile.haml
+++ b/app/views/layouts/application.mobile.haml
@@ -4,7 +4,7 @@
 
 !!!
 %html{:lang => I18n.locale.to_s, :dir => (rtl?) ? 'rtl' : 'ltr'}
-  %head{:prefix => og_prefix}
+  %head
     %title
       = pod_name
 
@@ -30,8 +30,7 @@
     / NOTE(we will enable these once we don't have to rely on back/forward buttons anymore)
     /%meta{:name => "apple-mobile-web-app-capable", :content => "yes"}
     /%link{:rel => "apple-touch-startup-image", :href => "/images/apple-splash.png"}
-
-    = render 'layouts/open_graph'
+    = yield :meta_data
 
     = chartbeat_head_block
 

--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -6,7 +6,7 @@
   = @presenter.name
 
 - content_for :meta_data do
-  = raw metas_tags(@presenter.metas_attributes)
+  = metas_tags @presenter.metas_attributes
 
 .container-fluid#profile_container
   .row

--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -3,7 +3,10 @@
 -#   the COPYRIGHT file.
 
 - content_for :page_title do
-  = @person.name
+  = @presenter.name
+
+- content_for :meta_data do
+  = raw metas_tags(@presenter.metas_attributes)
 
 .container-fluid#profile_container
   .row

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -6,7 +6,7 @@
   = post.page_title
 
 - content_for :meta_data do
-  = raw metas_tags(post.metas_attributes)
+  = metas_tags post.metas_attributes
 
 - content_for :content do
   #container.container-fluid

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -3,7 +3,10 @@
 -#   the COPYRIGHT file.
 
 - content_for :page_title do
-  = post_page_title post
+  = post.page_title
+
+- content_for :meta_data do
+  = raw metas_tags(post.metas_attributes)
 
 - content_for :content do
   #container.container-fluid

--- a/app/views/tags/show.haml
+++ b/app/views/tags/show.haml
@@ -5,6 +5,9 @@
 - content_for :page_title do
   = @stream.display_tag_name
 
+- content_for :meta_data do
+  = raw metas_tags(@stream.metas_attributes)
+
 .container-fluid#tags_show
   .row
     .col-md-3.hidden-xs

--- a/app/views/tags/show.haml
+++ b/app/views/tags/show.haml
@@ -6,7 +6,7 @@
   = @stream.display_tag_name
 
 - content_for :meta_data do
-  = raw metas_tags(@stream.metas_attributes)
+  = metas_tags @stream.metas_attributes
 
 .container-fluid#tags_show
   .row

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -144,6 +144,9 @@ defaults:
         limit_removals_to_per_day: 100
     source_url:
     default_color_theme: "original"
+    default_metas:
+      title: 'diaspora* social network'
+      description: 'diaspora* is the online social world where you are in control.'
   services:
     facebook:
       enable: false

--- a/config/diaspora.yml.example
+++ b/config/diaspora.yml.example
@@ -539,6 +539,15 @@ configuration: ## Section
     ## ("original" for the theme in "app/assets/stylesheets/color_themes/original/", for
     ## example).
     #default_color_theme: "original"
+
+    ## Default meta tags
+    ## You can change here the default meta tags content included on the pages of your pod.
+    ## Title will be used for the opengraph og:site_name property while description will be used
+    ## for description and og:description.
+    default_metas:
+      #title: 'diaspora* social network'
+      #description: 'diaspora* is the online social world where you are in control.'
+
   ## Posting from Diaspora to external services (all are disabled by default).
   services: ## Section
 

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -265,7 +265,6 @@ describe PeopleController, :type => :controller do
         presenter = PersonPresenter.new(@person)
         methods_properties = {
           comma_separated_tags:    { html_attribute: 'name',     name: 'keywords'              },
-          description:             { html_attribute: 'name',     name: 'description'           },
           url:                     { html_attribute: 'property', name: 'og:url'                },
           title:                   { html_attribute: 'property', name: 'og:title'              },
           image_url:               { html_attribute: 'property', name: 'og:image'              },

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -227,7 +227,7 @@ describe PeopleController, :type => :controller do
       end
 
       it "assigns the right person" do
-        get :show, :id => @person.to_param
+        get :show, id: @person.to_param
         expect(assigns(:presenter).id).to eq(@presenter.id)
       end
     end
@@ -264,19 +264,21 @@ describe PeopleController, :type => :controller do
       it "includes the correct meta tags" do
         presenter = PersonPresenter.new(@person)
         methods_properties = {
-          comma_separated_tags:    { html_attribute: 'name',     name: 'keywords'              },
-          url:                     { html_attribute: 'property', name: 'og:url'                },
-          title:                   { html_attribute: 'property', name: 'og:title'              },
-          image_url:               { html_attribute: 'property', name: 'og:image'              },
-          first_name:              { html_attribute: 'property', name: 'og:profile:first_name' },
-          last_name:               { html_attribute: 'property', name: 'og:profile:last_name'  },
+          comma_separated_tags: {html_attribute: "name",     name: "keywords"},
+          url:                  {html_attribute: "property", name: "og:url"},
+          title:                {html_attribute: "property", name: "og:title"},
+          image_url:            {html_attribute: "property", name: "og:image"},
+          first_name:           {html_attribute: "property", name: "og:profile:first_name"},
+          last_name:            {html_attribute: "property", name: "og:profile:last_name"}
         }
 
         get :show, id: @person.to_param
 
-        methods_properties.each do |method,property|
+        methods_properties.each do |method, property|
           value = presenter.send(method)
-          expect(response.body).to include(%{<meta #{property[:html_attribute]}="#{property[:name]}" content="#{value}" />})
+          expect(response.body).to include(
+            "<meta #{property[:html_attribute]}=\"#{property[:name]}\" content=\"#{value}\" />"
+          )
         end
       end
     end

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -146,6 +146,11 @@ describe PeopleController, :type => :controller do
   end
 
   describe '#show' do
+    before do
+      @person = FactoryGirl.create(:user).person
+      @presenter = PersonPresenter.new(@person, @user)
+    end
+
     it "404s if the id is invalid" do
       get :show, :id => 'delicious'
       expect(response.code).to eq("404")
@@ -161,9 +166,15 @@ describe PeopleController, :type => :controller do
       expect(response.code).to eq("404")
     end
 
+    it "returns a person presenter" do
+      expect(PersonPresenter).to receive(:new).with(@person, @user).and_return(@presenter)
+      get :show, username: @person.username
+      expect(assigns(:presenter).person).to eq(@presenter.person)
+    end
+
     it 'finds a person via username' do
-      get :show, username: @user.username
-      expect(assigns(:person)).to eq(@user.person)
+      get :show, username: @person.username
+      expect(assigns(:presenter).to_json).to eq(@presenter.to_json)
     end
 
     it "404s if no person is found via diaspora handle" do
@@ -172,8 +183,8 @@ describe PeopleController, :type => :controller do
     end
 
     it 'finds a person via diaspora handle' do
-      get :show, username: @user.diaspora_handle
-      expect(assigns(:person)).to eq(@user.person)
+      get :show, username: @person.diaspora_handle
+      expect(assigns(:presenter).to_json).to eq(@presenter.to_json)
     end
 
     it 'redirects home for closed account' do
@@ -216,8 +227,13 @@ describe PeopleController, :type => :controller do
       end
 
       it "assigns the right person" do
-        get :show, :id => @user.person.to_param
-        expect(assigns(:person)).to eq(@user.person)
+        get :show, :id => @person.to_param
+        expect(assigns(:presenter).id).to eq(@presenter.id)
+      end
+
+      it 'contains the right metas' do
+        get :show, username: @person.diaspora_handle
+        expect(response.body).to include(@person.profile.bio)
       end
     end
 

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -46,6 +46,7 @@ describe PostsController, type: :controller do
           get :show, id: reshare_id, format: :mobile
           expect(response).to be_success
         end
+
       end
 
       context "given a post that the user is not allowed to see" do
@@ -64,6 +65,7 @@ describe PostsController, type: :controller do
     context "user not signed in" do
       context "given a public post" do
         let(:public) { alice.post(:status_message, text: "hello", public: true) }
+        let(:public_with_tags) { alice.post(:status_message, text: "#hi #howareyou", public: true) }
 
         it "shows a public post" do
           get :show, id: public.id
@@ -81,6 +83,33 @@ describe PostsController, type: :controller do
           expected_xml = DiasporaFederation::Salmon::XmlPayload.pack(Diaspora::Federation::Entities.post(public)).to_xml
           expect(response.body).to eq(expected_xml)
         end
+
+        it "includes the correct uniques meta tags" do
+          presenter = PostPresenter.new(public)
+          methods_properties = {
+            comma_separated_tags:    { html_attribute: 'name',     name: 'keywords'                  },
+            description:             { html_attribute: 'name',     name: 'description'               },
+            url:                     { html_attribute: 'property', name: 'og:url'                    },
+            title:                   { html_attribute: 'property', name: 'og:title'                  },
+            published_time_iso8601:  { html_attribute: 'property', name: 'og:article:published_time' },
+            modified_time_iso8601:   { html_attribute: 'property', name: 'og:article:modified_time'  },
+            author_name:             { html_attribute: 'property', name: 'og:article:author'         },
+          }
+
+          get :show, id: public.id, format: :html
+
+          methods_properties.each do |method,property|
+            value = presenter.send(method)
+            expect(response.body).to include(%{<meta #{property[:html_attribute]}="#{property[:name]}" content="#{value}" />})
+          end
+        end
+
+        it "includes the correct multiple meta tags" do
+          get :show, id: public_with_tags.id, format: :html
+
+          expect(response.body).to include('<meta property="og:article:tag" content="hi" />')
+          expect(response.body).to include('<meta property="og:article:tag" content="howareyou" />')
+       end
       end
 
       context "given a limited post" do

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -46,7 +46,6 @@ describe PostsController, type: :controller do
           get :show, id: reshare_id, format: :mobile
           expect(response).to be_success
         end
-
       end
 
       context "given a post that the user is not allowed to see" do
@@ -87,20 +86,22 @@ describe PostsController, type: :controller do
         it "includes the correct uniques meta tags" do
           presenter = PostPresenter.new(public)
           methods_properties = {
-            comma_separated_tags:    { html_attribute: 'name',     name: 'keywords'                  },
-            description:             { html_attribute: 'name',     name: 'description'               },
-            url:                     { html_attribute: 'property', name: 'og:url'                    },
-            title:                   { html_attribute: 'property', name: 'og:title'                  },
-            published_time_iso8601:  { html_attribute: 'property', name: 'og:article:published_time' },
-            modified_time_iso8601:   { html_attribute: 'property', name: 'og:article:modified_time'  },
-            author_name:             { html_attribute: 'property', name: 'og:article:author'         },
+            comma_separated_tags:   {html_attribute: "name",     name: "keywords"},
+            description:            {html_attribute: "name",     name: "description"},
+            url:                    {html_attribute: "property", name: "og:url"},
+            title:                  {html_attribute: "property", name: "og:title"},
+            published_time_iso8601: {html_attribute: "property", name: "og:article:published_time"},
+            modified_time_iso8601:  {html_attribute: "property", name: "og:article:modified_time"},
+            author_name:            {html_attribute: "property", name: "og:article:author"}
           }
 
           get :show, id: public.id, format: :html
 
-          methods_properties.each do |method,property|
+          methods_properties.each do |method, property|
             value = presenter.send(method)
-            expect(response.body).to include(%{<meta #{property[:html_attribute]}="#{property[:name]}" content="#{value}" />})
+            expect(response.body).to include(
+              "<meta #{property[:html_attribute]}=\"#{property[:name]}\" content=\"#{value}\" />"
+            )
           end
         end
 
@@ -109,7 +110,7 @@ describe PostsController, type: :controller do
 
           expect(response.body).to include('<meta property="og:article:tag" content="hi" />')
           expect(response.body).to include('<meta property="og:article:tag" content="howareyou" />')
-       end
+        end
       end
 
       context "given a limited post" do

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -122,12 +122,23 @@ describe TagsController, :type => :controller do
       end
 
       it "includes the correct meta tags" do
-        get :show, :name => 'yes'
+        tag_url = tag_url "yes", host: AppConfig.pod_uri.host, port: AppConfig.pod_uri.port
+
+        get :show, name: "yes"
+
         expect(response.body).to include('<meta name="keywords" content="yes" />')
-        expect(response.body).to include(%{<meta property="og:url" content="#{tag_url 'yes', host: AppConfig.pod_uri.host, port: AppConfig.pod_uri.port}" />})
-        expect(response.body).to include(%{<meta property="og:title" content="#yes" />})
-        expect(response.body).to include(%{<meta name="description" content="#{I18n.t('streams.tags.title', {'tags': 'yes'})}" />})
-        expect(response.body).to include(%{<meta property="og:description" content="#{I18n.t('streams.tags.title', {'tags': 'yes'})}" />})
+        expect(response.body).to include(
+          %(<meta property="og:url" content="#{tag_url}" />)
+        )
+        expect(response.body).to include(
+          '<meta property="og:url" content="yes" />'
+        )
+        expect(response.body).to include(
+          %(<meta name="description" content="#{I18n.t('streams.tags.title', tags: 'yes')}" />)
+        )
+        expect(response.body).to include(
+          %(<meta property="og:description" content=\"#{I18n.t('streams.tags.title', tags: 'yes')}" />")
+        )
       end
     end
   end

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -131,13 +131,13 @@ describe TagsController, :type => :controller do
           %(<meta property="og:url" content="#{tag_url}" />)
         )
         expect(response.body).to include(
-          '<meta property="og:url" content="yes" />'
+          '<meta property="og:title" content="#yes" />'
         )
         expect(response.body).to include(
           %(<meta name="description" content="#{I18n.t('streams.tags.title', tags: 'yes')}" />)
         )
         expect(response.body).to include(
-          %(<meta property="og:description" content=\"#{I18n.t('streams.tags.title', tags: 'yes')}" />")
+          %(<meta property="og:description" content=\"#{I18n.t('streams.tags.title', tags: 'yes')}" />)
         )
       end
     end

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -120,6 +120,15 @@ describe TagsController, :type => :controller do
           expect(JSON.parse(response.body).first["guid"]).to eq(post2.guid)
         end
       end
+
+      it "includes the correct meta tags" do
+        get :show, :name => 'yes'
+        expect(response.body).to include('<meta name="keywords" content="yes" />')
+        expect(response.body).to include(%{<meta property="og:url" content="#{tag_url 'yes', host: AppConfig.pod_uri.host, port: AppConfig.pod_uri.port}" />})
+        expect(response.body).to include(%{<meta property="og:title" content="#yes" />})
+        expect(response.body).to include(%{<meta name="description" content="#{I18n.t('streams.tags.title', {'tags': 'yes'})}" />})
+        expect(response.body).to include(%{<meta property="og:description" content="#{I18n.t('streams.tags.title', {'tags': 'yes'})}" />})
+      end
     end
   end
 

--- a/spec/helpers/meta_data_helper_spec.rb
+++ b/spec/helpers/meta_data_helper_spec.rb
@@ -1,22 +1,22 @@
-require 'spec_helper'
+require "spec_helper"
 
-describe MetaDataHelper, :type => :helper do
-
-  describe '#meta_tag' do
+describe MetaDataHelper, type: :helper do
+  describe "#meta_tag" do
     it "returns an empty string if passed an empty hash" do
       expect(meta_tag({})).to eq("")
     end
 
     it "returns a meta tag with the passed attributes" do
       attributes = {name: "test", content: "foo"}
-      expect(meta_tag attributes).to eq('<meta name="test" content="foo" />')
+      expect(meta_tag(attributes)).to eq('<meta name="test" content="foo" />')
     end
 
     it "returns a list of the same meta type if the value for :content in the passed attribute is an array" do
-      attribute = {property: "og:tag", content: ['tag_1', 'tag_2']}
-      expect(meta_tag attribute).to eq(
-        "<meta property=\"og:tag\" content=\"tag_1\" />\n" +
-        "<meta property=\"og:tag\" content=\"tag_2\" />")
+      attributes = {property: "og:tag", content: %w(tag_1 tag_2)}
+      expect(meta_tag(attributes)).to eq(
+        %(<meta property="og:tag" content="tag_1" />\n) +
+        %(<meta property="og:tag" content="tag_2" />)
+      )
     end
   end
 
@@ -27,28 +27,28 @@ describe MetaDataHelper, :type => :helper do
         og_website:  {property: "og:website", content: "http://www.test2.com"}
       }
       default_attributes = {
-        description: {name: "description", content: "default description" },
-        og_url:      {property: "og:url",  content: "http://www.defaulturl.com" }
+        description: {name: "description", content: "default description"},
+        og_url:      {property: "og:url",  content: "http://www.defaulturl.com"}
       }
       allow(helper).to receive(:general_metas).and_return(default_attributes)
     end
 
     it "returns the default meta datas if passed nothing" do
-      metas_html = %{<meta name="description" content="default description" />\n} +
-                   %{<meta property="og:url" content="http://www.defaulturl.com" />}
+      metas_html = %(<meta name="description" content="default description" />\n) +
+                   %(<meta property="og:url" content="http://www.defaulturl.com" />)
       expect(helper.metas_tags).to eq(metas_html)
     end
 
     it "combines by default the general meta datas with the passed attributes" do
-      metas_html = %{<meta name="description" content="i am a test" />\n} +
-                   %{<meta property="og:url" content="http://www.defaulturl.com" />\n} +
-                   %{<meta property="og:website" content="http://www.test2.com" />}
-      expect(helper.metas_tags @attributes).to eq(metas_html)
+      metas_html = %(<meta name="description" content="i am a test" />\n) +
+                   %(<meta property="og:url" content="http://www.defaulturl.com" />\n) +
+                   %(<meta property="og:website" content="http://www.test2.com" />)
+      expect(helper.metas_tags(@attributes)).to eq(metas_html)
     end
 
     it "does not combines the general meta datas with the passed attributes if option is disabled" do
-      default_metas_html = %{<meta name="description" content="default description" />\n} +
-                           %{<meta property="og:url" content="http://www.defaulturl.com" />}
+      default_metas_html = %(<meta name="description" content="default description" />\n) +
+                           %(<meta property="og:url" content="http://www.defaulturl.com" />)
       expect(helper.metas_tags(@attributes, false)).not_to include(default_metas_html)
     end
   end

--- a/spec/helpers/meta_data_helper_spec.rb
+++ b/spec/helpers/meta_data_helper_spec.rb
@@ -15,7 +15,7 @@ describe MetaDataHelper, type: :helper do
       attributes = {property: "og:tag", content: %w(tag_1 tag_2)}
       expect(meta_tag(attributes)).to eq(
         %(<meta property="og:tag" content="tag_1" />\n) +
-        %(<meta property="og:tag" content="tag_2" />\n)
+        %(<meta property="og:tag" content="tag_2" />)
       )
     end
   end

--- a/spec/helpers/meta_data_helper_spec.rb
+++ b/spec/helpers/meta_data_helper_spec.rb
@@ -21,15 +21,15 @@ describe MetaDataHelper, :type => :helper do
   end
 
   describe '#metas_tags' do
-    it "returns an empty string if passed an empty array" do
+    it "returns an empty string if passed an empty hash" do
       expect(metas_tags([])).to eq("")
     end
 
     it "returns a list of meta tags" do
-      attributes_list = [
-        {name: "description", content: "diaspora* is the online social world where you are in control."},
-        {property: "og:url", content: "http://www.example.com"},
-      ]
+      attributes_list = {
+        description: {name: "description", content: "diaspora* is the online social world where you are in control."},
+        og_url:      {property: "og:url", content: "http://www.example.com"},
+      }
       metas_html = <<-EOF
 <meta name="description" content="diaspora* is the online social world where you are in control." />
 <meta property="og:url" content="http://www.example.com" />

--- a/spec/helpers/meta_data_helper_spec.rb
+++ b/spec/helpers/meta_data_helper_spec.rb
@@ -11,6 +11,13 @@ describe MetaDataHelper, :type => :helper do
       attributes = {name: "test", content: "foo"}
       expect(meta_tag attributes).to eq('<meta name="test" content="foo" />')
     end
+
+    it "returns a list of the same meta type if the value for :content in the passed attribute is an array" do
+      attribute = {property: "og:tag", content: ['tag_1', 'tag_2']}
+      expect(meta_tag attribute).to eq(
+        "<meta property=\"og:tag\" content=\"tag_1\" />\n" +
+        "<meta property=\"og:tag\" content=\"tag_2\" />")
+    end
   end
 
   describe '#metas_tags' do

--- a/spec/helpers/meta_data_helper_spec.rb
+++ b/spec/helpers/meta_data_helper_spec.rb
@@ -21,21 +21,35 @@ describe MetaDataHelper, :type => :helper do
   end
 
   describe '#metas_tags' do
-    it "returns an empty string if passed an empty hash" do
-      expect(metas_tags([])).to eq("")
+    before do
+      @attributes = {
+        description: {name: "description", content: "i am a test"},
+        og_website:  {property: "og:website", content: "http://www.test2.com"}
+      }
+      default_attributes = {
+        description: {name: "description", content: "default description" },
+        og_url:      {property: "og:url",  content: "http://www.defaulturl.com" }
+      }
+      allow(helper).to receive(:general_metas).and_return(default_attributes)
     end
 
-    it "returns a list of meta tags" do
-      attributes_list = {
-        description: {name: "description", content: "diaspora* is the online social world where you are in control."},
-        og_url:      {property: "og:url", content: "http://www.example.com"},
-      }
-      metas_html = <<-EOF
-<meta name="description" content="diaspora* is the online social world where you are in control." />
-<meta property="og:url" content="http://www.example.com" />
-      EOF
-      metas_html.chop!
-      expect(metas_tags(attributes_list)).to eq(metas_html)
+    it "returns the default meta datas if passed nothing" do
+      metas_html = %{<meta name="description" content="default description" />\n} +
+                   %{<meta property="og:url" content="http://www.defaulturl.com" />}
+      expect(helper.metas_tags).to eq(metas_html)
+    end
+
+    it "combines by default the general meta datas with the passed attributes" do
+      metas_html = %{<meta name="description" content="i am a test" />\n} +
+                   %{<meta property="og:url" content="http://www.defaulturl.com" />\n} +
+                   %{<meta property="og:website" content="http://www.test2.com" />}
+      expect(helper.metas_tags @attributes).to eq(metas_html)
+    end
+
+    it "does not combines the general meta datas with the passed attributes if option is disabled" do
+      default_metas_html = %{<meta name="description" content="default description" />\n} +
+                           %{<meta property="og:url" content="http://www.defaulturl.com" />}
+      expect(helper.metas_tags(@attributes, false)).not_to include(default_metas_html)
     end
   end
 end

--- a/spec/helpers/meta_data_helper_spec.rb
+++ b/spec/helpers/meta_data_helper_spec.rb
@@ -27,6 +27,7 @@ describe MetaDataHelper, :type => :helper do
 <meta name="description" content="diaspora* is the online social world where you are in control." />
 <meta property="og:url" content="http://www.example.com" />
       EOF
+      metas_html.chop!
       expect(metas_tags(attributes_list)).to eq(metas_html)
     end
   end

--- a/spec/helpers/meta_data_helper_spec.rb
+++ b/spec/helpers/meta_data_helper_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe MetaDataHelper, :type => :helper do
+
+  describe '#meta_tag' do
+    it "returns an empty string if passed an empty hash" do
+      expect(meta_tag({})).to eq("")
+    end
+
+    it "returns a meta tag with the passed attributes" do
+      attributes = {name: "test", content: "foo"}
+      expect(meta_tag attributes).to eq('<meta name="test" content="foo" />')
+    end
+  end
+
+  describe '#metas_tags' do
+    it "returns an empty string if passed an empty array" do
+      expect(metas_tags([])).to eq("")
+    end
+
+    it "returns a list of meta tags" do
+      attributes_list = [
+        {name: "description", content: "diaspora* is the online social world where you are in control."},
+        {property: "og:url", content: "http://www.example.com"},
+      ]
+      metas_html = <<-EOF
+<meta name="description" content="diaspora* is the online social world where you are in control." />
+<meta property="og:url" content="http://www.example.com" />
+      EOF
+      expect(metas_tags(attributes_list)).to eq(metas_html)
+    end
+  end
+end

--- a/spec/helpers/meta_data_helper_spec.rb
+++ b/spec/helpers/meta_data_helper_spec.rb
@@ -15,7 +15,7 @@ describe MetaDataHelper, type: :helper do
       attributes = {property: "og:tag", content: %w(tag_1 tag_2)}
       expect(meta_tag(attributes)).to eq(
         %(<meta property="og:tag" content="tag_1" />\n) +
-        %(<meta property="og:tag" content="tag_2" />)
+        %(<meta property="og:tag" content="tag_2" />\n)
       )
     end
   end

--- a/spec/helpers/open_graph_helper_spec.rb
+++ b/spec/helpers/open_graph_helper_spec.rb
@@ -1,20 +1,6 @@
 require 'spec_helper'
 
 describe OpenGraphHelper, :type => :helper do
-  describe 'og_page_post_tags' do
-    it 'handles a reshare of a deleted post' do
-      reshare = FactoryGirl.build(:reshare, root: nil, id: 123)
-
-      expect {
-        helper.og_page_post_tags(reshare)
-      }.to_not raise_error
-    end
-
-    it 'handles a normal post' do
-      post = FactoryGirl.create(:status_message)
-      expect(helper.og_page_post_tags(post)).to include helper.og_url(post_url(post))
-    end
-  end
 
   describe 'og_html' do
     scenarios = {


### PR DESCRIPTION
Fixes #6840
- Add opengraph and general meta tags to posts, profile and tags views.
- Added a few methods to retrieve the meta data to the existing Person/Post presenter and created a TagPresenter (would like to get some feedback on my approach: I hope it makes sense for you to have a presenter  for a Stream::Tag, just the same as we have presenters for ActiveRecord models).
- Introduced a MetaDatahelper
- Moved the hardcoded contents already set for meta tags to config/defaults.yml

Hope I'm following your styleguides correctly and that my tests are good enough!
