### PR TITLE
Remove specs about services swallowing exceptions

### DIFF
--- a/spec/models/services/facebook_spec.rb
+++ b/spec/models/services/facebook_spec.rb
@@ -16,14 +16,6 @@ describe Services::Facebook, :type => :model do
       @service.post(@post)
     end
 
-    it 'swallows exception raised by facebook always being down' do
-      skip "temporarily disabled to figure out while some requests are failing"
-
-      stub_request(:post,"https://graph.facebook.com/me/feed").
-        to_raise(StandardError)
-      @service.post(@post)
-    end
-
     it 'removes text formatting markdown from post text' do
       message = double(urls: [])
       expect(message).to receive(:plain_text_without_markdown).and_return("")

--- a/spec/models/services/twitter_spec.rb
+++ b/spec/models/services/twitter_spec.rb
@@ -25,12 +25,6 @@ describe Services::Twitter, :type => :model do
       expect(@post.tweet_id).to match "1234"
     end
 
-    it 'swallows exception raised by twitter always being down' do
-      skip
-      expect_any_instance_of(Twitter::REST::Client).to receive(:update).and_raise(StandardError)
-      @service.post(@post)
-    end
-
     it 'should call build_twitter_post' do
       url = "foo"
       expect(@service).to receive(:build_twitter_post).with(@post, 0)


### PR DESCRIPTION
Fixes #4020.

The behavior has been removed in 2012 with https://github.com/diaspora/diaspora/commit/3cb7003361869db520a0703067182fd86a0eaaf4.
