### PR TITLE
Remove started sharing notifications where the contact doesn't exist

### DIFF
--- a/db/migrate/20160820181334_remove_started_sharing_notifications_without_contact.rb
+++ b/db/migrate/20160820181334_remove_started_sharing_notifications_without_contact.rb
@@ -1,0 +1,11 @@
+class RemoveStartedSharingNotificationsWithoutContact < ActiveRecord::Migration
+  class Notification < ActiveRecord::Base
+  end
+
+  def up
+    Notification.where(type: "Notifications::StartedSharing", target_type: "Person")
+                .joins("INNER JOIN people ON people.id = notifications.target_id")
+                .joins("LEFT OUTER JOIN contacts ON contacts.person_id = people.id")
+                .delete_all("contacts.id IS NULL")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160813115514) do
+ActiveRecord::Schema.define(version: 20160820181334) do
 
   create_table "account_deletions", force: :cascade do |t|
     t.string   "diaspora_handle", limit: 255


### PR DESCRIPTION
Before #6873 we deleted contacts when someone blocks a person, but we didn't drop the notification for the started sharing event. In #6864 we try to get the contact for the notification, which is not there anymore.

So we need to remove the notifications for the contacts that don't exit anymore.
