### PR TITLE
Use Person.by_account_identifier to find the author

### DIFF
--- a/lib/diaspora/federation/receive.rb
+++ b/lib/diaspora/federation/receive.rb
@@ -180,7 +180,7 @@ module Diaspora
       end
 
       private_class_method def self.author_of(entity)
-        Person.find_by(diaspora_handle: entity.author)
+        Person.by_account_identifier(entity.author)
       end
 
       private_class_method def self.build_location(entity)

--- a/spec/lib/diaspora/federation/receive_spec.rb
+++ b/spec/lib/diaspora/federation/receive_spec.rb
@@ -585,6 +585,17 @@ describe Diaspora::Federation::Receive do
 
         Diaspora::Federation::Receive.perform(status_message_entity)
       end
+
+      it "finds the correct author if the author is not lowercase" do
+        status_message_entity = FactoryGirl.build(:status_message_entity, author: sender.diaspora_handle.upcase)
+
+        received = Diaspora::Federation::Receive.perform(status_message_entity)
+
+        status_message = StatusMessage.find_by!(guid: status_message_entity.guid)
+
+        expect(received).to eq(status_message)
+        expect(status_message.author).to eq(sender)
+      end
     end
 
     context "with poll" do


### PR DESCRIPTION
This is needed if the author is not lowercase in the received message (hubzilla?). But relay will still fail, because we'll resend the message with a lowercase author, which makes the author_signature invalid. But at least receive will work with this.
