### PR TITLE
Move notifications and conversations links in collapsed header on small devices

### DIFF
--- a/app/assets/templates/header_tpl.jst.hbs
+++ b/app/assets/templates/header_tpl.jst.hbs
@@ -12,7 +12,7 @@
           <a href="/stream" class="navbar-brand" data-stream-title="{{t "my_stream"}}">
             {{ podname }}
           </a>
-          <ul class="nav nav-badges visible-sm visible-xs">
+          <ul class="nav nav-badges visible-sm">
             <li>
               <a href="/notifications" title="{{t "header.notifications"}}" class="notifications-link nav-badge">
                 <i class="entypo-bell"></i>
@@ -36,6 +36,8 @@
           <ul class="nav navbar-nav navbar-left">
             <li><a href="/stream">{{t "my_stream"}}</a></li>
             <li><a href="/activity">{{t "my_activity"}}</a></li>
+            <li class="visible-xs"><a href="/notifications">{{t "header.notifications"}}</a></li>
+            <li class="visible-xs"><a href="/conversations">{{t "header.conversations"}}</a></li>
             <li class="visible-sm visible-xs"><a href="/mobile/toggle">{{t "header.toggle_mobile"}}</a></li>
           </ul>
 


### PR DESCRIPTION
On devices smaller than 768px (phones) the links will be in the header dropdown, between 768px and 992px (tablets) they will be in the header but won't open the notification dropdown (that's the current behavior) and for a width >=992px you will have the normal header.

**Before (phones)**
![phone_before](https://cloud.githubusercontent.com/assets/3798614/17836846/4c9f3382-67a0-11e6-9ed9-01d1edf95483.png)

**After (phones)**
![phone_after](https://cloud.githubusercontent.com/assets/3798614/17836847/4ca1d93e-67a0-11e6-9f6c-396f6251046d.png)
![phone_after_expanded](https://cloud.githubusercontent.com/assets/3798614/17836853/7ae32b4a-67a0-11e6-8c6e-8ad1d92e8754.png)

Tablet and desktop versions didn't change.
