### PR TITLE
Remove stream title from main stream

### DIFF
--- a/app/assets/javascripts/app/app.js
+++ b/app/assets/javascripts/app/app.js
@@ -108,12 +108,6 @@ var app = {
 
       evt.preventDefault();
       var link = $(this);
-      if(link.data("stream-title") && link.data("stream-title").length) {
-        $(".stream-title").text(link.data("stream-title"));
-      } else {
-        $(".stream-title").text(link.text());
-      }
-
       $("html, body").animate({scrollTop: 0});
 
       // app.router.navigate doesn't tell us if it changed the page,

--- a/app/assets/javascripts/app/views/aspects_list_view.js
+++ b/app/assets/javascripts/app/views/aspects_list_view.js
@@ -15,7 +15,6 @@ app.views.AspectsList = app.views.Base.extend({
 
   initialize: function() {
     this.collection.on("change", this.toggleSelector, this);
-    this.collection.on("change", this.updateStreamTitle, this);
     this.collection.on("aspectStreamFetched", this.updateAspectList, this);
     app.events.on("aspect:create", function(id) { window.location = "/contacts?a_id=" + id });
   },
@@ -26,7 +25,6 @@ app.views.AspectsList = app.views.Base.extend({
 
   postRenderTemplate: function() {
     this.collection.each(this.appendAspect, this);
-    this.updateStreamTitle();
     this.toggleSelector();
   },
 
@@ -56,10 +54,6 @@ app.views.AspectsList = app.views.Base.extend({
     } else {
       selector.text(Diaspora.I18n.t('aspect_navigation.select_all'));
     }
-  },
-
-  updateStreamTitle: function() {
-    $(".stream-title").text(this.collection.toSentence());
   },
 
   updateAspectList: function() {

--- a/app/assets/stylesheets/stream.scss
+++ b/app/assets/stylesheets/stream.scss
@@ -5,6 +5,7 @@
 }
 
 .main-stream-publisher {
+  margin-top: 20px;
   padding: 0;
 
   .avatar {

--- a/app/views/aspects/_aspect_stream.haml
+++ b/app/views/aspects/_aspect_stream.haml
@@ -2,10 +2,6 @@
 -#   licensed under the Affero General Public License version 3 or later.  See
 -#   the COPYRIGHT file.
 
-- if user_signed_in? && @person != current_user.person
-  %h3.stream-title
-    = stream.title
-
 .container-fluid.main-stream-publisher
   .pull-left.hidden-xs
     = owner_image_link

--- a/features/desktop/keyboard_navigation.feature
+++ b/features/desktop/keyboard_navigation.feature
@@ -25,7 +25,7 @@ Feature: Keyboard navigation
   Scenario: navigate downwards after changing the stream
     When I go to the activity stream page
     And I click on selector "[data-stream='stream'] a"
-    Then I should see "Stream" within ".stream-title"
+    Then I should see "Stream" within "#stream_selection .selected"
 
     When I press the "J" key somewhere
     Then post 1 should be highlighted


### PR DESCRIPTION
I have been made aware of the fact that the stream title just tells you what you can already see in the left sidebar. For the multi stream you see the word "Stream" three times: in the header, in the sidebar and as the stream title. When selecting the aspects stream the stream title needs 3 lines for the account on my production pod.

This PR keeps the title for the tag stream (`/tag/diaspora`) since there is no stream selection in the left sidebar on that page and it tells you on which tag page you are right now.

**Before**
![before_aspects_stream](https://cloud.githubusercontent.com/assets/3798614/17836932/8850885a-67a4-11e6-9382-504ee0c624c7.png)
![before_stream](https://cloud.githubusercontent.com/assets/3798614/17836931/884feb52-67a4-11e6-8498-916fd940e09e.png)

**After**
![after_aspects_stream](https://cloud.githubusercontent.com/assets/3798614/17836933/8f26caea-67a4-11e6-9ceb-d198c86cd477.png)
![after_stream](https://cloud.githubusercontent.com/assets/3798614/17836934/8f61be34-67a4-11e6-82b0-095c63427fbf.png)
