### PR TITLE
Display images inline in profile bio

### DIFF
--- a/app/assets/templates/profile_sidebar_tpl.jst.hbs
+++ b/app/assets/templates/profile_sidebar_tpl.jst.hbs
@@ -11,7 +11,7 @@
       {{#if bio}}
         <li>
           <h4>{{t 'profile.bio'}}</h4>
-          <div class="{{txtDirClass bio}}">{{fmtText bio}}</div>
+          <div class="{{txtDirClass bio}} markdown-content">{{fmtText bio}}</div>
         </li>
       {{/if}}
       {{#if location}}


### PR DESCRIPTION
Fixes #7020. We don't have the problem on conversation pages since we still use redcarpet on those.
