### PR TITLE
Only update interacted_at on new comments

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -38,8 +38,9 @@ class Comment < ActiveRecord::Base
     self.text.strip! unless self.text.nil?
   end
 
-  after_commit :on => :create do
-    self.parent.update_comments_counter
+  after_commit on: :create do
+    parent.update_comments_counter
+    parent.touch(:interacted_at) if parent.respond_to?(:interacted_at)
   end
 
   after_destroy do

--- a/lib/diaspora/relayable.rb
+++ b/lib/diaspora/relayable.rb
@@ -11,10 +11,6 @@ module Diaspora
 
         delegate :public?, to: :parent
         delegate :author, :diaspora_handle, to: :parent, prefix: true
-
-        after_commit :on => :create do
-          parent.touch(:interacted_at) if parent.respond_to?(:interacted_at)
-        end
       end
     end
 

--- a/spec/lib/evil_query_spec.rb
+++ b/spec/lib/evil_query_spec.rb
@@ -83,8 +83,8 @@ describe EvilQuery::Participation do
       expect(posts.map(&:id)).to match_array([@status_messageA.id, @status_messageB.id, @status_messageE.id])
     end
 
-    it "returns the posts that the user has commented on or liked with the most recently acted on ones first" do
-      expect(posts.map(&:id)).to eq([@status_messageE.id, @status_messageA.id, @status_messageB.id])
+    it "returns the posts that the user has commented on most recently first" do
+      expect(posts.map(&:id)).to eq([@status_messageE.id, @status_messageB.id, @status_messageA.id])
     end
   end
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -66,6 +66,16 @@ describe Comment, type: :model do
     end
   end
 
+  describe "interacted_at" do
+    it "sets the interacted at of the parent to the created at of the comment" do
+      Timecop.travel(Time.zone.now + 1.minute)
+
+      comment = Comment::Generator.new(alice, status_bob, "why so formal?").build
+      comment.save
+      expect(status_bob.reload.interacted_at.to_i).to eq(comment.created_at.to_i)
+    end
+  end
+
   it_behaves_like "it is relayable" do
     let(:remote_parent) { FactoryGirl.create(:status_message, author: remote_raphael) }
     let(:local_parent) { local_luke.post(:status_message, text: "hi", to: local_luke.aspects.first) }

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -43,6 +43,16 @@ describe Like, type: :model do
     end
   end
 
+  describe "interacted_at" do
+    it "doesn't change the interacted at timestamp of the parent" do
+      interacted_at = status.reload.interacted_at.to_i
+
+      Timecop.travel(Time.zone.now + 1.minute)
+      Like::Generator.new(alice, status).build.save
+      expect(status.reload.interacted_at.to_i).to eq(interacted_at)
+    end
+  end
+
   it_behaves_like "it is relayable" do
     let(:remote_parent) { FactoryGirl.create(:status_message, author: remote_raphael) }
     let(:local_parent) { local_luke.post(:status_message, text: "hi", to: local_luke.aspects.first) }

--- a/spec/shared_behaviors/relayable.rb
+++ b/spec/shared_behaviors/relayable.rb
@@ -5,17 +5,6 @@
 require "spec_helper"
 
 shared_examples_for "it is relayable" do
-  describe "interacted_at" do
-    it "sets the interacted at of the parent to the created at of the relayable post" do
-      Timecop.freeze Time.now do
-        relayable.save
-        if relayable.parent.respond_to?(:interacted_at) #I'm sorry.
-          expect(relayable.parent.interacted_at.to_i).to eq(relayable.created_at.to_i)
-        end
-      end
-    end
-  end
-
   describe "validations" do
     context "author ignored by parent author" do
       context "the author is on the parent object author's ignore list when object is created" do


### PR DESCRIPTION
I got feedback from many users, that they don't understand how the "my activity" stream is sorted, because they have posts on the top, but don't see why (including myself 😼). The user doesn't see if a like was added, and it is also not imported for the user to see the post again then. And we have notifications if someone likes a users own posts, so no need to move it on top of the "my activity" stream here too.
