### PR TITLE
Indicate proper way to report bugs in sidebar, close #4779

### DIFF
--- a/app/views/streams/main_stream.html.haml
+++ b/app/views/streams/main_stream.html.haml
@@ -81,8 +81,8 @@
                   tag_path(name: t("aspects.index.help.tag_question"))))
               %li
                 != t("aspects.index.help.find_a_bug",
-                  link: link_to("#" + t("aspects.index.help.tag_bug"),
-                  tag_path(name: t("aspects.index.help.tag_bug"))))
+                  link: link_to(t("aspects.index.help.tag_bug"),
+                  "https://wiki.diasporafoundation.org/How_to_report_a_bug"))
               %li
                 != t("aspects.index.help.feature_suggestion",
                   link: link_to("#" + t("aspects.index.help.tag_feature"),


### PR DESCRIPTION
Update the `bug` link in the sidebar to the [report bug wiki page](https://wiki.diasporafoundation.org/How_to_report_a_bug)

I stumbled over this ticket https://github.com/diaspora/diaspora/issues/4779 and thought I could fix it. Let me know if more/ other things are requried
