### PR TITLE
make session-cookie HttpOnly

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Diaspora::Application.config.session_store :cookie_store, key: '_diaspora_session', httponly: false
+Diaspora::Application.config.session_store :cookie_store, key: "_diaspora_session", httponly: true


### PR DESCRIPTION
This was changed to `false` in 2010 to make websockets work, but diaspora doesn't have websockets anymore, so we can change this back to `HttpOnly`.
