### PR TITLE
Remove user_photo method from users controller

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@
 #   the COPYRIGHT file.
 
 class UsersController < ApplicationController
-  before_action :authenticate_user!, except: %i(new create public user_photo)
+  before_action :authenticate_user!, except: %i(new create public)
   respond_to :html
 
   def edit
@@ -116,16 +116,6 @@ class UsersController < ApplicationController
 
   def download_photos
     redirect_to current_user.exported_photos_file.url
-  end
-
-  def user_photo
-    username = params[:username].split('@')[0]
-    user = User.find_by_username(username)
-    if user.present?
-      redirect_to user.image_url
-    else
-      render :nothing => true, :status => 404
-    end
   end
 
   def confirm_email

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -172,7 +172,6 @@ Diaspora::Application.routes.draw do
     end
   end
   get '/u/:username' => 'people#show', :as => 'user_profile', :constraints => { :username => /[^\/]+/ }
-  get '/u/:username/profile_photo' => 'users#user_photo', :constraints => { :username => /[^\/]+/ }
 
   # External
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -47,18 +47,6 @@ describe UsersController, :type => :controller do
     end
   end
 
-  describe 'user_photo' do
-    it 'should return the url of the users profile photo' do
-      get :user_photo, :username => @user.username
-      expect(response).to redirect_to(@user.profile.image_url)
-    end
-
-    it 'should 404 if no user is found' do
-      get :user_photo, :username => 'none'
-      expect(response).not_to be_success
-    end
-  end
-
   describe '#public' do
     it 'renders xml if atom is requested' do
       sm = FactoryGirl.create(:status_message, :public => true, :author => @user.person)


### PR DESCRIPTION
The method seems to be unused and brakeman found [a possible unprotected redirect](https://codeclimate.com/github/diaspora/diaspora/app/controllers/users_controller.rb#security).
