### PR TITLE
Cleanup invalid unconfirmed emails

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -466,7 +466,7 @@ class User < ActiveRecord::Base
 
   # Whenever email is set, clear all unconfirmed emails which match
   def remove_invalid_unconfirmed_emails
-    User.where(unconfirmed_email: email).update_all(unconfirmed_email: nil) if email_changed?
+    User.where(unconfirmed_email: email).update_all(unconfirmed_email: nil, confirm_email_token: nil) if email_changed?
   end
 
   # Generate public/private keys for User and associated Person

--- a/db/migrate/20160902180630_remove_invalid_unconfirmed_emails.rb
+++ b/db/migrate/20160902180630_remove_invalid_unconfirmed_emails.rb
@@ -1,0 +1,9 @@
+class RemoveInvalidUnconfirmedEmails < ActiveRecord::Migration
+  class User < ActiveRecord::Base
+  end
+
+  def up
+    User.joins("INNER JOIN users as valid_user ON users.unconfirmed_email = valid_user.email")
+        .where("users.id != valid_user.id").update_all(unconfirmed_email: nil, confirm_email_token: nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160901072443) do
+ActiveRecord::Schema.define(version: 20160902180630) do
 
   create_table "account_deletions", force: :cascade do |t|
     t.string   "diaspora_handle", limit: 255

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -306,11 +306,12 @@ describe User, :type => :model do
         expect(alice).not_to be_valid
       end
 
-      it "resets a matching unconfirmed_email on save" do
-        eve.update_attribute :unconfirmed_email, "new@example.com"
-        alice.update_attribute :email, "new@example.com"
+      it "resets a matching unconfirmed_email and confirm_email_token on save" do
+        eve.update_attributes(unconfirmed_email: "new@example.com", confirm_email_token: SecureRandom.hex(15))
+        alice.update_attribute(:email, "new@example.com")
         eve.reload
         expect(eve.unconfirmed_email).to eql(nil)
+        expect(eve.confirm_email_token).to eql(nil)
       end
     end
 


### PR DESCRIPTION
Also remove confirm_email_token when unconfirmed_email is removed.

The validation was added in #6905.

Fixes #7048
