### PR TITLE
[API] Override forgery settings in controllers

### DIFF
--- a/app/controllers/api/openid_connect/clients_controller.rb
+++ b/app/controllers/api/openid_connect/clients_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module OpenidConnect
     class ClientsController < ApplicationController
+      skip_before_action :verify_authenticity_token
+
       rescue_from OpenIDConnect::HttpError do |e|
         http_error_page_as_json(e)
       end

--- a/app/controllers/api/openid_connect/token_endpoint_controller.rb
+++ b/app/controllers/api/openid_connect/token_endpoint_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module OpenidConnect
     class TokenEndpointController < ApplicationController
+      skip_before_action :verify_authenticity_token
+
       def create
         req = Rack::Request.new(request.env)
         if req["client_assertion_type"] == "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"

--- a/spec/controllers/api/openid_connect/clients_controller_spec.rb
+++ b/spec/controllers/api/openid_connect/clients_controller_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe Api::OpenidConnect::ClientsController, type: :controller do
+describe Api::OpenidConnect::ClientsController, type: :controller, suppress_csrf_verification: :none do
   describe "#create" do
     context "when valid parameters are passed" do
       it "should return a client id" do

--- a/spec/controllers/api/openid_connect/token_endpoint_controller_spec.rb
+++ b/spec/controllers/api/openid_connect/token_endpoint_controller_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+describe Api::OpenidConnect::TokenEndpointController, type: :controller, suppress_csrf_verification: :none do
+  let(:auth) { FactoryGirl.create(:auth_with_read) }
+
+  describe "#create" do
+    it "returns 200 on success" do
+      post :create,
+           grant_type:    "authorization_code",
+           code:          auth.create_code,
+           redirect_uri:  auth.redirect_uri,
+           scope:         auth.scopes.join(" "),
+           client_id:     auth.o_auth_application.client_id,
+           client_secret: auth.o_auth_application.client_secret
+      expect(response.code).to eq("200")
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -373,18 +373,27 @@ FactoryGirl.define do
     o_auth_application
     user
     scopes %w(openid sub aud profile picture nickname name read)
+    after(:build) {|m|
+      m.redirect_uri = m.o_auth_application.redirect_uris[0]
+    }
   end
 
   factory :auth_with_read_and_ppid, class: Api::OpenidConnect::Authorization do
     association :o_auth_application, factory: :o_auth_application_with_ppid
     user
     scopes %w(openid sub aud profile picture nickname name read)
+    after(:build) {|m|
+      m.redirect_uri = m.o_auth_application.redirect_uris[0]
+    }
   end
 
   factory :auth_with_read_and_write, class: Api::OpenidConnect::Authorization do
     o_auth_application
     user
     scopes %w(openid sub aud profile picture nickname name read write)
+    after(:build) {|m|
+      m.redirect_uri = m.o_auth_application.redirect_uris[0]
+    }
   end
 
   # Factories for the DiasporaFederation-gem

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -143,3 +143,9 @@ Shoulda::Matchers.configure do |config|
     with.library :rails
   end
 end
+
+shared_context suppress_csrf_verification: :none do
+  before do
+    ActionController::Base.allow_forgery_protection = true
+  end
+end


### PR DESCRIPTION
ClientsController and TokenEndpointController are called from the outside, so CSRF verification prevents them from normal operation.

fix #7059
