### PR TITLE
Prevent overflow of interaction avatars in the single post view

### DIFF
--- a/app/assets/stylesheets/single-post-view.scss
+++ b/app/assets/stylesheets/single-post-view.scss
@@ -147,4 +147,8 @@
   .interaction-avatars {
     line-height: 25px;
   }
+
+  .interaction-avatars {
+    overflow: hidden;
+  }
 }

--- a/app/assets/templates/single-post-viewer/single-post-interactions_tpl.jst.hbs
+++ b/app/assets/templates/single-post-viewer/single-post-interactions_tpl.jst.hbs
@@ -1,39 +1,39 @@
 {{#if resharesCount}}
   <div id="reshares" class="clearfix">
-    <span class="count">
+    <div class="count">
       <i class="entypo-reshare middle gray"></i>
       <span>{{resharesCount}}</span>
-    </span>
-    <span class="interaction-avatars">
+    </div>
+    <div class="interaction-avatars">
       {{#each reshares}}
         {{#linkToAuthor author}}
           {{{personImage this 'small' 'micro'}}}
         {{/linkToAuthor}}
       {{/each}}
-    </span>
+    </div>
   </div>
 {{/if}}
 {{#if likesCount}}
   <div id="likes" class="clearfix">
-    <span class="count">
+    <div class="count">
       <i class="entypo-heart middle gray"></i>
       <span>{{likesCount}}</span>
-    </span>
-    <span class="interaction-avatars">
+    </div>
+    <div class="interaction-avatars">
       {{#each likes}}
         {{#linkToAuthor author}}
           {{{personImage this 'small' 'micro'}}}
         {{/linkToAuthor}}
       {{/each}}
-    </span>
+    </div>
   </div>
 {{/if}}
 {{#if commentsCount}}
   <div id="comments-meta" class="clearfix">
-    <span class="count">
+    <div class="count">
       <i class="entypo-comment middle gray"></i>
       <span>{{commentsCount}}</span>
-    </span>
+    </div>
   </div>
 {{else}}
   <div class="no-comments">


### PR DESCRIPTION
**before**:

![before](https://cloud.githubusercontent.com/assets/3798614/18270957/fd348abc-742f-11e6-935a-1e771a895e2e.png)

**after**:

![after](https://cloud.githubusercontent.com/assets/3798614/18270938/e4f84baa-742f-11e6-9f1c-83a89f1bfe56.png)

(Don't be confused by the wrong likes count. I added the avatars manually.)
