### PR TITLE
Remove remotipart gem and remotipart photo uploads

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,6 @@ gem "activerecord-import", "0.15.0"
 gem "carrierwave", "0.11.2"
 gem "fog",         "1.38.0"
 gem "mini_magick", "4.5.1"
-gem "remotipart",  "1.2.1"
 
 # GUID generation
 gem "uuid", "2.3.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1019,7 +1019,6 @@ DEPENDENCIES
   rb-fsevent (= 0.9.7)
   rb-inotify (= 0.9.7)
   redcarpet (= 3.3.4)
-  remotipart (= 1.2.1)
   responders (= 2.2.0)
   rspec-rails (= 3.5.1)
   rubocop (= 0.40.0)

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -6,7 +6,6 @@
 //= require js-routes
 //= require underscore
 //= require backbone
-//= require jquery.remotipart
 //= require autosize
 //= require charcount
 //= require jquery-placeholder

--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -43,18 +43,7 @@ class PhotosController < ApplicationController
 
   def create
     rescuing_photo_errors do
-      if remotipart_submitted?
-        @photo = current_user.build_post(:photo, photo_params)
-        if @photo.save
-          respond_to do |format|
-            format.json { render :json => {"success" => true, "data" => @photo.as_api_response(:backbone)} }
-          end
-        else
-          respond_with @photo, :location => photos_path, :error => message
-        end
-      else
-        legacy_create
-      end
+      legacy_create
     end
   end
 


### PR DESCRIPTION
This has been added in #3068. [Remotipart](https://github.com/JangoSteve/remotipart) adds support for photo uploads via rails remote forms and it looks like we don't do this anymore.
