### PR TITLE
Fix ID token issuer field to match discovery data

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -110,3 +110,6 @@ module Diaspora
     end
   end
 end
+
+Rails.application.routes.default_url_options[:host] = AppConfig.pod_uri.host
+Rails.application.routes.default_url_options[:port] = AppConfig.pod_uri.port

--- a/lib/api/openid_connect/id_token.rb
+++ b/lib/api/openid_connect/id_token.rb
@@ -51,7 +51,7 @@ module Api
       def claims
         sub = build_sub
         @claims ||= {
-          iss:       AppConfig.environment.url,
+          iss:       Rails.application.routes.url_helpers.root_url,
           sub:       sub,
           aud:       @authorization.o_auth_application.client_id,
           exp:       @expires_at.to_i,

--- a/spec/models/api/openid_connect/id_token_spec.rb
+++ b/spec/models/api/openid_connect/id_token_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+
+describe Api::OpenidConnect::IdToken, type: :model do
+  describe "#to_jwt" do
+    let(:auth) { FactoryGirl.create(:auth_with_read) }
+    let(:id_token) { Api::OpenidConnect::IdToken.new(auth, "nonce") }
+
+    describe "decoded data" do
+      let(:decoded_hash) {
+        JSON::JWT.decode(id_token.to_jwt, Api::OpenidConnect::IdTokenConfig::PRIVATE_KEY)
+      }
+      let(:discovery_controller) {
+        Api::OpenidConnect::DiscoveryController.new.tap {|controller|
+          controller.request = ActionController::TestRequest.new
+          controller.request.host = AppConfig.pod_uri.authority
+          controller.response = ActionController::TestResponse.new
+        }
+      }
+      let(:openid_webfinger) {
+        JSON.parse(discovery_controller.webfinger[0])
+      }
+
+      it "issuer value must much the one we provided in OpenID discovery routine" do
+        expect(decoded_hash["iss"]).to eq(openid_webfinger["links"][0]["href"])
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,8 +24,6 @@ end
 
 ProcessedImage.enable_processing = false
 UnprocessedImage.enable_processing = false
-Rails.application.routes.default_url_options[:host] = AppConfig.pod_uri.host
-Rails.application.routes.default_url_options[:port] = AppConfig.pod_uri.port
 
 def alice
   @alice ||= User.find_by(username: "alice")


### PR DESCRIPTION
OpenID Connect spec says:

"The issuer returned by discovery MUST exactly match the value of iss in the ID Token."

https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier
