### PR TITLE
Load jquery in the head on mobile

### DIFF
--- a/app/views/conversations/new.mobile.haml
+++ b/app/views/conversations/new.mobile.haml
@@ -2,8 +2,6 @@
 -#   licensed under the Affero General Public License version 3 or later.  See
 -#   the COPYRIGHT file.
 
-= javascript_include_tag :jquery
-
 :javascript
   $(document).ready(function () {
     var data = $.parseJSON( "#{escape_javascript(@contacts_json)}" ),

--- a/app/views/layouts/application.mobile.haml
+++ b/app/views/layouts/application.mobile.haml
@@ -48,6 +48,8 @@
     - if Rails.env.test?
       = stylesheet_link_tag :poltergeist_disable_transition, media: "all"
 
+    = jquery_include_tag
+
     = yield(:head)
 
     = include_gon(:camel_case => true)
@@ -64,7 +66,6 @@
         = yield
 
     / javascripts at the bottom
-    = jquery_include_tag
     = javascript_include_tag "mobile/mobile"
     = load_javascript_locales
     = include_chartbeat

--- a/app/views/profiles/_edit_public.haml
+++ b/app/views/profiles/_edit_public.haml
@@ -1,6 +1,4 @@
 - content_for :head do
-  - if mobile
-    = javascript_include_tag :jquery
   :javascript
     $(document).ready(function () {
       var data = $.parseJSON( '#{@tags_array.to_json.gsub("'", "\\\\'")}' ),

--- a/app/views/status_messages/bookmarklet.mobile.haml
+++ b/app/views/status_messages/bookmarklet.mobile.haml
@@ -19,6 +19,3 @@
       $("#status_message_text").val(contents);
     }
   });
-
-- content_for(:head) do
-  = javascript_include_tag :jquery

--- a/app/views/users/getting_started.mobile.haml
+++ b/app/views/users/getting_started.mobile.haml
@@ -3,8 +3,6 @@
 -#   the COPYRIGHT file.
 
 - content_for :head do
-  = javascript_include_tag :jquery
-
   :javascript
     $(document).ready(function () {
       var data = $.parseJSON( '#{@tags_array.to_json.gsub("'", "\\\\'")}' ),


### PR DESCRIPTION
Some pages need jquery in the head and instead of loading it twice on these pages, it is better and easier to load it in the head on all pages. It should be in the cache after the first load anyway.

Also these pages still tried to load jquery 1 which didn't work anymore.
