### PR TITLE
Add support for setting BOSH access protocol via chat configuration

### DIFF
--- a/app/helpers/jsxc_helper.rb
+++ b/app/helpers/jsxc_helper.rb
@@ -1,11 +1,12 @@
 module JsxcHelper
   def get_bosh_endpoint
+    proto = AppConfig.chat.server.bosh.proto
     port = AppConfig.chat.server.bosh.port
     bind = AppConfig.chat.server.bosh.bind
     host = AppConfig.pod_uri.host
 
     unless AppConfig.chat.server.bosh.proxy?
-      return "http://#{host}:#{port}#{bind}"
+      return "#{proto}://#{host}:#{port}#{bind}"
     end
     AppConfig.url_to bind
   end

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -56,6 +56,7 @@ defaults:
       certs: "config/certs"
       bosh:
         proxy: false
+        proto: 'http'
         address: '0.0.0.0'
         port: 5280
         bind: '/http-bind'

--- a/config/diaspora.yml.example
+++ b/config/diaspora.yml.example
@@ -246,6 +246,9 @@ configuration: ## Section
         ## connect directly to the port specified below.
         #proxy: true
 
+        ## Configure the protocol used to access the BOSH endpoint
+        #proto: http
+
         ## Configure the address that vines should listen on.
         #address: '0.0.0.0'
 


### PR DESCRIPTION
Greetings!

I had to add this on my own Pod to enable HTTPS access to my BOSH server.

Thanks,
Lance Gilbert
