### PR TITLE
Fix 4319 postdefault

### DIFF
--- a/app/assets/javascripts/app/pages/settings.js
+++ b/app/assets/javascripts/app/pages/settings.js
@@ -4,6 +4,12 @@ app.pages.Settings = Backbone.View.extend({
     $(".settings-visibility").tooltip({placement: "top"});
     $(".profile-visibility-hint").tooltip({placement: "top"});
     $("[name='profile[public_details]']").bootstrapSwitch();
+
+    var form = $("#post-default-aspects");
+    this.viewAspectSelector = new app.views.PublisherAspectSelector({
+      el: $(".aspect_dropdown"),
+      form: form
+    });
   }
 });
 // @license-end

--- a/app/helpers/aspect_global_helper.rb
+++ b/app/helpers/aspect_global_helper.rb
@@ -17,7 +17,7 @@ module AspectGlobalHelper
       aspect = stream.aspect
       aspect_ids = stream.aspect_ids
     elsif current_user
-      aspects = current_user.aspects
+      aspects = current_user.post_default_aspects
       aspect = aspects.first
       aspect_ids = current_user.aspect_ids
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -252,6 +252,17 @@ class User < ActiveRecord::Base
     end
   end
 
+  def post_default_aspects
+    self.aspects.where(post_default: true).to_a
+  end
+
+  def update_post_default_aspects(post_default_aspect_ids)
+    self.aspects.each do |aspect|
+      enable = post_default_aspect_ids.include?(aspect.id.to_s)
+      aspect.update_attribute(:post_default, enable)
+    end
+  end
+
   def salmon(post)
     Salmon::EncryptedSlap.create_by_user_and_activity(self, post.to_diaspora_xml)
   end
@@ -502,7 +513,8 @@ class User < ActiveRecord::Base
       self[field] = nil
     end
     [:getting_started,
-     :show_community_spotlight_in_stream].each do |field|
+     :show_community_spotlight_in_stream,
+     :post_default_public].each do |field|
       self[field] = false
     end
     self[:disable_mail] = true

--- a/app/views/users/_edit.haml
+++ b/app/views/users/_edit.haml
@@ -115,6 +115,19 @@
           .clearfix= f.submit t(".change"), class: "btn btn-primary pull-right"
     %hr
 
+    .row
+      .col-md-12
+        %h3
+          = t('.default_post_visibility')
+          - # 'You can always change this default selection before you post.'
+        = form_for current_user, url: edit_user_path, html: {method: :put, id: "post-default-aspects", class: "form-horizontal"} do |f|
+          = f.hidden_field :post_default_public, value: false
+          - selected_aspects = current_user.post_default_aspects
+          = render :partial => "publisher/aspect_dropdown", :locals => { :selected_aspects => selected_aspects }
+          .small-horizontal-spacer
+          .clearfix= f.submit t(".change"), class: "btn btn-primary pull-right"
+    %hr
+
 
     .row
       .col-md-12

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -1143,6 +1143,7 @@ en:
       following: "Sharing settings"
       auto_follow_back: "Automatically share with users who start sharing with you"
       auto_follow_aspect: "Aspect for users you automatically share with:"
+      default_post_visibility: "Default aspects selected for posting"
       receive_email_notifications: "Receive email notifications when:"
       started_sharing: "someone starts sharing with you"
       someone_reported: "someone sends a report"

--- a/db/migrate/20160829170244_add_post_default_to_aspects.rb
+++ b/db/migrate/20160829170244_add_post_default_to_aspects.rb
@@ -1,0 +1,11 @@
+class AddPostDefaultToAspects < ActiveRecord::Migration
+  def self.up
+    add_column :aspects, :post_default, :boolean, default: true
+    add_column :users, :post_default_public, :boolean, default: false
+  end
+  
+  def self.down
+    remove_column :aspects, :post_default
+    remove_column :users, :post_default_public
+  end
+end

--- a/lib/stream/multi.rb
+++ b/lib/stream/multi.rb
@@ -22,12 +22,17 @@ class Stream::Multi < Stream::Base
     end.compact
   end
 
+  # Override base class method
+  def aspects
+    user.post_default_aspects
+  end
+
   private
   def publisher_opts
     if welcome?
       {open: true, prefill: publisher_prefill, public: true, explain: true}
     else
-      super
+      {public: user.post_default_public}
     end
   end
 

--- a/lib/stream/public.rb
+++ b/lib/stream/public.rb
@@ -19,4 +19,10 @@ class Stream::Public < Stream::Base
   def can_comment?(post)
     post.author.local?
   end
+  
+  # Overriding base class method
+  def publisher_opts
+    # We need this option to make public the default selected aspect for this Stream.
+    {:public => true}
+  end
 end

--- a/spec/lib/stream/multi_spec.rb
+++ b/spec/lib/stream/multi_spec.rb
@@ -32,7 +32,7 @@ describe Stream::Multi do
     it 'provides no opts if welcome? is not set' do
       prefill_text = "sup?"
       allow(@stream).to receive(:welcome?).and_return(false)
-      expect(@stream.send(:publisher_opts)).to eq({})
+      expect(@stream.send(:publisher_opts)).to eq({:public=>false})
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -936,10 +936,11 @@ describe User, :type => :model do
         expect(@user.reload.disable_mail).to be true
       end
 
-      it 'sets getting_started and show_community_spotlight_in_stream fields to false' do
+      it 'sets getting_started and show_community_spotlight_in_stream and post_default_public fields to false' do
         @user.clear_account!
         expect(@user.reload.getting_started).to be false
         expect(@user.reload.show_community_spotlight_in_stream).to be false
+        expect(@user.reload.post_default_public).to be false
       end
     end
 


### PR DESCRIPTION
Please consider my contribution for issue #4319 that has been open for a long time.

In this change we add an aspect drop down selector on the user settings page. After selecting and saving these post_default aspects they will be used in the main stream's publisher for preselecting the aspects to post to.

In addition, we preselect the 'public' aspect in the publisher for the public activities stream. This makes the behavior analogous to the My Aspects stream, where we preselect the aspects of the aspect stream.
