### PR TITLE
Add In-Reply-To and References headers to notification mails

### DIFF
--- a/app/mailers/notification_mailers/also_commented.rb
+++ b/app/mailers/notification_mailers/also_commented.rb
@@ -8,6 +8,7 @@ module NotificationMailers
 
       if mail?
         @headers[:from] = "\"#{@comment.author_name} (diaspora*)\" <#{AppConfig.mail.sender_address}>"
+        @headers[:in_reply_to] = @headers[:references] = "<#{@comment.parent.guid}@#{AppConfig.pod_uri.host}>"
         if @comment.public?
           @headers[:subject] = "Re: #{@comment.comment_email_subject}"
         else

--- a/app/mailers/notification_mailers/comment_on_post.rb
+++ b/app/mailers/notification_mailers/comment_on_post.rb
@@ -6,6 +6,7 @@ module NotificationMailers
       @comment = Comment.find(comment_id)
 
       @headers[:from] = "\"#{@comment.author_name} (diaspora*)\" <#{AppConfig.mail.sender_address}>"
+      @headers[:in_reply_to] = @headers[:references] = "<#{@comment.parent.guid}@#{AppConfig.pod_uri.host}>"
       if @comment.public?
         @headers[:subject] = "Re: #{@comment.comment_email_subject}"
       else

--- a/app/mailers/notification_mailers/liked.rb
+++ b/app/mailers/notification_mailers/liked.rb
@@ -7,6 +7,7 @@ module NotificationMailers
       @like = Like.find(like_id)
 
       @headers[:subject] = I18n.t('notifier.liked.liked', :name => @sender.name)
+      @headers[:in_reply_to] = @headers[:references] = "<#{@like.parent.guid}@#{AppConfig.pod_uri.host}>"
     end
   end
 end

--- a/app/mailers/notification_mailers/mentioned.rb
+++ b/app/mailers/notification_mailers/mentioned.rb
@@ -7,6 +7,7 @@ module NotificationMailers
       @post = Mention.find_by_id(target_id).post
 
       @headers[:subject] = I18n.t('notifier.mentioned.subject', :name => @sender.name)
+      @headers[:in_reply_to] = @headers[:references] = "<#{@post.guid}@#{AppConfig.pod_uri.host}>"
     end
   end
 end

--- a/app/mailers/notification_mailers/private_message.rb
+++ b/app/mailers/notification_mailers/private_message.rb
@@ -9,6 +9,7 @@ module NotificationMailers
 
       @headers[:from] = "\"#{@message.author_name} (diaspora*)\" <#{AppConfig.mail.sender_address}>"
       @headers[:subject] = I18n.t("notifier.private_message.subject")
+      @headers[:in_reply_to] = @headers[:references] = "<#{@conversation.guid}@#{AppConfig.pod_uri.host}>"
     end
   end
 end

--- a/app/mailers/notification_mailers/reshared.rb
+++ b/app/mailers/notification_mailers/reshared.rb
@@ -1,13 +1,14 @@
 module NotificationMailers
   class Reshared < NotificationMailers::Base
     attr_accessor :reshare
-    
+
     delegate :root, to: :reshare, prefix: true
 
     def set_headers(reshare_id)
       @reshare = Reshare.find(reshare_id)
 
       @headers[:subject] = I18n.t('notifier.reshared.reshared', :name => @sender.name)
+      @headers[:in_reply_to] = @headers[:references] = "<#{@reshare.root_guid}@#{AppConfig.pod_uri.host}>"
     end
   end
 end

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -94,6 +94,11 @@ describe Notifier, type: :mailer do
       expect(@mail.subject).to include(@post.author.name)
     end
 
+    it "IN-REPLY-TO and REFERENCES: references the mentioning post" do
+      expect(@mail.in_reply_to).to eq("#{@post.guid}@#{AppConfig.pod_uri.host}")
+      expect(@mail.references).to eq("#{@post.guid}@#{AppConfig.pod_uri.host}")
+    end
+
     it "has the post text in the body" do
       expect(@mail.body.encoded).to include(@post.text)
     end
@@ -170,6 +175,11 @@ describe Notifier, type: :mailer do
       expect(@mail.to).to eq([alice.email])
     end
 
+    it "IN-REPLY-TO and REFERENCES: references the reshared post" do
+      expect(@mail.in_reply_to).to eq("#{@post.guid}@#{AppConfig.pod_uri.host}")
+      expect(@mail.references).to eq("#{@post.guid}@#{AppConfig.pod_uri.host}")
+    end
+
     it "BODY: contains the truncated original post" do
       expect(@mail.body.encoded).to include(@post.message.plain_text)
     end
@@ -214,6 +224,11 @@ describe Notifier, type: :mailer do
 
     it "SUBJECT: should not has a snippet of the private message contents" do
       expect(@mail.subject).not_to include(@cnv.subject)
+    end
+
+    it "IN-REPLY-TO and REFERENCES: references the containing conversation" do
+      expect(@mail.in_reply_to).to eq("#{@cnv.guid}@#{AppConfig.pod_uri.host}")
+      expect(@mail.references).to eq("#{@cnv.guid}@#{AppConfig.pod_uri.host}")
     end
 
     it "BODY: does not contain the message text" do
@@ -288,6 +303,11 @@ describe Notifier, type: :mailer do
 
       it "SUBJECT: has a snippet of the post contents, without markdown and without newlines" do
         expect(comment_mail.subject).to eq("Re: Headline")
+      end
+
+      it "IN-REPLY-TO and REFERENCES: references the commented post" do
+        expect(comment_mail.in_reply_to).to eq("#{comment.parent.guid}@#{AppConfig.pod_uri.host}")
+        expect(comment_mail.references).to eq("#{comment.parent.guid}@#{AppConfig.pod_uri.host}")
       end
 
       context "BODY" do
@@ -365,6 +385,11 @@ describe Notifier, type: :mailer do
           expect(mail.subject).not_to include("Limited headline")
         end
 
+        it "IN-REPLY-TO and REFERENCES: references the commented post" do
+          expect(mail.in_reply_to).to eq("#{comment.parent.guid}@#{AppConfig.pod_uri.host}")
+          expect(mail.references).to eq("#{comment.parent.guid}@#{AppConfig.pod_uri.host}")
+        end
+
         it "BODY: does not show the limited post" do
           expect(mail.body.encoded).not_to include("Limited headline")
         end
@@ -389,6 +414,11 @@ describe Notifier, type: :mailer do
 
       it "SUBJECT: does not show the limited post" do
         expect(mail.subject).not_to include("Limited headline")
+      end
+
+      it "IN-REPLY-TO and REFERENCES: references the liked post" do
+        expect(mail.in_reply_to).to eq("#{like.parent.guid}@#{AppConfig.pod_uri.host}")
+        expect(mail.references).to eq("#{like.parent.guid}@#{AppConfig.pod_uri.host}")
       end
 
       it "BODY: does not show the limited post" do


### PR DESCRIPTION
This allows mail clients to collapse mails regarding the same object. Likes, comments and reshares will be grouped by the respective post, private messages will be grouped by the containing conversation.
