### PR TITLE
[WIP] Automated test pods deployment feature [feedback wanted]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -259,6 +259,9 @@ group :development do
   gem "simplecov", "0.12.0", require: false
 
   gem "turbo_dev_assets", "0.0.2"
+
+  # Test pods deployment tool
+  gem "diaspora_podz_replicator", github: "cmrd-senya/diaspora_podz_replicator", submodules: true
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,16 @@
+GIT
+  remote: git://github.com/cmrd-senya/diaspora_podz_replicator.git
+  revision: 5731e683584fef9d1d9730ba7626c6aa5b2daad5
+  submodules: true
+  specs:
+    diaspora_podz_replicator (0.1.0.dev)
+      capistrano (~> 3.0)
+      capistrano-db-tasks.senya (~> 0.4)
+      capistrano-rails (~> 1.1)
+      capistrano-rails-collection (~> 0.1)
+      capistrano-rvm (~> 0.1)
+      trollop (~> 2.1)
+
 GEM
   remote: https://rubygems.org/
   remote: https://rails-assets.org/
@@ -49,6 +62,8 @@ GEM
       activesupport (>= 3.0.0)
       rack (>= 1.1.0)
     addressable (2.4.0)
+    airbrussh (1.1.1)
+      sshkit (>= 1.6.1, != 1.7.0)
     arel (6.0.3)
     asset_sync (1.1.0)
       activemodel
@@ -72,6 +87,26 @@ GEM
     buftok (0.2.0)
     builder (3.2.2)
     byebug (9.0.5)
+    capistrano (3.6.1)
+      airbrussh (>= 1.0.0)
+      capistrano-harrow
+      i18n
+      rake (>= 10.0.0)
+      sshkit (>= 1.9.0)
+    capistrano-bundler (1.2.0)
+      capistrano (~> 3.1)
+      sshkit (~> 1.2)
+    capistrano-db-tasks.senya (0.4.1)
+      capistrano (>= 3.0.0)
+    capistrano-harrow (0.5.3)
+    capistrano-rails (1.2.0)
+      capistrano (~> 3.1)
+      capistrano-bundler (~> 1.1)
+    capistrano-rails-collection (0.1.0)
+      capistrano-rails (~> 1.1)
+    capistrano-rvm (0.1.2)
+      capistrano (~> 3.0)
+      sshkit (~> 1.2)
     capybara (2.10.1)
       addressable
       mime-types (>= 1.16)
@@ -519,6 +554,9 @@ GEM
     naught (1.1.0)
     nenv (0.3.0)
     nested_form (0.3.2)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (3.2.0)
     nio4r (1.2.1)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
@@ -818,6 +856,9 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
+    sshkit (1.11.4)
+      net-scp (>= 1.1.2)
+      net-ssh (>= 2.8.0)
     state_machine (1.2.0)
     swd (1.0.1)
       activesupport (>= 3)
@@ -933,6 +974,7 @@ DEPENDENCIES
   diaspora-prosody-config (= 0.0.7)
   diaspora_federation-rails (= 0.1.5)
   diaspora_federation-test (= 0.1.5)
+  diaspora_podz_replicator!
   entypo-rails (= 3.0.0.pre.rc2)
   eye (= 0.8.1)
   factory_girl_rails (= 4.7.0)
@@ -1046,4 +1088,4 @@ DEPENDENCIES
   will_paginate (= 3.1.5)
 
 BUNDLED WITH
-   1.13.5
+   1.13.6


### PR DESCRIPTION
After a discussion with @jhass at #7037 I rethought the idea of test pods deployment.

I've extracted rake tasks for pods deployment to a gem, which I called [diaspora_podz_replicator](https://github.com/cmrd-senya/diaspora_podz_replicator). Since the deployment process depends on [diaspora-replica](https://github.com/joebew42/diaspora-replica), I also bundled replica sources to that gem, so that clients of the gem doesn't need to manage git submodules themselves.

So now this gem is the way to add a possibility to deploy diaspora test pods to any application, including diaspora. This is not only required for some future federation test automation, but also simplifies your life, when you want to test some functionality manually with the set of disposable pods. Also one may want to use it for the purposes of testing some code against diaspora and it's API.

The gem introuduce an executable CLI utility called preplica. This way it's not generally necessary to tie it with the diaspora repository, you may use the tool outside of it if you want. However, having it in means that it picks up reasonable defaults and work out-of-box without extra configuration, while using it outside means you would have to point at least configuration file and diaspora source path manually.

Relatively to #7037, this gonna be a base. #7037 is about introducing federation tests and this changeset is a tool that is gonna be used for that. So if this PR is accepted, I'll rebase #7037 on it considering this new feature.

Of course, this will require some love and discussions to make the PR and the gem more clean, so I'm setting [WIP] right away. But as an MVP it works for now.
### Requirements
- LXC
- Vagrant -- this one isn't provided as a rubygem anymore, so one must install it explicitly
- About 5 Gb free space

On Ubuntu 16.04 LXC can be installed by

```
sudo apt-get install lxc cgroup-lite
```

Vagrant must be installed from the upstream package ([download page](https://www.vagrantup.com/downloads.html)), the version from repositories is buggy.
### Prepare environment

1) **(optional)** Create a config at `config/replica.yml`:

```
configuration:
  pod_count: 3
  pods:
    2:
      revision: "master"
    1:
      revision: "develop"
    3:
      revision: "develop"
```

If no config file provided, the defaults are used, which are pod_count=1, revision=HEAD.

2) **(optional)** Add pods hostnames to `/etc/hosts`

```
...
192.168.11.6    pod1.diaspora.local
192.168.11.8    pod2.diaspora.local
192.168.11.10    pod3.diaspora.local
192.168.11.12    pod4.diaspora.local
...
```

Pods are addressed using domain names which should be accessible from your host. IP addresses are hardcoded in Vagrant file of my customized replica version. If you don't change your `/etc/hosts`, you'll still be able to access them using their IP addresses. But the domains the pods are configurated to will be `podN.diaspora.local` (so to access alice on pod2 from pod1 you'll type alice@pod2.diaspora.local).

3) Vagrant must be allowed to execute containers without asking password (must be run without `sudo`)

```
vagrant lxc sudoers
```

4) I also had to issue this command on Ubuntu 16.04. Not sure if it's really mandatory or just a requirement due to some my local misconfiguration. Ubuntu 14.04 never required this.

```
sudo mount cgroup /sys/fs/cgroup//devices -t cgroup -o rw,relatime,devices,release_agent=/run/cgmanager/agents/cgm-release-agent.devices
```
### How to use it
#### Deploy pods software

Use

```
bundle exec preplica deploy
```

It'll create a proper number of LXC containers and populate them with diaspora software. Might take a while, especially for the very first time.
#### Launch pods software

 If the deployment has been finished successfully, you may launch the pods' software by

```
bundle exec preplica launch
```

Now you may access the pods by their domains `podN.diaspora.local`.
#### Stop pods software

```
bundle exec preplica stop
```
#### Halt the VMs

```
bundle exec preplica halt
```
#### Destroy the VMs

If you want to clean up and remove these virtual machines, run

```
bundle exec preplica clean
```
### Logs

Log files are written to `<diaspora root>/log` directory with `replica.<timestamp>.log` name. Might be changed with `--logdir` command line option.

Opinions?
