### PR TITLE
Bump secure_headers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -139,7 +139,7 @@ gem "open_graph_reader", "0.6.1"
 
 # Security Headers
 
-gem "secure_headers", "3.4.1"
+gem "secure_headers", "3.5.0"
 
 # Services
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -778,7 +778,7 @@ GEM
     scss_lint (0.49.0)
       rake (>= 0.9, < 12)
       sass (~> 3.4.20)
-    secure_headers (3.4.1)
+    secure_headers (3.5.0)
       useragent
     securecompare (1.0.0)
     shellany (0.0.1)
@@ -1028,7 +1028,7 @@ DEPENDENCIES
   ruby-oembed (= 0.10.1)
   rubyzip (= 1.2.0)
   sass-rails (= 5.0.6)
-  secure_headers (= 3.4.1)
+  secure_headers (= 3.5.0)
   shoulda-matchers (= 3.1.1)
   sidekiq (= 4.2.2)
   sidekiq-cron (= 0.4.4)

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,7 +1,7 @@
 SecureHeaders::Configuration.default do |config|
   config.hsts = SecureHeaders::OPT_OUT # added by Rack::SSL
 
-  config.csp = {
+  csp = {
     default_src:     %w('none'),
     child_src:       %w('self' www.youtube.com w.soundcloud.com twitter.com platform.twitter.com syndication.twitter.com
                         player.vimeo.com www.mixcloud.com www.dailymotion.com media.ccc.de bandcamp.com
@@ -19,41 +19,32 @@ SecureHeaders::Configuration.default do |config|
 
   if AppConfig.environment.assets.host.present?
     asset_host = Addressable::URI.parse(AppConfig.environment.assets.host.get).host
-    config.csp[:script_src] << asset_host
-    config.csp[:style_src] << asset_host
+    csp[:script_src] << asset_host
+    csp[:style_src] << asset_host
   end
 
   if AppConfig.chat.enabled?
-    config.csp[:media_src] << "data:"
+    csp[:media_src] << "data:"
 
     unless AppConfig.chat.server.bosh.proxy?
-      config.csp[:connect_src] << "#{AppConfig.pod_uri.host}:#{AppConfig.chat.server.bosh.port}"
+      csp[:connect_src] << "#{AppConfig.pod_uri.host}:#{AppConfig.chat.server.bosh.port}"
     end
   end
 
   if AppConfig.privacy.mixpanel_uid.present?
-    config.csp[:script_src] << "api.mixpanel.com"
-    config.csp[:connect_src] << "api.mixpanel.com"
+    csp[:script_src] << "api.mixpanel.com"
+    csp[:connect_src] << "api.mixpanel.com"
   end
 
-  config.csp[:script_src] << "code.jquery.com" if AppConfig.privacy.jquery_cdn?
-  config.csp[:script_src] << "static.chartbeat.com" if AppConfig.privacy.chartbeat_uid.present?
-  config.csp[:form_action] << "www.paypal.com" if AppConfig.settings.paypal_donations.enable?
+  csp[:script_src] << "code.jquery.com" if AppConfig.privacy.jquery_cdn?
+  csp[:script_src] << "static.chartbeat.com" if AppConfig.privacy.chartbeat_uid.present?
+  csp[:form_action] << "www.paypal.com" if AppConfig.settings.paypal_donations.enable?
 
-  config.csp[:report_only] = AppConfig.settings.csp.report_only?
-  config.csp[:report_uri] = [AppConfig.settings.csp.report_uri] if AppConfig.settings.csp.report_uri.present?
+  csp[:report_uri] = [AppConfig.settings.csp.report_uri] if AppConfig.settings.csp.report_uri.present?
 
-  # Add frame-src but don't spam the log with DEPRECATION warnings.
-  # We need frame-src to support older versions of Chrome, because secure_headers handles all Chrome browsers as
-  # "modern" browser, and ignores the version of the browser. We can drop this once we support only Chrome
-  # versions with child-src support.
-  module SecureHeaders
-    class ContentSecurityPolicy
-      private
-
-      def normalize_child_frame_src
-        @config[:frame_src] = @config[:child_src]
-      end
-    end
+  if AppConfig.settings.csp.report_only?
+    config.csp_report_only = csp
+  else
+    config.csp = csp
   end
 end


### PR DESCRIPTION
Version 3.5 supports two CSP headers (enforced/report-only).

Also remove the `frame-src` hack.
