### PR TITLE
Fix tag page when default aspect is "public" or a single aspect

### DIFF
--- a/app/views/status_messages/bookmarklet.html.haml
+++ b/app/views/status_messages/bookmarklet.html.haml
@@ -4,4 +4,4 @@
       .col-md-12
         %h4
           =t('bookmarklet.post_something')
-        = render partial: 'publisher/publisher', locals: { aspect: :profile, :selected_aspects => @aspects,  :aspect_ids => @aspect_ids }
+        = render partial: "publisher/publisher", locals: publisher_aspects_for(nil)

--- a/app/views/tags/show.haml
+++ b/app/views/tags/show.haml
@@ -26,7 +26,7 @@
             = @stream.display_tag_name
 
         - if current_user
-          = render 'publisher/publisher', :selected_aspects => @stream.aspect_ids, :aspect_ids => @stream.aspect_ids, aspect: @stream.aspect
+          = render "publisher/publisher", publisher_aspects_for(@stream)
 
         #main_stream.stream
 


### PR DESCRIPTION
And: Use default visibility also for bookmarklet
