### PR TITLE
Suppress deprecation warning: disable csp in report-only mode

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -43,6 +43,7 @@ SecureHeaders::Configuration.default do |config|
   csp[:report_uri] = [AppConfig.settings.csp.report_uri] if AppConfig.settings.csp.report_uri.present?
 
   if AppConfig.settings.csp.report_only?
+    config.csp = SecureHeaders::OPT_OUT
     config.csp_report_only = csp
   else
     config.csp = csp


### PR DESCRIPTION
Explicitly opt-out  `Content-Security-Policy` in report-only mode.

uplift? @denschub :)
