### PR TITLE
Add setting for a custom changelog url.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,6 +12,8 @@ module ApplicationHelper
   end
 
   def changelog_url
+    return AppConfig.settings.changelog_url.get if AppConfig.settings.changelog_url.present?
+
     url = "https://github.com/diaspora/diaspora/blob/master/Changelog.md"
     url.sub!('/master/', "/#{AppConfig.git_revision}/") if AppConfig.git_revision.present?
     url

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -144,6 +144,7 @@ defaults:
         warn_days: 30
         limit_removals_to_per_day: 100
     source_url:
+    changelog_url:
     default_color_theme: "original"
     default_metas:
       title: 'diaspora* social network'

--- a/config/diaspora.yml.example
+++ b/config/diaspora.yml.example
@@ -535,6 +535,11 @@ configuration: ## Section
     ## If not set your pod will provide a downloadable archive.
     #source_url: 'https://example.org/username/diaspora'
 
+    ## Changelog URL
+    ## URL to the changelog of the diaspora-version your pod is currently running.
+    ## If not set an auto-generated url to github is used.
+    #changelog_url: "https://github.com/diaspora/diaspora/blob/master/Changelog.md"
+
     ## Default color theme
     ## You can change which color theme is displayed when a user is not signed in
     ## or has not selected any color theme from the available ones. You simply have

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -89,14 +89,28 @@ describe ApplicationHelper, :type => :helper do
   end
 
   describe "#changelog_url" do
+    let(:changelog_url_setting) {
+      double.tap {|double| allow(AppConfig).to receive(:settings).and_return(double(changelog_url: double)) }
+    }
+
     it "defaults to master branch changleog" do
+      expect(changelog_url_setting).to receive(:present?).and_return(false)
       expect(AppConfig).to receive(:git_revision).and_return(nil)
       expect(changelog_url).to eq("https://github.com/diaspora/diaspora/blob/master/Changelog.md")
     end
 
     it "displays the changelog for the current git revision if set" do
+      expect(changelog_url_setting).to receive(:present?).and_return(false)
       expect(AppConfig).to receive(:git_revision).twice.and_return("123")
       expect(changelog_url).to eq("https://github.com/diaspora/diaspora/blob/123/Changelog.md")
+    end
+
+    it "displays the configured changelog url if set" do
+      expect(changelog_url_setting).to receive(:present?).and_return(true)
+      expect(changelog_url_setting).to receive(:get)
+        .and_return("https://github.com/diaspora/diaspora/blob/develop/Changelog.md")
+      expect(AppConfig).not_to receive(:git_revision)
+      expect(changelog_url).to eq("https://github.com/diaspora/diaspora/blob/develop/Changelog.md")
     end
   end
 


### PR DESCRIPTION
I think this can be merged to the `next-minor` branch, because it doesn't change the default behavior, it only provides an additional setting.

fixes #7073