### PR TITLE
Properly format JSON for reshares to hide 'reshare' button on already reshared posts

### DIFF
--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -104,7 +104,7 @@ class PostPresenter < BasePresenter
   end
 
   def user_reshare
-    @post.reshare_for(current_user)
+    @post.reshare_for(current_user).try(:as_api_response, :backbone)
   end
 
   def already_participated_in_poll

--- a/features/desktop/reshare.feature
+++ b/features/desktop/reshare.feature
@@ -42,11 +42,25 @@ Feature: public repost
     And I sign in as "bob@bob.bob"
     Then I should see "Original post deleted by author" within ".reshare"
 
-  # should be covered in rspec, so testing that the post is added to
-  # app.stream in jasmine should be enough coverage
-  Scenario: When I reshare, it shows up on my profile page
-    Given I sign in as "alice@alice.alice"
-    And I confirm the alert after I follow "Reshare"
+  Scenario: Reshare a post from the stream
+    When I sign in as "alice@alice.alice"
+    Then I should see a ".reshare" within ".feedback"
+    When I confirm the alert after I follow "Reshare"
     Then I should see a flash message indicating success
     And I should see a flash message containing "successfully"
     And I should not see a ".reshare" within ".feedback"
+
+  Scenario: Reshare a post from another user's profile
+    When I sign in as "alice@alice.alice"
+    And I am on "bob@bob.bob"'s page
+    Then I should see a ".reshare" within ".feedback"
+    When I confirm the alert after I follow "Reshare"
+    Then I should see a flash message indicating success
+    And I should see a flash message containing "successfully"
+    And I should not see a ".reshare" within ".feedback"
+
+  Scenario: Try to reshare an already reshared post from another user's profile
+    Given the post with text "reshare this!" is reshared by "alice@alice.alice"
+    When I sign in as "alice@alice.alice"
+    And I am on "bob@bob.bob"'s page
+    Then I should not see a ".reshare" within ".feedback"


### PR DESCRIPTION
Fixes #4816 and #6594.