### PR TITLE
Report view

### DIFF
--- a/app/assets/stylesheets/report.scss
+++ b/app/assets/stylesheets/report.scss
@@ -1,5 +1,9 @@
 #reports {
-  .reason {
+  .reason-label {
+    font-weight: bold;
+  }
+
+  .content {
     padding-bottom: 20px;
   }
   form input {

--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -6,7 +6,7 @@ module ReportHelper
   def report_content(report)
     case (item = report.item)
     when Post
-      raw t("report.post_label", title: link_to(post_page_title(item), post_path(item.id)))
+      raw t("report.post_label", content: link_to(post_message(item), post_path(item.id)))
     when Comment
       raw t("report.comment_label", data: link_to(
         h(comment_message(item)),

--- a/app/views/report/index.html.haml
+++ b/app/views/report/index.html.haml
@@ -17,11 +17,14 @@
               .panel-heading
                 .reporter.pull-right
                   = raw t("report.reported_label", person: link_to(username, user_profile_path(username)))
-                .title
-                  = report_content(report)
-              .panel-body
                 .reason
-                  = t("report.reason_label", text: report.text)
+                  %span.reason-label
+                    = t("report.reason_label")
+                  %span
+                    = report.text
+              .panel-body
+                .content
+                  = report_content(report)
 
                 = button_to t("report.reported_user_details"),
                   user_search_path(admins_controller_user_search: {guid: report.reported_author.guid}),

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -946,10 +946,10 @@ en:
 
   report:
     title: "Reports overview"
-    post_label: "<b>Post</b>: %{title}"
-    comment_label: "<b>Comment</b>:<br>%{data}"
+    post_label: "<b>Post</b>: %{content}"
+    comment_label: "<b>Comment</b>: %{data}"
     reported_label: "<b>Reported by</b> %{person}"
-    reason_label: "Reason: %{text}"
+    reason_label: "Reason:"
     review_link: "Mark as reviewed"
     delete_link: "Delete item"
     reported_user_details: "Details on reported user"


### PR DESCRIPTION
Before:
![old_report_view](https://cloud.githubusercontent.com/assets/6507951/20176512/708b8d58-a748-11e6-8cfe-c61fb3c6093d.png)

This PR:
![new_report_view](https://cloud.githubusercontent.com/assets/6507951/20176517/7735f242-a748-11e6-888a-b6f5255ea13e.png)

I think it's more logical to display **reason** and **reported by** on the same line. Besides sometimes **Post** sections are displayed on 2 or 3 lines, and break headers.

I also now display full message on **Post** section, because, as a podmin, sometimes one and half line is not enough to understand report without clicking on it. I think it can be usefull for spam, for instance: you have the full message and don't have to click on every spam message to delete them.

I was thinking to truncate messages (20 lines?) but my ruby skills are very limited. Any help appreciated :)