### PR TITLE
Force jasmine fails on syntax errors

### DIFF
--- a/spec/javascripts/onerror-fail.js
+++ b/spec/javascripts/onerror-fail.js
@@ -1,0 +1,7 @@
+window.onerror = function(errorMsg, url, lineNumber) {
+  describe("Test suite", function() {
+    it("shouldn't skip tests because of syntax errors", function() {
+      fail(errorMsg + " in file " + url + " in line " + lineNumber);
+    });
+  });
+};

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -53,6 +53,7 @@ helpers:
 #   - **/*[sS]pec.js
 #
 spec_files:
+  - onerror-fail.js
   - "**/**/*[sS]pec.js"
 
 # src_dir


### PR DESCRIPTION
Jasmine skips tests when there is a syntax error in the spec file. This means that we won't notice this unless eslint finds the syntax error.

For more information see https://github.com/jasmine/jasmine/issues/326.

This PR forces jasmine to fail on syntax errors. The error I fixed in https://github.com/diaspora/diaspora/commit/5269a0d3c0038a516eeb32e6f751e91084d0ddb4 would show the following error:

```
Failures:
          Test suite shouldn't skip tests because of syntax errors

          Failed: SyntaxError: Unexpected token ')' in file http://localhost:35307/__spec__/app/views/aspect_membership_view_spec.js in line 62
          stack@http://localhost:35307/__jasmine__/jasmine.js:1640:37
buildExpectationResult@http://localhost:35307/__jasmine__/jasmine.js:1610:19
expectationResultFactory@http://localhost:35307/__jasmine__/jasmine.js:655:40
addExpectationResult@http://localhost:35307/__jasmine__/jasmine.js:342:58
fail@http://localhost:35307/__jasmine__/jasmine.js:1019:45
fail@http://localhost:35307/__jasmine__/jasmine.js:3624:28
http://localhost:35307/__spec__/onerror-fail.js:4:11
```