### PR TITLE
Don't show browser notifications on pageload

### DIFF
--- a/app/assets/javascripts/app/collections/notifications.js
+++ b/app/assets/javascripts/app/collections/notifications.js
@@ -11,12 +11,8 @@ app.collections.Notifications = Backbone.Collection.extend({
   timeout: 300000, // 5 minutes
 
   initialize: function() {
-    this.pollNotifications();
-
-    setTimeout(function() {
-      setInterval(this.pollNotifications.bind(this), this.timeout);
-    }.bind(this), this.timeout);
-
+    this.fetch();
+    setInterval(this.pollNotifications.bind(this), this.timeout);
     Diaspora.BrowserNotification.requestPermission();
   },
 

--- a/spec/javascripts/app/collections/notifications_collection_spec.js
+++ b/spec/javascripts/app/collections/notifications_collection_spec.js
@@ -1,9 +1,9 @@
 describe("app.collections.Notifications", function() {
   describe("initialize", function() {
-    it("calls pollNotifications", function() {
-      spyOn(app.collections.Notifications.prototype, "pollNotifications");
+    it("calls fetch", function() {
+      spyOn(app.collections.Notifications.prototype, "fetch");
       new app.collections.Notifications();
-      expect(app.collections.Notifications.prototype.pollNotifications).toHaveBeenCalled();
+      expect(app.collections.Notifications.prototype.fetch).toHaveBeenCalled();
     });
 
     it("calls Diaspora.BrowserNotification.requestPermission", function() {
@@ -23,6 +23,16 @@ describe("app.collections.Notifications", function() {
       expect(target.unreadCount).toBe(0);
       expect(target.unreadCountByType).toEqual({});
     });
+
+    it("repeatedly calls pollNotifications", function() {
+      spyOn(app.collections.Notifications.prototype, "pollNotifications").and.callThrough();
+      var collection = new app.collections.Notifications();
+      expect(app.collections.Notifications.prototype.pollNotifications).not.toHaveBeenCalled();
+      jasmine.clock().tick(collection.timeout);
+      expect(app.collections.Notifications.prototype.pollNotifications).toHaveBeenCalledTimes(1);
+      jasmine.clock().tick(collection.timeout);
+      expect(app.collections.Notifications.prototype.pollNotifications).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe("pollNotifications", function() {
@@ -31,9 +41,9 @@ describe("app.collections.Notifications", function() {
     });
 
     it("calls fetch", function() {
-      spyOn(app.collections.Notifications.prototype, "fetch");
+      spyOn(this.target, "fetch");
       this.target.pollNotifications();
-      expect(app.collections.Notifications.prototype.fetch).toHaveBeenCalled();
+      expect(this.target.fetch).toHaveBeenCalled();
     });
 
     it("doesn't call Diaspora.BrowserNotification.spawnNotification when there are no new notifications", function() {
@@ -51,14 +61,6 @@ describe("app.collections.Notifications", function() {
       this.target.pollNotifications();
       this.target.trigger("finishedLoading");
       expect(Diaspora.BrowserNotification.spawnNotification).toHaveBeenCalled();
-    });
-
-    it("refreshes after timeout", function() {
-      spyOn(app.collections.Notifications.prototype, "pollNotifications").and.callThrough();
-      this.target.pollNotifications();
-      expect(app.collections.Notifications.prototype.pollNotifications).toHaveBeenCalledTimes(1);
-      jasmine.clock().tick(2 * this.target.timeout);
-      expect(app.collections.Notifications.prototype.pollNotifications).toHaveBeenCalledTimes(2);
     });
   });
 


### PR DESCRIPTION
by calling `fetch` instead of `pollNotifications`. When loading the page you already see that you have new notifications and I don't think that a browser notification is needed here.

I also removed the `setTimeout` call when initializing the notifications collection. `pollNotifications` will be called the first time after `this.timeout` and we don't need an additional timeout here. (See https://html.spec.whatwg.org/multipage/webappapis.html#timer-initialisation-steps)