### PR TITLE
Remove the duplicate "stream" container…

### DIFF
--- a/app/views/conversations/_show.haml
+++ b/app/views/conversations/_show.haml
@@ -25,4 +25,4 @@
   - for participant in conversation.participants
     = person_image_link(participant, :size => :thumb_small)
 
-= render partial: 'messages', locals: { conversation: conversation }
+= render partial: "messages", locals: {conversation: conversation}

--- a/app/views/conversations/_show.haml
+++ b/app/views/conversations/_show.haml
@@ -25,5 +25,4 @@
   - for participant in conversation.participants
     = person_image_link(participant, :size => :thumb_small)
 
-.stream
-  = render partial: 'messages', locals: { conversation: conversation }
+= render partial: 'messages', locals: { conversation: conversation }


### PR DESCRIPTION
…which already gets added in the "messages" partial.

This is to remove the duplicate `<div class="stream">` container in the conversations view.