### PR TITLE
Remove user_methods require line

### DIFF
--- a/spec/support/fixture_builder.rb
+++ b/spec/support/fixture_builder.rb
@@ -1,5 +1,3 @@
-require File.join(File.dirname(__FILE__), "user_methods.rb")
-
 FixtureBuilder.configure do |fbuilder|
 
   # rebuild fixtures automatically when these files change:


### PR DESCRIPTION
No need to explicitly require user_methods.rb since it is already required in spec_helper.rb