### PR TITLE
Added support for 3rd party s3-compatible object storage

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -26,6 +26,9 @@ defaults:
       bucket:
       region:
       cache: true
+      host: "s3.amazonaws.com"
+      endpoint: "https://s3.amazonaws.com"
+
     image_redirect_url:
     assets:
       serve: false

--- a/config/diaspora.yml.example
+++ b/config/diaspora.yml.example
@@ -116,6 +116,8 @@ configuration: ## Section
       #secret: 'change_me'
       #bucket: 'my_photos'
       #region: 'us-east-1'
+      #host: 's3.amazonaws.com'
+      #endpoint: 'https://s3.amazonaws.com'
 
       ## Use max-age header on Amazon S3 resources (default=true).
       ## When true, this allows locally cached images to be served for up to

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -12,7 +12,10 @@ CarrierWave.configure do |config|
         provider:              'AWS',
         aws_access_key_id:     AppConfig.environment.s3.key.get,
         aws_secret_access_key: AppConfig.environment.s3.secret.get,
-        region:                AppConfig.environment.s3.region.get
+        region:                AppConfig.environment.s3.region.get,
+        host:                  AppConfig.environment.s3.host.get,
+        endpoint:              AppConfig.environment.s3.endpoint.get,
+        path_style:            true
     }
     if AppConfig.environment.s3.cache?
       config.fog_attributes['Cache-Control'] = 'max-age=31536000'


### PR DESCRIPTION
In regards to issue #7243, I was able to modify the carrierwave settings to enable my pod to use minio as an s3 backend. For some reason using the 'bucketname.example.com' form of uploading was throwing an SSLv3 error, so I had to enable `:path_style = true` to get around this, which uses 'example.com/bucketname' instead.