### PR TITLE
Fix year bg color on /notifications

### DIFF
--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -10,7 +10,6 @@
     .framed-content { padding-bottom: 10px; }
 
     .year {
-      background-color: $white;
       color: $text-grey;
       font-size: 40px;
       line-height: 40px;


### PR DESCRIPTION
**Before**
![notif](https://cloud.githubusercontent.com/assets/930064/21597264/ec5c522c-d147-11e6-928d-01a97f5b8bbf.png)
**After**
![notif2](https://cloud.githubusercontent.com/assets/930064/21597265/ec87335c-d147-11e6-8e88-d0ba85486d9c.png)

If we really want to be able to set a specific color to the year background we should use another variable than `$white` but I feel this is useless.