### PR TITLE
Remove Vines mention, fix #7262

### DIFF
--- a/config/diaspora.yml.example
+++ b/config/diaspora.yml.example
@@ -249,7 +249,7 @@ configuration: ## Section
         ## Configure the protocol used to access the BOSH endpoint
         #proto: http
 
-        ## Configure the address that vines should listen on.
+        ## Configure the address that prosody should listen on.
         #address: '0.0.0.0'
 
         ## Configure the BOSH port.


### PR DESCRIPTION
I checked but found no other mention of "vines" except in the changelog so we're good.