### PR TITLE
Increase the spacing above and below post contents

### DIFF
--- a/app/assets/stylesheets/stream_element.scss
+++ b/app/assets/stylesheets/stream_element.scss
@@ -96,7 +96,17 @@
       font-size: $font-size-small;
       line-height: $font-size-small;
     }
-    .post-content p:last-of-type { margin-bottom: 0; }
+
+    .post-content {
+      .markdown-content {
+        padding: .8em 0 .4em;
+      }
+
+      p:last-of-type {
+        margin-bottom: 0;
+      }
+    }
+
     .nsfw-shield {
       color: $text-grey;
       padding: 5px 10px;


### PR DESCRIPTION
Posts look incredibly cramped below their title line. This PR increases the spacing a bit.

Before:
<img width="867" alt="screen shot 2017-01-03 at 22 31 31" src="https://cloud.githubusercontent.com/assets/344777/21623825/9168423c-d204-11e6-8865-89f0bfb94a16.png">

After:
<img width="868" alt="screen shot 2017-01-03 at 22 31 12" src="https://cloud.githubusercontent.com/assets/344777/21623828/95062b02-d204-11e6-8fb7-91c5bb448f69.png">