### PR TITLE
Bump json

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem "diaspora_federation-rails", "0.1.7"
 # API and JSON
 
 gem "acts_as_api", "0.4.3"
-gem "json",        "1.8.3"
+gem "json",        "1.8.6"
 gem "json-schema", "2.7.0"
 
 # Authentication

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -449,7 +449,7 @@ GEM
       sprockets-rails
     js_image_paths (0.1.0)
       rails (~> 4.0)
-    json (1.8.3)
+    json (1.8.6)
     json-jwt (1.6.3)
       activesupport
       bindata
@@ -954,7 +954,7 @@ DEPENDENCIES
   jquery-ui-rails (= 5.0.5)
   js-routes (= 1.2.9)
   js_image_paths (= 0.1.0)
-  json (= 1.8.3)
+  json (= 1.8.6)
   json-schema (= 2.7.0)
   json_spec (= 1.1.4)
   leaflet-rails (= 0.7.7)


### PR DESCRIPTION
Json 1.8.3 was incompatible with Ruby 2.4. Rails 4.2 is still incompatible but that will be fixed in the next release. I tried https://github.com/rails/rails/issues/27670#issuecomment-272433797 and it looks like that's is the only thing left we need for Ruby 2.4 support.