### PR TITLE
Update spring binstub

### DIFF
--- a/bin/spring
+++ b/bin/spring
@@ -7,9 +7,10 @@ unless defined?(Spring)
   require 'rubygems'
   require 'bundler'
 
-  if (match = Bundler.default_lockfile.read.match(/^GEM$.*?^    (?:  )*spring \((.*?)\)$.*?^$/m))
-    Gem.paths = { 'GEM_PATH' => [Bundler.bundle_path.to_s, *Gem.path].uniq }
-    gem 'spring', match[1]
+  lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
+  if spring = lockfile.specs.detect { |spec| spec.name == "spring" }
+    Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
+    gem 'spring', spring.version
     require 'spring/binstub'
   end
 end


### PR DESCRIPTION
Fixes the ``Array values in the parameter to `Gem.paths=` are deprecated.`` warning.