### PR TITLE
Bump asset_sync

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ gem "activerecord-import", "0.15.0"
 
 # File uploading
 
-gem "fog",         "1.38.0", require: "fog/aws"
+gem "fog-aws",     "1.2.0"
 gem "carrierwave", "0.11.2"
 gem "mini_magick", "4.5.1"
 
@@ -231,7 +231,7 @@ group :production do # we don"t install these on travis to speed up test runs
 
   # Third party asset hosting
 
-  gem "asset_sync", "1.1.0", require: false
+  gem "asset_sync", "2.0.0", require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ GEM
   remote: https://rubygems.org/
   remote: https://rails-assets.org/
   specs:
-    CFPropertyList (2.3.2)
     actionmailer (4.2.7.1)
       actionpack (= 4.2.7.1)
       actionview (= 4.2.7.1)
@@ -50,9 +49,10 @@ GEM
       rack (>= 1.1.0)
     addressable (2.4.0)
     arel (6.0.4)
-    asset_sync (1.1.0)
+    asset_sync (2.0.0)
       activemodel
-      fog (>= 1.8.0)
+      fog-core
+      mime-types
       unf
     ast (2.3.0)
     attr_required (1.0.1)
@@ -65,7 +65,7 @@ GEM
       sass (>= 3.3.4)
     bootstrap-switch-rails (3.3.3)
     buftok (0.2.0)
-    builder (3.2.2)
+    builder (3.2.3)
     byebug (9.0.5)
     capybara (2.10.1)
       addressable
@@ -196,7 +196,7 @@ GEM
       rake
     ethon (0.10.1)
       ffi (>= 1.3.0)
-    excon (0.49.0)
+    excon (0.54.0)
     execjs (2.7.0)
     eye (0.8.1)
       celluloid (~> 0.17.3)
@@ -217,135 +217,21 @@ GEM
     faraday_middleware (0.10.0)
       faraday (>= 0.7.4, < 0.10)
     ffi (1.9.14)
-    fission (0.5.0)
-      CFPropertyList (~> 2.2)
     fixture_builder (0.4.1)
       activerecord (>= 2)
       activesupport (>= 2)
-    fog (1.38.0)
-      fog-aliyun (>= 0.1.0)
-      fog-atmos
-      fog-aws (>= 0.6.0)
-      fog-brightbox (~> 0.4)
-      fog-cloudatcost (~> 0.1.0)
-      fog-core (~> 1.32)
-      fog-dynect (~> 0.0.2)
-      fog-ecloud (~> 0.1)
-      fog-google (<= 0.1.0)
-      fog-json
-      fog-local
-      fog-openstack
-      fog-powerdns (>= 0.1.1)
-      fog-profitbricks
-      fog-rackspace
-      fog-radosgw (>= 0.0.2)
-      fog-riakcs
-      fog-sakuracloud (>= 0.0.4)
-      fog-serverlove
-      fog-softlayer
-      fog-storm_on_demand
-      fog-terremark
-      fog-vmfusion
-      fog-voxel
-      fog-vsphere (>= 0.4.0)
-      fog-xenserver
-      fog-xml (~> 0.1.1)
-      ipaddress (~> 0.5)
-    fog-aliyun (0.1.0)
-      fog-core (~> 1.27)
-      fog-json (~> 1.0)
-      ipaddress (~> 0.8)
-      xml-simple (~> 1.1)
-    fog-atmos (0.1.0)
-      fog-core
-      fog-xml
-    fog-aws (0.9.2)
-      fog-core (~> 1.27)
+    fog-aws (1.2.0)
+      fog-core (~> 1.38)
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
       ipaddress (~> 0.8)
-    fog-brightbox (0.10.1)
-      fog-core (~> 1.22)
-      fog-json
-      inflecto (~> 0.0.2)
-    fog-cloudatcost (0.1.2)
-      fog-core (~> 1.36)
-      fog-json (~> 1.0)
-      fog-xml (~> 0.1)
-      ipaddress (~> 0.8)
-    fog-core (1.40.0)
+    fog-core (1.43.0)
       builder
       excon (~> 0.49)
       formatador (~> 0.2)
-    fog-dynect (0.0.3)
-      fog-core
-      fog-json
-      fog-xml
-    fog-ecloud (0.3.0)
-      fog-core
-      fog-xml
-    fog-google (0.1.0)
-      fog-core
-      fog-json
-      fog-xml
     fog-json (1.0.2)
       fog-core (~> 1.0)
       multi_json (~> 1.10)
-    fog-local (0.3.0)
-      fog-core (~> 1.27)
-    fog-openstack (0.1.5)
-      fog-core (>= 1.38)
-      fog-json (>= 1.0)
-      fog-xml (>= 0.1)
-      ipaddress (>= 0.8)
-    fog-powerdns (0.1.1)
-      fog-core (~> 1.27)
-      fog-json (~> 1.0)
-      fog-xml (~> 0.1)
-    fog-profitbricks (0.0.5)
-      fog-core
-      fog-xml
-      nokogiri
-    fog-rackspace (0.1.1)
-      fog-core (>= 1.35)
-      fog-json (>= 1.0)
-      fog-xml (>= 0.1)
-      ipaddress (>= 0.8)
-    fog-radosgw (0.0.5)
-      fog-core (>= 1.21.0)
-      fog-json
-      fog-xml (>= 0.0.1)
-    fog-riakcs (0.1.0)
-      fog-core
-      fog-json
-      fog-xml
-    fog-sakuracloud (1.7.5)
-      fog-core
-      fog-json
-    fog-serverlove (0.1.2)
-      fog-core
-      fog-json
-    fog-softlayer (1.1.1)
-      fog-core
-      fog-json
-    fog-storm_on_demand (0.1.1)
-      fog-core
-      fog-json
-    fog-terremark (0.1.0)
-      fog-core
-      fog-xml
-    fog-vmfusion (0.1.0)
-      fission
-      fog-core
-    fog-voxel (0.1.0)
-      fog-core
-      fog-xml
-    fog-vsphere (0.6.4)
-      fog-core
-      rbvmomi (~> 1.8)
-    fog-xenserver (0.2.3)
-      fog-core
-      fog-xml
     fog-xml (0.1.2)
       fog-core
       nokogiri (~> 1.5, >= 1.5.11)
@@ -429,7 +315,6 @@ GEM
       actionpack (>= 3.0.0)
       i18n-inflector (~> 2.6)
       railties (>= 3.0.0)
-    inflecto (0.0.2)
     ipaddress (0.8.3)
     jasmine (2.5.1)
       jasmine-core (>= 2.5.1, < 3.0.0)
@@ -712,10 +597,6 @@ GEM
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
-    rbvmomi (1.8.2)
-      builder
-      nokogiri (>= 1.4.1)
-      trollop
     redcarpet (3.3.4)
     redis (3.3.1)
     redis-namespace (1.5.2)
@@ -838,7 +719,6 @@ GEM
     timers (4.1.1)
       hitimes
     tins (1.12.0)
-    trollop (2.1.2)
     turbo_dev_assets (0.0.2)
     twitter (5.16.0)
       addressable (~> 2.3)
@@ -898,7 +778,6 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
     will_paginate (3.1.5)
-    xml-simple (1.1.5)
     xpath (2.0.0)
       nokogiri (~> 1.3)
     yard (0.8.7.6)
@@ -912,7 +791,7 @@ DEPENDENCIES
   acts-as-taggable-on (= 3.5.0)
   acts_as_api (= 0.4.3)
   addressable (= 2.4.0)
-  asset_sync (= 1.1.0)
+  asset_sync (= 2.0.0)
   autoprefixer-rails (= 6.5.1)
   bootstrap-sass (= 3.3.7)
   bootstrap-switch-rails (= 3.3.3)
@@ -936,7 +815,7 @@ DEPENDENCIES
   faraday-cookie_jar (= 0.0.6)
   faraday_middleware (= 0.10.0)
   fixture_builder (= 0.4.1)
-  fog (= 1.38.0)
+  fog-aws (= 1.2.0)
   fuubar (= 2.2.0)
   gon (= 6.1.0)
   guard (= 2.14.0)


### PR DESCRIPTION
This new version now has `fog-core` instead of `fog` as dependency. We can now only add `fog-aws` as dependency and remove all other fog provider (30 dependencies less! 🎉 ).

Since I have no AWS, maybe somebody with AWS can test if everything still works. Pinging @jramos because he did #7201.