### PR TITLE
Enable CSP in .diaspora.yml.example

### DIFF
--- a/config/diaspora.yml.example
+++ b/config/diaspora.yml.example
@@ -574,7 +574,7 @@ configuration: ## Section
       ## Report-Only header (default=true)
       ## By default diaspora* adds only a "Content-Security-Policy-Report-Only" header. If you set
       ## this to false, the "Content-Security-Policy" header is added instead.
-      #report_only: false
+      report_only: false
 
       ## CSP report URI (default=)
       ## You can set an URI here, where the user agent reports violations as JSON document via a POST request.


### PR DESCRIPTION
Users don't change defaults, so shipping this defaulting to off isn't really enough. It can't be enabled by default for everyone because it might break people's installs unexpectedly, so we enable it only for new installs by putting it in the example config.

Context: https://github.com/diaspora/diaspora/issues/7293#issuecomment-275014255