### PR TITLE
New mention syntax - backend changes

### DIFF
--- a/lib/diaspora/mentionable.rb
+++ b/lib/diaspora/mentionable.rb
@@ -29,8 +29,8 @@ module Diaspora::Mentionable
     people = [*people]
 
     msg_text.to_s.gsub(REGEX) {|match_str|
-      name, handle = mention_attrs(match_str)
-      person = people.find {|p| p.diaspora_handle == handle }
+      name, diaspora_id = mention_attrs(match_str)
+      person = people.find {|p| p.diaspora_handle == diaspora_id }
 
       ERB::Util.h(MentionsInternal.mention_link(person, name, opts))
     }
@@ -42,10 +42,7 @@ module Diaspora::Mentionable
   # @param [String] text containing mentions
   # @return [Array<Person>] array of people
   def self.people_from_string(msg_text)
-    identifiers = msg_text.to_s.scan(REGEX).map do |match_str|
-      identifier = match_str.second.strip
-      identifier if Validation::Rule::DiasporaId.new.valid_value?(identifier)
-    end
+    identifiers = msg_text.to_s.scan(REGEX).map {|match_str| match_str.second.strip }
 
     identifiers.compact.uniq.map {|identifier| find_or_fetch_person_by_identifier(identifier) }.compact
   end
@@ -61,16 +58,30 @@ module Diaspora::Mentionable
     mentioned_ppl = people_from_string(msg_text)
 
     msg_text.to_s.gsub(REGEX) {|match_str|
-      name, handle = mention_attrs(match_str)
-      person = mentioned_ppl.find {|p| p.diaspora_handle == handle }
+      name, diaspora_id = mention_attrs(match_str)
+      person = mentioned_ppl.find {|p| p.diaspora_handle == diaspora_id }
       mention = MentionsInternal.profile_link(person, name) unless allowed_people.include?(person.id)
 
       mention || match_str
     }
   end
 
+  # Regex to find mentions with new syntax, only used for backporting to old syntax
+  NEW_SYNTAX_REGEX = /@\{[^ ]+\}/
+
+  # replaces new syntax with old syntax, to be compatible with old pods
+  # @deprecated remove when most of the posts can handle the new syntax
+  def self.backport_mention_syntax(text)
+    text.to_s.gsub(NEW_SYNTAX_REGEX) do |match_str|
+      _, diaspora_id = mention_attrs(match_str)
+      person = find_or_fetch_person_by_identifier(diaspora_id)
+      old_syntax = "@{#{person.name}; #{diaspora_id}}" if person
+      old_syntax || match_str
+    end
+  end
+
   private_class_method def self.find_or_fetch_person_by_identifier(identifier)
-    Person.find_or_fetch_by_identifier(identifier)
+    Person.find_or_fetch_by_identifier(identifier) if Validation::Rule::DiasporaId.new.valid_value?(identifier)
   rescue DiasporaFederation::Discovery::DiscoveryError
     nil
   end

--- a/lib/diaspora/mentions_container.rb
+++ b/lib/diaspora/mentions_container.rb
@@ -3,6 +3,11 @@ module Diaspora
     extend ActiveSupport::Concern
 
     included do
+      before_create do
+        # TODO: remove when most of the posts can handle the new syntax
+        self.text = Diaspora::Mentionable.backport_mention_syntax(text) if text
+      end
+
       after_create :create_mentions
       has_many :mentions, as: :mentions_container, dependent: :destroy
     end

--- a/lib/diaspora/message_renderer.rb
+++ b/lib/diaspora/message_renderer.rb
@@ -79,7 +79,7 @@ module Diaspora
       end
 
       def make_mentions_plain_text
-        @message = Diaspora::Mentionable.format message, [], plain_text: true
+        @message = Diaspora::Mentionable.format message, options[:mentioned_people], plain_text: true
       end
 
       def render_tags

--- a/spec/lib/diaspora/mentionable_spec.rb
+++ b/spec/lib/diaspora/mentionable_spec.rb
@@ -175,4 +175,29 @@ STR
       expect(txt).to include(@mention_b)
     end
   end
+
+  describe ".backport_mention_syntax" do
+    it "replaces the new syntax with the old syntax" do
+      text = "mention @{#{@people[0].diaspora_handle}} text"
+      expected_text = "mention @{#{@people[0].name}; #{@people[0].diaspora_handle}} text"
+      expect(Diaspora::Mentionable.backport_mention_syntax(text)).to eq(expected_text)
+    end
+
+    it "does not change the text, when the mention includes a name" do
+      text = "mention @{#{@names[0]}; #{@people[0].diaspora_handle}} text"
+      expect(Diaspora::Mentionable.backport_mention_syntax(text)).to eq(text)
+    end
+
+    it "does not change the text, when the person is not found" do
+      text = "mention @{non_existing_user@example.org} text"
+      expect(Person).to receive(:find_or_fetch_by_identifier).with("non_existing_user@example.org").and_return(nil)
+      expect(Diaspora::Mentionable.backport_mention_syntax(text)).to eq(text)
+    end
+
+    it "does not change the text, when the diaspora ID is invalid" do
+      text = "mention @{invalid_diaspora_id} text"
+      expect(Person).not_to receive(:find_or_fetch_by_identifier)
+      expect(Diaspora::Mentionable.backport_mention_syntax(text)).to eq(text)
+    end
+  end
 end

--- a/spec/lib/diaspora/message_renderer_spec.rb
+++ b/spec/lib/diaspora/message_renderer_spec.rb
@@ -191,6 +191,18 @@ describe Diaspora::MessageRenderer do
       text = "#hashtag message"
       expect(message(text).plain_text_without_markdown).to eq text
     end
+
+    context "with mention" do
+      it "contains the name of the mentioned person" do
+        msg = message("@{#{alice.diaspora_handle}} is cool", mentioned_people: alice.person)
+        expect(msg.plain_text_without_markdown).to eq "#{alice.name} is cool"
+      end
+
+      it "uses the name from mention when the mention contains a name" do
+        msg = message("@{Alice; #{alice.diaspora_handle}} is cool", mentioned_people: alice.person)
+        expect(msg.plain_text_without_markdown).to eq "Alice is cool"
+      end
+    end
   end
 
   describe "#urls" do

--- a/spec/shared_behaviors/mentions_container.rb
+++ b/spec/shared_behaviors/mentions_container.rb
@@ -10,6 +10,16 @@ shared_examples_for "it is mentions container" do
     target
   }
 
+  describe ".before_create" do
+    it "backports mention syntax to old syntax" do
+      text = "mention @{#{people[0].diaspora_handle}} text"
+      expected_text = "mention @{#{people[0].name}; #{people[0].diaspora_handle}} text"
+      obj = FactoryGirl.build(described_class.to_s.underscore.to_sym, text: text, author: alice.person)
+      obj.save
+      expect(obj.text).to eq(expected_text)
+    end
+  end
+
   describe ".after_create" do
     it "calls create_mentions" do
       expect(target).to receive(:create_mentions).and_call_original


### PR DESCRIPTION
This are the changes needed in the backend for #7276.

It adds support for the new syntax and converts new syntax to the old syntax on create (to be backward compatible with old pods when changing the frontend to the new syntax).
