### PR TITLE
Bump markdown-it-diaspora-mention

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,7 +96,7 @@ source "https://rails-assets.org" do
 
   gem "rails-assets-markdown-it",                         "8.2.2"
   gem "rails-assets-markdown-it-hashtag",                 "0.4.0"
-  gem "rails-assets-markdown-it-diaspora-mention",        "1.1.0"
+  gem "rails-assets-markdown-it-diaspora-mention",        "1.1.1"
   gem "rails-assets-markdown-it-sanitizer",               "0.4.3"
   gem "rails-assets-markdown-it--markdown-it-for-inline", "0.1.1"
   gem "rails-assets-markdown-it-sub",                     "1.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -666,7 +666,7 @@ GEM
       rails-assets-jquery (>= 1.6)
     rails-assets-markdown-it--markdown-it-for-inline (0.1.1)
     rails-assets-markdown-it (8.2.2)
-    rails-assets-markdown-it-diaspora-mention (1.1.0)
+    rails-assets-markdown-it-diaspora-mention (1.1.1)
     rails-assets-markdown-it-hashtag (0.4.0)
     rails-assets-markdown-it-sanitizer (0.4.3)
     rails-assets-markdown-it-sub (1.0.0)
@@ -1002,7 +1002,7 @@ DEPENDENCIES
   rails-assets-jquery-textchange (= 0.2.3)!
   rails-assets-markdown-it (= 8.2.2)!
   rails-assets-markdown-it--markdown-it-for-inline (= 0.1.1)!
-  rails-assets-markdown-it-diaspora-mention (= 1.1.0)!
+  rails-assets-markdown-it-diaspora-mention (= 1.1.1)!
   rails-assets-markdown-it-hashtag (= 0.4.0)!
   rails-assets-markdown-it-sanitizer (= 0.4.3)!
   rails-assets-markdown-it-sub (= 1.0.0)!


### PR DESCRIPTION
Implements https://github.com/diaspora/diaspora/pull/7300#discussion_r98343218, fixes mentions for user names with semicolons.