### PR TITLE
Use jQuery 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,13 +86,13 @@ gem "entypo-rails", "3.0.0"
 # JavaScript
 
 gem "handlebars_assets", "0.23.1"
-gem "jquery-rails",      "4.2.1"
+gem "jquery-rails",      "4.2.2"
 gem "jquery-ui-rails",   "5.0.5"
 gem "js-routes",         "1.3.3"
 gem "js_image_paths",    "0.1.0"
 
 source "https://rails-assets.org" do
-  gem "rails-assets-jquery",                              "2.2.4" # Should be kept in sync with jquery-rails
+  gem "rails-assets-jquery",                              "3.1.1" # Should be kept in sync with jquery-rails
 
   gem "rails-assets-highlightjs",                         "9.9.0"
   gem "rails-assets-markdown-it",                         "8.3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -324,7 +324,7 @@ GEM
       rake
     jasmine-core (2.5.2)
     jasmine-jquery-rails (2.0.3)
-    jquery-rails (4.2.1)
+    jquery-rails (4.2.2)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
@@ -540,7 +540,7 @@ GEM
     rails-assets-jasmine (2.5.2)
     rails-assets-jasmine-ajax (3.3.1)
       rails-assets-jasmine (~> 2)
-    rails-assets-jquery (2.2.4)
+    rails-assets-jquery (3.1.1)
     rails-assets-jquery-colorbox (1.6.4)
       rails-assets-jquery (>= 1.3.2)
     rails-assets-jquery-fullscreen-plugin (0.5.0)
@@ -831,7 +831,7 @@ DEPENDENCIES
   i18n-inflector-rails (= 1.0.7)
   jasmine (= 2.5.2)
   jasmine-jquery-rails (= 2.0.3)
-  jquery-rails (= 4.2.1)
+  jquery-rails (= 4.2.2)
   jquery-ui-rails (= 5.0.5)
   js-routes (= 1.3.3)
   js_image_paths (= 0.1.0)
@@ -878,7 +878,7 @@ DEPENDENCIES
   rails-assets-fine-uploader (= 5.13.0)!
   rails-assets-highlightjs (= 9.9.0)!
   rails-assets-jasmine-ajax (= 3.3.1)!
-  rails-assets-jquery (= 2.2.4)!
+  rails-assets-jquery (= 3.1.1)!
   rails-assets-jquery-placeholder (= 2.3.1)!
   rails-assets-jquery-textchange (= 0.2.3)!
   rails-assets-markdown-it (= 8.3.0)!
@@ -928,4 +928,4 @@ DEPENDENCIES
   will_paginate (= 3.1.5)
 
 BUNDLED WITH
-   1.14.5
+   1.14.6

--- a/app/assets/javascripts/jasmine-load-all.js
+++ b/app/assets/javascripts/jasmine-load-all.js
@@ -1,4 +1,4 @@
-//= require jquery2
+//= require jquery3
 //= require handlebars.runtime
 //= require templates
 //= require main

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -52,11 +52,13 @@ module ApplicationHelper
   def jquery_include_tag
     buf = []
     if AppConfig.privacy.jquery_cdn?
-      version = Jquery::Rails::JQUERY_2_VERSION
+      version = Jquery::Rails::JQUERY_3_VERSION
       buf << [javascript_include_tag("//code.jquery.com/jquery-#{version}.min.js")]
-      buf << [nonced_javascript_tag("!window.jQuery && document.write(unescape('#{j javascript_include_tag('jquery2')}'));")]
+      buf << [
+        nonced_javascript_tag("!window.jQuery && document.write(unescape('#{j javascript_include_tag('jquery3')}'));")
+      ]
     else
-      buf << [javascript_include_tag("jquery2")]
+      buf << [javascript_include_tag("jquery3")]
     end
     buf << [javascript_include_tag("jquery_ujs")]
     buf << [nonced_javascript_tag("jQuery.ajaxSetup({'cache': false});")]

--- a/config/application.rb
+++ b/config/application.rb
@@ -68,7 +68,7 @@ module Diaspora
     config.assets.precompile += %w(
       contact-list.js
       ie.js
-      jquery2.js
+      jquery3.js
       jquery_ujs.js
       main.js
       jsxc.js

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -54,7 +54,7 @@ describe ApplicationHelper, :type => :helper do
       end
 
       it 'includes jquery.js from asset pipeline' do
-        expect(helper.jquery_include_tag).to match(/jquery2\.js/)
+        expect(helper.jquery_include_tag).to match(/jquery3\.js/)
         expect(helper.jquery_include_tag).not_to match(/jquery\.com/)
       end
     end

--- a/spec/javascripts/app/app_spec.js
+++ b/spec/javascripts/app/app_spec.js
@@ -62,6 +62,10 @@ describe("app", function() {
   });
 
   describe("setupAjaxErrorRedirect", function() {
+    beforeEach(function() {
+      app.setupAjaxErrorRedirect();
+    });
+
     it("redirects to /users/sign_in on 401 ajax responses", function() {
       spyOn(app, "_changeLocation");
       $.ajax("/test");
@@ -115,7 +119,6 @@ describe("app", function() {
       beforeEach(function() {
         app.stream = {basePath: function() { return "/stream"; }};
         app.notificationsCollection = {fetch: $.noop};
-        spyOn(Backbone.history, "start");
         this.link = $("<a href='/backbone-link' rel='backbone'>");
         spec.content().append(this.link);
         app.setupBackboneLinks();
@@ -123,6 +126,7 @@ describe("app", function() {
 
       afterEach(function() {
         app.stream = undefined;
+        Backbone.history.stop();
       });
 
       it("calls Backbone.history.navigate", function() {


### PR DESCRIPTION
fixes #7179 

There are some breaking changes in jQuery 3. They are described in the [upgrade guide](https://jquery.com/upgrade-guide/3.0/).

The deprecated methods that was used in diaspora and had to be replaced:
- `.selector` property of jQuery object has been removed. This was largerly used in jasmine specs in order to test object type. Instead of the deprecated method I used [`.is`](https://api.jquery.com/is/) method. Since this approach requires real objects in DOM to be instanciated, I had to update examples code where it wasn't so.
- `error`, `unload`, `success` event helpers has been replaced with the non-deprecated aliases.

Also there was an issue, when bootstrap tried to use "#" as a selector. "#" is not a valid selector in jQuery 3 anymore and it produces an exception if anyone tries to use it so. It happened when bootstrap [called](https://github.com/twbs/bootstrap/blob/0b9c4a4007c44201dce9a6cc1a38407005c26c86/js/dropdown.js#L25) `attr('data-target')` on an object and received "#". In bootstrap v4 which is a current dev version it [can't happen](https://github.com/twbs/bootstrap/blob/v4-dev/js/src/util.js#L118), but since it's not released yet we can use a hack here. Later f91731d55bfd890f6918336cc44da472d3b395a9 can be just reverted.

Tests are green for me (let's see what travis will say). I didn't do deep manual testing. @pravi, could you test it please, since you were interested in having this implemented?