### PR TITLE
Issue#7297 Disallow blocking admins

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@
 ## Features
 * Add links to the aspects and followed tags pages on mobile [#7265](https://github.com/diaspora/diaspora/pull/7265)
 * diaspora\* is now available in Gàidhlig, Occitan, and Schwiizerdütsch
+* admins cannot be blocked anymore [#7279](https://github.com/diaspora/diaspora/issues/7297)
 
 # 0.6.2.0
 

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -8,10 +8,15 @@ class Block < ActiveRecord::Base
   validates :person_id, :presence => true, :uniqueness => { :scope => :user_id }
 
   validate :not_blocking_yourself
+  validate :not_blocking_podmin
 
   def not_blocking_yourself
     if self.user.person.id == self.person_id
       errors[:person_id] << "stop blocking yourself!"
     end
+  end
+
+  def not_blocking_podmin
+    errors[:person_id] << t("blocks.create.failure.podmin") if Role.exists?(person_id: person_id, name: "admin")
   end
 end

--- a/spec/models/block_spec.rb
+++ b/spec/models/block_spec.rb
@@ -4,5 +4,11 @@ describe Block, :type => :model do
       block = alice.blocks.create(person: alice.person)
       expect(block.errors[:person_id].size).to eq(1)
     end
+
+    it "doesnt allow you to block an admin" do
+      Role.add_admin(bob.person)
+      block = alice.blocks.create(person: bob.person)
+      expect(block.errors[:person_id].size).to eq(1)
+    end
   end
 end


### PR DESCRIPTION
This fixes a part of issue #7297 . It is now impossible to block admins.