### PR TITLE
Make the #newhere post public again

### DIFF
--- a/app/helpers/aspect_global_helper.rb
+++ b/app/helpers/aspect_global_helper.rb
@@ -11,7 +11,7 @@ module AspectGlobalHelper
     options
   end
 
-  def publisher_aspects_for(stream=nil)
+  def publisher_aspects_for(stream)
     if stream
       aspects = stream.aspects
       aspect = stream.aspect
@@ -24,17 +24,5 @@ module AspectGlobalHelper
       return {}
     end
     {selected_aspects: aspects, aspect: aspect, aspect_ids: aspect_ids}
-  end
-
-  def public_selected?(selected_aspects)
-    "public" == selected_aspects.try(:first)
-  end
-
-  def all_aspects_selected?(aspects, selected_aspects)
-    !aspects.empty? && aspects.size == selected_aspects.size && !public_selected?(selected_aspects)
-  end
-
-  def aspect_selected?(aspect, aspects, selected_aspects)
-    selected_aspects.include?(aspect) && !all_aspects_selected?(aspects, selected_aspects)
   end
 end

--- a/app/helpers/interim_stream_hackiness_helper.rb
+++ b/app/helpers/interim_stream_hackiness_helper.rb
@@ -38,12 +38,4 @@ module InterimStreamHackinessHelper
      []
     end
   end
-
-  def publisher_method(method)
-    @stream.try(:publisher).try(method) == true
-  end
-
-  def publisher_open
-    publisher_method(:open)
-  end
 end

--- a/app/helpers/publisher_helper.rb
+++ b/app/helpers/publisher_helper.rb
@@ -24,4 +24,22 @@ module PublisherHelper
       end
     end
   end
+
+  def public_selected?(selected_aspects)
+    "public" == selected_aspects.try(:first) || publisher_boolean?(:public)
+  end
+
+  def all_aspects_selected?(selected_aspects)
+    !all_aspects.empty? && all_aspects.size == selected_aspects.size && !public_selected?(selected_aspects)
+  end
+
+  def aspect_selected?(aspect, selected_aspects)
+    selected_aspects.include?(aspect) && !all_aspects_selected?(selected_aspects) && !public_selected?(selected_aspects)
+  end
+
+  private
+
+  def publisher_boolean?(option)
+    @stream.try(:publisher).try(option) == true
+  end
 end

--- a/app/helpers/publisher_helper.rb
+++ b/app/helpers/publisher_helper.rb
@@ -3,24 +3,18 @@
 #   the COPYRIGHT file.
 
 module PublisherHelper
-  def remote?
-    params[:controller] != "tags"
-  end
-
   def service_button(service)
-    provider_title = I18n.t(
-      "services.index.share_to",
-      provider: service.provider.titleize)
+    provider_title = I18n.t("services.index.share_to", provider: service.provider.titleize)
     content_tag :div,
                 class:   "btn btn-link service_icon dim",
                 title:   "#{provider_title} (#{service.nickname})",
-                id:      "#{service.provider}",
-                maxchar: "#{service.class::MAX_CHARACTERS}",
+                id:      service.provider,
+                maxchar: service.class::MAX_CHARACTERS,
                 data:    {toggle: "tooltip", placement: "bottom"} do
       if service.provider == "wordpress"
         content_tag(:span, "", class: "social-media-logos-wordpress-16x16")
       else
-        content_tag(:i, "", class: "entypo-social-#{ service.provider } small")
+        content_tag(:i, "", class: "entypo-social-#{service.provider} small")
       end
     end
   end
@@ -35,6 +29,10 @@ module PublisherHelper
 
   def aspect_selected?(aspect, selected_aspects)
     selected_aspects.include?(aspect) && !all_aspects_selected?(selected_aspects) && !public_selected?(selected_aspects)
+  end
+
+  def publisher_open?
+    publisher_boolean?(:open)
   end
 
   private

--- a/app/views/aspects/_aspect_dropdown.html.haml
+++ b/app/views/aspects/_aspect_dropdown.html.haml
@@ -15,7 +15,7 @@
     - else
       %i.entypo-lock.small#visibility-icon
       %span.text
-        - if all_aspects_selected?(all_aspects, selected_aspects)
+        - if all_aspects_selected?(selected_aspects)
           = t("all_aspects")
         - elsif selected_aspects.size == 1
           = selected_aspects.first.name
@@ -31,7 +31,7 @@
         %span.text
           = t("public")
     %li.all_aspects.radio{"data-aspect_id" => "all_aspects",
-      :class => ("selected" if all_aspects_selected?(all_aspects, selected_aspects))}
+      :class => ("selected" if all_aspects_selected?(selected_aspects))}
       %a
         %span.status_indicator
           %i.glyphicon.glyphicon-ok
@@ -40,7 +40,7 @@
     %li.divider
     - all_aspects.each do |aspect|
       %li.aspect_selector{"data-aspect_id" => aspect.id,
-        :class => ("selected" if aspect_selected?(aspect, all_aspects, selected_aspects))}
+        :class => ("selected" if aspect_selected?(aspect, selected_aspects))}
         %a
           %span.status_indicator
             %i.glyphicon.glyphicon-ok

--- a/app/views/publisher/_publisher.html.haml
+++ b/app/views/publisher/_publisher.html.haml
@@ -42,7 +42,7 @@
 
       - if public_selected?(selected_aspects)
         = hidden_field_tag "aspect_ids[]", "public"
-      - elsif all_aspects_selected?(all_aspects, selected_aspects)
+      - elsif all_aspects_selected?(selected_aspects)
         = hidden_field_tag "aspect_ids[]", "all_aspects"
       - else
         - for aspect_id in aspect_ids

--- a/app/views/publisher/_publisher.html.haml
+++ b/app/views/publisher/_publisher.html.haml
@@ -1,4 +1,4 @@
-.row.publisher#publisher{class: ((aspect == :profile || publisher_open) ? "mention_popup" : "closed")}
+.row.publisher#publisher{class: ((aspect == :profile || publisher_open?) ? "mention_popup" : "closed")}
   .content_creation
     = form_for(StatusMessage.new) do |status|
       = status.error_messages

--- a/features/desktop/signs_up.feature
+++ b/features/desktop/signs_up.feature
@@ -37,6 +37,11 @@ Feature: new user registration
     Then I should be on the stream page
     And I close the publisher
 
+  Scenario: first status message is public
+    When I confirm the alert after I follow "awesome_button"
+    Then I should be on the stream page
+    And I should see "Public" within ".aspect_dropdown"
+
   Scenario: new user without any tags posts first status message
     When I confirm the alert after I follow "awesome_button"
     Then I should be on the stream page

--- a/spec/helpers/publisher_helper_spec.rb
+++ b/spec/helpers/publisher_helper_spec.rb
@@ -1,0 +1,69 @@
+describe PublisherHelper, type: :helper do
+  describe "#public_selected?" do
+    it "returns true when the selected_aspects contains 'public'" do
+      expect(helper.public_selected?(["public"])).to be_truthy
+    end
+
+    it "returns true when the publisher is set to public" do
+      @stream = double(publisher: double(public: true))
+      expect(helper.public_selected?(alice.aspects.to_a)).to be_truthy
+    end
+
+    it "returns false when the selected_aspects does not contain 'public' and the publisher is not public" do
+      @stream = double(publisher: double(public: false))
+      expect(helper.public_selected?(alice.aspects.to_a)).to be_falsey
+    end
+
+    it "returns false when the selected_aspects does not contain 'public' and there is no stream" do
+      expect(helper.public_selected?(alice.aspects.to_a)).to be_falsey
+    end
+  end
+
+  describe "#all_aspects_selected?" do
+    it "returns true when the selected_aspects are the same size as all_aspects from the user" do
+      expect(helper).to receive(:all_aspects).twice.and_return(alice.aspects.to_a)
+      expect(helper.all_aspects_selected?(alice.aspects.to_a)).to be_truthy
+    end
+
+    it "returns false when not all aspects are selected" do
+      alice.aspects.create(name: "other")
+      expect(helper).to receive(:all_aspects).twice.and_return(alice.aspects.to_a)
+      expect(helper.all_aspects_selected?([alice.aspects.first])).to be_falsey
+    end
+
+    it "returns false when the user does not have aspects" do
+      expect(helper).to receive(:all_aspects).and_return([])
+      expect(helper.all_aspects_selected?(alice.aspects.to_a)).to be_falsey
+    end
+
+    it "returns false when the publisher is set to public" do
+      @stream = double(publisher: double(public: true))
+      expect(helper).to receive(:all_aspects).twice.and_return(alice.aspects.to_a)
+      expect(helper.all_aspects_selected?(alice.aspects.to_a)).to be_falsey
+    end
+  end
+
+  describe "#aspect_selected?" do
+    before do
+      alice.aspects.create(name: "other")
+      allow(helper).to receive(:all_aspects).and_return(alice.aspects.to_a)
+    end
+
+    it "returns true when the selected_aspects contains the aspect" do
+      expect(helper.aspect_selected?(alice.aspects.first, [alice.aspects.first])).to be_truthy
+    end
+
+    it "returns false when the selected_aspects does not contain the aspect" do
+      expect(helper.aspect_selected?(alice.aspects.first, [alice.aspects.second])).to be_falsey
+    end
+
+    it "returns false when all aspects are selected" do
+      expect(helper.aspect_selected?(alice.aspects.first, alice.aspects.to_a)).to be_falsey
+    end
+
+    it "returns false when the publisher is set to public" do
+      @stream = double(publisher: double(public: true))
+      expect(helper.aspect_selected?(alice.aspects.first, [alice.aspects.first])).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
This fixes a regression from #7118.

I also did some refactorings after discussing with @svbergerem how to fix this the best. We decided to move the helper methods to the `PublisherHelper` because they are used from the publisher, and the settings for the publisher.

I also removed the `aspects` parameter and used the `all_aspects` helper directly. I think that it is better readable to have less parameters. Also I was first confused whats the difference between `aspects` and `selected_aspects` is.