### PR TITLE
Unify blue color variables

### DIFF
--- a/app/assets/stylesheets/_mixins.scss
+++ b/app/assets/stylesheets/_mixins.scss
@@ -107,10 +107,10 @@ $default-border-radius: 3px;
       opacity: 0.9;
 
       a {
-        color: lighten($blue, 25%);
+        color: lighten($link-color, 25%);
       }
       a:visited {
-        color: $blue;
+        color: $link-color;
       }
     }
     .desc {

--- a/app/assets/stylesheets/bootstrap-variables.scss
+++ b/app/assets/stylesheets/bootstrap-variables.scss
@@ -676,7 +676,7 @@ $list-group-border: transparent;
 $list-group-border-radius: 0;
 
 //** Background color of single list items on hover
-$list-group-hover-bg: $link-color;
+$list-group-hover-bg: $brand-primary;
 //** Text color of active list items
 $list-group-active-color: $white;
 //** Background color of active list items

--- a/app/assets/stylesheets/bootstrap-variables.scss
+++ b/app/assets/stylesheets/bootstrap-variables.scss
@@ -33,7 +33,7 @@ $brand-success: #8EDE3D !default;
 // $text-color:            $gray-dark
 
 //** Global textual link color.
-$link-color: rgb(42,156,235) !default;
+$link-color: $blue !default;
 //** Link hover color set via `darken()` function.
 // $link-hover-color:      darken($link-color, 15%)
 //** Link hover decoration.
@@ -676,7 +676,7 @@ $list-group-border: transparent;
 $list-group-border-radius: 0;
 
 //** Background color of single list items on hover
-$list-group-hover-bg: $blue;
+$list-group-hover-bg: $link-color;
 //** Text color of active list items
 $list-group-active-color: $white;
 //** Background color of active list items

--- a/app/assets/stylesheets/color_themes/_color_theme_override_dark.scss
+++ b/app/assets/stylesheets/color_themes/_color_theme_override_dark.scss
@@ -56,7 +56,7 @@ body {
 
   .opengraph a { color: lighten($gray-lighter, 27%); }
 
-  .tag:hover { background-color: desaturate(darken($blue, 35%), 20%); }
+  .tag:hover { background-color: desaturate(darken($link-color, 35%), 20%); }
 
   #profile_container .profile_header {
     #author_info #sharing_message.entypo-check { color: lighten($green, 10%); }

--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -39,7 +39,7 @@
     }
 
     >.highlighted {
-      border-left: 3px solid $blue;
+      border-left: 3px solid $link-color;
       padding-left: 3px;
     }
   }

--- a/app/assets/stylesheets/conversations.scss
+++ b/app/assets/stylesheets/conversations.scss
@@ -73,7 +73,7 @@
     }
 
     &:hover, &.unread:hover, &.selected:hover {
-      background-color: lighten($link-color, 5%);
+      background-color: lighten($brand-primary, 5%);
       cursor: pointer;
       .participants {
         border-color: rgba($border-grey, 1);
@@ -84,7 +84,7 @@
     }
 
     &.unread { background-color: $background-grey; }
-    &.selected { background-color: $link-color; }
+    &.selected { background-color: $brand-primary; }
 
     .last_author, .last_message {
       font-size: 12px;

--- a/app/assets/stylesheets/conversations.scss
+++ b/app/assets/stylesheets/conversations.scss
@@ -73,7 +73,7 @@
     }
 
     &:hover, &.unread:hover, &.selected:hover {
-      background-color: lighten($blue,5%);
+      background-color: lighten($link-color, 5%);
       cursor: pointer;
       .participants {
         border-color: rgba($border-grey, 1);
@@ -84,7 +84,7 @@
     }
 
     &.unread { background-color: $background-grey; }
-    &.selected { background-color: $blue; }
+    &.selected { background-color: $link-color; }
 
     .last_author, .last_message {
       font-size: 12px;
@@ -144,7 +144,7 @@
       float: right;
       line-height: normal;
       font-weight: normal;
-      color: $blue;
+      color: $link-color;
     }
   }
 

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -53,7 +53,7 @@
           color: $gray-light;
           padding-left: 55px;
           &:hover {
-            background-color: $link-color;
+            background-color: $brand-primary;
             color: $gray-lighter;
           }
         }
@@ -105,7 +105,7 @@
         }
       }
       .view_all {
-        background-color: $link-color;
+        background-color: $brand-primary;
         border-top: 3px solid $dropdown-bg;
         text-align: center;
         a {

--- a/app/assets/stylesheets/hovercard.scss
+++ b/app/assets/stylesheets/hovercard.scss
@@ -53,7 +53,7 @@
     padding-bottom: 0px;
     font-size: 16px;
     a {
-      color: $blue;
+      color: $link-color;
       font-weight: bold !important;
     }
   }

--- a/app/assets/stylesheets/markdown-editor.scss
+++ b/app/assets/stylesheets/markdown-editor.scss
@@ -115,7 +115,7 @@
   > li {
     > a { padding: 7px 15px; }
 
-    &:not(.active) * { color: $brand-primary; }
+    &:not(.active) * { color: $link-color; }
 
     &.active * { color: $black; }
   }

--- a/app/assets/stylesheets/navbar_left.scss
+++ b/app/assets/stylesheets/navbar_left.scss
@@ -24,8 +24,8 @@
     }
 
     &:hover, &:hover a, &:hover [class^="entypo"] {
-      background-color: $link-color;
-      border-color: $link-color;
+      background-color: $brand-primary;
+      border-color: $brand-primary;
       color: $white;
     }
   }

--- a/app/assets/stylesheets/navbar_left.scss
+++ b/app/assets/stylesheets/navbar_left.scss
@@ -24,8 +24,8 @@
     }
 
     &:hover, &:hover a, &:hover [class^="entypo"] {
-      background-color: $blue;
-      border-color: $blue;
+      background-color: $link-color;
+      border-color: $link-color;
       color: $white;
     }
   }

--- a/app/assets/stylesheets/opengraph.scss
+++ b/app/assets/stylesheets/opengraph.scss
@@ -15,7 +15,7 @@
     }
   }
   a:hover {
-    color: $blue;
+    color: $link-color;
   }
 
   .thumb {

--- a/app/assets/stylesheets/publisher.scss
+++ b/app/assets/stylesheets/publisher.scss
@@ -102,7 +102,7 @@
         padding-left: 10px;
         margin-bottom: 0;
         color: lighten($text-grey,20%);
-        a { color: lighten($blue,20%); }
+        a { color: lighten($link-color, 20%); }
       }
 
       &.with_attachments #photodropzone_container {

--- a/app/assets/stylesheets/single-post-view.scss
+++ b/app/assets/stylesheets/single-post-view.scss
@@ -83,7 +83,7 @@
         color: #f55f5a;
       }
       i.entypo-reshare:hover {
-        color: #3f8fba;
+        color: $blue;
       }
       time {
         float: right;
@@ -115,7 +115,7 @@
   .no-comments { text-align: center; }
 
   a {
-    color: $blue;
+    color: $link-color;
   }
   .count {
     float: left;

--- a/app/assets/stylesheets/stream_element.scss
+++ b/app/assets/stylesheets/stream_element.scss
@@ -90,7 +90,7 @@
       font-weight: bold;
       margin-bottom: 4px;
     }
-    a.author-name { color: $blue; }
+    a.author-name { color: $link-color; }
     .feedback {
       margin-top: 5px;
       font-size: $font-size-small;

--- a/app/assets/stylesheets/tag.scss
+++ b/app/assets/stylesheets/tag.scss
@@ -3,15 +3,15 @@
   font-weight: bold;
   &:hover {
     text-decoration: underline;
-    background-color: lighten($blue, 47%);
+    background-color: lighten($link-color, 47%);
   }
 }
 
-a.tag { color: $blue; }
+a.tag { color: $link-color; }
 
 h1.tag {
-  border-bottom: 2px dotted $blue;
-  &:hover { border-bottom: 2px dotted $blue; }
+  border-bottom: 2px dotted $link-color;
+  &:hover { border-bottom: 2px dotted $link-color; }
 }
 
 .info {


### PR DESCRIPTION
Fixes #6656. All links now use `$link-color` which is the same as `$blue`. `$blue` is only used to color reshare icons. We still have `$brand-primary` which we use for things like buttons or backgrounds.

There are three pronto errors which I'm not planning to fix.