### PR TITLE
Increase time to wait before showing the hovercard

### DIFF
--- a/app/assets/javascripts/app/views/hovercard_view.js
+++ b/app/assets/javascripts/app/views/hovercard_view.js
@@ -91,7 +91,7 @@ app.views.Hovercard = app.views.Base.extend({
     this.parent = el;
     this._positionHovercard();
     this._populateHovercard();
-  }, 700),
+  }, 1000),
 
   _populateHovercard: function() {
     var href = this.href();


### PR DESCRIPTION
At least for me the current wait time is not long enough so it happens quite often that I open hovercards accidentally. Opening them after a seconds should still be fast enough.