### PR TITLE
Remove some unused color-theme overrides

### DIFF
--- a/app/assets/stylesheets/color_themes/_color_theme_override.scss
+++ b/app/assets/stylesheets/color_themes/_color_theme_override.scss
@@ -1,18 +1,5 @@
 /* Raw CSS */
 body {
-  a,
-  a.tag,
-  .btn-link,
-  #main_stream .stream-element > .media a.author-name,
-  #hovercard h4 a,
-  .stream-element .from a.self {
-    color: $link-color;
-
-    &:hover, &:focus {
-      color: darken($link-color, 10%);
-    }
-  }
-
   #publisher_textarea_wrapper > #button_container > span.markdownIndications > a {
     color: fade-out($link-color, 0.4);
   }


### PR DESCRIPTION
After #7318 `$link-color` is used by default, no need to override anymore.