### PR TITLE
Change color of author-name on hover

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -60,10 +60,6 @@ pre { word-wrap: break-word; }
   }
 }
 
-.author-name {
-  color: inherit;
-}
-
 .back-to-top {
   background-color: $border-dark-grey;
   border-radius: 4px;

--- a/app/assets/stylesheets/color_themes/_color_theme_override_dark.scss
+++ b/app/assets/stylesheets/color_themes/_color_theme_override_dark.scss
@@ -50,7 +50,7 @@ body {
   @import 'highlightjs/darcula';
 
   #single-post-content .head {
-    #post-info .author { color: lighten($gray-lighter, 27%); }
+    .author-name { color: lighten($gray-lighter, 27%); }
     #single-post-actions i.entypo-heart.red:hover { color: $red; }
   }
 

--- a/app/assets/stylesheets/hovercard.scss
+++ b/app/assets/stylesheets/hovercard.scss
@@ -53,7 +53,6 @@
     padding-bottom: 0px;
     font-size: 16px;
     a {
-      color: $link-color;
       font-weight: bold !important;
     }
   }

--- a/app/assets/stylesheets/single-post-view.scss
+++ b/app/assets/stylesheets/single-post-view.scss
@@ -7,7 +7,6 @@
     border-bottom: 1px solid $border-grey;
     padding: 10px 0;
     #post-info {
-      .author{ color: $grey; }
       .info {
         color: lighten($text-grey,10%);
         font-size: 12px;
@@ -22,6 +21,9 @@
         padding-left: 10px;
       }
     }
+
+    .author-name { color: $grey; }
+
     .near-from {
       color: $text-grey;
       font-size: 12px;

--- a/app/assets/stylesheets/stream_element.scss
+++ b/app/assets/stylesheets/stream_element.scss
@@ -90,7 +90,6 @@
       font-weight: bold;
       margin-bottom: 4px;
     }
-    a.author-name { color: $link-color; }
     .feedback {
       margin-top: 5px;
       font-size: $font-size-small;


### PR DESCRIPTION
This already happened before #7325 in some color themes and I don't see why author-name should look different from other links.

For those who review this PR: `author-name` elements are only created via [handlebars-helper/linkToAuthor](https://github.com/diaspora/diaspora/blob/99351bd152f7e4672c77df8d8326995d416525c3/app/assets/javascripts/app/helpers/handlebars-helpers.js#L26) (`grep -Rn "author-name" app`) and this is used in the single post view, stream elements, comments, likes and reshares (`grep -Rn "linkToAuthor" app/`) that are rendered client side.