### PR TITLE
twitter: #status_destroy is deprecated. Use #destroy_status instead.

### DIFF
--- a/app/models/services/twitter.rb
+++ b/app/models/services/twitter.rb
@@ -106,6 +106,6 @@ class Services::Twitter < Service
   end
 
   def delete_from_twitter service_post_id
-    client.status_destroy service_post_id
+    client.destroy_status service_post_id
   end
 end


### PR DESCRIPTION
Found this in my logs today.