### PR TITLE
Fix mentioned in comments notifications

### DIFF
--- a/app/mailers/notification_mailers/also_commented.rb
+++ b/app/mailers/notification_mailers/also_commented.rb
@@ -7,7 +7,6 @@ module NotificationMailers
       @comment = Comment.find_by_id(comment_id)
 
       if mail?
-        @headers[:from] = "\"#{@comment.author_name} (diaspora*)\" <#{AppConfig.mail.sender_address}>"
         @headers[:in_reply_to] = @headers[:references] = "<#{@comment.parent.guid}@#{AppConfig.pod_uri.host}>"
         if @comment.public?
           @headers[:subject] = "Re: #{@comment.comment_email_subject}"

--- a/app/mailers/notification_mailers/comment_on_post.rb
+++ b/app/mailers/notification_mailers/comment_on_post.rb
@@ -5,7 +5,6 @@ module NotificationMailers
     def set_headers(comment_id)
       @comment = Comment.find(comment_id)
 
-      @headers[:from] = "\"#{@comment.author_name} (diaspora*)\" <#{AppConfig.mail.sender_address}>"
       @headers[:in_reply_to] = @headers[:references] = "<#{@comment.parent.guid}@#{AppConfig.pod_uri.host}>"
       if @comment.public?
         @headers[:subject] = "Re: #{@comment.comment_email_subject}"

--- a/app/mailers/notification_mailers/mentioned_in_comment.rb
+++ b/app/mailers/notification_mailers/mentioned_in_comment.rb
@@ -5,6 +5,7 @@ module NotificationMailers
     def set_headers(target_id) # rubocop:disable Style/AccessorMethodName
       @comment = Mention.find_by_id(target_id).mentions_container
 
+      @headers[:in_reply_to] = @headers[:references] = "<#{@comment.parent.guid}@#{AppConfig.pod_uri.host}>"
       @headers[:subject] = I18n.t("notifier.mentioned.subject", name: @sender.name)
     end
   end

--- a/app/mailers/notification_mailers/private_message.rb
+++ b/app/mailers/notification_mailers/private_message.rb
@@ -3,11 +3,10 @@ module NotificationMailers
     attr_accessor :message, :conversation, :participants
 
     def set_headers(message_id)
-      @message  = Message.find_by_id(message_id)
+      @message = Message.find_by_id(message_id)
       @conversation = @message.conversation
       @participants = @conversation.participants
 
-      @headers[:from] = "\"#{@message.author_name} (diaspora*)\" <#{AppConfig.mail.sender_address}>"
       @headers[:subject] = I18n.t("notifier.private_message.subject")
       @headers[:in_reply_to] = @headers[:references] = "<#{@conversation.guid}@#{AppConfig.pod_uri.host}>"
     end

--- a/app/models/notifications/mentioned_in_comment.rb
+++ b/app/models/notifications/mentioned_in_comment.rb
@@ -11,7 +11,7 @@ module Notifications
     end
 
     def self.filter_mentions(mentions, mentionable, _recipient_user_ids)
-      mentions.includes(:person).merge(Person.allowed_to_be_mentioned_in_a_comment_to(mentionable.parent)).distinct
+      mentions.includes(:person).merge(Person.allowed_to_be_mentioned_in_a_comment_to(mentionable.parent))
     end
 
     def mail_job

--- a/app/models/notifications/mentioned_in_comment.rb
+++ b/app/models/notifications/mentioned_in_comment.rb
@@ -11,7 +11,7 @@ module Notifications
     end
 
     def self.filter_mentions(mentions, mentionable, _recipient_user_ids)
-      mentions.joins(:person).merge(Person.allowed_to_be_mentioned_in_a_comment_to(mentionable.parent))
+      mentions.includes(:person).merge(Person.allowed_to_be_mentioned_in_a_comment_to(mentionable.parent)).distinct
     end
 
     def mail_job

--- a/spec/integration/mentioning_spec.rb
+++ b/spec/integration/mentioning_spec.rb
@@ -376,6 +376,18 @@ describe "mentioning", type: :request do
           end
         end
       end
+
+      it "only creates one notification for the mentioned person, when mentioned person commented twice before" do
+        parent = FactoryGirl.create(:status_message_in_aspect, author: author.person)
+        mentioned_user = FactoryGirl.create(:user_with_aspect, friends: [author])
+        mentioned_user.comment!(parent, "test comment 1")
+        mentioned_user.comment!(parent, "test comment 2")
+        comment = inlined_jobs do
+          author.comment!(parent, text_mentioning(mentioned_user))
+        end
+
+        expect(notifications_about_mentioning(mentioned_user, comment).count).to eq(1)
+      end
     end
   end
 end

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -281,7 +281,9 @@ describe Notifier, type: :mailer do
     let(:comment) { eve.comment!(commented_post, "Totally is") }
 
     describe ".comment_on_post" do
-      let(:comment_mail) { Notifier.send_notification("comment_on_post", bob.id, person.id, comment.id).deliver_now }
+      let(:comment_mail) {
+        Notifier.send_notification("comment_on_post", bob.id, eve.person.id, comment.id).deliver_now
+      }
 
       it "TO: goes to the right person" do
         expect(comment_mail.to).to eq([bob.email])
@@ -322,7 +324,7 @@ describe Notifier, type: :mailer do
     end
 
     describe ".also_commented" do
-      let(:comment_mail) { Notifier.send_notification("also_commented", bob.id, person.id, comment.id) }
+      let(:comment_mail) { Notifier.send_notification("also_commented", bob.id, eve.person.id, comment.id) }
 
       it "TO: goes to the right person" do
         expect(comment_mail.to).to eq([bob.email])

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -120,6 +120,11 @@ describe Notifier, type: :mailer do
       expect(mail.subject).to include(comment.author.name)
     end
 
+    it "IN-REPLY-TO and REFERENCES: references the commented post" do
+      expect(mail.in_reply_to).to eq("#{comment.parent.guid}@#{AppConfig.pod_uri.host}")
+      expect(mail.references).to eq("#{comment.parent.guid}@#{AppConfig.pod_uri.host}")
+    end
+
     it "has the comment link in the body" do
       expect(mail.body.encoded).to include(post_url(comment.parent, anchor: comment.guid))
     end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -24,16 +24,6 @@ describe Person, :type => :model do
           Person.for_json.first.serialized_public_key
         }.to raise_error ActiveModel::MissingAttributeError
       end
-
-      it 'selects distinct people' do
-        aspect = bob.aspects.create(:name => 'hilarious people')
-        aspect.contacts << bob.contact_for(eve.person)
-        person_ids = Person.for_json.joins(:contacts => :aspect_memberships).
-          where(:contacts => {:user_id => bob.id},
-               :aspect_memberships => {:aspect_id => bob.aspect_ids}).map{|p| p.id}
-
-        expect(person_ids.uniq).to eq(person_ids)
-      end
     end
 
     describe '.local' do
@@ -131,9 +121,17 @@ describe Person, :type => :model do
         ).to match_array([alice, bob, eve, kate].map(&:person_id))
       end
 
+      it "selects distinct people" do
+        alice.comment!(status_bob, "hyi")
+        alice.comment!(status_bob, "how are you?")
+        expect(
+          Person.allowed_to_be_mentioned_in_a_comment_to(status_bob).ids
+        ).to match_array([alice, bob].map(&:person_id))
+      end
+
       it "returns all for public posts" do
         status_bob.update(public: true) # set parent public
-        expect(Person.allowed_to_be_mentioned_in_a_comment_to(status_bob)).to eq(Person.all)
+        expect(Person.allowed_to_be_mentioned_in_a_comment_to(status_bob).ids).to match_array(Person.ids)
       end
     end
 


### PR DESCRIPTION
After upgrading my pod to develop (with mentions in comments) I found some stuff:
* I received multiple notifications when I already commented multiple times on that post
* The notification mails were not added to the thread of the post

And while fixing this, I saw that we add the `From` header again for some notification mails (it is added already in the [`default_headers`](https://github.com/diaspora/diaspora/blob/27b4a44e4a2c2013794eaabc3aaa319aa6909894/app/mailers/notification_mailers/base.rb#L42)), so I cleaned this up too.