### PR TITLE
Use autosize in modals

### DIFF
--- a/app/assets/javascripts/app/helpers/modal_helper.js
+++ b/app/assets/javascripts/app/helpers/modal_helper.js
@@ -7,6 +7,7 @@
 
     modalBody.load(url, function(){
       $(id).find("#modalWaiter").remove();
+      autosize($("textarea", modalBody));
       $(id).trigger("modal:loaded");
     });
   };


### PR DESCRIPTION
Fixes #7338 and missing autosize in conversation forms on the profile page and the contacts page. Regression from #6674.