### PR TITLE
[Design] WIP - Diaspora UI Cleanup

### DIFF
--- a/app/assets/stylesheets/_application.scss
+++ b/app/assets/stylesheets/_application.scss
@@ -112,3 +112,8 @@
 
 // OpenID Connect (API)
 @import 'openid_connect_error_page';
+
+
+.btn-success {
+      box-shadow: 0px 1px #c2ef9b inset;
+}

--- a/app/assets/stylesheets/bootstrap-variables.scss
+++ b/app/assets/stylesheets/bootstrap-variables.scss
@@ -17,7 +17,7 @@ $gray:                   lighten($gray-base, 33.5%); // #555
 // $gray-lighter:           lighten($gray-base, 93.5%) // #eee
 
 $brand-primary: darken(#0097FF,5%) !default; // darker creation-blue
-$brand-success: #8EDE3D !default;
+$brand-success: #627d47 !default;
 // $brand-info:            #5bc0de
 // $brand-warning:         #f0ad4e
 // $brand-danger:          #d9534f
@@ -158,9 +158,9 @@ $font-size-small: 11px !default;
 // $btn-primary-bg:                 $brand-primary
 // $btn-primary-border:             darken($btn-primary-bg, 5%)
 
-$btn-success-color: #333 !default;
-// $btn-success-bg:                 $brand-success
-// $btn-success-border:             darken($btn-success-bg, 5%)
+$btn-success-color: #95c179 !default;
+$btn-success-bg:                 $brand-success;
+$btn-success-border:             #627d47;
 
 // $btn-info-color:                 #fff
 // $btn-info-bg:                    $brand-info

--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -1,4 +1,7 @@
 .comment_stream {
+    border: 1px solid #efefef;
+    border-radius: 3px;
+    background: #f9f8f8;
   .show_comments {
     border-top: 1px solid $border-grey;
     line-height: $line-height-computed;
@@ -22,15 +25,18 @@
     .media { margin: 5px; }
   }
 
+.comments > .comment {
+  padding: 10px 0px 10px 10px;
+  margin: 4px 10px 0px 10px;
+  border-bottom: 1px solid #eaeaea;
+}
+
   .comments > .comment,
   .comment.new-comment-form-wrapper {
     .avatar {
       height: 35px;
       width: 35px;
     }
-    margin: 0;
-    border-top: 1px dotted $border-grey;
-    padding: 10px 0;
 
     .info {
       margin-top: 5px;
@@ -44,7 +50,11 @@
     }
   }
 
-  .comment.new-comment-form-wrapper { padding-bottom: 0; }
+  .comment.new-comment-form-wrapper {
+    padding-bottom: 0;
+    background-color: #fff;
+    border-radius: 0;
+  }
 
   .submit_button {
     margin-top: 10px;

--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -1,6 +1,5 @@
 .comment_stream {
-    border: 1px solid #efefef;
-    border-radius: 3px;
+    border-top: 1px solid #efefef;
     background: #f9f8f8;
   .show_comments {
     border-top: 1px solid $border-grey;
@@ -26,7 +25,7 @@
   }
 
 .comments > .comment {
-  padding: 10px 0px 10px 10px;
+  padding: 10px 0px 10px 0px;
   margin: 4px 10px 0px 10px;
   border-bottom: 1px solid #eaeaea;
 }
@@ -52,7 +51,6 @@
 
   .comment.new-comment-form-wrapper {
     padding-bottom: 0;
-    background-color: #fff;
     border-radius: 0;
   }
 
@@ -69,7 +67,7 @@
     resize: none;
   }
   textarea.comment_box:focus, textarea.comment_box:valid, textarea.comment_box:active {
-    border-color: $border-dark-grey;
+    border-color: #e6e6e6;
     & + .submit_button { display: block; }
     min-height: 35px;
     box-shadow: none;

--- a/app/assets/stylesheets/hovercard.scss
+++ b/app/assets/stylesheets/hovercard.scss
@@ -1,6 +1,5 @@
 #hovercard {
   border-radius: 2px;
-  box-shadow: 0 0 5px #666666;
 
   position: relative;
   display: inline-block;

--- a/app/assets/stylesheets/opengraph.scss
+++ b/app/assets/stylesheets/opengraph.scss
@@ -4,10 +4,10 @@
   text-decoration: none;
   font-style: normal;
   margin: 10px 0px 10px 0px;
-  border-top: solid 1px $border-grey;
-  border-bottom: solid 1px $border-grey;
-  padding: 10px 0px 5px 0px;
+  border: solid 1px #ddd;
+  padding: 0px;
   overflow: hidden;
+  border-radius: 3px;
   a {
     color: #000;
     .og-title {
@@ -20,9 +20,9 @@
 
   .thumb {
     float: left;
-    margin: 5px;
+    margin: 0px;
     margin-left: 0;
-    max-width: 150px;
+    max-width: 200px;
     padding-right: 5px;
 
     .video-overlay {

--- a/app/assets/stylesheets/poll.scss
+++ b/app/assets/stylesheets/poll.scss
@@ -2,7 +2,7 @@
   border-bottom: 1px solid $border-grey;
   border-top: 1px solid $border-grey;
   margin: 10px 0;
-  padding: 10px 0 5px;
+  padding: 10px 3px 5px;
 
   .toggle-result-wrapper {
     display: inline-block;

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -1,11 +1,9 @@
 #profile_container {
   .profile_header {
     margin-bottom: 15px;
-    background-color: #fff;
     padding: 5px;
     margin-top: 10px;
-    border: 1px solid $border-grey;
-    border-radius: 3px;
+    text-shadow: 1px 1px 0px #fff;
 
     #edit_profile, #unblock_user_button, .aspect_dropdown {
       margin-top: 15px;
@@ -114,16 +112,22 @@
 
   #profile {
     margin-bottom: 35px;
+    border-radius: 20px 20px 0px 0px;
 
     #profile_photo {
       margin-top: 10px;
-      padding-bottom: 10px;
       text-align: center;
+    }
+
+    #profile_photo img {
+      border-radius: 20px 20px 0px 0px;
+      border: 1px solid #c1c1c1;
+      border-bottom: 0px;
     }
 
     ul#profile_information {
       margin: 0;
-      padding: 10px;
+      padding: 0px 10px 0px 10px;
       list-style: none;
       overflow-x: hidden;
       word-wrap: break-word;

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -1,12 +1,11 @@
 #profile_container {
   .profile_header {
     margin-bottom: 15px;
-    background-color: $framed-background;
-    padding-left: 10px;
-    padding-right: 10px;
-    padding-top: 20px;
-    margin-top: -20px;
-    box-shadow: $card-shadow;
+    background-color: #fff;
+    padding: 5px;
+    margin-top: 10px;
+    border: 1px solid $border-grey;
+    border-radius: 3px;
 
     #edit_profile, #unblock_user_button, .aspect_dropdown {
       margin-top: 15px;
@@ -15,7 +14,7 @@
     #author_info {
       h2 {
         line-height: 35px;
-        margin-top: 10px;
+        margin-top: 0px;
         margin-bottom: 0px;
       }
       #name {
@@ -23,7 +22,8 @@
       }
       #diaspora_handle {
         color: $text-color-pale;
-        font-size: 20px;
+        font-size: 15px;
+        font-weight: 300;
       }
       #sharing_message {
         cursor: default;
@@ -52,7 +52,7 @@
     }
 
     #profile-horizontal-bar {
-      border-top: 1px dashed $border-grey;
+      border-top: 1px solid $border-grey;
       min-height: 50px;
       margin-top: 10px;
       #profile_buttons {
@@ -113,7 +113,6 @@
   }
 
   #profile {
-    padding: 20px;
     margin-bottom: 35px;
 
     #profile_photo {
@@ -123,9 +122,8 @@
     }
 
     ul#profile_information {
-      border-top: 1px dashed $border-grey;
       margin: 0;
-      padding: 0;
+      padding: 10px;
       list-style: none;
       overflow-x: hidden;
       word-wrap: break-word;

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -7,6 +7,7 @@
 
     #edit_profile, #unblock_user_button, .aspect_dropdown {
       margin-top: 15px;
+      text-shadow: none;
     }
 
     #author_info {
@@ -50,9 +51,8 @@
     }
 
     #profile-horizontal-bar {
-      border-top: 1px solid $border-grey;
       min-height: 50px;
-      margin-top: 10px;
+      text-shadow: none;
       #profile_buttons {
         padding: 10px 0;
         > .profile_button {
@@ -73,6 +73,10 @@
         list-style: none;
         margin: 0;
         padding: 0;
+        display: inline-block;
+        background-color: #fff;
+        border-radius: 3px;
+        border: 1px solid #dadada;
         > li {
           display: inline-block;
           &.active {

--- a/app/assets/stylesheets/publisher.scss
+++ b/app/assets/stylesheets/publisher.scss
@@ -18,7 +18,7 @@
       margin-top: 0;
     }
 
-    #publisher_textarea_wrapper { border: 1px solid $border-grey !important; }
+    #publisher_textarea_wrapper { border: 1px solid #ccc !important; }
   }
 
   .container-fluid{ padding: 0; }

--- a/app/assets/stylesheets/publisher.scss
+++ b/app/assets/stylesheets/publisher.scss
@@ -3,9 +3,6 @@
   color: #999;
   margin: 0;
   margin-bottom: 20px;
-  width: 98%;
-  margin-left: auto;
-  margin-right: auto;
 
   &.closed {
     #button_container,

--- a/app/assets/stylesheets/publisher.scss
+++ b/app/assets/stylesheets/publisher.scss
@@ -1,8 +1,11 @@
 .publisher {
   z-index: 1;
-  color: $text-grey;
+  color: #999;
   margin: 0;
   margin-bottom: 20px;
+  width: 98%;
+  margin-left: auto;
+  margin-right: auto;
 
   &.closed {
     #button_container,

--- a/app/assets/stylesheets/sidebar.scss
+++ b/app/assets/stylesheets/sidebar.scss
@@ -3,7 +3,6 @@
   background-color: $framed-background;
   border: 1px solid $border-grey;
   border-top: 0;
-  box-shadow: $card-shadow;
 
   .header,
   .sidebar-header {

--- a/app/assets/stylesheets/stream.scss
+++ b/app/assets/stylesheets/stream.scss
@@ -5,8 +5,8 @@
 }
 
 .main-stream-publisher {
-  margin-top: 20px;
-  padding: 0;
+  margin-top: 10px;
+  padding: 10px;
 
   .avatar {
     height: 50px;

--- a/app/assets/stylesheets/stream_element.scss
+++ b/app/assets/stylesheets/stream_element.scss
@@ -63,7 +63,7 @@
 #main_stream .stream-element {
   margin-bottom: 20px;
   border: 1px solid $border-grey;
-  box-shadow: $card-shadow;
+  border-radius: 3px;
 
   &.highlighted {
     border-left: 3px solid $brand-primary;

--- a/app/assets/stylesheets/stream_element.scss
+++ b/app/assets/stylesheets/stream_element.scss
@@ -62,8 +62,6 @@
 
 #main_stream .stream-element {
   margin-bottom: 20px;
-  border: 1px solid $border-grey;
-  border-radius: 3px;
 
   &.highlighted {
     border-left: 3px solid $brand-primary;
@@ -72,15 +70,25 @@
 }
 
 .stream-element {
-  background-color: $framed-background;
   padding: 10px;
+
+  .post-wrapper {
+    border: 1px solid #ddd;
+    border-radius: 3px;
+    background-color: #f9f8f8;
+  }
+
+  .post-content-wrapper {
+    padding: 10px;
+    background-color: #fff;
+  }
 
   & > .media {
     &.shield-active .nsfw-hidden { display: none; }
     &:not(.shield-active) .nsfw-shield { display: none; }
     &:not(.shield-off) .nsfw-off { display: none; }
     & > .img > .avatar {
-      margin-top: 5px;
+      margin-top: 2px;
       &.small {
         height: 50px;
         width: 50px;

--- a/app/assets/stylesheets/stream_element.scss
+++ b/app/assets/stylesheets/stream_element.scss
@@ -60,8 +60,45 @@
   }
 }
 
+@keyframes fadein {
+    from {
+        opacity:0;
+    }
+    to {
+        opacity:1;
+    }
+}
+@-moz-keyframes fadein { /* Firefox */
+    from {
+        opacity:0;
+    }
+    to {
+        opacity:1;
+    }
+}
+@-webkit-keyframes fadein { /* Safari and Chrome */
+    from {
+        opacity:0;
+    }
+    to {
+        opacity:1;
+    }
+}
+@-o-keyframes fadein { /* Opera */
+    from {
+        opacity:0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
 #main_stream .stream-element {
   margin-bottom: 20px;
+  animation: fadein 2s;
+-moz-animation: fadein 2s; /* Firefox */
+-webkit-animation: fadein 2s; /* Safari and Chrome */
+-o-animation: fadein 2s; /* Opera */
 
   &.highlighted {
     border-left: 3px solid $brand-primary;

--- a/app/assets/templates/profile_sidebar_tpl.jst.hbs
+++ b/app/assets/templates/profile_sidebar_tpl.jst.hbs
@@ -1,5 +1,5 @@
 
-<div id="profile_photo" class="profile_photo">
+<div id="profile_photo" class="profile_photo sidebar_photo">
   {{#linkToPerson this}}
     {{{personImage this "large"}}}
   {{/linkToPerson}}

--- a/app/assets/templates/stream-element_tpl.jst.hbs
+++ b/app/assets/templates/stream-element_tpl.jst.hbs
@@ -5,7 +5,8 @@
     </a>
   {{/with}}
 
-  <div class="bd">
+  <div class="bd post-wrapper">
+    <div class="post-content-wrapper">
     {{#if loggedIn}}
       <div class="post-controls"></div>
     {{/if}}
@@ -33,10 +34,10 @@
 
     <div class="post-content"> </div>
     <div class="status-message-location nsfw-hidden"> </div>
-
     <div class="feedback nsfw-hidden"> </div>
     <div class="likes nsfw-hidden"> </div>
     <div class="reshares nsfw-hidden"> </div>
+    </div>
     <div class="comments nsfw-hidden"> </div>
   </div>
 </div>


### PR DESCRIPTION
I apologize in advance if this isn't the best way to go about the issue. I am opening this PR not as a concrete, finalized proposal for a fully realized design. Instead, I would like to use this thread for discussion on a work-in-progress refactor of Diaspora's default styling.

This is intended to be a work-in-progress. I hope to avoid dragging my feet too much. This is intended to be an open discussion to generate feedback and insight on what other approaches to visual design and layout can be taken. As such, it could take a little while.

### Areas of Interest

- [ ] Post Styling (Started)
- [ ] Icon-Functions (Investigating)
- [ ] Content Animations (Started)
- [ ] Profiles (Started)

**Post Styling**
<img width="891" alt="sean_tilley" src="https://cloud.githubusercontent.com/assets/401560/23542783/e270a4c2-ffa3-11e6-8590-cdfe31c3204c.png">
There are two places I think posts can be improved: style, and function. At the moment, posts are white padded cards wrapped in box shadows. Comments and post content have a minimal amount of visual separation using dotted lines.

While style can boil down to personal preference, I think there are some ways to improve the general way a post looks.

<img width="861" alt="diaspora_" src="https://cloud.githubusercontent.com/assets/401560/23542562/dbbca94c-ffa2-11e6-998b-2067f2367244.png">
In this example, the box shadows have been done away with in favor of a solid border. Posts rely on a slightly darker background to visually distinguish themselves from the rest of the post. I think this creates a clear visual separation between the two sections of a stream post without creating too much of a clash.

Additionally, avatars are displayed on the outside of the post body - this gets rid of extra margin on the post body's left side, and moves the post content and comment width to a slightly less elongated length.  

**Icon-functions**
  
<img width="1184" alt="i_spend_all_day_thinking_about_cubes_" src="https://cloud.githubusercontent.com/assets/401560/23542625/16cbaace-ffa3-11e6-9bb0-431255aa8cd6.png">
At the moment, post interactions are represented in an incongruent way between the stream view, and the single post view. One design question I've been wondering about concerns whether it would make sense to attempt design parity between the two views - after all, the mobile stream seems to benefit from its icon-centric design for post interactions.

<img width="696" alt="diaspora_" src="https://cloud.githubusercontent.com/assets/401560/23543399/e81a3390-ffa6-11e6-8a90-6c15ef8a9a77.png">


**Content Animations**
This gif is a little slow, and the color profile didn't exactly translate - however, there are some small, basic css animations that could be leveraged when loading a stream. New posts quickly fade in, both when they're being loaded, and when new entries are created.
![stream-load](https://cloud.githubusercontent.com/assets/401560/23543501/5291d6ce-ffa7-11e6-8b98-b1cfc36247a5.gif)

**Profiles**
<img width="1184" alt="sean_tilley" src="https://cloud.githubusercontent.com/assets/401560/23543814/cde85fe0-ffa8-11e6-8566-af0614881ebd.png">
Profiles are purely speculative at this point. I think it might be possible to simplify the placement of tabs, tags, and the Aspects dropdown
