### PR TITLE
Disable Rails/HttpPositionalArguments cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,9 @@ AllCops:
 Rails:
   Enabled: true
 
+Rails/HttpPositionalArguments:
+  Enabled: false
+
 # Commonly used screens these days easily fit more than 80 characters.
 Metrics/LineLength:
   Max: 120


### PR DESCRIPTION
See http://rubocop.readthedocs.io/en/latest/cops_rails/#railshttppositionalarguments.

It only applies to Rails >= 5