### PR TITLE
Use empty selector where "#" was used as a selector before (jQuery 2 -> 3 upgrade)

### DIFF
--- a/app/assets/javascripts/helpers/markdown_editor.js
+++ b/app/assets/javascripts/helpers/markdown_editor.js
@@ -65,7 +65,7 @@ Diaspora.MarkdownEditor.prototype = {
     var tabElement = $("<ul class='nav nav-tabs btn-group write-preview-tabs'></ul>");
 
     var writeTab = $("<li class='active full-height' role='presentation'></li>");
-    this.writeLink = $("<a class='full-height md-write-tab' href='#'></a>")
+    this.writeLink = $("<a class='full-height md-write-tab' href='#' data-target=' '></a>")
       .attr("title", Diaspora.I18n.t("publisher.markdown_editor.tooltips.write"));
 
     this.writeLink.append($("<i class='visible-sm visible-xs visible-md diaspora-custom-compose'></i>"));
@@ -80,7 +80,7 @@ Diaspora.MarkdownEditor.prototype = {
     writeTab.append(this.writeLink);
 
     var previewTab = $("<li class='full-height' role='presentation'></li>");
-    this.previewLink = $("<a class='full-height md-preview-tab' href='#'></a>")
+    this.previewLink = $("<a class='full-height md-preview-tab' href='#' data-target=' '></a>")
       .attr("title", Diaspora.I18n.t("publisher.markdown_editor.tooltips.preview"));
 
     this.previewLink.append($("<i class='visible-sm visible-xs visible-md entypo-search'>"));

--- a/app/assets/templates/header_tpl.jst.hbs
+++ b/app/assets/templates/header_tpl.jst.hbs
@@ -43,7 +43,7 @@
 
           <ul class="nav navbar-nav navbar-left nav-badges hidden-sm hidden-xs">
             <li class="dropdown" id="notification-dropdown">
-              <a id="notifications-link" href="/notifications" title="{{t "header.notifications"}}" class="notifications-link nav-badge hidden-sm hidden-xs" role="button" data-toggle="dropdown" aria-expanded="false" data-target="#">
+              <a id="notifications-link" href="/notifications" title="{{t "header.notifications"}}" class="notifications-link nav-badge hidden-sm hidden-xs" role="button" data-toggle="dropdown" aria-expanded="false" data-target=" ">
                 <i class="entypo-bell"></i>
                 <span class="badge badge-important {{#unless current_user.notifications_count}} hidden {{/unless}}">
                   {{current_user.notifications_count}}

--- a/app/views/aspects/_no_contacts_message.haml
+++ b/app/views/aspects/_no_contacts_message.haml
@@ -9,7 +9,7 @@
   %p
     != t(".try_adding_some_more_contacts",
          invite_link: link_to(t(".invite_link_text"),
-                                "#",
+                                " ",
                                 class: "invitations-link",
                                 data: {toggle: "modal"}))
 


### PR DESCRIPTION
In jQuery 3 "#" is disallowed as a selector. Here is a somewhat hacky way to force use an empty selector where "#" was used as a selector before.

See #7303