### PR TITLE
Disable autocomplete for the conversation form recipient input

### DIFF
--- a/app/views/conversations/_new.haml
+++ b/app/views/conversations/_new.haml
@@ -4,7 +4,12 @@
     .form-group
       %label#to-label{for: "contacts-search-input"}= t(".to")
       .recipients-tag-list.clearfix#recipients-tag-list
-      = text_field_tag "contact_autocomplete", nil, id: "contacts-search-input", class: "form-control"
+      = text_field_tag "contact_autocomplete",
+                       nil,
+                       id: "contacts-search-input",
+                       class: "form-control",
+                       autocomplete: "off"
+
       - unless defined?(mobile) && mobile
         = text_field_tag "person_ids", nil, id: "contact-ids", type: "hidden",
                                             aria: {labelledby: "to-label"}


### PR DESCRIPTION
We use typeahead for the text field so the browser autocomplete should be turned off.