### PR TITLE
Fix block user failing feature

### DIFF
--- a/app/assets/javascripts/app/views/stream_post_views.js
+++ b/app/assets/javascripts/app/views/stream_post_views.js
@@ -28,9 +28,11 @@ app.views.StreamPost = app.views.Post.extend({
                      ".permalink"].join(", "),
 
   initialize : function(){
-    var personId = this.model.get("author").id;
-    app.events.on("person:block:"+personId, this.remove, this);
-
+    // If we are on a user page, we don't want to remove posts on block
+    if (!app.page.model.has("profile")) {
+      var personId = this.model.get("author").id;
+      app.events.on("person:block:" + personId, this.remove, this);
+    }
     this.model.on("remove", this.remove, this);
     //subviews
     this.commentStreamView = new app.views.CommentStream({model : this.model});

--- a/features/desktop/blocks_user.feature
+++ b/features/desktop/blocks_user.feature
@@ -18,6 +18,7 @@ Feature: Blocking a user from the stream
   Scenario: Blocking a user from the profile page
     When I am on "alice@alice.alice"'s page
     And I confirm the alert after I click on the profile block button
-    Then "All your base are belong to us!" should be post 1
+    Then I should see "Stop ignoring" within "#unblock_user_button"
+    And "All your base are belong to us!" should be post 1
     When I go to the home page
     Then I should not see any posts in my stream


### PR DESCRIPTION
Alright so I was annoyed by the "randomly" failing features and especially the `features/desktop/blocks_user.feature:18 # Scenario: Blocking a user from the profile page` one so I decided to have a quick look. And... I discovered that the failure was not random at all. In fact, the test was failing for a good reason, and it is the local green which was a bug. Since https://github.com/diaspora/diaspora/pull/5027 we immediately remove the posts from a stream when the author is ignored. And since https://github.com/diaspora/diaspora/pull/6617 we still display posts of an author on his profile. This works fine on F5, but **when you ignore a user on his profile pages, the posts are removed**, making the test fails (as it checks the post is displayed). There is a transition, so phantomJS is too quick and the post is still there when the check is done locally, but on Travis, the post is removed before the check is done, so the test failed.

In this PR, I fixed the problem first by checking in the test that the dropdown becomes "stop ignoring" when a user is ignored, so locally it has another step to do before it checks if the post is there. This makes the test becomes red like on travis. Then I fixed the code by checking in the StreamPost view that we are not on a user profile, based on the URL, to activate the "remove post immediately" feature. Making the test green again, locally and, hopefully, on Travis.

There is probably a better way to know if we're on the author profile than to use the URL. Suggestions? @svbergerem 