### PR TITLE
Fix sharing indicator on profile page for blocked users

### DIFF
--- a/app/assets/javascripts/app/models/person.js
+++ b/app/assets/javascripts/app/models/person.js
@@ -30,7 +30,7 @@ app.models.Person = Backbone.Model.extend({
   },
 
   isBlocked: function() {
-    return (this.get('relationship') === 'blocked');
+    return (this.get("block") !== false);
   },
 
   block: function() {

--- a/app/presenters/person_presenter.rb
+++ b/app/presenters/person_presenter.rb
@@ -52,7 +52,6 @@ class PersonPresenter < BasePresenter
 
   def relationship
     return false unless current_user
-    return :blocked if is_blocked?
 
     contact = current_user_person_contact
     return :not_sharing unless contact

--- a/spec/javascripts/app/models/person_spec.js
+++ b/spec/javascripts/app/models/person_spec.js
@@ -4,7 +4,7 @@ describe("app.models.Person", function() {
     this.mutualContact = factory.person({relationship: "mutual"});
     this.sharingContact = factory.person({relationship: "sharing"});
     this.receivingContact = factory.person({relationship: "receiving"});
-    this.blockedContact = factory.person({relationship: "blocked", block: {id: 1}});
+    this.blockedContact = factory.person({relationship: "sharing", block: {id: 1}});
   });
 
   describe("initialize", function() {
@@ -20,9 +20,9 @@ describe("app.models.Person", function() {
     it("indicates if the person is sharing", function() {
       expect(this.mutualContact.isSharing()).toBeTruthy();
       expect(this.sharingContact.isSharing()).toBeTruthy();
+      expect(this.blockedContact.isSharing()).toBeTruthy();
 
       expect(this.receivingContact.isSharing()).toBeFalsy();
-      expect(this.blockedContact.isSharing()).toBeFalsy();
     });
   });
 

--- a/spec/javascripts/jasmine_helpers/factory.js
+++ b/spec/javascripts/jasmine_helpers/factory.js
@@ -153,6 +153,7 @@ var factory = {
       "name": "Bob Grimm",
       "diaspora_id": "bob@localhost:3000",
       "relationship": "sharing",
+      "block": false,
       "is_own_profile": false
     };
     return _.extend({}, defaults, overrides);

--- a/spec/presenters/person_presenter_spec.rb
+++ b/spec/presenters/person_presenter_spec.rb
@@ -92,12 +92,6 @@ describe PersonPresenter do
     end
 
     context "relationship" do
-      it "is blocked?" do
-        allow(current_user).to receive(:block_for) { double(id: 1) }
-        allow(current_user).to receive(:contact_for) { non_contact }
-        expect(@p.full_hash[:relationship]).to be(:blocked)
-      end
-
       it "is mutual?" do
         allow(current_user).to receive(:contact_for) { mutual_contact }
         expect(@p.full_hash[:relationship]).to be(:mutual)
@@ -116,6 +110,19 @@ describe PersonPresenter do
       it "isn't sharing?" do
         allow(current_user).to receive(:contact_for) { non_contact }
         expect(@p.full_hash[:relationship]).to be(:not_sharing)
+      end
+    end
+
+    describe "block" do
+      it "contains the block id if it exists" do
+        allow(current_user).to receive(:contact_for) { non_contact }
+        allow(current_user).to receive(:block_for) { double(id: 1) }
+        expect(@p.full_hash[:block][:id]).to be(1)
+      end
+
+      it "is false if no block is present" do
+        allow(current_user).to receive(:contact_for) { non_contact }
+        expect(@p.full_hash[:block]).to be(false)
       end
     end
   end


### PR DESCRIPTION
Now it really tells you if they are sharing with you.