### PR TITLE
Increase maximal height of large thumbnail

### DIFF
--- a/app/uploaders/processed_image.rb
+++ b/app/uploaders/processed_image.rb
@@ -18,16 +18,15 @@ class ProcessedImage < CarrierWave::Uploader::Base
   end
 
   version :thumb_small do
-    process :resize_to_fill => [50,50]
+    process resize_to_fill: [50, 50]
   end
   version :thumb_medium do
-    process :resize_to_limit => [100,100]
+    process resize_to_limit: [100, 100]
   end
   version :thumb_large do
-    process :resize_to_limit => [300,300]
+    process resize_to_limit: [300, 1500]
   end
   version :scaled_full do
-    process :resize_to_limit => [700,nil]
+    process resize_to_limit: [700, nil]
   end
-
 end


### PR DESCRIPTION
Fixes #6248, supersedes #6244.

Here is a test with a 500x3000px image:

**before**
![screen shot 2017-03-22 at 12 58 22](https://cloud.githubusercontent.com/assets/3798614/24197127/b2307672-0f00-11e7-8e80-9c08ccf85b10.png)

**after**
![screen shot 2017-03-22 at 12 57 43](https://cloud.githubusercontent.com/assets/3798614/24197128/b230da04-0f00-11e7-8cb3-caa77da666f3.png)