### PR TITLE
Remove posts after response

### DIFF
--- a/app/assets/javascripts/app/views.js
+++ b/app/assets/javascripts/app/views.js
@@ -132,19 +132,20 @@ app.views.Base = Backbone.View.extend({
 
   destroyModel: function(evt) {
     evt && evt.preventDefault();
-    var self = this;
     var url = this.model.urlRoot + "/" + this.model.id;
 
     if( confirm(_.result(this, "destroyConfirmMsg")) ) {
       this.$el.addClass("deleting");
-      this.model.destroy({ url: url })
-        .done(function() {
-          self.remove();
-        })
-        .fail(function() {
-          self.$el.removeClass("deleting");
+      this.model.destroy({
+        url: url,
+        success: function() {
+          this.remove();
+        }.bind(this),
+        error: function() {
+          this.$el.removeClass("deleting");
           app.flashMessages.error(Diaspora.I18n.t("failed_to_remove"));
-        });
+        }.bind(this)
+      });
     }
   },
 

--- a/app/assets/javascripts/app/views/post_controls_view.js
+++ b/app/assets/javascripts/app/views/post_controls_view.js
@@ -76,6 +76,10 @@ app.views.PostControls = app.views.Base.extend({
     $.post(Routes.postParticipation(this.model.get("id")), {_method: "delete"}, function() {
       this.model.set({participation: false});
     }.bind(this));
+  },
+
+  destroyModel: function() {
+    this.post.destroyModel();
   }
 });
 // @license-end

--- a/app/assets/javascripts/app/views/stream_post_views.js
+++ b/app/assets/javascripts/app/views/stream_post_views.js
@@ -33,7 +33,6 @@ app.views.StreamPost = app.views.Post.extend({
       var personId = this.model.get("author").id;
       app.events.on("person:block:" + personId, this.remove, this);
     }
-    this.model.on("remove", this.remove, this);
     //subviews
     this.commentStreamView = new app.views.CommentStream({model : this.model});
     this.oEmbedView = new app.views.OEmbed({model : this.model});

--- a/app/assets/stylesheets/stream_element.scss
+++ b/app/assets/stylesheets/stream_element.scss
@@ -4,7 +4,8 @@
     margin: 0px;
   }
   &.deleting {
-    > .media { opacity: 0.3; }
+    opacity: .3;
+
     .control-icons { display: none !important; }
   }
 }

--- a/spec/javascripts/app/views/post_controls_view_spec.js
+++ b/spec/javascripts/app/views/post_controls_view_spec.js
@@ -74,12 +74,15 @@ describe("app.views.PostControls", function() {
     });
 
     it("calls destroyModel when removing a post", function() {
-      spyOn(app.views.PostControls.prototype, "destroyModel");
+      spyOn(app.views.PostControls.prototype, "destroyModel").and.callThrough();
+      spyOn(app.views.Post.prototype, "destroyModel");
       app.currentUser = new app.models.User(this.model.attributes.author);
-      this.view = new app.views.PostControls({model: this.model});
+      this.postView = new app.views.Post({model: this.model});
+      this.view = new app.views.PostControls({model: this.model, post: this.postView});
       this.view.render();
       this.view.$(".remove_post.delete").click();
       expect(app.views.PostControls.prototype.destroyModel).toHaveBeenCalled();
+      expect(app.views.Post.prototype.destroyModel).toHaveBeenCalled();
     });
 
     it("calls hidePost when hiding a post", function() {


### PR DESCRIPTION
With this PR the opacity of posts is decreased after clicking the delete button. If the server response shows a successful removal the post is removed from the stream. Otherwise it goes back to the initial state.

![post_remove_before](https://cloud.githubusercontent.com/assets/3798614/24226250/a6bedb16-0f65-11e7-80c8-ca7592849e54.png)

![post_remove_after](https://cloud.githubusercontent.com/assets/3798614/24226249/a6bb0f2c-0f65-11e7-91c2-c5ccceb19db8.png)

Fixes #5445.