### PR TITLE
Fix comment mentions spacing

### DIFF
--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -64,4 +64,12 @@
     min-height: 35px;
     box-shadow: none;
   }
+
+  .twitter-typeahead {
+    // typeahead sets this to `display: inline-block` which adds additional space between
+    // the comment textarea and the submit button.
+    // scss-lint:disable ImportantRule
+    display: block !important;
+    // scss-lint:enable ImportantRule
+  }
 }


### PR DESCRIPTION
**before**
![comment_mentions_spacing_before](https://cloud.githubusercontent.com/assets/3798614/24293720/7e6d2f58-1093-11e7-9846-013cd4470943.png)

**after**
![comment_mentions_spacing_after](https://cloud.githubusercontent.com/assets/3798614/24293721/7e810064-1093-11e7-9b40-06ef4ed60d93.png)