### PR TITLE
Only backport mention syntax when the author is local

### DIFF
--- a/lib/diaspora/mentions_container.rb
+++ b/lib/diaspora/mentions_container.rb
@@ -5,7 +5,7 @@ module Diaspora
     included do
       before_create do
         # TODO: remove when most of the posts can handle the new syntax
-        self.text = Diaspora::Mentionable.backport_mention_syntax(text) if text
+        self.text = Diaspora::Mentionable.backport_mention_syntax(text) if text && author.local?
       end
 
       after_create :create_mentions

--- a/spec/shared_behaviors/mentions_container.rb
+++ b/spec/shared_behaviors/mentions_container.rb
@@ -18,6 +18,13 @@ shared_examples_for "it is mentions container" do
       obj.save
       expect(obj.text).to eq(expected_text)
     end
+
+    it "doesn't backport mention syntax if author is not local" do
+      text = "mention @{#{people[0].diaspora_handle}} text"
+      obj = FactoryGirl.build(described_class.to_s.underscore.to_sym, text: text, author: remote_raphael)
+      obj.save
+      expect(obj.text).to eq(text)
+    end
   end
 
   describe ".after_create" do


### PR DESCRIPTION
We don't need to change new to old syntax when we receive a post from a
newer pod, since we can handle the new syntax. This is only needed when
sending it to older pods.

related to #7392