### PR TITLE
Disable rack session cookie for sidekiq

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,9 @@
 #   licensed under the Affero General Public License version 3 or later.  See
 #   the COPYRIGHT file.
 
-require 'sidekiq/web'
+require "sidekiq/web"
 require "sidekiq/cron/web"
+Sidekiq::Web.set :sessions, false # disable rack session cookie
 
 Diaspora::Application.routes.draw do
 


### PR DESCRIPTION
Since 4.2.3 sidekiq allows to disable its own session cookie for the case where the app provides a session already.

Always when I opened `/sidekiq` after long time (with an old `rack.session`-cookie) I was logged out from diaspora. With this setting sidekiq doesn't use this cookie anymore, so lets hope that fixes it :)