### PR TITLE
Use post page title in atom feed

### DIFF
--- a/app/helpers/activity_streams_helper.rb
+++ b/app/helpers/activity_streams_helper.rb
@@ -1,0 +1,12 @@
+module ActivityStreamsHelper
+  def add_activitystreams_author(target, person)
+    target.author do |author|
+      author.name person.name
+      author.uri local_or_remote_person_path(person, absolute: true)
+
+      author.tag! "activity:object-type", "http://activitystrea.ms/schema/1.0/person"
+      author.tag! "poco:preferredUsername", person.username
+      author.tag! "poco:displayName", person.name
+    end
+  end
+end

--- a/app/views/users/public.atom.builder
+++ b/app/views/users/public.atom.builder
@@ -17,21 +17,16 @@ atom_feed("xmlns:thr"       => "http://purl.org/syndication/thread/1.0",
 	    'media:height' => '100', :href => "#{@user.image_url}"
   feed.tag! :link, :href => "#{AppConfig.environment.pubsub_server}", :rel => 'hub'
 
-  feed.author do |author|
-    author.name @user.name
-    author.uri local_or_remote_person_path(@user.person, :absolute => true)
-
-    author.tag! 'activity:object-type', 'http://activitystrea.ms/schema/1.0/person'
-    author.tag! 'poco:preferredUsername', @user.username
-    author.tag! 'poco:displayName', @user.name
-  end
+  add_activitystreams_author(feed, @user.person)
 
   @posts.each do |post|
     feed.entry post, :url => "#{@user.url}p/#{post.id}",
       :id => "#{@user.url}p/#{post.id}" do |entry|
 
-      entry.title post.message.title
+      entry.title post_page_title(post)
       entry.content post.message.markdownified(disable_hovercards: true), :type => 'html'
+      add_activitystreams_author(entry, post.author)
+
       entry.tag! 'activity:verb', 'http://activitystrea.ms/schema/1.0/post'
       entry.tag! 'activity:object-type', 'http://activitystrea.ms/schema/1.0/note'
     end

--- a/spec/helpers/posts_helper_spec.rb
+++ b/spec/helpers/posts_helper_spec.rb
@@ -17,6 +17,13 @@ describe PostsHelper, :type => :helper do
         post_page_title(post)
       end
     end
+
+    context "with a reshare" do
+      it "returns 'Reshare by...'" do
+        reshare = FactoryGirl.create(:reshare, author: alice.person)
+        expect(post_page_title(reshare)).to eq I18n.t("posts.show.reshare_by", author: reshare.author_name)
+      end
+    end
   end
 
 


### PR DESCRIPTION
Fixes #7249 

I also wasn't able to reproduce the issue but now it uses the same code as the posts presenter.