### PR TITLE
Don't raise when the public key of a person is "broken"

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -295,6 +295,8 @@ class Person < ActiveRecord::Base
 
   def public_key
     OpenSSL::PKey::RSA.new(serialized_public_key)
+  rescue OpenSSL::PKey::RSAError
+    nil
   end
 
   def exported_key

--- a/config/initializers/diaspora_federation.rb
+++ b/config/initializers/diaspora_federation.rb
@@ -72,8 +72,7 @@ DiasporaFederation.configure do |config|
     end
 
     on :fetch_public_key do |diaspora_id|
-      key = Person.find_or_fetch_by_identifier(diaspora_id).serialized_public_key
-      OpenSSL::PKey::RSA.new(key) unless key.nil?
+      Person.find_or_fetch_by_identifier(diaspora_id).public_key
     end
 
     on :fetch_related_entity do |entity_type, guid|

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -560,6 +560,19 @@ describe Person, :type => :model do
     end
   end
 
+  describe "#public_key" do
+    it "returns the public key for the person" do
+      key = @person.public_key
+      expect(key).to be_a(OpenSSL::PKey::RSA)
+      expect(key.to_s).to eq(@person.serialized_public_key)
+    end
+
+    it "handles broken keys and returns nil" do
+      @person.update_attributes(serialized_public_key: "broken")
+      expect(@person.public_key).to be_nil
+    end
+  end
+
   context 'people finders for webfinger' do
     let(:user) { FactoryGirl.create(:user) }
     let(:person) { FactoryGirl.create(:person) }


### PR DESCRIPTION
Breaking a public key of a person can be used to "block" receiving posts from this person on the pod. So we should handle that case better and not just trigger many retries for something that will fail again.