### PR TITLE
Fix issue #7363

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -432,6 +432,7 @@ class User < ActiveRecord::Base
     return unless AppConfig.settings.welcome_message.enabled? && AppConfig.admins.account?
     sender_username = AppConfig.admins.account.get
     sender = User.find_by(username: sender_username)
+    return if sender.nil?
     conversation = sender.build_conversation(
       participant_ids: [sender.person.id, person.id],
       subject:         AppConfig.settings.welcome_message.subject.get,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -875,6 +875,12 @@ describe User, :type => :model do
         user.send_welcome_message
         expect(user.conversations.count).to eq 0
       end
+
+      it "should send no welcome message if podmin is invalid" do
+        AppConfig.admins.account = "invalid"
+        user.send_welcome_message
+        expect(user.conversations.count).to eq 0
+      end
     end
 
     context "with welcome message disabled" do


### PR DESCRIPTION
Simple fix for issue #7363  - server crash if admin set in diaspora.yml is not a valid user and the welcome message is enabled.

Not sure how to write a test for this issue or if one is even needed.
