### PR TITLE
Use guid with some of links

### DIFF
--- a/app/assets/templates/single-post-viewer/single-post-content_tpl.jst.hbs
+++ b/app/assets/templates/single-post-viewer/single-post-content_tpl.jst.hbs
@@ -39,11 +39,11 @@
             {{/if}}
             <span class="post-time">
               {{#if root}}
-                <a href="/posts/{{root.id}}">
+                <a href="/posts/{{root.guid}}">
                   <time datetime="{{root.created_at}}" title="{{localTime root.created_at}}" />
                 </a>
               {{else}}
-                <a href="/posts/{{id}}">
+                <a href="/posts/{{guid}}">
                   <time datetime="{{created_at}}" title="{{localTime created_at}}" />
                 </a>
               {{/if}}
@@ -91,7 +91,7 @@
           </span>
           <div class="post-context">
             <span class="post-time">
-              <a href="/posts/{{id}}">
+              <a href="/posts/{{guid}}">
                 <time datetime="{{created_at}}" title="{{localTime created_at}}" />
               </a>
             </span>

--- a/app/assets/templates/stream-element_tpl.jst.hbs
+++ b/app/assets/templates/stream-element_tpl.jst.hbs
@@ -24,7 +24,7 @@
             <time class="timeago" data-original-title="{{{localTime created_at}}}" datetime="{{created_at}}" />
           </a>
 
-          <a href="/posts/{{id}}" class="permalink" title="{{t "stream.permalink"}}">
+          <a href="/posts/{{guid}}" class="permalink" title="{{t "stream.permalink"}}">
             <i class="entypo-link"></i>
           </a>
         {{/if}}


### PR DESCRIPTION
Use guid instead of id at permalink and in single post view

This changes links from `/posts/:id` to `/posts/:guid` where the links are not clicked very often. Id search is faster than guid search so we can't change it everywhere, but these links are not very useful for clicking, but can be used for easier guid look up.

![2017-05-15 10-22-10](https://cloud.githubusercontent.com/assets/10187586/26047043/4cdf03d6-395a-11e7-94bb-81d24adf8570.png)
![2017-05-15 10-22-35](https://cloud.githubusercontent.com/assets/10187586/26047044/4cfecb12-395a-11e7-8a18-f282d8094e09.png)

P.S. Might need some tests to be fixed
