### PR TITLE
Save email without confirmation when podmail is disabled.

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -211,15 +211,23 @@ class UsersController < ApplicationController
   end
 
   def change_email(user_data)
-    @user.unconfirmed_email = user_data[:email]
-    if @user.save
-      @user.send_confirm_email
-      if @user.unconfirmed_email
+    if AppConfig.mail.enable?
+      @user.unconfirmed_email = user_data[:email]
+      if @user.save
+        @user.send_confirm_email
         flash.now[:notice] = t("users.update.unconfirmed_email_changed")
+      else
+        @user.reload # match user object with the database
+        flash.now[:error] = t("users.update.unconfirmed_email_not_changed")
       end
     else
-      @user.reload # match user object with the database
-      flash.now[:error] = t("users.update.unconfirmed_email_not_changed")
+      @user.email = user_data[:email]
+      if @user.save
+        flash.now[:notice] = t("users.update.settings_updated")
+      else
+        @user.reload
+        flash.now[:error] = t("users.update.unconfirmed_email_not_changed")
+      end
     end
   end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -203,6 +203,13 @@ describe UsersController, :type => :controller do
         expect(Workers::Mail::ConfirmEmail).to receive(:perform_async).with(@user.id).once
         put(:update, :id => @user.id, :user => { :email => "my@newemail.com"})
       end
+
+      it "saves unconfirmed_email when podmail is disabled" do
+        AppConfig.mail.enable = false
+        put(:update, id: @user.id, user: {email: "my@newemail.com"})
+        @user.reload
+        expect(@user.email).to eql("my@newemail.com")
+      end
     end
 
     describe "email settings" do


### PR DESCRIPTION
Fix and test for issue #7195 

Not entirely sure this is optimal - I kept the first user save so that the validations on the unconfirmed email could run, and then checked podmail status before setting email and saving again.