### PR TITLE
Switch PercentLiteralDelimiters to new default

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -164,16 +164,6 @@ Lint/Debugger:
 Style/NumericPredicate:
   EnforcedStyle: comparison
 
-# Old defaults from rubocop < 0.48.1
-Style/PercentLiteralDelimiters:
-  PreferredDelimiters:
-    default: '()'
-    '%i': '()'
-    '%I': '()'
-    '%r': '{}'
-    '%w': '()'
-    '%W': '()'
-
 # Reset some HoundCI changes back to Rubocop defaults
 Style/DotPosition:
   EnforcedStyle: leading


### PR DESCRIPTION
This is a follow up for  #7443 where I kept the old default, but since there were no objections there, I just created this PR. So if there are objections to change this, we can also discuss that on discourse, but I think everybody affected by this change should be on GitHub anyway.

The [ruby style guide](https://github.com/bbatsov/ruby-style-guide#percent-literal-braces) suggests to use `[]` for array literals(`%w`, `%i`, `%W`, `%I`) and I think that makes more sense than `()` too.