### PR TITLE
Add access to the report page on mobile for moderators

### DIFF
--- a/app/views/layouts/_drawer.mobile.haml
+++ b/app/views/layouts/_drawer.mobile.haml
@@ -52,5 +52,12 @@
                 = t("admins.admin_bar.report")
             %li= link_to t("admins.admin_bar.pod_network"), admin_pods_path
             %li= link_to t("admins.admin_bar.sidekiq_monitor"), sidekiq_path
+      - elsif current_user.moderator?
+        %li
+          %a{href: report_index_path}
+            - if unreviewed_reports_count > 0
+              .pull-right.badge
+                = unreviewed_reports_count
+            = t("admins.admin_bar.report")
       %li= link_to t("layouts.application.toggle"), toggle_mobile_path
       %li= link_to t("layouts.header.logout"), destroy_user_session_path, method: :delete

--- a/features/mobile/drawer.feature
+++ b/features/mobile/drawer.feature
@@ -106,10 +106,20 @@ Feature: Navigate between pages using the header menu and the drawer
     And I click on "Settings" in the drawer
     Then I should be on my account settings page
 
+  Scenario: navigate to the moderation page
+    Given a moderator with email "bob@bob.bob"
+    And I sign in as "bob@bob.bob" on the mobile website
+    When I open the drawer
+    Then I should not see "Admin" within "#drawer"
+    And I should see "Reports" within "#drawer"
+    When I click on "Reports" in the drawer
+    Then I should see "Reports overview" within "#main h1"
+
   Scenario: navigate to the admin pages
     Given an admin with email "bob@bob.bob"
     And I sign in as "bob@bob.bob" on the mobile website
     When I open the drawer
+    Then I should not see "Reports" within "#drawer"
     Then I should not see "Dashboard" within "#drawer"
     When I click on "Admin" in the drawer
     And I click on "Dashboard" in the drawer
@@ -131,3 +141,8 @@ Feature: Navigate between pages using the header menu and the drawer
     Then I should see "Pod network " within "#main h2"
     When I click on "Admin" in the drawer
     Then I should see "Sidekiq monitor" within "#drawer"
+
+  Scenario: users doesn't have access to the admin pages
+    When I open the drawer
+    Then I should not see "Admin" within "#drawer"
+    Then I should not see "Reports" within "#drawer"

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -25,6 +25,11 @@ Given /^a nsfw user with email "([^\"]*)"$/ do |email|
   user.profile.update_attributes(:nsfw => true)
 end
 
+Given /^a moderator with email "([^\"]*)"$/ do |email|
+  user = create_user(email: email)
+  Role.add_moderator(user)
+end
+
 Given /^an admin with email "([^\"]*)"$/ do |email|
   user = create_user(email: email)
   Role.add_admin(user)


### PR DESCRIPTION
Follow up of #7295 where I forgot about the moderator role. This PR add a link in the mobile drawer to allow moderators to access the report page.
I also added a test to be sure that those links are not displayed to normal users.

@SuperTux88 I know you branched 0.6.7.0 tonight, as you're the one who dispatches commits everywhere, you decide if this can be included in it or not ;) (The review should be very easy).