### PR TITLE
Fix height too high on mobile SPV, closes #7402

### DIFF
--- a/app/assets/stylesheets/mobile/mobile.scss
+++ b/app/assets/stylesheets/mobile/mobile.scss
@@ -55,7 +55,6 @@ textarea { resize: vertical; }
   overflow: auto;
   position: relative;
   text-align: left;
-  min-height: 34px;
   padding: 10px 0 0 0;
   list-style: none;
 


### PR DESCRIPTION
Looks like the min-height was not needed even for the  `.stream-element` elems. 