### PR TITLE
Center .excellence-box contents

### DIFF
--- a/app/assets/stylesheets/navbar_left.scss
+++ b/app/assets/stylesheets/navbar_left.scss
@@ -122,6 +122,7 @@
 
   .excellence-box {
     margin-top: 10px;
+    text-align: center;
 
     .content {
       font-size: $font-size-base;


### PR DESCRIPTION
Before:

<img width="289" alt="screen shot 2017-07-06 at 03 43 16" src="https://user-images.githubusercontent.com/344777/27891996-7e02d76e-61fd-11e7-9591-3798e1866d33.png">

After:

<img width="282" alt="screen shot 2017-07-06 at 03 43 35" src="https://user-images.githubusercontent.com/344777/27892000-85fd971a-61fd-11e7-968e-6091dd021c48.png">

Feels more natural to me.