### PR TITLE
Fix: Check for asset precompilation when starting server

### DIFF
--- a/script/server
+++ b/script/server
@@ -150,7 +150,7 @@ then
 fi
 
 # Check if assets are precompiled
-if [ "$RAILS_ENV" = "production" -a -z "$(find public/assets -maxdepth 1 -name 'main-*.js' -print -quit 2>/dev/null)" ]
+if [ "$RAILS_ENV" = "production" -a -z "$(find public/assets/ -maxdepth 1 -name 'main-*.js' -print -quit 2>/dev/null)" ]
 then
   fatal "You're running in production mode without having assets
 precompiled. Now and after each update before you restart the


### PR DESCRIPTION
I set up my public/assets folder to by symlinked (working with Capistrano) and the server script falsely reported that my assets were not compiled. Adding a trailing slash to public/assets fixes the problem.

Since having the trailing slash makes the check work for all cases (someone is using a regular directory or a symlink), I thought it would not hurt to make this minor update.

Adding [ci skip] since it seems redundant to run tests for this :smiley: 

---

**Edit**: Uhmmmm. so much for skipping the CI tests... :confused:  Guess, it should have gone in the commit, not the PR. Sorry! :man_shrugging: 

**Edit 2:** Rebased as #7488