### PR TITLE
Issue #6559: Changed default mail FROM header and tests

### DIFF
--- a/app/mailers/notification_mailers/base.rb
+++ b/app/mailers/notification_mailers/base.rb
@@ -38,8 +38,9 @@ module NotificationMailers
         host: "#{AppConfig.pod_uri.host}",
         to:   name_and_address(@recipient.name, @recipient.email)
       }
-
-      headers[:from] = "\"#{@sender.name} (diaspora*)\" <#{AppConfig.mail.sender_address}>" if @sender.present?
+      return headers if @sender.blank?
+      sender_in_header = @sender.profile.full_name.empty? ? @sender.username : @sender.name
+      headers[:from] = "\"Diaspora* (#{sender_in_header})\" <#{AppConfig.mail.sender_address}>"
 
       headers
     end

--- a/app/mailers/notification_mailers/base.rb
+++ b/app/mailers/notification_mailers/base.rb
@@ -34,13 +34,13 @@ module NotificationMailers
 
     def default_headers
       headers = {
-        from: AppConfig.mail.sender_address.get,
+        from: "\"#{AppConfig.settings.pod_name}\" <#{AppConfig.mail.sender_address}>",
         host: "#{AppConfig.pod_uri.host}",
         to:   name_and_address(@recipient.name, @recipient.email)
       }
       return headers if @sender.blank?
       sender_in_header = @sender.profile.full_name.empty? ? @sender.username : @sender.name
-      headers[:from] = "\"Diaspora* (#{sender_in_header})\" <#{AppConfig.mail.sender_address}>"
+      headers[:from] = "\"#{AppConfig.settings.pod_name} (#{sender_in_header})\" <#{AppConfig.mail.sender_address}>"
 
       headers
     end

--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -1,5 +1,5 @@
 class ReportMailer < ActionMailer::Base
-  default from: AppConfig.mail.sender_address
+  default from: "\"#{AppConfig.settings.pod_name}\" <#{AppConfig.mail.sender_address}>"
 
   def self.new_report(report_id)
     report = Report.find_by_id(report_id)

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -246,7 +246,7 @@ describe Notifier, type: :mailer do
     end
 
     it "FROM: contains the sender's name" do
-      expect(@mail["From"].to_s).to eq("\"#{@cnv.author.name} (diaspora*)\" <#{AppConfig.mail.sender_address}>")
+      expect(@mail["From"].to_s).to eq("\"Diaspora* (#{@cnv.author.name})\" <#{AppConfig.mail.sender_address}>")
     end
 
     it "should use a generic subject" do
@@ -290,7 +290,7 @@ describe Notifier, type: :mailer do
       end
 
       it "FROM: contains the sender's name" do
-        expect(comment_mail["From"].to_s).to eq("\"#{eve.name} (diaspora*)\" <#{AppConfig.mail.sender_address}>")
+        expect(comment_mail["From"].to_s).to eq("\"Diaspora* (#{eve.name})\" <#{AppConfig.mail.sender_address}>")
       end
 
       it "SUBJECT: has a snippet of the post contents, without markdown and without newlines" do
@@ -331,7 +331,7 @@ describe Notifier, type: :mailer do
       end
 
       it "FROM: has the name of person commenting as the sender" do
-        expect(comment_mail["From"].to_s).to eq("\"#{eve.name} (diaspora*)\" <#{AppConfig.mail.sender_address}>")
+        expect(comment_mail["From"].to_s).to eq("\"Diaspora* (#{eve.name})\" <#{AppConfig.mail.sender_address}>")
       end
 
       it "SUBJECT: has a snippet of the post contents, without markdown and without newlines" do
@@ -386,7 +386,7 @@ describe Notifier, type: :mailer do
         end
 
         it "FROM: contains the sender's name" do
-          expect(mail["From"].to_s).to eq("\"#{bob.name} (diaspora*)\" <#{AppConfig.mail.sender_address}>")
+          expect(mail["From"].to_s).to eq("\"Diaspora* (#{bob.name})\" <#{AppConfig.mail.sender_address}>")
         end
 
         it "SUBJECT: does not show the limited post" do
@@ -411,7 +411,7 @@ describe Notifier, type: :mailer do
         end
 
         it "FROM: contains the sender's name" do
-          expect(mail["From"].to_s).to eq("\"#{bob.name} (diaspora*)\" <#{AppConfig.mail.sender_address}>")
+          expect(mail["From"].to_s).to eq("\"Diaspora* (#{bob.name})\" <#{AppConfig.mail.sender_address}>")
         end
 
         it "SUBJECT: does not show the limited post" do
@@ -442,7 +442,7 @@ describe Notifier, type: :mailer do
       end
 
       it "FROM: contains the sender's name" do
-        expect(mail["From"].to_s).to eq("\"#{bob.name} (diaspora*)\" <#{AppConfig.mail.sender_address}>")
+        expect(mail["From"].to_s).to eq("\"Diaspora* (#{bob.name})\" <#{AppConfig.mail.sender_address}>")
       end
 
       it "SUBJECT: does not show the limited post" do
@@ -478,7 +478,11 @@ describe Notifier, type: :mailer do
       expect(@confirm_email.to).to eq([bob.unconfirmed_email])
     end
 
-    it "has the unconfirmed emil in the subject" do
+    it "FROM: header should be the default sender address" do
+      expect(@confirm_email["From"].to_s).to eq(AppConfig.mail.sender_address.to_s)
+    end
+
+    it "has the unconfirmed email in the subject" do
       expect(@confirm_email.subject).to include(bob.unconfirmed_email)
     end
 
@@ -500,6 +504,10 @@ describe Notifier, type: :mailer do
 
     it "goes to the right person" do
       expect(email.to).to eq([alice.email])
+    end
+
+    it "FROM: header should be the default sender address" do
+      expect(email["From"].to_s).to eq(AppConfig.mail.sender_address.to_s)
     end
 
     it "has the correct subject" do
@@ -534,6 +542,12 @@ describe Notifier, type: :mailer do
       expect {
         Notifier.send_notification("started_sharing", bob.id, person.id)
       }.to_not raise_error
+    end
+
+    it "FROM: header should be 'Diaspora* (username)' when there is no first and last name" do
+      bob.person.profile.update_attributes(first_name: "", last_name: "")
+      mail = Notifier.send_notification("started_sharing", alice.id, bob.person.id)
+      expect(mail["From"].to_s).to eq("\"Diaspora* (#{bob.person.username})\" <#{AppConfig.mail.sender_address}>")
     end
   end
 end

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -1,5 +1,7 @@
 describe Notifier, type: :mailer do
   let(:person) { FactoryGirl.create(:person) }
+  let(:pod_name) { AppConfig.settings.pod_name }
+
 
   before do
     Notifier.deliveries = []
@@ -246,7 +248,7 @@ describe Notifier, type: :mailer do
     end
 
     it "FROM: contains the sender's name" do
-      expect(@mail["From"].to_s).to eq("\"Diaspora* (#{@cnv.author.name})\" <#{AppConfig.mail.sender_address}>")
+      expect(@mail["From"].to_s).to eq("\"#{pod_name} (#{@cnv.author.name})\" <#{AppConfig.mail.sender_address}>")
     end
 
     it "should use a generic subject" do
@@ -290,7 +292,7 @@ describe Notifier, type: :mailer do
       end
 
       it "FROM: contains the sender's name" do
-        expect(comment_mail["From"].to_s).to eq("\"Diaspora* (#{eve.name})\" <#{AppConfig.mail.sender_address}>")
+        expect(comment_mail["From"].to_s).to eq("\"#{pod_name} (#{eve.name})\" <#{AppConfig.mail.sender_address}>")
       end
 
       it "SUBJECT: has a snippet of the post contents, without markdown and without newlines" do
@@ -331,7 +333,7 @@ describe Notifier, type: :mailer do
       end
 
       it "FROM: has the name of person commenting as the sender" do
-        expect(comment_mail["From"].to_s).to eq("\"Diaspora* (#{eve.name})\" <#{AppConfig.mail.sender_address}>")
+        expect(comment_mail["From"].to_s).to eq("\"#{pod_name} (#{eve.name})\" <#{AppConfig.mail.sender_address}>")
       end
 
       it "SUBJECT: has a snippet of the post contents, without markdown and without newlines" do
@@ -386,7 +388,7 @@ describe Notifier, type: :mailer do
         end
 
         it "FROM: contains the sender's name" do
-          expect(mail["From"].to_s).to eq("\"Diaspora* (#{bob.name})\" <#{AppConfig.mail.sender_address}>")
+          expect(mail["From"].to_s).to eq("\"#{pod_name} (#{bob.name})\" <#{AppConfig.mail.sender_address}>")
         end
 
         it "SUBJECT: does not show the limited post" do
@@ -411,7 +413,7 @@ describe Notifier, type: :mailer do
         end
 
         it "FROM: contains the sender's name" do
-          expect(mail["From"].to_s).to eq("\"Diaspora* (#{bob.name})\" <#{AppConfig.mail.sender_address}>")
+          expect(mail["From"].to_s).to eq("\"#{pod_name} (#{bob.name})\" <#{AppConfig.mail.sender_address}>")
         end
 
         it "SUBJECT: does not show the limited post" do
@@ -442,7 +444,7 @@ describe Notifier, type: :mailer do
       end
 
       it "FROM: contains the sender's name" do
-        expect(mail["From"].to_s).to eq("\"Diaspora* (#{bob.name})\" <#{AppConfig.mail.sender_address}>")
+        expect(mail["From"].to_s).to eq("\"#{pod_name} (#{bob.name})\" <#{AppConfig.mail.sender_address}>")
       end
 
       it "SUBJECT: does not show the limited post" do
@@ -478,8 +480,8 @@ describe Notifier, type: :mailer do
       expect(@confirm_email.to).to eq([bob.unconfirmed_email])
     end
 
-    it "FROM: header should be the default sender address" do
-      expect(@confirm_email["From"].to_s).to eq(AppConfig.mail.sender_address.to_s)
+    it "FROM: header should be the pod name with default sender address" do
+      expect(@confirm_email["From"].to_s).to eq("#{pod_name} <#{AppConfig.mail.sender_address}>")
     end
 
     it "has the unconfirmed email in the subject" do
@@ -506,8 +508,8 @@ describe Notifier, type: :mailer do
       expect(email.to).to eq([alice.email])
     end
 
-    it "FROM: header should be the default sender address" do
-      expect(email["From"].to_s).to eq(AppConfig.mail.sender_address.to_s)
+    it "FROM: header should be the pod name + default sender address" do
+      expect(email["From"].to_s).to eq("#{pod_name} <#{AppConfig.mail.sender_address}>")
     end
 
     it "has the correct subject" do
@@ -544,10 +546,10 @@ describe Notifier, type: :mailer do
       }.to_not raise_error
     end
 
-    it "FROM: header should be 'Diaspora* (username)' when there is no first and last name" do
+    it "FROM: header should be 'pod_name (username)' when there is no first and last name" do
       bob.person.profile.update_attributes(first_name: "", last_name: "")
       mail = Notifier.send_notification("started_sharing", alice.id, bob.person.id)
-      expect(mail["From"].to_s).to eq("\"Diaspora* (#{bob.person.username})\" <#{AppConfig.mail.sender_address}>")
+      expect(mail["From"].to_s).to eq("\"#{pod_name} (#{bob.person.username})\" <#{AppConfig.mail.sender_address}>")
     end
   end
 end

--- a/spec/mailers/report_spec.rb
+++ b/spec/mailers/report_spec.rb
@@ -41,6 +41,11 @@ describe Report, type: :mailer do
       expect(ActionMailer::Base.deliveries[1].to[0]).to include(@user2.email)
     end
 
+    it "FROM: header should be the default sender address" do
+      ReportMailer.new_report(@post_report.id).each(&:deliver_now)
+      expect(ReportMailer.default[:from].to_s).to eq(AppConfig.mail.sender_address.to_s)
+    end
+
     it "should send mail in recipent's prefered language" do
       ReportMailer.new_report(@post_report.id).each(&:deliver_now)
       expect(ActionMailer::Base.deliveries[0].subject).to match("Ein neuer post wurde als anstößig markiert")

--- a/spec/mailers/report_spec.rb
+++ b/spec/mailers/report_spec.rb
@@ -41,9 +41,10 @@ describe Report, type: :mailer do
       expect(ActionMailer::Base.deliveries[1].to[0]).to include(@user2.email)
     end
 
-    it "FROM: header should be the default sender address" do
+    it "FROM: header should be the pod name + default sender address" do
       ReportMailer.new_report(@post_report.id).each(&:deliver_now)
-      expect(ReportMailer.default[:from].to_s).to eq(AppConfig.mail.sender_address.to_s)
+      pod_name = AppConfig.settings.pod_name
+      expect(ReportMailer.default[:from].to_s).to eq("\"#{pod_name}\" <#{AppConfig.mail.sender_address}>")
     end
 
     it "should send mail in recipent's prefered language" do


### PR DESCRIPTION
Hey
so here's our first pull request. We had some remarks and questions regarding our solution. Here we go:

Code:
- We changed the default_headers method in the `app/mailers/notification_mailers/base.rb` file to defer between the case where sender has a First and/or Last name and the case where the sender has no First and Last name, but just a diaspora handle.

We have decided the following about the headers:
- Sender present/Firsname Lastname exists: We opted for the `Diaspora* (Firstname Lastname)`. "On behalf of" seemed quite formal to us. But of course we are open to changing it again.
- Sender present/Firstname Lastname doesn’t exist: `Diaspora*`.
We chose the above mentioned solutions as they are short, clear and does. 
- No sender present: We decided to keep this case without `Diaspora*` so that you see directly which email it comes from (is this in most cases a no-reply email?). We address this option even though the issue doesn’t refer to that case.

Other options, we discussed were:
a. when Firstname and/or Lastname is present: 
	`Diaspora* (from Firstname Lastname) <no-reply@example.org>`, 
	`Diaspora* Notifications (from Firstname Lastname) <no-reply@example.org`>, 
	`Diaspora* (on behalf of Firstname Lastname) <no-reply@example.org>`.

b. when Firstname and/or Lastname is missing: 
	`<no-reply@example.org>`, 
	`Diaspora* Notifications <no-reply@example.org>`.

c. when no sender is present:
	`Diaspora* <no-reply@example.org>`

We need to keep in mind that any additional string in the header will require translations. 

Something else we encountered regarding the default sender_address: if the pod admin configured an email address in the `defaults.yml`, a reply will go that email. This can be quite confusing because the user will think they write the sender but actually it goes to the admin. (could be a privacy issue too)

Tests:
- we changed the already existing tests regarding the FROM header in the `spec/notifier_spec.rb`
- we wrote tests for the case when there is no sender: 
	- reports (`report_spec.rb` line 44)
	- confirm_email (`spec/notifier_spec.rb` line 481)
	- csrf_token_fail (`spec/notifier_spec.rb` line 502)
- we wrote a test for the case when there is a sender but no First and/or Last name (`notifier_spec.rb `line 547). We placed the test for now in the describe 'base' block at the bottom of the file. We were wondering whether we should write this test for all notification types or keep it at the bottom in the describe 'base' block?

Another tests issue:
We realized that not for all notification types there are tests regarding the FROM: header. Do they need to be added in each describe “notification type” block. Now it seems not to be a bit inconsitent. (The following notification types have so far no test regarding FROM: reshared, liked, mentioned, mentioned_in_comment, started_sharing). We didn’t want to include this in this pull request, because we feel it’s beyond the scope of the 6559 issue. Should we create a new issue to discuss this?

As this is our first contribution, we hope we didn't break any conventions. Let us know, we're happy to learn. :)