### PR TITLE
Fix: Failing 'Signs Up'-Feature Tests

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -17,8 +17,8 @@
       = javascript_include_tag :main, :templates
       = load_javascript_locales
 
-    = render "head"
     = include_color_theme
+    = render "head"
     = translation_missing_warnings
 
   %body{class: "page-#{controller_name} action-#{action_name}"}


### PR DESCRIPTION
This fixes the randomly failing desktop/signs_up.feature:56 test. The reason is interesting. It has to do with the order in which the stylesheet and scripts are loaded in the head.

I know this sounds odd but I actually tested this heavily.

First of all, here is desktop/signs_up.feature:56 for you:

~~~ruby
  Scenario: new user with some tags posts first status message
    When I fill in the following:
      | profile_first_name | some name        |
    And I fill in "tags" with "#rockstar"
    And I press the first ".as-result-item" within "#as-results-tags"
    And I follow "awesome_button"
    Then I should be on the stream page
    And the publisher should be expanded
    When I wait for the popovers to appear
    And I click close on all the popovers
    And I submit the publisher
    Then "Hey everyone, I’m #newhere. I’m interested in #rockstar." should be post 1
~~~

The test sometimes 'randomly' fails on 'And I submit the publisher'. This is what that step does:

~~~ruby
    txt = find("#publisher #status_message_text").value
    find("#publisher .btn-primary").click
    # wait for the publisher to be closed
    expect(find("#publisher")["class"]).to include("closed")
    # wait for the content to appear
    expect(find("#main_stream")).to have_content(txt)
~~~

The failure is because this expectation fails: `expect(find("#publisher")["class"]).to include("closed")`

The method `close()` in `app/assets/javascripts/app/views/publisher_view.js` is responsible for adding the class 'closed' to the #publisher (ln 429). Close() in turn is triggered by the event 'publisher:add' (ln 68). 'publisher:add' in turn is triggered by `createStatusMessage()` (ln 206).

After inserting some console.log statements into the JS code responsible for handling the publisher (`app/assets/javascripts/app/views/publisher_view.js`), we can actually see that in all 'random' failures the JS method `createStatusMessage()` (same file) is **not** being called (as opposed to all the passing ones).

In randomly failing tests, `createStatusMessage()` does not get called because the submit button is disabled. We can see that also with the console.log statements. In failing tests, the submit button is disabled because the method responsible for en-/disabling the button `_submittable()` (same file) returns false. It is expected to be returning true (and does so in all passing tests).

Why is `_submittable()` returning false? This is because it is calling `this.viewPollCreator.validatePoll()` (line 481 of same file) and that returns false.

Why does `validatePoll()` in app/assets/javascripts/app/views/publisher/poll_creator_view.js return false? That is because poll options are not being hidden and so the method validates the inputs and determines they are invalid. They are correctly being hidden in passing tests.

Why are these poll options not being hidden? This is because the stylesheet -- sometimes -- is not fully loaded when the script executes. And therefore the .poll-creator-container does not have style `display: none;`. You can find that rule specified line 203 of app/assets/stylesheets/publisher.scss.

Why is the stylesheet not fully loaded? Turns out that JQuery does **not** wait until the stylesheet is loaded. This is from the JQuery docs (quoted from https://stackoverflow.com/a/1324720/6451879):

> The ready() method no longer tries to make any guarantees about waiting for all stylesheets to be loaded. Instead all CSS files should be included before the scripts on the page. More Information

> Note: Please make sure that all stylesheets are included before your scripts (especially those that call the ready function). Doing so will make sure that all element properties are correctly defined before jQuery code begins executing. Failure to do this will cause sporadic problems, especially on WebKit-based browsers such as Safari.

I agree that sounds crazy but it actually fixes the problem to load the stylesheet **before** the scripts, as I've tried to show by running 120 reps of the feature both pre- and post-fix in #7496 .

PR #7496 also includes introduces some console.log statements in the code that will illustrate this behavior. Here a (trimmed) example of a passing test:

~~~ruby
  Scenario: 1) new user with some tags posts first status message                    # features/repetitions/signs_up_56.feature:11

    When I fill in the following:                                                    # features/step_definitions/web_steps.rb:59

      | profile_first_name | some name |

    And I fill in "tags" with "#rockstar"                                            # features/step_definitions/web_steps.rb:42

    And I press the first ".as-result-item" within "#as-results-tags"                # features/step_definitions/custom_web_steps.rb:165

Validating 0 poll inputs...

Poll is valid            # first thing to notice: Javascript console output shows BEFORE the step that triggers it. That's because Cucumber does not 'put' the name of the step until it has passed or failed.

Checking if post can be submitted:  # this is our _submittable() function checking if the submit button should be enabled or not

Post has text or photo: true    # we have text

Post poll does not exist or is invalid: true    # and we have no poll

Post is submittable.      # so let's enable the button

# ... (same as above b/c it gets re-run on various events, such as textChange)

    And I follow "awesome_button"                                                    # features/step_definitions/web_steps.rb:36

    Then I should be on the stream page                                              # features/step_definitions/web_steps.rb:174

    And the publisher should be expanded                                             # features/step_definitions/custom_web_steps.rb:71

    When I wait for the popovers to appear                                           # features/step_definitions/custom_web_steps.rb:230

    And I click close on all the popovers                                            # features/step_definitions/custom_web_steps.rb:234

'Post' button has been clicked...   # great! The submit button has been clicked and our post is being saved. Yuhee!    Look out for this one - you will not see it in the failing test.

# ... (irrelevant now)

    And I submit the publisher                                                       # features/step_definitions/posts_steps.rb:84

    Then "Hey everyone, I’m #newhere. I’m interested in #rockstar." should be post 1 # features/step_definitions/stream_steps.rb:9
~~~


Okay, and here a failing test:

~~~ruby
  Scenario: 5) new user with some tags posts first status message                    # features/repetitions/signs_up_56.feature:63

    When I fill in the following:                                                    # features/step_definitions/web_steps.rb:59

      | profile_first_name | some name |

    And I fill in "tags" with "#rockstar"                                            # features/step_definitions/web_steps.rb:42

    And I press the first ".as-result-item" within "#as-results-tags"                # features/step_definitions/custom_web_steps.rb:165

Validating 3 poll inputs...     # Wait, what? Which three poll inputs? The poll is supposed to be hidden as per the stylesheet!

Poll is not valid                # Oh no... This is going in a bad direction

Checking if post can be submitted:

Post has text or photo: true

Post poll does not exist or is invalid: false      # Stopppppppp!

Post is not submittable.                                   # Oh, here we have the problem...

Validating 3 poll inputs...                     # Stop it now!

Poll is not valid

Checking if post can be submitted:

Post has text or photo: true

Post poll does not exist or is invalid: false

Post is not submittable.                  # This is gonna fail big time... :/

    And I follow "awesome_button"                                                    # features/step_definitions/web_steps.rb:36

    Then I should be on the stream page                                              # features/step_definitions/web_steps.rb:174

    And the publisher should be expanded                                             # features/step_definitions/custom_web_steps.rb:71

    When I wait for the popovers to appear                                           # features/step_definitions/custom_web_steps.rb:230

    And I click close on all the popovers                                            # features/step_definitions/custom_web_steps.rb:234

    And I submit the publisher                                                       # features/step_definitions/posts_steps.rb:84

      expected "mention_popup publisher row" to include "closed" (RSpec::Expectations::ExpectationNotMetError)

      ./features/support/publishing_cuke_helpers.rb:31:in `submit_publisher'

      ./features/step_definitions/posts_steps.rb:85:in `/^I submit the publisher$/'

      features/repetitions/signs_up_56.feature:73:in `And I submit the publisher'

    Then "Hey everyone, I’m #newhere. I’m interested in #rockstar." should be post 1 # features/step_definitions/stream_steps.rb:9

# aaaand failed because click did not trigger post submission and therefore the 'closed' class was not applied
~~~


If you check Travis, you will see that all 'randomly' failing feature:56 tests are identical to this one.


This primarily fixes more than just feature:56. But it might also positively affect a few other ones. It does not solve all feature failures as I'm still getting a few on my fork even with the fix.