### PR TITLE
Send public profiles publicly

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -40,6 +40,10 @@ class Profile < ActiveRecord::Base
     Person.joins(:contacts).where(contacts: {user_id: person.owner_id})
   end
 
+  def public?
+    public_details?
+  end
+
   def diaspora_handle
     #get the parent diaspora handle, unless we want to access a profile without a person
     (self.person) ? self.person.diaspora_handle : self[:diaspora_handle]

--- a/lib/diaspora/federation/entities.rb
+++ b/lib/diaspora/federation/entities.rb
@@ -160,7 +160,8 @@ module Diaspora
           location:         profile.location,
           searchable:       profile.searchable,
           nsfw:             profile.nsfw,
-          tag_string:       profile.tag_string
+          tag_string:       profile.tag_string,
+          public:           profile.public_details
         )
       end
 

--- a/lib/diaspora/federation/receive.rb
+++ b/lib/diaspora/federation/receive.rb
@@ -122,7 +122,8 @@ module Diaspora
             location:         entity.location,
             searchable:       entity.searchable,
             nsfw:             entity.nsfw,
-            tag_string:       entity.tag_string
+            tag_string:       entity.tag_string,
+            public_details:   entity.public
           )
         end
       end

--- a/spec/lib/diaspora/federation/entities_spec.rb
+++ b/spec/lib/diaspora/federation/entities_spec.rb
@@ -188,6 +188,7 @@ describe Diaspora::Federation::Entities do
       expect(federation_entity.searchable).to eq(diaspora_entity.searchable)
       expect(federation_entity.nsfw).to eq(diaspora_entity.nsfw)
       expect(federation_entity.tag_string.split(" ")).to match_array(diaspora_entity.tag_string.split(" "))
+      expect(federation_entity.public).to eq(diaspora_entity.public_details)
     end
 
     it "builds a reshare" do

--- a/spec/lib/diaspora/federation/receive_spec.rb
+++ b/spec/lib/diaspora/federation/receive_spec.rb
@@ -415,6 +415,7 @@ describe Diaspora::Federation::Receive do
       expect(profile.searchable).to eq(profile_entity.searchable)
       expect(profile.nsfw).to eq(profile_entity.nsfw)
       expect(profile.tag_string.split(" ")).to match_array(profile_entity.tag_string.split(" "))
+      expect(profile.public_details).to eq(profile_entity.public)
     end
   end
 

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -185,6 +185,18 @@ describe Profile, :type => :model do
     end
   end
 
+  describe "public?" do
+    it "is public if public_details is true" do
+      profile = FactoryGirl.build(:profile, public_details: true)
+      expect(profile.public?).to be_truthy
+    end
+
+    it "is not public if public_details is false" do
+      profile = FactoryGirl.build(:profile, public_details: false)
+      expect(profile.public?).to be_falsey
+    end
+  end
+
   describe 'date=' do
     let(:profile) { FactoryGirl.build(:profile) }
 


### PR DESCRIPTION
This will help big public profiles (for example hq@pod.diaspora.software), and it's public anyway, so no need to encrypt them.

fixes #3164