### PR TITLE
Exclude ignored people from followed tags when building stream-relation

### DIFF
--- a/lib/evil_query.rb
+++ b/lib/evil_query.rb
@@ -71,7 +71,7 @@ module EvilQuery
 
     def followed_tags_posts!
       logger.debug("[EVIL-QUERY] followed_tags_posts!")
-      StatusMessage.public_tag_stream(@user.followed_tag_ids)
+      StatusMessage.public_tag_stream(@user.followed_tag_ids).excluding_hidden_content(@user)
     end
 
     def mentioned_posts

--- a/spec/lib/evil_query_spec.rb
+++ b/spec/lib/evil_query_spec.rb
@@ -28,6 +28,18 @@ describe EvilQuery::MultiStream do
       expect(evil_query.make_relation!.map(&:id)).not_to include(public_post.id)
       expect(evil_query.make_relation!.map(&:id)).not_to include(private_post.id)
     end
+
+    it "doesn't include posts with tags from ignored users" do
+      tag = ActsAsTaggableOn::Tag.find_or_create_by(name: "test")
+      alice.tag_followings.create(tag_id: tag.id)
+      alice.blocks.create(person_id: eve.person_id)
+
+      bob_post = bob.post(:status_message, text: "public #test post 1", to: "all", public: true)
+      eve_post = eve.post(:status_message, text: "public #test post 2", to: "all", public: true)
+
+      expect(evil_query.make_relation!.map(&:id)).to include(bob_post.id)
+      expect(evil_query.make_relation!.map(&:id)).not_to include(eve_post.id)
+    end
   end
 end
 


### PR DESCRIPTION
This improves the main stream when you have less or inactive contacts and ignored an active person that posts many posts with tags. When the person is only removed after collecting all post ids, you don't see posts with tags from other people.

This is only a quickfix and not a clean solution (but I currently don't have the time to rewrite everything). It's probably still broken, but it's now less broken than before.