### PR TITLE
Improve responsive header in desktop version

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -43,6 +43,7 @@ If so, please delete it since it will prevent the federation from working proper
 * Support direct links to comments on mobile [#7508](https://github.com/diaspora/diaspora/pull/7508)
 * Add inviter first and last name in the invitation e-mail [#7484](https://github.com/diaspora/diaspora/pull/7484)
 * Add markdown editor for comments and conversations [#7482](https://github.com/diaspora/diaspora/pull/7482)
+* Improve responsive header in desktop version [#7509](https://github.com/diaspora/diaspora/pull/7509)
 
 # 0.6.8.0
 

--- a/app/assets/javascripts/app/views/notification_dropdown_view.js
+++ b/app/assets/javascripts/app/views/notification_dropdown_view.js
@@ -26,7 +26,6 @@ app.views.NotificationDropdown = app.views.Base.extend({
 
   toggleDropdown: function(evt){
     evt.stopPropagation();
-    if (!$("#notifications-link .entypo-bell:visible").length) { return true; }
     evt.preventDefault();
     if(this.dropdownShowing()){ this.hideDropdown(evt); }
     else{ this.showDropdown(); }

--- a/app/assets/stylesheets/color_themes/_color_theme_override_dark.scss
+++ b/app/assets/stylesheets/color_themes/_color_theme_override_dark.scss
@@ -1,11 +1,6 @@
 // Only overriding existing selectors here, so disable some lint rules
 // scss-lint:disable IdSelector, SelectorFormat, NestingDepth, SelectorDepth, QualifyingElement
 body {
-  .navbar.navbar-fixed-top #user-menu .dropdown-menu > li > a {
-    color: $text-color;
-    &:hover { color: $white; }
-  }
-
   .publisher {
     form {
       #publisher_textarea_wrapper { background-color: $gray; }

--- a/app/assets/stylesheets/color_themes/_color_theme_override_dark.scss
+++ b/app/assets/stylesheets/color_themes/_color_theme_override_dark.scss
@@ -1,7 +1,7 @@
 // Only overriding existing selectors here, so disable some lint rules
 // scss-lint:disable IdSelector, SelectorFormat, NestingDepth, SelectorDepth, QualifyingElement
 body {
-  .navbar.navbar-fixed-top #user_menu .dropdown-menu > li > a {
+  .navbar.navbar-fixed-top #user-menu .dropdown-menu > li > a {
     color: $text-color;
     &:hover { color: $white; }
   }

--- a/app/assets/stylesheets/color_themes/dark/_style.scss
+++ b/app/assets/stylesheets/color_themes/dark/_style.scss
@@ -59,7 +59,8 @@ $dropdown-link-hover-color: $dropdown-link-color;
 
 //== Navbar
 $navbar-inverse-bg: $gray-darker;
-$navbar-inverse-link-hover-color: $text-color;
+$navbar-inverse-link-color: $gray-lighter;
+$navbar-inverse-link-hover-color: $white;
 $navbar-inverse-brand-hover-color: $navbar-inverse-link-hover-color;
 
 //== Tabs

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -247,4 +247,12 @@
       }
     }
   }
+
+  @media (max-width: $screen-xs-max) {
+    .nav-badges .dropdown-menu {
+      position: fixed;
+      top: $navbar-height;
+      width: 100%;
+    }
+  }
 }

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -175,13 +175,13 @@
       width: 100%;
 
       a {
-        color: #9d9d9d;
+        color: $navbar-inverse-link-color;
         font-weight: bold;
         padding: 10px 15px;
 
         &:hover {
-          background-color: transparent;
-          color: #fff;
+          background-color: $navbar-inverse-link-hover-bg;
+          color: $navbar-inverse-link-hover-color;
         }
       }
     }
@@ -215,12 +215,12 @@
       width: 100%;
 
       a {
-        color: $gray-light;
+        color: $navbar-inverse-link-color;
         padding-left: 55px;
 
         &:hover {
-          background-color: $brand-primary;
-          color: $gray-lighter;
+          background-color: $list-group-hover-bg;
+          color: $list-group-link-hover-color;
         }
       }
 

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -1,3 +1,14 @@
+.not-connected-menu {
+  .navbar-left {
+    float: left;
+  }
+
+  .navbar-right,
+  .navbar-right li {
+    float: right;
+  }
+}
+
 .navbar.navbar-fixed-top {
   border-bottom: none;
   box-shadow: 1px 0 2px $black;
@@ -13,13 +24,14 @@
     margin-left: -15px;
   }
 
-  #header-title {
+  .header-title {
     margin-top: -7px;
 
     img {
       height: 32px;
       opacity: .7;
     }
+
     img:hover {
       opacity: 1;
     }
@@ -107,27 +119,16 @@
     }
   }
 
-  #user_menu {
+  .user-avatar {
+    height: $navbar-height;
+    margin-bottom: -$navbar-padding-vertical;
+    margin-right: 10px;
+    margin-top: -$navbar-padding-vertical;
+    padding: ($navbar-height - 30px) / 2 0;
+
     .avatar {
       height: 30px;
       width: 30px;
-    }
-    .user-avatar {
-      height: $navbar-height;
-      padding: ($navbar-height - 30px)/2 0;
-      margin-bottom: -$navbar-padding-vertical;
-      margin-top: -$navbar-padding-vertical;
-      margin-right: 10px;
-    }
-  }
-
-  .not-connected-menu {
-    .navbar-left {
-      float: left;
-    }
-    .navbar-right,
-    .navbar-right li {
-      float: right;
     }
   }
 
@@ -147,30 +148,27 @@
       }
     }
 
-    #navbar-collapse {
-      .form-group,
-      .twitter-typeahead {
-        display: block !important;
-        margin-bottom: 0;
+    .form-group,
+    .twitter-typeahead {
+      margin-bottom: 0;
 
-        &,
-        input { width: 100%; }
-      }
+      &,
+      input { width: 100%; }
     }
 
     .nav-badges .dropdown-menu {
       width: 300px;
     }
 
-    #user_menu .dropdown-menu {
+    .user-menu-dropdown {
+      background-color: transparent;
+      border: 0;
+      box-shadow: none;
       display: block;
+      margin-top: -8px; // To compensate parent ul margin
+      padding: 0;
       position: static;
       width: 100%;
-      background-color: transparent;
-      box-shadow: none;
-      border: 0;
-      padding: 0;
-      margin-top: -8px; // To compensate parent ul margin
 
       a {
         color: #9d9d9d;
@@ -178,8 +176,8 @@
         padding: 10px 15px;
 
         &:hover {
-          color: #fff;
           background-color: transparent;
+          color: #fff;
         }
       }
     }
@@ -199,26 +197,26 @@
       }
     }
 
-    #user_menu {
+    #user-menu {
       &.open .dropdown-toggle { background-color: darken($navbar-inverse-bg, 7%); }
       .dropdown-toggle {
         margin: 0 1px;
         min-width: 160px;
       }
+    }
 
-      .dropdown-menu {
-        background-color: darken($navbar-inverse-bg, 7%);
-        border-top: 0;
-        width: 100%;
+    .user-menu-dropdown {
+      background-color: darken($navbar-inverse-bg, 7%);
+      border-top: 0;
+      width: 100%;
 
-        > li > a {
-          color: $gray-light;
-          padding-left: 55px;
+      a {
+        color: $gray-light;
+        padding-left: 55px;
 
-          &:hover {
-            background-color: $brand-primary;
-            color: $gray-lighter;
-          }
+        &:hover {
+          background-color: $brand-primary;
+          color: $gray-lighter;
         }
       }
     }

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -117,6 +117,16 @@
     }
   }
 
+  .not-connected-menu {
+    .navbar-left {
+      float: left;
+    }
+    .navbar-right,
+    .navbar-right li {
+      float: right;
+    }
+  }
+
   @media (max-width: $grid-float-breakpoint-max) {
 
     .navbar-nav.hidden-xs {

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -136,6 +136,8 @@
     }
   }
 
+  .navbar-form .form-control { display: inline-block; }
+
   @media (max-width: $grid-float-breakpoint-max) {
 
     .navbar-nav.hidden-xs {

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -25,7 +25,7 @@
   }
 
   .header-title {
-    margin-top: -7px;
+    margin: (($navbar-height - 32px - 2 * $navbar-padding-vertical) / 2) 0;
 
     img {
       height: 32px;
@@ -50,7 +50,7 @@
   }
 
   .nav-badge {
-    padding: 16px 12px;
+    padding: $navbar-padding-vertical 12px;
 
     .badge {
       position: absolute;
@@ -140,7 +140,11 @@
 
     .navbar-nav.hidden-xs {
       margin: 0;
-      margin-top: 6px;
+
+      a {
+        padding-bottom: $navbar-padding-vertical;
+        padding-top: $navbar-padding-vertical;
+      }
     }
 
     .nav-badge {
@@ -164,12 +168,20 @@
       width: 300px;
     }
 
+    .navbar-collapse {
+      padding-top: $navbar-padding-vertical / 2;
+
+      .navbar-nav {
+        margin-bottom: 0;
+        margin-top: 0;
+      }
+    }
+
     .user-menu-dropdown {
       background-color: transparent;
       border: 0;
       box-shadow: none;
       display: block;
-      margin-top: -8px; // To compensate parent ul margin
       padding: 0;
       position: static;
       width: 100%;
@@ -177,7 +189,7 @@
       a {
         color: $navbar-inverse-link-color;
         font-weight: bold;
-        padding: 10px 15px;
+        padding: $nav-link-padding;
 
         &:hover {
           background-color: $navbar-inverse-link-hover-bg;
@@ -189,9 +201,13 @@
 
   @media (min-width: $grid-float-breakpoint) {
 
+    .navbar-form { // set correct margin for small inputs
+      margin-bottom: ($navbar-height - $input-height-small) / 2;
+      margin-top: ($navbar-height - $input-height-small) / 2;
+    }
+
     [type="search"] {
       @include transition(width);
-      margin-top: 2px;
       width: 200px;
 
       &:not(.active) {

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -6,63 +6,47 @@
   .navbar-brand {
     font-weight: bold;
     font-size: $font-size-h3;
+    margin-left: -15px;
   }
 
-  @media (max-width: $grid-float-breakpoint-max) {
-    .navbar-header > .nav li { display: inline-block !important; }
-    .nav-badge {
-      color: $navbar-inverse-link-color;
-      padding-left: 12px;
-      padding-right: 12px;
-      &:hover { color: $navbar-inverse-link-hover-color; }
-      &:hover,
-      &:focus {
-        background-color: transparent;
-      }
+  #header-title {
+    margin-top: -7px;
+
+    img {
+      height: 32px;
+      opacity: .7;
     }
-    #navbar-collapse {
-      .form-group, .twitter-typeahead  {
-        display: block !important;
-        margin-bottom: 0;
-        &, & input { width: 100% }
-      }
+    img:hover {
+      opacity: 1;
     }
   }
-  @media (min-width: $grid-float-breakpoint) {
-    input[type="search"] {
-      @include transition(width);
-      margin-top: 2px;
-      width: 200px;
-      &:not(.active) {
-        background-color: $navbar-inverse-bg;
-        border-color: $gray-light;
-        width: 150px;
-      }
-    }
-    #user_menu {
-      &.open .dropdown-toggle { background-color: darken($navbar-inverse-bg, 7%); }
-      .dropdown-toggle {
-        margin: 0 1px;
-        min-width: 160px;
-      }
-      .dropdown-menu {
-        background-color: darken($navbar-inverse-bg, 7%);
-        border-top: none;
-        width: 100%;
-        & > li > a {
-          color: $gray-light;
-          padding-left: 55px;
-          &:hover {
-            background-color: $brand-primary;
-            color: $gray-lighter;
-          }
-        }
-      }
+
+  .navbar-header > ul,
+  .navbar-header > ul li {
+    float: left;
+  }
+
+  [class^="entypo-"],
+  [class*="entypo-"] {
+    color: inherit;
+    font-size: $font-size-h3;
+    vertical-align: middle;
+  }
+
+  .nav-badge {
+    padding: 16px 12px;
+
+    .badge {
+      position: absolute;
+      right: 10px;
+      top: 10px;
     }
   }
 
   .navbar-nav:not(.nav-badges) > li > a { font-weight: bold; }
   .nav-badges {
+    margin: 0;
+
     li { height: $navbar-height; }
     .dropdown-open {
       background-color: $dropdown-bg;
@@ -118,19 +102,6 @@
       }
     }
   }
-  [class^="entypo-"], [class*="entypo-"] {
-    color: inherit;
-    font-size: $font-size-h3;
-    vertical-align: middle;
-  }
-  .nav-badge {
-    margin-bottom: -2px;
-    .badge {
-      position: absolute;
-      right: 10px;
-      top: 10px;
-    }
-  }
 
   #user_menu {
     .avatar {
@@ -143,6 +114,77 @@
       margin-bottom: -$navbar-padding-vertical;
       margin-top: -$navbar-padding-vertical;
       margin-right: 10px;
+    }
+  }
+
+  @media (max-width: $grid-float-breakpoint-max) {
+
+    .navbar-nav.hidden-xs {
+      margin: 0;
+      margin-top: 6px;
+    }
+
+    .nav-badge {
+      color: $navbar-inverse-link-color;
+      &:hover { color: $navbar-inverse-link-hover-color; }
+      &:hover,
+      &:focus {
+        background-color: transparent;
+      }
+    }
+
+    #navbar-collapse {
+      .form-group,
+      .twitter-typeahead {
+        display: block !important;
+        margin-bottom: 0;
+
+        &,
+        input { width: 100%; }
+      }
+    }
+
+    .nav-badges .dropdown-menu {
+      width: 300px;
+    }
+  }
+
+  @media (min-width: $grid-float-breakpoint) {
+
+    [type="search"] {
+      @include transition(width);
+      margin-top: 2px;
+      width: 200px;
+
+      &:not(.active) {
+        background-color: $navbar-inverse-bg;
+        border-color: $gray-light;
+        width: 150px;
+      }
+    }
+
+    #user_menu {
+      &.open .dropdown-toggle { background-color: darken($navbar-inverse-bg, 7%); }
+      .dropdown-toggle {
+        margin: 0 1px;
+        min-width: 160px;
+      }
+
+      .dropdown-menu {
+        background-color: darken($navbar-inverse-bg, 7%);
+        border-top: 0;
+        width: 100%;
+
+        > li > a {
+          color: $gray-light;
+          padding-left: 55px;
+
+          &:hover {
+            background-color: $brand-primary;
+            color: $gray-lighter;
+          }
+        }
+      }
     }
   }
 }

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -1,7 +1,11 @@
 .navbar.navbar-fixed-top {
   border-bottom: none;
   box-shadow: 1px 0 2px $black;
-  a:focus {outline: 0 none; }
+  a:focus { outline: 0 none; }
+
+  .in {
+    overflow-y: visible; // Avoid search result dropdown to be hidden
+  }
 
   .navbar-brand {
     font-weight: bold;

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -147,6 +147,28 @@
     .nav-badges .dropdown-menu {
       width: 300px;
     }
+
+    #user_menu .dropdown-menu {
+      display: block;
+      position: static;
+      width: 100%;
+      background-color: transparent;
+      box-shadow: none;
+      border: 0;
+      padding: 0;
+      margin-top: -8px; // To compensate parent ul margin
+
+      a {
+        color: #9d9d9d;
+        font-weight: bold;
+        padding: 10px 15px;
+
+        &:hover {
+          color: #fff;
+          background-color: transparent;
+        }
+      }
+    }
   }
 
   @media (min-width: $grid-float-breakpoint) {

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -119,6 +119,10 @@
     }
   }
 
+  .user-menu-dropdown {
+    padding: 0;
+  }
+
   .user-avatar {
     height: $navbar-height;
     margin-bottom: -$navbar-padding-vertical;
@@ -197,7 +201,7 @@
       }
     }
 
-    #user-menu {
+    .user-menu {
       &.open .dropdown-toggle { background-color: darken($navbar-inverse-bg, 7%); }
       .dropdown-toggle {
         margin: 0 1px;
@@ -218,6 +222,10 @@
           background-color: $brand-primary;
           color: $gray-lighter;
         }
+      }
+
+      li:last-child a {
+        padding-bottom: 6px;
       }
     }
   }

--- a/app/assets/stylesheets/mobile/header.scss
+++ b/app/assets/stylesheets/mobile/header.scss
@@ -37,6 +37,11 @@ $mobile-navbar-height: 46px;
     padding: 7px 15px;
     margin: 0 0 0 -15px;
     height: $mobile-navbar-height;
+
+    img {
+      height: 30px;
+      width: 30px;
+    }
   }
 
   #nav-badges {
@@ -85,12 +90,6 @@ $mobile-navbar-height: 46px;
       padding: 2px 6px;
       position: absolute;
       background-color: $red;
-    }
-  }
-  #header-title{
-    img {
-      height: 30px;
-      width: 30px;
     }
   }
 }

--- a/app/assets/stylesheets/mobile/header.scss
+++ b/app/assets/stylesheets/mobile/header.scss
@@ -33,7 +33,7 @@ $mobile-navbar-height: 46px;
     li { float: left; }
   }
 
-  #header-title {
+  .header-title {
     padding: 7px 15px;
     margin: 0 0 0 -15px;
     height: $mobile-navbar-height;

--- a/app/assets/templates/header_tpl.jst.hbs
+++ b/app/assets/templates/header_tpl.jst.hbs
@@ -10,46 +10,24 @@
             <span class="icon-bar"></span>
           </button>
           <a href="/stream" class="navbar-brand" data-stream-title="{{t "my_stream"}}">
-            {{ podname }}
+            <span class="hidden-xs">{{ podname }}</span>
+            <span id="header-title" class="visible-xs">
+              <img src="/assets/branding/logos/asterisk_white_mobile.png" alt="{{ podname }}" />
+            </span>
           </a>
-          <ul class="nav nav-badges visible-sm">
-            <li>
-              <a href="/notifications" title="{{t "header.notifications"}}" class="notifications-link nav-badge">
-                <i class="entypo-bell"></i>
-                <span class="badge badge-important {{#unless current_user.notifications_count}} hidden {{/unless}}">
-                  {{current_user.notifications_count}}
-                </span>
-              </a>
-            </li>
-            <li>
-              <a href="/conversations" title="{{t "header.conversations"}}" class="conversations-link nav-badge">
-                <i class="entypo-mail"></i>
-                <span class="badge badge-important {{#unless current_user.unread_messages_count}} hidden {{/unless}}">
-                  {{current_user.unread_messages_count}}
-                </span>
-              </a>
-            </li>
-          </ul>
-        </div>
-
-        <div class="collapse navbar-collapse" id="navbar-collapse">
-          <ul class="nav navbar-nav navbar-left">
+          <ul class="nav navbar-nav hidden-xs">
             <li><a href="/stream">{{t "my_stream"}}</a></li>
             <li><a href="/activity">{{t "my_activity"}}</a></li>
-            <li class="visible-xs"><a href="/notifications">{{t "header.notifications"}}</a></li>
-            <li class="visible-xs"><a href="/conversations">{{t "header.conversations"}}</a></li>
-            <li class="visible-sm visible-xs"><a href="/mobile/toggle">{{t "header.toggle_mobile"}}</a></li>
           </ul>
-
-          <ul class="nav navbar-nav navbar-left nav-badges hidden-sm hidden-xs">
+          <ul class="nav navbar-nav nav-badges">
             <li class="dropdown" id="notification-dropdown">
-              <a id="notifications-link" href="/notifications" title="{{t "header.notifications"}}" class="notifications-link nav-badge hidden-sm hidden-xs" role="button" data-toggle="dropdown" aria-expanded="false" data-target=" ">
+              <a id="notifications-link" href="/notifications" title="{{t "header.notifications"}}" class="notifications-link nav-badge"
+                role="button" data-toggle="dropdown" aria-expanded="false" data-target=" ">
                 <i class="entypo-bell"></i>
                 <span class="badge badge-important {{#unless current_user.notifications_count}} hidden {{/unless}}">
                   {{current_user.notifications_count}}
                 </span>
               </a>
-
               <ul class="dropdown-menu" role="menu">
                 <div class="header">
                   <div class="pull-right">
@@ -71,17 +49,22 @@
                   </a>
                 </div>
               </ul>
-
             </li>
-
             <li>
-              <a id="conversations-link" href="/conversations" title="{{t "header.conversations"}}" class="conversations-link nav-badge hidden-sm hidden-xs">
+              <a href="/conversations" title="{{t "header.conversations"}}" class="conversations-link nav-badge">
                 <i class="entypo-mail"></i>
                 <span class="badge badge-important {{#unless current_user.unread_messages_count}} hidden {{/unless}}">
                   {{current_user.unread_messages_count}}
                 </span>
               </a>
             </li>
+          </ul>
+        </div>
+        <div class="collapse navbar-collapse" id="navbar-collapse">
+          <ul class="nav navbar-nav navbar-left visible-sm visible-xs">
+            <li class="visible-xs"><a href="/stream">{{t "my_stream"}}</a></li>
+            <li class="visible-xs"><a href="/activity">{{t "my_activity"}}</a></li>
+            <li><a href="/mobile/toggle">{{t "header.toggle_mobile"}}</a></li>
           </ul>
 
           <ul class="nav navbar-nav navbar-right">

--- a/app/assets/templates/header_tpl.jst.hbs
+++ b/app/assets/templates/header_tpl.jst.hbs
@@ -69,7 +69,7 @@
 
           <ul class="nav navbar-nav navbar-right">
             <li class="dropdown" id="user_menu">
-              <a href="{{urlTo "person" current_user.guid}}" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
+              <a href="{{urlTo "person" current_user.guid}}" class="dropdown-toggle hidden-xs hidden-sm" data-toggle="dropdown" role="button" aria-expanded="false">
                 <span class="user-avatar pull-left">
                   {{{personImage current_user "small"}}}
                 </span>

--- a/app/assets/templates/header_tpl.jst.hbs
+++ b/app/assets/templates/header_tpl.jst.hbs
@@ -11,7 +11,7 @@
           </button>
           <a href="/stream" class="navbar-brand" data-stream-title="{{t "my_stream"}}">
             <span class="hidden-xs">{{ podname }}</span>
-            <span id="header-title" class="visible-xs">
+            <span class="visible-xs header-title">
               <img src="/assets/branding/logos/asterisk_white_mobile.png" alt="{{ podname }}" />
             </span>
           </a>
@@ -68,7 +68,7 @@
           </ul>
 
           <ul class="nav navbar-nav navbar-right">
-            <li class="dropdown" id="user_menu">
+            <li class="dropdown" id="user-menu">
               <a href="{{urlTo "person" current_user.guid}}" class="dropdown-toggle hidden-xs hidden-sm" data-toggle="dropdown" role="button" aria-expanded="false">
                 <span class="user-avatar pull-left">
                   {{{personImage current_user "small"}}}
@@ -77,7 +77,7 @@
                 <span class="caret"></span>
               </a>
 
-              <ul class="dropdown-menu" role="menu">
+              <ul class="dropdown-menu user-menu-dropdown" role="menu">
                 <li><a href="/people/{{current_user.guid}}">{{t "header.profile"}}</a></li>
                 <li><a href="/contacts">{{t "header.contacts"}}</a></li>
                 <li><a href="/user/edit">{{t "header.settings"}}</a></li>

--- a/app/assets/templates/header_tpl.jst.hbs
+++ b/app/assets/templates/header_tpl.jst.hbs
@@ -11,9 +11,9 @@
           </button>
           <a href="/stream" class="navbar-brand" data-stream-title="{{t "my_stream"}}">
             <span class="hidden-xs">{{ podname }}</span>
-            <span class="visible-xs header-title">
+            <div class="visible-xs-block header-title">
               <img src="{{imageUrl 'branding/logos/asterisk_white_mobile.png'}}" alt="{{ podname }}" />
-            </span>
+            </div>
           </a>
           <ul class="nav navbar-nav hidden-xs">
             <li><a href="/stream">{{t "my_stream"}}</a></li>
@@ -61,9 +61,9 @@
           </ul>
         </div>
         <div class="collapse navbar-collapse" id="navbar-collapse">
-          <ul class="nav navbar-nav navbar-left visible-sm visible-xs">
-            <li class="visible-xs"><a href="/stream">{{t "my_stream"}}</a></li>
-            <li class="visible-xs"><a href="/activity">{{t "my_activity"}}</a></li>
+          <ul class="nav navbar-nav navbar-left visible-sm-block visible-xs-block">
+            <li class="visible-xs-block"><a href="/stream">{{t "my_stream"}}</a></li>
+            <li class="visible-xs-block"><a href="/activity">{{t "my_activity"}}</a></li>
             <li><a href="/mobile/toggle">{{t "header.toggle_mobile"}}</a></li>
           </ul>
 

--- a/app/assets/templates/header_tpl.jst.hbs
+++ b/app/assets/templates/header_tpl.jst.hbs
@@ -12,7 +12,7 @@
           <a href="/stream" class="navbar-brand" data-stream-title="{{t "my_stream"}}">
             <span class="hidden-xs">{{ podname }}</span>
             <span class="visible-xs header-title">
-              <img src="/assets/branding/logos/asterisk_white_mobile.png" alt="{{ podname }}" />
+              <img src="{{imageUrl 'branding/logos/asterisk_white_mobile.png'}}" alt="{{ podname }}" />
             </span>
           </a>
           <ul class="nav navbar-nav hidden-xs">
@@ -51,7 +51,7 @@
               </ul>
             </li>
             <li>
-              <a href="/conversations" title="{{t "header.conversations"}}" class="conversations-link nav-badge">
+              <a id="conversations-link" href="/conversations" title="{{t "header.conversations"}}" class="conversations-link nav-badge">
                 <i class="entypo-mail"></i>
                 <span class="badge badge-important {{#unless current_user.unread_messages_count}} hidden {{/unless}}">
                   {{current_user.unread_messages_count}}
@@ -68,7 +68,7 @@
           </ul>
 
           <ul class="nav navbar-nav navbar-right">
-            <li class="dropdown" id="user-menu">
+            <li class="dropdown user-menu" id="user-menu">
               <a href="{{urlTo "person" current_user.guid}}" class="dropdown-toggle hidden-xs hidden-sm" data-toggle="dropdown" role="button" aria-expanded="false">
                 <span class="user-avatar pull-left">
                   {{{personImage current_user "small"}}}

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -9,4 +9,11 @@
         .container-fluid
           .row
             .col-md-12
-              = render "layouts/header_not_connected"
+              .not-connected-menu
+                .navbar-header.navbar-left
+                  .hidden-xs
+                    = link_to AppConfig.settings.pod_name, root_path, class: "navbar-brand"
+                  .visible-xs.header-title
+                    = link_to(image_tag("branding/logos/asterisk_white_mobile.png", class: "img-responsive"),
+                        root_path, class: "navbar-brand")
+                = render "layouts/header_not_connected"

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -13,7 +13,7 @@
                 .navbar-header.navbar-left
                   .hidden-xs
                     = link_to AppConfig.settings.pod_name, root_path, class: "navbar-brand"
-                  .visible-xs.header-title
+                  .visible-xs-block.header-title
                     = link_to(image_tag("branding/logos/asterisk_white_mobile.png", class: "img-responsive"),
                         root_path, class: "navbar-brand")
                 = render "layouts/header_not_connected"

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -10,13 +10,6 @@
           .row
             .col-md-12
               .navbar-header
-                %button.navbar-toggle.collapsed{type: "button", data: {toggle: "collapse", target: "#navbar-collapse"}}
-                  %span.sr-only
-                    = t("layouts.header.toggle_navigation")
-                  %span.icon-bar
-                  %span.icon-bar
-                  %span.icon-bar
-                = link_to AppConfig.settings.pod_name, root_path, class: "navbar-brand"
 
               .collapse.navbar-collapse#navbar-collapse
                 = render "layouts/header_not_connected"

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -9,7 +9,4 @@
         .container-fluid
           .row
             .col-md-12
-              .navbar-header
-
-              .collapse.navbar-collapse#navbar-collapse
-                = render "layouts/header_not_connected"
+              = render "layouts/header_not_connected"

--- a/app/views/layouts/_header.mobile.haml
+++ b/app/views/layouts/_header.mobile.haml
@@ -2,7 +2,7 @@
   .container-fluid
     .navbar
       = link_to(image_tag("branding/logos/asterisk_white_mobile.png", class: "img-responsive"),
-          stream_path, id: "header-title", class: "navbar-brand")
+          stream_path, class: "navbar-brand header-title")
 
       - if user_signed_in?
         %ul.nav.navbar-nav#nav-badges

--- a/app/views/layouts/_header_not_connected.haml
+++ b/app/views/layouts/_header_not_connected.haml
@@ -1,12 +1,4 @@
-.not-connected-menu
-  .navbar-header.navbar-left
-    .hidden-xs
-      = link_to AppConfig.settings.pod_name, root_path, class: "navbar-brand"
-    .visible-xs#header-title
-      = link_to(image_tag("branding/logos/asterisk_white_mobile.png", class: "img-responsive"),
-          root_path, class: "navbar-brand")
-
-  %ul.nav.navbar-nav.navbar-right
-    - if AppConfig.settings.enable_registrations? && !current_page?(controller: "/registrations", action: :new)
-      %li= link_to t("devise.shared.links.sign_up"), new_user_registration_path, class: "login"
-    %li= link_to t("devise.shared.links.sign_in"), new_user_session_path, class: "login"
+%ul.nav.navbar-nav.navbar-right
+  - if AppConfig.settings.enable_registrations? && !current_page?(controller: "/registrations", action: :new)
+    %li= link_to t("devise.shared.links.sign_up"), new_user_registration_path, class: "login"
+  %li= link_to t("devise.shared.links.sign_in"), new_user_session_path, class: "login"

--- a/app/views/layouts/_header_not_connected.haml
+++ b/app/views/layouts/_header_not_connected.haml
@@ -1,4 +1,12 @@
-%ul.nav.navbar-nav.navbar-right
-  - if AppConfig.settings.enable_registrations? && !current_page?(controller: "/registrations", action: :new)
-    %li= link_to t("devise.shared.links.sign_up"), new_user_registration_path, class: "login"
-  %li= link_to t("devise.shared.links.sign_in"), new_user_session_path, class: "login"
+.not-connected-menu
+  .navbar-header.navbar-left
+    .hidden-xs
+      = link_to AppConfig.settings.pod_name, root_path, class: "navbar-brand"
+    .visible-xs#header-title
+      = link_to(image_tag("branding/logos/asterisk_white_mobile.png", class: "img-responsive"),
+          root_path, class: "navbar-brand")
+
+  %ul.nav.navbar-nav.navbar-right
+    - if AppConfig.settings.enable_registrations? && !current_page?(controller: "/registrations", action: :new)
+      %li= link_to t("devise.shared.links.sign_up"), new_user_registration_path, class: "login"
+    %li= link_to t("devise.shared.links.sign_in"), new_user_session_path, class: "login"

--- a/features/mobile/drawer.feature
+++ b/features/mobile/drawer.feature
@@ -9,7 +9,7 @@ Feature: Navigate between pages using the header menu and the drawer
 
   Scenario: navigate to the stream page
     When I go to the activity stream page
-    And I click on selector "#header-title"
+    And I click on selector ".header-title"
     Then I should be on the stream page
 
   Scenario: navigate to the notification page

--- a/features/support/user_cuke_helpers.rb
+++ b/features/support/user_cuke_helpers.rb
@@ -47,7 +47,7 @@ module UserCukeHelpers
     if mobile
       expect(page).to have_css "#menu-badge"
     else
-      expect(find("#user_menu")).to have_content "#{@me.first_name} #{@me.last_name}"
+      expect(find("#user-menu")).to have_content "#{@me.first_name} #{@me.last_name}"
     end
   end
 
@@ -58,8 +58,8 @@ module UserCukeHelpers
 
   # go to user menu, expand it, and click logout
   def manual_logout
-    find("#user_menu .dropdown-toggle").click
-    find("#user_menu li:last-child a").click
+    find("#user-menu .dropdown-toggle").click
+    find("#user-menu li:last-child a").click
   end
 
   def manual_logout_mobile

--- a/spec/javascripts/app/views/header_view_spec.js
+++ b/spec/javascripts/app/views/header_view_spec.js
@@ -44,13 +44,13 @@ describe("app.views.Header", function() {
       it("displays if the current user is an admin", function(){
         loginAs(_.extend(this.userAttrs, {admin : true}));
         this.view.render();
-        expect(this.view.$("#user_menu").html()).toContain("/admins");
+        expect(this.view.$("#user-menu").html()).toContain("/admins");
       });
 
       it("does not display if the current user is not an admin", function(){
         loginAs(_.extend(this.userAttrs, {admin : false}));
         this.view.render();
-        expect(this.view.$("#user_menu").html()).not.toContain("/admins");
+        expect(this.view.$("#user-menu").html()).not.toContain("/admins");
       });
     });
   });

--- a/spec/javascripts/app/views/notifications_view_spec.js
+++ b/spec/javascripts/app/views/notifications_view_spec.js
@@ -142,18 +142,13 @@ describe("app.views.Notifications", function() {
         });
 
         it("changes the header notifications count", function() {
-          var badge1 = $(".notifications-link:eq(0) .badge");
-          var badge2 = $(".notifications-link:eq(1) .badge");
+          var badge = $(".notifications-link .badge");
 
-          expect(parseInt(badge1.text(), 10)).toBe(this.collection.unreadCount);
-          expect(parseInt(badge2.text(), 10)).toBe(this.collection.unreadCount);
+          expect(parseInt(badge.text(), 10)).toBe(this.collection.unreadCount);
 
           this.collection.unreadCount++;
           this.view.updateView();
-          expect(parseInt(badge1.text(), 10)).toBe(this.collection.unreadCount);
-
-          this.view.updateView();
-          expect(parseInt(badge2.text(), 10)).toBe(this.collection.unreadCount);
+          expect(parseInt(badge.text(), 10)).toBe(this.collection.unreadCount);
         });
 
         it("disables the mark-all-read-link button", function() {


### PR DESCRIPTION
I played a bit with the header of the desktop version to improve its responsiveness.

The desktop menu didn't change:
**Before**
![screen shot 2017-07-31 at 21 34 35](https://user-images.githubusercontent.com/930064/28795408-07b74e54-763a-11e7-9bfc-0947d50894fa.png)
**After**
![screen shot 2017-07-31 at 21 34 47](https://user-images.githubusercontent.com/930064/28795409-07bb8294-763a-11e7-8459-66186e38d2a1.png)

The "Stream" and "My activity" links have been kept in the "tablet" breakpoint at 992px.
**Before**
![screen shot 2017-07-31 at 21 35 17](https://user-images.githubusercontent.com/930064/28795412-07c4dc68-763a-11e7-92e9-63e3022e1bf5.png)
**After**
![screen shot 2017-07-31 at 21 35 36](https://user-images.githubusercontent.com/930064/28795410-07be0384-763a-11e7-8230-2d4e43e307ed.png)

The pod name has been replace in mobile view, so the notification and conversation icons can be kept:
**Before**
![screen shot 2017-07-31 at 21 53 00](https://user-images.githubusercontent.com/930064/28795579-b6530fac-763a-11e7-8d51-e4739820dbf7.png)

**After**
![screen shot 2017-07-31 at 21 53 07](https://user-images.githubusercontent.com/930064/28795587-ba767970-763a-11e7-849e-8d939766f72e.png)

Also, I improved the menu by directly inserting the submenu for mobile and tablet (this didn't change for desktop):
**Before**
![screen shot 2017-07-31 at 21 53 16](https://user-images.githubusercontent.com/930064/28795594-c05a8e58-763a-11e7-8cc5-68159d1639ac.png)

**After**
![screen shot 2017-07-31 at 21 53 22](https://user-images.githubusercontent.com/930064/28795599-c544bd9e-763a-11e7-8abf-f23f3214a138.png)


This fixes https://github.com/diaspora/diaspora/issues/7019