### PR TITLE
Fix bookmarklet for sprockets 3

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -72,6 +72,7 @@ module Diaspora
       jquery_ujs.js
       main.js
       jsxc.js
+      bookmarklet.js
       mobile/bookmarklet.js
       mobile/mobile.js
       templates.js

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -5,11 +5,6 @@ namespace :assets do
     renderer.render
   end
 
-  desc "Uglify bookmarklet snippet"
-  task :uglify_bookmarklet => :environment do
-    BookmarkletRenderer.compile
-  end
-
   desc "Create non digest assets"
   task non_digest_assets: :environment do
     logger = ::Logging::Logger["assets:non_digest_assets"]
@@ -35,7 +30,6 @@ namespace :assets do
   # Augment precompile with error page generation
   task :precompile do
     Rake::Task["assets:generate_error_pages"].invoke
-    Rake::Task["assets:uglify_bookmarklet"].invoke
     Rake::Task["assets:non_digest_assets"].invoke
   end
 end

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -10,14 +10,13 @@ namespace :assets do
     logger = ::Logging::Logger["assets:non_digest_assets"]
 
     non_digest_assets = Diaspora::Application.config.assets.non_digest_assets
-    manifest_path = Dir.glob(Rails.root.join("public", "assets", ".sprockets-manifest-*.json")).first
 
-    JSON.load(File.new(manifest_path))["assets"].each do |logical_path, digested_path|
+    Rails.application.assets_manifest.assets.each do |logical_path, digested_path|
       logical_pathname = Pathname.new(logical_path)
       next unless non_digest_assets.any? {|testpath| logical_pathname.fnmatch?(testpath, File::FNM_PATHNAME) }
 
-      full_digested_path     = File.join(Rails.root, "public/assets", digested_path)
-      full_non_digested_path = File.join(Rails.root, "public/assets", logical_path)
+      full_digested_path     = Rails.root.join("public", "assets", digested_path)
+      full_non_digested_path = Rails.root.join("public", "assets", logical_path)
 
       next unless FileUtils.uptodate?(full_digested_path, [full_non_digested_path])
 


### PR DESCRIPTION
This fixes:
```
rake aborted!
NoMethodError: undefined method `[]' for nil:NilClass
/srv/diaspora/lib/bookmarklet_renderer.rb:9:in `source_name'
/srv/diaspora/lib/bookmarklet_renderer.rb:22:in `compile'
/srv/diaspora/lib/tasks/assets.rake:10:in `block (2 levels) in <top (required)>'
/srv/diaspora/lib/tasks/assets.rake:38:in `block (2 levels) in <top (required)>'
Tasks: TOP => assets:uglify_bookmarklet
```
in production environment.

`Rails.application.assets` is only available when `config.assets.compile` is true (which is false in production). So the old way with a separate rake task doesn't work in production. But we can get the filename of the precompiled file from `Rails.application.assets_manifest.assets`.

(The second commit is only a small refactoring after I found `Rails.application.assets_manifest.assets`)