### PR TITLE
Cleanup .gitignore and add note about .well-known to the changelog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,27 +10,15 @@ app/assets/images/custom/
 
 # Configuration files
 config/diaspora.yml
-config/heroku.yml
 config/initializers/secret_token.rb
-config/redis.conf
-config/deploy_config.yml
-config/schedule.rb
 .bundle
 vendor/bundle/
 vendor/cache/
 config/database.yml
-.rvmrc_custom
-.rvmrc.local
 config/oidc_key.pem
-
-# Mailing list stuff
-config/email_offset
-config/mailing_list.csv
 
 # Generated files
 log/
-public/stylesheets/*.css
-public/diaspora
 spec/fixtures/*.y*ml
 spec/fixtures/*.fixture.*
 coverage/
@@ -53,17 +41,13 @@ doc/
 public/uploads/
 public/assets/
 public/source.tar*
-public/.well-known
-tmp/**/
 tmp/
-*.sqlite3
 
 # Temporary files of every sort
 .sass-cache/
 .DS_Store
 .idea
 .redcar
-.rvmrc
 .stgit*
 *.swap
 *.swo
@@ -76,7 +60,6 @@ tmp/
 nbproject
 patches-*
 capybara-*.html
-dump.rdb
 
 # Rubinius's JIT
 *.rbc

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,11 @@
 This release recommends using Ruby 2.4, while retaining Ruby 2.3 as an officially supported version.
 Ruby 2.1 is no longer officially supported.
 
+## Delete public/.well-known/
+
+Before upgrading, please check if your `public/` folder contains a hidden `.well-known/` folder.
+If so, please delete it since it will prevent the federation from working properly.
+
 ## Refactor
 
 * Make the mention syntax more flexible [#7305](https://github.com/diaspora/diaspora/pull/7305)


### PR DESCRIPTION
I noticed that some pods still have a static `/.well-known/host-meta` from the past. That wasn't a problem, because the old file had the same content as the generated version from the federation lib. But with the new federation-lib 0.2.0 the content changed, and with the old static file webfinger doesn't work anymore. So I added a note to the changelog, so people need to check if they have an old cached `public/.well-known` and if so, delete it.

I also cleaned up some other old unused lines from the `.gitignore`.