### PR TITLE
Move back to top to the right to avoid misclicks

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -71,7 +71,7 @@ pre { word-wrap: break-word; }
   line-height: 50px;
   opacity: 0;
   position: fixed;
-  right: 54px;
+  right: 20px;
   transition: opacity ease 400ms;
   width: 50px;
   z-index: 49;


### PR DESCRIPTION
I have users complaining about clicking on back-to-top instead of the "comment" button.
This misclick is easy on 1367px screens:
![capture du 2017-08-08 13-04-12](https://user-images.githubusercontent.com/930064/29069214-35075330-7c3a-11e7-9a41-52f45b89f39e.png)

So I moved it to the right, at the same margin than it has with the bottom:
![screen shot 2017-08-08 at 12 55 11](https://user-images.githubusercontent.com/930064/29069205-2cd7c24e-7c3a-11e7-9df5-8ac42a548f05.png)

The only possible problem I see is if it overlaps the chat. But I don't manage to activate the chat and I still think it is unsupported at the moment, so not a blocker to that imo. If someone wants to test though, he's welcome.

