### PR TITLE
Hide 'Sign in' header link on the connection page

### DIFF
--- a/app/views/layouts/_header_not_connected.haml
+++ b/app/views/layouts/_header_not_connected.haml
@@ -1,4 +1,5 @@
 %ul.nav.navbar-nav.navbar-right
   - if AppConfig.settings.enable_registrations? && !current_page?(controller: "/registrations", action: :new)
     %li= link_to t("devise.shared.links.sign_up"), new_user_registration_path, class: "login"
-  %li= link_to t("devise.shared.links.sign_in"), new_user_session_path, class: "login"
+  - unless current_page?(controller: "/sessions", action: :new)
+    %li= link_to t("devise.shared.links.sign_in"), new_user_session_path, class: "login"


### PR DESCRIPTION
This pull request removes the "Sign in" link in the header on the connection page (`/users/sign_in`) for both mobile and desktop version of diaspora*. I find this link confusing especially on mobile because it could give the user the feeling it will send the connection form when it's only a link to the page where you already are. So I think it can be removed.