### PR TITLE
Use config.eager_load_paths instead of config.autoload_once_paths

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -35,8 +35,8 @@ module Diaspora
     # -- all .rb files in that directory are automatically loaded.
 
     # Custom directories with classes and modules you want to be autoloadable.
-    config.autoload_paths      += %W{#{config.root}/app}
-    config.autoload_once_paths += %W{#{config.root}/lib}
+    config.autoload_paths      += %W[#{config.root}/app]
+    config.autoload_once_paths += %W[#{config.root}/lib]
 
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -9,6 +9,7 @@ Rails.application.configure do
   # and those relying on copy on write to perform better.
   # Rake tasks automatically ignore this option for performance.
   config.eager_load = true
+  config.eager_load_paths += %W[#{config.root}/lib]
 
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false


### PR DESCRIPTION
See http://guides.rubyonrails.org/upgrading_ruby_on_rails.html#autoloading-is-disabled-after-booting-in-the-production-environment