### PR TITLE
Disable rendering logging in production

### DIFF
--- a/config/logging.rb
+++ b/config/logging.rb
@@ -85,6 +85,7 @@ Logging::Rails.configure do |config|
   Logging.logger.root.level = config.log_level
 
   # log-levels from the diaspora.yml for SQL and federation debug-logging
+  Logging.logger[ActionView::Base].level = Rails.env.development? ? :debug : :warn
   Logging.logger[ActiveRecord::Base].level = AppConfig.environment.logging.debug.sql? ? :debug : :info
   Logging.logger[DiasporaFederation::Salmon::MagicEnvelope].level =
     AppConfig.environment.logging.debug.federation? ? :debug : :info


### PR DESCRIPTION
I'm not interested in tons of this in production, it only makes the logs big:
```
[2017-08-13T05:25:28] INFO  PID-24712 TID-24412820 ActionView::Base:   Rendered notifications/_notification.haml (9.6ms)
[2017-08-13T05:25:28] INFO  PID-24712 TID-24412820 ActionView::Base:   Rendered notifications/_notification.haml (6.6ms)
[2017-08-13T05:25:28] INFO  PID-24712 TID-24412820 ActionView::Base:   Rendered notifications/_notification.haml (6.0ms)
[2017-08-13T05:25:28] INFO  PID-24712 TID-24412820 ActionView::Base:   Rendered notifications/_notification.haml (2.9ms)
[2017-08-13T05:25:28] INFO  PID-24712 TID-24412820 ActionView::Base:   Rendered notifications/_notification.haml (2.6ms)
[2017-08-13T05:25:28] INFO  PID-24712 TID-24412820 ActionView::Base:   Rendered notifications/_notification.haml (5.9ms)
[2017-08-13T05:25:28] INFO  PID-24712 TID-24412820 ActionView::Base:   Rendered notifications/_notification.haml (2.6ms)
[2017-08-13T05:25:28] INFO  PID-24712 TID-24412820 ActionView::Base:   Rendered notifications/_notification.haml (5.4ms)
[2017-08-13T05:25:28] INFO  PID-24712 TID-24412820 ActionView::Base:   Rendered notifications/_notification.haml (6.4ms)
[2017-08-13T05:25:28] INFO  PID-24712 TID-24412820 ActionView::Base:   Rendered notifications/_notification.haml (2.5ms)
```