### PR TITLE
add jquery are you sure to comment form

### DIFF
--- a/app/assets/javascripts/app/views/comment_stream_view.js
+++ b/app/assets/javascripts/app/views/comment_stream_view.js
@@ -37,6 +37,8 @@ app.views.CommentStream = app.views.Base.extend({
       }.bind(this),
       onFocus: this.openForm.bind(this)
     });
+
+    this.$("form").areYouSure();
   },
 
   presenter: function(){

--- a/features/desktop/comments.feature
+++ b/features/desktop/comments.feature
@@ -19,6 +19,7 @@ Feature: commenting
     When I focus the comment field
     And I fill in the following:
         | text            | is that a poodle?    |
+    And I reject the alert after I follow "My activity"
     And I press "Comment"
     Then I should see "is that a poodle?" within ".comment"
     And I should see "less than a minute ago" within ".comment time"

--- a/spec/javascripts/app/views/comment_stream_view_spec.js
+++ b/spec/javascripts/app/views/comment_stream_view_spec.js
@@ -92,6 +92,12 @@ describe("app.views.CommentStream", function(){
       expect(renderedPreview).toBe("<div class='preview-content'>" + renderedText + "</div>");
       expect(renderedPreview).toContain("Alice Awesome");
     });
+
+    it("calls jQuery.AreYouSure()", function() {
+      spyOn($.fn, "areYouSure");
+      this.view.postRenderTemplate();
+      expect($.fn.areYouSure).toHaveBeenCalled();
+    });
   });
 
   describe("createComment", function() {


### PR DESCRIPTION
Right now I'm not adding `confirm on page` after dismissing the dialog (on `cuke`)
It seem that, right now it doesn't support:

```
When I am on "alice@alice.alice"'s page
Then I should be on "alice@alice.alice"'s page
```

Fix #7173 