### PR TITLE
added tag for supporting apps prior to Chrome M39

### DIFF
--- a/app/views/application/_head.haml
+++ b/app/views/application/_head.haml
@@ -4,6 +4,8 @@
 %meta{charset: "utf-8"}/
 = content_for?(:meta_data) ? yield(:meta_data) : metas_tags
 
+%meta{content: "yes", name: "mobile-web-app-capable"}/
+
 / favicon
 / For Apple devices
 %link{rel: "apple-touch-icon", href: image_path("apple-touch-icon.png")}
@@ -26,3 +28,4 @@
 = current_user_atom_tag
 
 = yield(:head)
+


### PR DESCRIPTION
Hi all,

This fixes #7485.

Added support for web apps prior to Chrome ver. M39 (with help of @alxlg and @SuperTux88) with the following (HAML) meta tag:

```%meta{:content => "yes", :name => "mobile-web-app-capable"}/```

Hope this solves the issue.