### PR TITLE
Remove avatar, name, timestamp and interactions from publisher preview

### DIFF
--- a/app/assets/javascripts/app/views/preview_post_view.js
+++ b/app/assets/javascripts/app/views/preview_post_view.js
@@ -5,7 +5,6 @@ app.views.PreviewPost = app.views.Post.extend({
   className: "stream-element loaded",
 
   subviews: {
-    ".feedback": "feedbackView",
     ".post-content": "postContentView",
     ".oembed": "oEmbedView",
     ".opengraph": "openGraphView",
@@ -13,21 +12,11 @@ app.views.PreviewPost = app.views.Post.extend({
     ".status-message-location": "postLocationStreamView"
   },
 
-  tooltipSelector: [
-    ".timeago",
-    ".delete",
-    ".permalink"
-  ].join(", "),
-
   initialize: function() {
     this.model.set("preview", true);
     this.oEmbedView = new app.views.OEmbed({model: this.model});
     this.openGraphView = new app.views.OpenGraph({model: this.model});
     this.pollView = new app.views.Poll({model: this.model});
-  },
-
-  feedbackView: function() {
-    return new app.views.Feedback({model: this.model});
   },
 
   postContentView: function() {

--- a/app/assets/stylesheets/publisher.scss
+++ b/app/assets/stylesheets/publisher.scss
@@ -197,10 +197,16 @@
     border: 0;
   }
 
-  // This rule is required until we switch to the newer release of bootstrap-markdown with
-  // the following commit in:
-  // https://github.com/toopay/bootstrap-markdown/commit/14a21c3837140144b27efc19c795d1a37fad70fb
-  .md-preview { min-height: 90px; }
+  .md-preview {
+    // This rule is required until we switch to the newer release of bootstrap-markdown with
+    // the following commit in:
+    // https://github.com/toopay/bootstrap-markdown/commit/14a21c3837140144b27efc19c795d1a37fad70fb
+    min-height: 90px;
+
+    .stream-element .post-content .markdown-content {
+      padding-top: 0;
+    }
+  }
 }
 
 .publisher-textarea-wrapper {

--- a/app/assets/templates/feedback_tpl.jst.hbs
+++ b/app/assets/templates/feedback_tpl.jst.hbs
@@ -13,29 +13,17 @@
   –
 </span>
 
-
-{{#if preview}}
-  <span>{{t "stream.like"}}</span>
-{{else}}
-  <a href="#" class="like" rel='nofollow'>
-    {{~#if userLike~}}
-      {{~t "stream.unlike"~}}
-    {{~else~}}
-      {{~t "stream.like"~}}
-    {{~/if~}}
-  </a>
-{{/if}}
+<a href="#" class="like" rel='nofollow'>
+  {{~#if userLike~}}
+    {{~t "stream.unlike"~}}
+  {{~else~}}
+    {{~t "stream.like"~}}
+  {{~/if~}}
+</a>
 ·
-{{#if preview}}
-  <span>{{t "stream.reshare"}}</span>
-  ·
-{{else if userCanReshare}}
+{{#if userCanReshare}}
   <a href="#" class="reshare" rel='nofollow'>{{t "stream.reshare"}}</a>
   ·
 {{/if}}
 
-{{#if preview}}
-  <span>{{t "stream.comment"}}</span>
-{{else}}
-  <a href="#" class="focus_comment_textarea" rel="nofollow">{{t "stream.comment"}}</a>
-{{/if}}
+<a href="#" class="focus_comment_textarea" rel="nofollow">{{t "stream.comment"}}</a>

--- a/app/assets/templates/stream-element_tpl.jst.hbs
+++ b/app/assets/templates/stream-element_tpl.jst.hbs
@@ -1,25 +1,26 @@
 <div class="media {{#if showPost}} {{#if nsfw}} shield-off {{/if}} {{else}} shield-active {{/if}}">
-  {{#with author}}
-    <a href="/people/{{guid}}" class="img {{{hovercardable this}}}">
-      {{{personImage this}}}
-    </a>
-  {{/with}}
+
+  {{#unless preview}}
+    {{#with author}}
+      <a href="/people/{{guid}}" class="img {{{hovercardable this}}}">
+        {{{personImage this}}}
+      </a>
+    {{/with}}
+  {{/unless}}
 
   <div class="bd">
-    {{#if loggedIn}}
-      <div class="post-controls"></div>
-    {{/if}}
+    {{#unless preview}}
+      {{#if loggedIn}}
+        <div class="post-controls"></div>
+      {{/if}}
 
-    <div>
-      {{#linkToAuthor author}}
-        {{~name~}}
-      {{/linkToAuthor}}
+      <div>
+        {{#linkToAuthor author}}
+          {{~name~}}
+        {{/linkToAuthor}}
 
-      <span class="details gray">
-        -
-        {{#if preview}}
-          <time class="timeago" data-original-title="{{{localTime created_at}}}" datetime="{{created_at}}" />
-        {{else}}
+        <span class="details gray">
+          -
           <a href="/posts/{{id}}">
             <time class="timeago" data-original-title="{{{localTime created_at}}}" datetime="{{created_at}}" />
           </a>
@@ -27,16 +28,18 @@
           <a href="/posts/{{guid}}" class="permalink" title="{{t "stream.permalink"}}">
             <i class="entypo-link"></i>
           </a>
-        {{/if}}
-      </span>
-    </div>
+        </span>
+      </div>
+    {{/unless}}
 
     <div class="post-content"> </div>
     <div class="status-message-location nsfw-hidden"> </div>
 
-    <div class="feedback nsfw-hidden"> </div>
-    <div class="likes nsfw-hidden"> </div>
-    <div class="reshares nsfw-hidden"> </div>
-    <div class="comments nsfw-hidden"> </div>
+    {{#unless preview}}
+      <div class="feedback nsfw-hidden"> </div>
+      <div class="likes nsfw-hidden"> </div>
+      <div class="reshares nsfw-hidden"> </div>
+      <div class="comments nsfw-hidden"> </div>
+    {{/unless}}
   </div>
 </div>

--- a/spec/javascripts/app/views/preview_post_view_spec.js
+++ b/spec/javascripts/app/views/preview_post_view_spec.js
@@ -36,12 +36,6 @@ describe("app.views.PreviewPost", function() {
   });
 
   describe("render", function() {
-    it("calls feedbackView", function() {
-      spyOn(app.views.PreviewPost.prototype, "feedbackView");
-      this.view.render();
-      expect(app.views.PreviewPost.prototype.feedbackView).toHaveBeenCalled();
-    });
-
     it("calls postContentView", function() {
       spyOn(app.views.PreviewPost.prototype, "postContentView");
       this.view.render();
@@ -52,14 +46,6 @@ describe("app.views.PreviewPost", function() {
       spyOn(app.views.PreviewPost.prototype, "postLocationStreamView");
       this.view.render();
       expect(app.views.PreviewPost.prototype.postLocationStreamView).toHaveBeenCalled();
-    });
-  });
-
-  describe("feedbackView", function() {
-    it("calls app.views.Feedback.initialise", function() {
-      spyOn(app.views.Feedback.prototype, "initialize");
-      this.view.feedbackView();
-      expect(app.views.Feedback.prototype.initialize).toHaveBeenCalledWith({model: this.model});
     });
   });
 


### PR DESCRIPTION
This doesn't add any value in the post preview:
* Avatar is already at the left-hand side of the publisher
* Timestamp is always "less than a minute ago"
* Interactions are disabled in the preview anyway

We don't display these things in the comment preview either, they only need space and don't add any value to the preview.

![](https://user-images.githubusercontent.com/458548/29254526-ee86c344-8096-11e7-92a8-082aa651c35f.png)