### PR TITLE
Try to fix invitations from stream and aspect navigation cukes

### DIFF
--- a/features/desktop/invitations.feature
+++ b/features/desktop/invitations.feature
@@ -52,7 +52,8 @@ Feature: Invitations
 
   Scenario: sends an invitation from the stream
     When I sign in as "alice@alice.alice"
-    And I press the first "a.invitations-link" within "#no_contacts"
+    Then I should see "There are no posts to display here yet." within ".no-posts-info"
+    When I press the first "a.invitations-link" within "#no_contacts"
     Then I should see "Invite someone to join diaspora*!" within "#invitationsModalLabel"
     And I fill in the following:
       | email_inviter_emails         | alex@example.com    |

--- a/features/step_definitions/aspects_steps.rb
+++ b/features/step_definitions/aspects_steps.rb
@@ -46,8 +46,13 @@ end
 
 When /^I select only "([^"]*)" aspect$/ do |aspect_name|
   click_link "My aspects"
+  expect(find("#aspect_stream_container")).to have_css(".loader.hidden", visible: false)
   within("#aspects_list") do
-    all(".selected").each {|node| node.find(:xpath, "..").click }
+    all(".selected").each do |node|
+      aspect_item = node.find(:xpath, "..")
+      aspect_item.click
+      expect(aspect_item).to have_no_css ".selected"
+    end
     expect(current_scope).to have_no_css ".selected"
   end
   step %Q(I select "#{aspect_name}" aspect as well)


### PR DESCRIPTION
These are the two most annoying randomly failing tests on travis, probably 80-90% of red builds are because of these two.

If this improves travis, I want to uplift that to the frozen release branch. Since this only changes tests and no code, that should be OK and hopefully we get green release builds then :)

#7373