### PR TITLE
Cucumber: Wait for post to be deleted before continuing

### DIFF
--- a/features/step_definitions/custom_web_steps.rb
+++ b/features/step_definitions/custom_web_steps.rb
@@ -109,6 +109,7 @@ When /^I click to delete the first post$/ do
   accept_alert do
     step "I prepare the deletion of the first post"
   end
+  expect(find(".stream")).to have_no_css(".stream-element.loaded.deleting")
 end
 
 When /^I click to hide the first post$/ do


### PR DESCRIPTION
This should fix: features/mobile/reshare.feature:32 # Scenario: Delete original reshared post