### PR TITLE
Change order of fields in fill_in_new_user_form

### DIFF
--- a/features/support/user_cuke_helpers.rb
+++ b/features/support/user_cuke_helpers.rb
@@ -69,8 +69,8 @@ module UserCukeHelpers
 
   def fill_in_new_user_form
     @username = "ohai"
-    fill_in('user_username', with: @username)
     fill_in('user_email', with: "#{@username}@example.com")
+    fill_in('user_username', with: @username)
     fill_in('user_password', with: 'secret')
     fill_in('user_password_confirmation', with: 'secret')
 


### PR DESCRIPTION
The `user_email` is the first field anyway, and login form as a `user_username` field too, so it maybe happens that we already fill in the `user_username` filed there before page load finished.