### PR TITLE
Fix local migration run without old private key

### DIFF
--- a/app/models/account_migration.rb
+++ b/app/models/account_migration.rb
@@ -26,6 +26,7 @@ class AccountMigration < ApplicationRecord
   # executes a migration plan according to this AccountMigration object
   def perform!
     raise "already performed" if performed?
+    validate_sender if locally_initiated?
 
     ActiveRecord::Base.transaction do
       account_deleter.tombstone_person_and_profile
@@ -111,6 +112,10 @@ class AccountMigration < ApplicationRecord
   def ephemeral_sender
     raise "can't build sender without old private key defined" if old_private_key.nil?
     EphemeralUser.new(old_person.diaspora_handle, old_private_key)
+  end
+
+  def validate_sender
+    sender # sender method raises exception when sender can't be instantiated
   end
 
   def update_all_references

--- a/spec/models/account_migration_spec.rb
+++ b/spec/models/account_migration_spec.rb
@@ -125,13 +125,21 @@ describe AccountMigration, type: :model do
       include_context "with local new user"
 
       it "dispatches account migration message" do
-        expect(account_migration).to receive(:sender).and_return(old_user)
+        expect(account_migration).to receive(:sender).twice.and_return(old_user)
         dispatcher = double
         expect(dispatcher).to receive(:dispatch)
         expect(Diaspora::Federation::Dispatcher).to receive(:build)
           .with(old_user, account_migration)
           .and_return(dispatcher)
         account_migration.perform!
+      end
+
+      it "doesn't run migration if old key is not provided" do
+        expect(embedded_account_deleter).not_to receive(:tombstone_person_and_profile)
+
+        expect {
+          account_migration.perform!
+        }.to raise_error "can't build sender without old private key defined"
       end
     end
 


### PR DESCRIPTION
It was possible to run migration locally without providing old private
key. This way migration was performed but not dispatched, which obviously
leads to desynchronization of the federation state so let's validate sender
before performing any actual actions.