### PR TITLE
use asset manifest instead of single entries in config.assets.precompile

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,0 +1,13 @@
+//= link contact-list.js
+//= link ie.js
+//= link jquery3.js
+//= link jquery_ujs.js
+//= link main.js
+//= link jsxc.js
+//= link bookmarklet.js
+//= link mobile/bookmarklet.js
+//= link mobile/mobile.js
+//= link templates.js
+//= link error_pages.css
+//= link admin.css
+//= link rtl.css

--- a/config/application.rb
+++ b/config/application.rb
@@ -72,23 +72,10 @@ module Diaspora
 
     # Precompile additional assets.
     # (application.js, application.css, and all non-JS/CSS in the app/assets are already added)
-    config.assets.precompile += %w[
-      contact-list.js
-      ie.js
-      jquery3.js
-      jquery_ujs.js
-      main.js
-      jsxc.js
-      bookmarklet.js
-      mobile/bookmarklet.js
-      mobile/mobile.js
-      templates.js
-
-      error_pages.css
-      admin.css
-      rtl.css
+    config.assets.precompile = %w[
       color_themes/*/desktop.css
       color_themes/*/mobile.css
+      manifest.js
     ]
 
     # See lib/tasks/assets.rake: non_digest_assets


### PR DESCRIPTION
This PR adds a `manifest.js` in which files or directories can be linked.
It has been introduced in Sprockets 3 and it's the preferred way for Sprockets 3.x and 4.x.
See also here: https://github.com/rails/sprockets/blob/master/UPGRADING.md#manifestjs
