### PR TITLE
Remove old message parameter from invite mail

### DIFF
--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -37,10 +37,8 @@ class Notifier < ApplicationMailer
     end
   end
 
-  def invite(email, message, inviter, invitation_code, locale)
+  def invite(email, inviter, invitation_code, locale)
     @inviter = inviter
-    @message = message
-    @locale = locale
     @invitation_code = invitation_code
 
     I18n.with_locale(locale) do

--- a/lib/email_inviter.rb
+++ b/lib/email_inviter.rb
@@ -1,9 +1,8 @@
 class EmailInviter
-  attr_accessor :emails, :message, :inviter, :locale
+  attr_accessor :emails, :inviter, :locale
 
   def initialize(emails, inviter, options={})
     options = options.symbolize_keys
-    self.message = options[:message]
     self.locale = options.fetch(:locale, 'en')
     self.inviter = inviter
     self.emails = emails
@@ -26,6 +25,6 @@ class EmailInviter
   private
 
   def mail(email)
-    Notifier.invite(email, message, inviter, invitation_code, locale).deliver_now
+    Notifier.invite(email, inviter, invitation_code, locale).deliver_now
   end
 end

--- a/spec/lib/email_inviter_spec.rb
+++ b/spec/lib/email_inviter_spec.rb
@@ -1,11 +1,10 @@
 describe EmailInviter do
   before do
-    @user = double(:invitation_code => 'coolcodebro', :present? => true, 
-                 :email => 'foo@bar.com')
+    @user = double(invitation_code: "coolcodebro", present?: true, email: "foo@bar.com")
     @emails = "mbs333@gmail.com, foo1@bar.com maxwell@dude.com"
   end
 
-  it 'has a list of emails' do 
+  it "has a list of emails" do
     inviter = EmailInviter.new(@emails, @user)
     expect(inviter.emails).not_to be_empty
   end
@@ -18,12 +17,6 @@ describe EmailInviter do
   it 'has an inviter' do
     inviter = EmailInviter.new(@emails, @user)
     expect(inviter.inviter).not_to be_nil
-  end
-
-  it 'can have a message' do
-    message = "you guys suck hard"
-    inviter = EmailInviter.new("emails", @user, :message =>  message)
-    expect(inviter.message).to eq(message) 
   end
 
   describe '#emails' do

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -502,7 +502,7 @@ describe Notifier, type: :mailer do
   end
 
   describe ".invite" do
-    let(:email) { Notifier.invite(alice.email, nil, bob, "1234", "en") }
+    let(:email) { Notifier.invite(alice.email, bob, "1234", "en") }
 
     it "goes to the right person" do
       expect(email.to).to eq([alice.email])
@@ -522,7 +522,7 @@ describe Notifier, type: :mailer do
 
     it "has the inviter id if the name is nil" do
       bob.person.profile.update_attributes(first_name: "", last_name: "")
-      mail = Notifier.invite(alice.email, nil, bob, "1234", "en")
+      mail = Notifier.invite(alice.email, bob, "1234", "en")
       expect(email.body.encoded).to_not include("#{bob.name} (#{bob.diaspora_handle})")
       expect(mail.body.encoded).to include(bob.person.diaspora_handle)
     end


### PR DESCRIPTION
This isn't used anymore.