### PR TITLE
Remove tiff support from photos

### DIFF
--- a/app/assets/javascripts/app/views/publisher/uploader_view.js
+++ b/app/assets/javascripts/app/views/publisher/uploader_view.js
@@ -5,7 +5,7 @@
 // progress. Attaches previews of finished uploads to the publisher.
 
 app.views.PublisherUploader = Backbone.View.extend({
-  allowedExtensions: ["jpg", "jpeg", "png", "gif", "tif", "tiff"],
+  allowedExtensions: ["jpg", "jpeg", "png", "gif"],
   sizeLimit: 4194304,  // bytes
 
   initialize: function(opts) {

--- a/app/assets/javascripts/mobile/mobile_file_uploader.js
+++ b/app/assets/javascripts/mobile/mobile_file_uploader.js
@@ -19,7 +19,7 @@ function createUploader(){
       }
     },
     validation: {
-      allowedExtensions: ["jpg", "jpeg", "png", "gif", "tif", "tiff"],
+      allowedExtensions: ["jpg", "jpeg", "png", "gif"],
       sizeLimit: 4194304
     },
     button: document.getElementById("file-upload-publisher"),

--- a/app/uploaders/processed_image.rb
+++ b/app/uploaders/processed_image.rb
@@ -10,7 +10,7 @@ class ProcessedImage < CarrierWave::Uploader::Base
   end
 
   def extension_whitelist
-    %w[jpg jpeg png gif tiff]
+    %w[jpg jpeg png gif]
   end
 
   def filename


### PR DESCRIPTION
Currently the list of supported extensions for photos in the frontend and the list in the backend are inconsistent. The fontend allows `tiff` and `tif` files while the backend does not (not everywhere at least).

I propose removing `tiff` and `tif` files from the lists of supported extensions for photos since the browser support for them is quite bad (none of the GIMP generated `tiff` files i tested could be displayed in either Chrome or Firefox).