### PR TITLE
fixes #7573 long poll answers; thanks to @svbergerem for the hint

### DIFF
--- a/app/assets/stylesheets/poll.scss
+++ b/app/assets/stylesheets/poll.scss
@@ -18,6 +18,7 @@
     box-shadow: 0 0 0;
     height: 10px;
     margin-bottom: 5px;
+    clear: both;
 
     .bar {
       background: $border-dark-grey none;
@@ -46,6 +47,7 @@
     font-weight: normal;
     margin-bottom: 5px;
     vertical-align: middle;
+    display: inline;
   }
 
   [type=radio],


### PR DESCRIPTION
### before:
![bildschirmfoto vom 2017-08-24 22-54-31](https://user-images.githubusercontent.com/1711504/29692443-5481a1c2-8930-11e7-9a64-779e4ca8cf54.png)
### after:
![bildschirmfoto vom 2017-08-25 00-56-39](https://user-images.githubusercontent.com/1711504/29692444-54a3f664-8930-11e7-9724-a3dcfb875b09.png)

Take a look at the poll results, they were hiding the bar if the answer is to long. Now it's above