### PR TITLE
Prevent users from zooming in IE Mobile

### DIFF
--- a/app/views/layouts/application.mobile.haml
+++ b/app/views/layouts/application.mobile.haml
@@ -12,7 +12,7 @@
     = render "head"
     = include_color_theme "mobile"
 
-    %meta{name: "viewport", content: "width=device-width, minimum-scale=1 maximum-scale=1"}/
+    %meta{name: "viewport", content: "width=device-width, minimum-scale=1, maximum-scale=1, user-scalable=no"}/
     %meta{name: "HandheldFriendly", content: "True"}/
     %meta{name: "MobileOptimized", content: "320"}/
     %meta{"http-equiv" => "cleartype", :content => "on"}/


### PR DESCRIPTION
Fixes #7499

According to https://msdn.microsoft.com/en-us/library/dn629259(v=vs.85).aspx, “the minimum-scale, maximum-scale, and initial-scale properties are currently unsupported for Internet Explorer for Windows Phone“.

For further information on the viewport properties see https://drafts.csswg.org/css-device-adapt/#viewport-meta