### PR TITLE
Remove rails_admin_histories table

### DIFF
--- a/db/migrate/20170827222357_remove_rails_admin_histories.rb
+++ b/db/migrate/20170827222357_remove_rails_admin_histories.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class RemoveRailsAdminHistories < ActiveRecord::Migration[5.1]
+  def up
+    drop_table :rails_admin_histories
+  end
+
+  def down
+    create_table :rails_admin_histories do |t|
+      t.text     :message
+      t.string   :username
+      t.integer  :item
+      t.string   :table
+      t.integer  :month,      limit: 2
+      t.integer  :year,       limit: 8
+      t.datetime :created_at,           null: false
+      t.datetime :updated_at,           null: false
+    end
+
+    add_index :rails_admin_histories, %i[item table month year], name:   :index_rails_admin_histories,
+                                                                 length: {table: 188}
+  end
+end


### PR DESCRIPTION
This was a leftover from rails_admin which was removed in #7440.

Not sure if we should merge this to 0.7.1.0 or 0.8.0.0, but since we already have migrations for 0.7.1.0 and removing a table should be really fast, I think we can add this as drive-by for 0.7.1.0.

I also already added the `# frozen_string_literal: true` comment from #7595 here.