### PR TITLE
Remove "string" column from "ppid" table

### DIFF
--- a/db/migrate/20170827231800_remove_string_column_from_ppid.rb
+++ b/db/migrate/20170827231800_remove_string_column_from_ppid.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveStringColumnFromPpid < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :ppid, :string, :string, limit: 32
+  end
+end


### PR DESCRIPTION
This was added by accident in 4e18f3849dcc5d36bda93e68b597b869735d5517.

Same as for #7597:

Not sure if we should merge this to 0.7.1.0 or 0.8.0.0, but since we already have migrations for 0.7.1.0 and this table probably is still empty, so removing a column should be really fast. I think we can add this as drive-by for 0.7.1.0.

I also already added the `# frozen_string_literal: true` comment from #7595 here.