### PR TITLE
Fix recipient prefill on contacts and profile page

### DIFF
--- a/app/assets/javascripts/app/pages/contacts.js
+++ b/app/assets/javascripts/app/pages/contacts.js
@@ -80,7 +80,15 @@ app.pages.Contacts = Backbone.View.extend({
 
   showMessageModal: function(){
     $("#conversationModal").on("modal:loaded", function() {
-      new app.views.ConversationsForm({prefill: gon.conversationPrefill});
+      var people = app.contacts.filter(function(contact) {
+        return contact.inAspect(app.aspect.get("id"));
+      }).map(function(contact) {
+        return _.extend({
+          avatar: contact.person.get("profile").avatar.small,
+          handle: contact.person.get("diaspora_id")
+        }, contact.person.attributes);
+      });
+      new app.views.ConversationsForm({prefill: people});
     });
     app.helpers.showModal("#conversationModal");
   },

--- a/app/assets/javascripts/app/pages/contacts.js
+++ b/app/assets/javascripts/app/pages/contacts.js
@@ -80,14 +80,9 @@ app.pages.Contacts = Backbone.View.extend({
 
   showMessageModal: function(){
     $("#conversationModal").on("modal:loaded", function() {
-      var people = app.contacts.filter(function(contact) {
+      var people = _.pluck(app.contacts.filter(function(contact) {
         return contact.inAspect(app.aspect.get("id"));
-      }).map(function(contact) {
-        return _.extend({
-          avatar: contact.person.get("profile").avatar.small,
-          handle: contact.person.get("diaspora_id")
-        }, contact.person.attributes);
-      });
+      }), "person");
       new app.views.ConversationsForm({prefill: people});
     });
     app.helpers.showModal("#conversationModal");

--- a/app/assets/javascripts/app/views/conversations_form_view.js
+++ b/app/assets/javascripts/app/views/conversations_form_view.js
@@ -52,8 +52,13 @@ app.views.ConversationsForm = app.views.Base.extend({
     this.setupAvatarFallback(personEl);
   },
 
-  prefill: function(handles) {
-    handles.forEach(this.addRecipient.bind(this));
+  prefill: function(people) {
+    people.forEach(function(person) {
+      this.addRecipient(_.extend({
+        avatar: person.get("profile").avatar.small,
+        handle: person.get("diaspora_id")
+      }, person.attributes));
+    }, this);
   },
 
   updateContactIdsListInput: function() {

--- a/app/assets/javascripts/app/views/profile_header_view.js
+++ b/app/assets/javascripts/app/views/profile_header_view.js
@@ -81,12 +81,7 @@ app.views.ProfileHeader = app.views.Base.extend({
 
   showMessageModal: function(){
     $("#conversationModal").on("modal:loaded", function() {
-      new app.views.ConversationsForm({
-        prefill: [_.extend({
-          avatar: this.model.get("profile").avatar.small,
-          handle: this.model.get("diaspora_id")
-        }, this.model.attributes)]
-      });
+      new app.views.ConversationsForm({prefill: [this.model]});
     }.bind(this));
     app.helpers.showModal("#conversationModal");
   }

--- a/app/assets/javascripts/app/views/profile_header_view.js
+++ b/app/assets/javascripts/app/views/profile_header_view.js
@@ -81,8 +81,13 @@ app.views.ProfileHeader = app.views.Base.extend({
 
   showMessageModal: function(){
     $("#conversationModal").on("modal:loaded", function() {
-      new app.views.ConversationsForm({prefill: gon.conversationPrefill});
-    });
+      new app.views.ConversationsForm({
+        prefill: [_.extend({
+          avatar: this.model.get("profile").avatar.small,
+          handle: this.model.get("diaspora_id")
+        }, this.model.attributes)]
+      });
+    }.bind(this));
     app.helpers.showModal("#conversationModal");
   }
 });

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -103,10 +103,6 @@ class ConversationsController < ApplicationController
 
       render :layout => true
     else
-      if params[:aspect_id]
-        gon.push conversation_prefill: current_user.aspects
-                                                   .find(params[:aspect_id]).contacts.map {|c| c.person.as_json }
-      end
       render :layout => false
     end
   end

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -103,9 +103,7 @@ class ConversationsController < ApplicationController
 
       render :layout => true
     else
-      if params[:contact_id]
-        gon.push conversation_prefill: [current_user.contacts.find(params[:contact_id]).person.as_json]
-      elsif params[:aspect_id]
+      if params[:aspect_id]
         gon.push conversation_prefill: current_user.aspects
                                                    .find(params[:aspect_id]).contacts.map {|c| c.person.as_json }
       end

--- a/app/views/conversations/new.html.haml
+++ b/app/views/conversations/new.html.haml
@@ -1,2 +1,1 @@
-= include_gon camel_case: true
-= render 'conversations/new'
+= render "conversations/new"

--- a/spec/controllers/conversations_controller_spec.rb
+++ b/spec/controllers/conversations_controller_spec.rb
@@ -20,11 +20,6 @@ describe ConversationsController, :type => :controller do
         get :new, params: {modal: true}
         expect(response).to be_success
       end
-
-      it "assigns a set of contacts if passed an aspect id" do
-        get :new, params: {aspect_id: alice.aspects.first.id, modal: true}
-        expect(controller.gon.conversation_prefill).to eq(alice.aspects.first.contacts.map {|c| c.person.as_json })
-      end
     end
 
     context "mobile" do

--- a/spec/controllers/conversations_controller_spec.rb
+++ b/spec/controllers/conversations_controller_spec.rb
@@ -21,11 +21,6 @@ describe ConversationsController, :type => :controller do
         expect(response).to be_success
       end
 
-      it "assigns a contact if passed a contact id" do
-        get :new, params: {contact_id: alice.contacts.first.id, modal: true}
-        expect(controller.gon.conversation_prefill).to eq([alice.contacts.first.person.as_json])
-      end
-
       it "assigns a set of contacts if passed an aspect id" do
         get :new, params: {aspect_id: alice.aspects.first.id, modal: true}
         expect(controller.gon.conversation_prefill).to eq(alice.aspects.first.contacts.map {|c| c.person.as_json })

--- a/spec/javascripts/app/pages/contacts_spec.js
+++ b/spec/javascripts/app/pages/contacts_spec.js
@@ -290,17 +290,20 @@ describe("app.pages.Contacts", function(){
     });
 
     it("initializes app.views.ConversationsForm with correct parameters when modal is loaded", function() {
-      gon.conversationPrefill = [
-        {id: 1, name: "diaspora user", handle: "diaspora-user@pod.tld"},
-        {id: 2, name: "other diaspora user", handle: "other-diaspora-user@pod.tld"},
-        {id: 3, name: "user@pod.tld", handle: "user@pod.tld"}
-      ];
-
       spyOn(app.views.ConversationsForm.prototype, "initialize");
+      app.aspect = new app.models.Aspect(app.contacts.first().get("aspect_memberships")[0].aspect);
       this.view.showMessageModal();
       $("#conversationModal").trigger("modal:loaded");
-      expect(app.views.ConversationsForm.prototype.initialize)
-        .toHaveBeenCalledWith({prefill: gon.conversationPrefill});
+      expect(app.views.ConversationsForm.prototype.initialize).toHaveBeenCalled();
+
+      var prefill = app.views.ConversationsForm.prototype.initialize.calls.mostRecent().args[0].prefill;
+      var people = app.contacts.filter(function(contact) { return contact.inAspect(app.aspect.get("id")); });
+      expect(prefill.length).toBe(people.length);
+
+      var person = app.contacts.first().person;
+      expect(prefill[0].handle).toBe(person.get("diaspora_id"));
+      expect(prefill[0].name).toBe(person.get("name"));
+      expect(prefill[0].avatar).toBe(person.get("profile").avatar.small);
     });
   });
 });

--- a/spec/javascripts/app/pages/contacts_spec.js
+++ b/spec/javascripts/app/pages/contacts_spec.js
@@ -297,13 +297,8 @@ describe("app.pages.Contacts", function(){
       expect(app.views.ConversationsForm.prototype.initialize).toHaveBeenCalled();
 
       var prefill = app.views.ConversationsForm.prototype.initialize.calls.mostRecent().args[0].prefill;
-      var people = app.contacts.filter(function(contact) { return contact.inAspect(app.aspect.get("id")); });
-      expect(prefill.length).toBe(people.length);
-
-      var person = app.contacts.first().person;
-      expect(prefill[0].handle).toBe(person.get("diaspora_id"));
-      expect(prefill[0].name).toBe(person.get("name"));
-      expect(prefill[0].avatar).toBe(person.get("profile").avatar.small);
+      var contacts = app.contacts.filter(function(contact) { return contact.inAspect(app.aspect.get("id")); });
+      expect(_.pluck(prefill, "id")).toEqual(contacts.map(function(contact) { return contact.person.id; }));
     });
   });
 });

--- a/spec/javascripts/app/views/conversations_form_view_spec.js
+++ b/spec/javascripts/app/views/conversations_form_view_spec.js
@@ -85,7 +85,11 @@ describe("app.views.ConversationsForm", function() {
 
   describe("prefill", function() {
     beforeEach(function() {
-      this.prefills = [{name: "diaspora user"}, {name: "other diaspora user"}, {name: "user"}];
+      this.prefills = [
+        factory.personWithProfile({"diaspora_id": "alice@pod.tld"}),
+        factory.personWithProfile({"diaspora_id": "bob@pod.tld"}),
+        factory.personWithProfile({"diaspora_id": "carol@pod.tld"})
+      ];
     });
 
     it("calls addRecipient for each prefilled participant", function() {
@@ -95,7 +99,14 @@ describe("app.views.ConversationsForm", function() {
       var allArgsFlattened = app.views.ConversationsForm.prototype.addRecipient.calls.allArgs().map(function(arg) {
         return arg[0];
       });
-      expect(allArgsFlattened).toEqual(this.prefills);
+
+      expect(_.pluck(allArgsFlattened, "handle")).toEqual(
+        this.prefills.map(function(person) { return person.get("diaspora_id"); })
+      );
+
+      expect(_.pluck(allArgsFlattened, "avatar")).toEqual(
+        this.prefills.map(function(person) { return person.get("profile").avatar.small; })
+      );
     });
   });
 

--- a/spec/javascripts/app/views/profile_header_view_spec.js
+++ b/spec/javascripts/app/views/profile_header_view_spec.js
@@ -4,8 +4,11 @@ describe("app.views.ProfileHeader", function() {
     this.model = factory.personWithProfile({
       diaspora_id: "my@pod",
       name: "User Name",
-      relationship: 'mutual',
-      profile: { tags: ['test'] }
+      relationship: "mutual",
+      profile: {
+        avatar: {small: "http://example.org/avatar.jpg"},
+        tags: ["test"]
+      }
     });
     this.view = new app.views.ProfileHeader({model: this.model});
     loginAs(factory.userAttrs());
@@ -71,17 +74,15 @@ describe("app.views.ProfileHeader", function() {
     });
 
     it("initializes app.views.ConversationsForm with correct parameters when modal is loaded", function() {
-      gon.conversationPrefill = [
-        {id: 1, name: "diaspora user", handle: "diaspora-user@pod.tld"},
-        {id: 2, name: "other diaspora user", handle: "other-diaspora-user@pod.tld"},
-        {id: 3, name: "user@pod.tld", handle: "user@pod.tld"}
-      ];
-
       spyOn(app.views.ConversationsForm.prototype, "initialize");
       spyOn($.fn, "load").and.callFake(function(url, callback) { callback(); });
       this.view.showMessageModal();
-      expect(app.views.ConversationsForm.prototype.initialize)
-        .toHaveBeenCalledWith({prefill: gon.conversationPrefill});
+      expect(app.views.ConversationsForm.prototype.initialize).toHaveBeenCalled();
+      var prefill = app.views.ConversationsForm.prototype.initialize.calls.mostRecent().args[0].prefill;
+      expect(prefill.length).toBe(1);
+      expect(prefill[0].handle).toBe("my@pod");
+      expect(prefill[0].name).toBe("User Name");
+      expect(prefill[0].avatar).toBe("http://example.org/avatar.jpg");
     });
   });
 });

--- a/spec/javascripts/app/views/profile_header_view_spec.js
+++ b/spec/javascripts/app/views/profile_header_view_spec.js
@@ -77,12 +77,9 @@ describe("app.views.ProfileHeader", function() {
       spyOn(app.views.ConversationsForm.prototype, "initialize");
       spyOn($.fn, "load").and.callFake(function(url, callback) { callback(); });
       this.view.showMessageModal();
-      expect(app.views.ConversationsForm.prototype.initialize).toHaveBeenCalled();
-      var prefill = app.views.ConversationsForm.prototype.initialize.calls.mostRecent().args[0].prefill;
-      expect(prefill.length).toBe(1);
-      expect(prefill[0].handle).toBe("my@pod");
-      expect(prefill[0].name).toBe("User Name");
-      expect(prefill[0].avatar).toBe("http://example.org/avatar.jpg");
+      expect(app.views.ConversationsForm.prototype.initialize).toHaveBeenCalledWith({
+        prefill: [this.model]
+      });
     });
   });
 });

--- a/spec/javascripts/jasmine_helpers/factory.js
+++ b/spec/javascripts/jasmine_helpers/factory.js
@@ -138,9 +138,11 @@ var factory = {
       "full_name": "bob grimm",
       "gender": "robot",
       "id": id,
-      "image_url": "http://localhost:3000/assets/user/default.png",
-      "image_url_medium": "http://localhost:3000/assets/user/default.png",
-      "image_url_small": "http://localhost:3000/assets/user/default.png",
+      "avatar": {
+        "small": "http://localhost:3000/assets/user/default.png",
+        "medium": "http://localhost:3000/assets/user/default.png",
+        "large": "http://localhost:3000/assets/user/default.png"
+      },
       "last_name": "Grimm",
       "location": "Earth",
       "nsfw": false,


### PR DESCRIPTION
Fixes #7586. All information for the prefill is already available before loading the modals and `gon.conversationPrefill` is unavailable on pods with enabled content security policy header.