### PR TITLE
Pronto selector fixes

### DIFF
--- a/app/assets/javascripts/app/helpers/handlebars-helpers.js
+++ b/app/assets/javascripts/app/helpers/handlebars-helpers.js
@@ -116,7 +116,7 @@ Handlebars.registerHelper("isCurrentProfilePage", function(id, diasporaHandle, o
 });
 
 Handlebars.registerHelper('aspectMembershipIndicator', function(contact,in_aspect) {
-  if(!app.aspect || !app.aspect.get('id')) return '<div class="aspect_membership_dropdown placeholder"></div>';
+  if(!app.aspect || !app.aspect.get('id')) return '<div class="aspect-membership-dropdown placeholder"></div>';
 
   var html = "<i class=\"entypo-";
   if( in_aspect === 'in_aspect' ) {

--- a/app/assets/javascripts/app/pages/contacts.js
+++ b/app/assets/javascripts/app/pages/contacts.js
@@ -17,7 +17,7 @@ app.pages.Contacts = Backbone.View.extend({
     this.chatToggle = $("#chat_privilege_toggle i");
     this.stream = opts.stream;
     this.stream.render();
-    $("#people_stream.contacts .header i").tooltip({"placement": "bottom"});
+    $("#people-stream.contacts .header i").tooltip({"placement": "bottom"});
     $(document).on("ajax:success", "form.edit_aspect", this.updateAspectName);
     app.events.on("aspect:create", function(){ window.location.reload() });
     app.events.on("aspect_membership:create", this.addAspectMembership, this);

--- a/app/assets/javascripts/app/pages/getting_started.js
+++ b/app/assets/javascripts/app/pages/getting_started.js
@@ -5,7 +5,7 @@ app.pages.GettingStarted = app.views.Base.extend({
   templateName: false,
 
   subviews: {
-    ".aspect_membership_dropdown": "aspectMembershipView"
+    ".aspect-membership-dropdown": "aspectMembershipView"
   },
 
   initialize: function(opts) {

--- a/app/assets/javascripts/app/pages/profile.js
+++ b/app/assets/javascripts/app/pages/profile.js
@@ -11,7 +11,7 @@ app.pages.Profile = app.views.Base.extend({
   subviews: {
     "#profile": "sidebarView",
     ".profile_header": "headerView",
-    "#main_stream": "streamView"
+    "#main-stream": "streamView"
   },
 
   tooltipSelector: ".profile_button .profile-header-icon, .sharing_message_container",

--- a/app/assets/javascripts/app/pages/settings.js
+++ b/app/assets/javascripts/app/pages/settings.js
@@ -11,7 +11,7 @@ app.pages.Settings = Backbone.View.extend({
     new Diaspora.ProfilePhotoUploader();
 
     this.viewAspectSelector = new app.views.PublisherAspectSelector({
-      el: $(".aspect_dropdown"),
+      el: $(".aspect-dropdown"),
       form: $("#post-default-aspects")
     });
     $("#update_profile_form").areYouSure();

--- a/app/assets/javascripts/app/router.js
+++ b/app/assets/javascripts/app/router.js
@@ -220,7 +220,7 @@ app.Router = Backbone.Router.extend({
       app.page.setupAvatarFallback($(".main-stream-publisher"));
     }
 
-    $("#main_stream").html(app.page.render().el);
+    $("#main-stream").html(app.page.render().el);
     this._hideInactiveStreamLists();
   },
 

--- a/app/assets/javascripts/app/router.js
+++ b/app/assets/javascripts/app/router.js
@@ -229,7 +229,7 @@ app.Router = Backbone.Router.extend({
   },
 
   renderAspectMembershipDropdowns: function($context) {
-    $context.find(".aspect_membership_dropdown.placeholder").each(function() {
+    $context.find(".aspect-membership-dropdown.placeholder").each(function() {
       var personId = $(this).data("personId");
       var view = new app.views.AspectMembership({person: app.contacts.findWhere({"person_id": personId}).person});
       $(this).html(view.render().$el);

--- a/app/assets/javascripts/app/views/aspect_membership_view.js
+++ b/app/assets/javascripts/app/views/aspect_membership_view.js
@@ -9,7 +9,7 @@
  */
 app.views.AspectMembership = app.views.Base.extend({
   templateName: "aspect_membership_dropdown",
-  className: "btn-group aspect-dropdown aspect_membership_dropdown",
+  className: "btn-group aspect-dropdown aspect-membership-dropdown",
 
   subviews: {
     ".newAspectContainer": "aspectCreateView"
@@ -124,7 +124,7 @@ app.views.AspectMembership = app.views.Base.extend({
   // show an error flash msg
   _displayError: function(model, resp) {
     this._done();
-    this.dropdown.closest(".aspect_membership_dropdown").removeClass("open"); // close the dropdown
+    this.dropdown.closest(".aspect-membership-dropdown").removeClass("open"); // close the dropdown
     app.flashMessages.handleAjaxError(resp);
   },
 

--- a/app/assets/javascripts/app/views/aspect_membership_view.js
+++ b/app/assets/javascripts/app/views/aspect_membership_view.js
@@ -9,7 +9,7 @@
  */
 app.views.AspectMembership = app.views.Base.extend({
   templateName: "aspect_membership_dropdown",
-  className: "btn-group aspect_dropdown aspect_membership_dropdown",
+  className: "btn-group aspect-dropdown aspect_membership_dropdown",
 
   subviews: {
     ".newAspectContainer": "aspectCreateView"

--- a/app/assets/javascripts/app/views/comment_stream_view.js
+++ b/app/assets/javascripts/app/views/comment_stream_view.js
@@ -7,7 +7,7 @@ app.views.CommentStream = app.views.Base.extend({
   className : "comment_stream",
 
   events: {
-    "keydown .comment_box": "keyDownOnCommentBox",
+    "keydown .comment-box": "keyDownOnCommentBox",
     "submit form": "createComment",
     "click .toggle_post_comments": "expandComments",
     "click form": "openForm"
@@ -26,11 +26,11 @@ app.views.CommentStream = app.views.Base.extend({
 
   postRenderTemplate : function() {
     this.model.comments.each(this.appendComment, this);
-    this.commentBox = this.$(".comment_box");
+    this.commentBox = this.$(".comment-box");
     this.commentSubmitButton = this.$("input[name='commit']");
     this.mentions = new app.views.CommentMention({el: this.$el, postId: this.model.get("id")});
 
-    this.mdEditor = new Diaspora.MarkdownEditor(this.$(".comment_box"), {
+    this.mdEditor = new Diaspora.MarkdownEditor(this.$(".comment-box"), {
       onPreview: function($mdInstance) {
         var renderedText = app.helpers.textFormatter($mdInstance.getContent(), this.mentions.getMentionedPeople());
         return "<div class='preview-content'>" + renderedText + "</div>";

--- a/app/assets/javascripts/app/views/contact_view.js
+++ b/app/assets/javascripts/app/views/contact_view.js
@@ -4,7 +4,7 @@ app.views.Contact = app.views.Base.extend({
   templateName: 'contact',
 
   subviews: {
-    ".aspect_membership_dropdown": "AspectMembershipView"
+    ".aspect-membership-dropdown": "AspectMembershipView"
   },
 
   events: {

--- a/app/assets/javascripts/app/views/content_view.js
+++ b/app/assets/javascripts/app/views/content_view.js
@@ -80,7 +80,7 @@ app.views.Content = app.views.Base.extend({
       });
     });
 
-    var photoAttachments = this.$(".photo_attachments");
+    var photoAttachments = this.$(".photo-attachments");
     if(photoAttachments.length > 0) {
       new app.views.Gallery({ el: photoAttachments });
     }
@@ -93,7 +93,7 @@ app.views.StatusMessage = app.views.Content.extend({
 
 app.views.ExpandedStatusMessage = app.views.StatusMessage.extend({
   postRenderTemplate : function(){
-    var photoAttachments = this.$(".photo_attachments");
+    var photoAttachments = this.$(".photo-attachments");
     if(photoAttachments.length > 0) {
       new app.views.Gallery({ el: photoAttachments });
     }

--- a/app/assets/javascripts/app/views/photos_view.js
+++ b/app/assets/javascripts/app/views/photos_view.js
@@ -15,7 +15,7 @@ app.views.Photos = app.views.InfScroll.extend({
   },
 
   postRenderTemplate: function(){
-    var photoAttachments = $("#main_stream > div");
+    var photoAttachments = $("#main-stream > div");
     if(photoAttachments.length > 0) {
       new app.views.Gallery({ el: photoAttachments });
     }

--- a/app/assets/javascripts/app/views/profile_header_view.js
+++ b/app/assets/javascripts/app/views/profile_header_view.js
@@ -4,7 +4,7 @@ app.views.ProfileHeader = app.views.Base.extend({
   templateName: 'profile_header',
 
   subviews: {
-    ".aspect_membership_dropdown": "aspectMembershipView"
+    ".aspect-membership-dropdown": "aspectMembershipView"
   },
 
   events: {

--- a/app/assets/javascripts/app/views/publisher_view.js
+++ b/app/assets/javascripts/app/views/publisher_view.js
@@ -129,7 +129,7 @@ app.views.Publisher = Backbone.View.extend({
       },
 
       onPostPreview: function() {
-        var photoAttachments = self.wrapperEl.find(".photo_attachments");
+        var photoAttachments = self.wrapperEl.find(".photo-attachments");
         if (photoAttachments.length > 0) {
           new app.views.Gallery({el: photoAttachments});
         }

--- a/app/assets/javascripts/app/views/publisher_view.js
+++ b/app/assets/javascripts/app/views/publisher_view.js
@@ -101,13 +101,13 @@ app.views.Publisher = Backbone.View.extend({
     });
 
     this.viewAspectSelector = new app.views.PublisherAspectSelector({
-      el: this.$(".public_toggle .aspect_dropdown"),
+      el: this.$(".public_toggle .aspect-dropdown"),
       form: form
     });
 
     this.viewGettingStarted = new app.views.PublisherGettingStarted({
       firstMessageEl:  this.inputEl,
-      visibilityEl: this.$(".public_toggle .aspect_dropdown > .dropdown-toggle"),
+      visibilityEl: this.$(".public_toggle .aspect-dropdown > .dropdown-toggle"),
       streamEl:     $("#main-stream")
     });
 

--- a/app/assets/javascripts/app/views/publisher_view.js
+++ b/app/assets/javascripts/app/views/publisher_view.js
@@ -36,7 +36,7 @@ app.views.Publisher = Backbone.View.extend({
 
     // init shortcut references to the various elements
     this.inputEl = this.$("#status_message_text");
-    this.wrapperEl = this.$("#publisher_textarea_wrapper");
+    this.wrapperEl = this.$("#publisher-textarea-wrapper");
     this.submitEl = this.$("input[type=submit], button#submit");
     this.photozoneEl = this.$("#photodropzone");
 
@@ -87,7 +87,7 @@ app.views.Publisher = Backbone.View.extend({
   },
 
   initSubviews: function() {
-    this.mention = new app.views.PublisherMention({ el: this.$("#publisher_textarea_wrapper") });
+    this.mention = new app.views.PublisherMention({ el: this.$("#publisher-textarea-wrapper") });
     if(this.prefillMention) {
       this.mention.prefillMention([this.prefillMention]);
     }

--- a/app/assets/javascripts/app/views/publisher_view.js
+++ b/app/assets/javascripts/app/views/publisher_view.js
@@ -108,7 +108,7 @@ app.views.Publisher = Backbone.View.extend({
     this.viewGettingStarted = new app.views.PublisherGettingStarted({
       firstMessageEl:  this.inputEl,
       visibilityEl: this.$(".public_toggle .aspect_dropdown > .dropdown-toggle"),
-      streamEl:     $("#main_stream")
+      streamEl:     $("#main-stream")
     });
 
     this.viewUploader = new app.views.PublisherUploader({

--- a/app/assets/javascripts/app/views/single-post-viewer/single_post_actions.js
+++ b/app/assets/javascripts/app/views/single-post-viewer/single_post_actions.js
@@ -26,8 +26,8 @@ app.views.SinglePostActions = app.views.Feedback.extend({
   },
 
   focusComment: function() {
-    $('.comment_stream .comment_box').focus();
-    $('html,body').animate({scrollTop: $('.comment_stream .comment_box').offset().top - ($('.comment_stream .comment_box').height() + 20)});
+    $('.comment_stream .comment-box').focus();
+    $('html,body').animate({scrollTop: $('.comment_stream .comment-box').offset().top - ($('.comment_stream .comment-box').height() + 20)});
     return false;
   },
 

--- a/app/assets/javascripts/app/views/stream_post_views.js
+++ b/app/assets/javascripts/app/views/stream_post_views.js
@@ -88,7 +88,7 @@ app.views.StreamPost = app.views.Post.extend({
   focusCommentTextarea: function(evt){
     evt.preventDefault();
     this.$(".new-comment-form-wrapper").removeClass("hidden");
-    this.$(".comment_box").focus();
+    this.$(".comment-box").focus();
 
     return this;
   }

--- a/app/assets/javascripts/contact-list.js
+++ b/app/assets/javascripts/contact-list.js
@@ -18,7 +18,7 @@ var List = {
 
     if (data.contacts) {
       var contacts = new app.collections.Contacts(data.contacts);
-      $(".aspect_membership_dropdown.placeholder").each(function() {
+      $(".aspect-membership-dropdown.placeholder").each(function() {
         var personId = $(this).data("personId");
         var view = new app.views.AspectMembership({person: contacts.findWhere({"person_id": personId}).person});
         $(this).html(view.render().$el);

--- a/app/assets/javascripts/contact-list.js
+++ b/app/assets/javascripts/contact-list.js
@@ -9,7 +9,7 @@ var List = {
   },
 
   handleSearchRefresh: function( data ) {
-    var streamEl = $("#people_stream.stream");
+    var streamEl = $("#people-stream.stream");
     var string = data.search_html || $("<p>", {
         text : Diaspora.I18n.t("people.not_found")
       });

--- a/app/assets/javascripts/mobile/mobile_comments.js
+++ b/app/assets/javascripts/mobile/mobile_comments.js
@@ -11,7 +11,7 @@
     initialize: function() {
       var self = this;
 
-      new Diaspora.MarkdownEditor(".comment_box");
+      new Diaspora.MarkdownEditor(".comment-box");
 
       this.stream().on("tap click", "a.show-comments", function(evt){
         evt.preventDefault();
@@ -43,7 +43,7 @@
     submitComment: function(evt){
       evt.preventDefault();
       var form = $(this);
-      var commentBox = form.find(".comment_box");
+      var commentBox = form.find(".comment-box");
       var commentText = $.trim(commentBox.val());
       if(!commentText){
         commentBox.focus();
@@ -169,7 +169,7 @@
 
     showCommentBox: function(link){
       var bottomBar = link.closest(".bottom-bar").first();
-      var textArea = bottomBar.find("textarea.comment_box").first()[0];
+      var textArea = bottomBar.find("textarea.comment-box").first()[0];
       bottomBar.find(".add-comment-switcher").removeClass("hidden");
       autosize(textArea);
     },

--- a/app/assets/javascripts/mobile/mobile_file_uploader.js
+++ b/app/assets/javascripts/mobile/mobile_file_uploader.js
@@ -33,7 +33,7 @@ function createUploader(){
         $("#fileInfo-publisher").text(fileName + " " + progress + "%");
       },
       onSubmit: function() {
-        $("#publisher_textarea_wrapper").addClass("with_attachments");
+        $("#publisher-textarea-wrapper").addClass("with_attachments");
         $("#photodropzone").append(
           "<li class='publisher_photo loading' style='position:relative;'>" +
           "<img alt='Ajax-loader2' src='" + ImagePaths.get("ajax-loader2.gif") + "' />" +
@@ -50,7 +50,7 @@ function createUploader(){
             url = responseJSON.data.photo.unprocessed_image.url,
             currentPlaceholder = $("li.loading").first();
 
-        $("#publisher_textarea_wrapper").addClass("with_attachments");
+        $("#publisher-textarea-wrapper").addClass("with_attachments");
         $("#new_status_message").append("<input type='hidden' value='" + id + "' name='photos[]' />");
 
         // replace image placeholders
@@ -76,7 +76,7 @@ function createUploader(){
               photo.fadeOut(400, function() {
                 photo.remove();
                 if ($(".publisher_photo").length === 0) {
-                  $("#publisher_textarea_wrapper").removeClass("with_attachments");
+                  $("#publisher-textarea-wrapper").removeClass("with_attachments");
                 }
               });
             }

--- a/app/assets/stylesheets/aspects.scss
+++ b/app/assets/stylesheets/aspects.scss
@@ -1,4 +1,4 @@
-.aspect_dropdown {
+.aspect-dropdown {
 
   li {
     @include selectable-list;

--- a/app/assets/stylesheets/color_themes/_color_theme_override.scss
+++ b/app/assets/stylesheets/color_themes/_color_theme_override.scss
@@ -1,6 +1,6 @@
 /* Raw CSS */
 body {
-  #publisher_textarea_wrapper > #button_container > span.markdownIndications > a {
+  #publisher-textarea-wrapper > #button_container > span.markdownIndications > a {
     color: fade-out($link-color, 0.4);
   }
 

--- a/app/assets/stylesheets/color_themes/_color_theme_override_dark.scss
+++ b/app/assets/stylesheets/color_themes/_color_theme_override_dark.scss
@@ -15,7 +15,7 @@ body {
   .md-input,
   .md-preview { background-color: $gray; }
 
-  .aspect_dropdown li a .text { color: $dropdown-link-color; }
+  .aspect-dropdown li a .text { color: $dropdown-link-color; }
 
   .info .tag { background-color: $gray-light; }
 

--- a/app/assets/stylesheets/color_themes/_color_theme_override_dark.scss
+++ b/app/assets/stylesheets/color_themes/_color_theme_override_dark.scss
@@ -61,7 +61,7 @@ body {
 
   #invitationsModal #email_invitation { border-top: 1px dashed $gray-light; }
 
-  #contacts_container #people_stream.contacts .stream-element.in_aspect {
+  #contacts_container #people-stream.contacts .stream-element.in_aspect {
     background-color: $state-success-bg;
     border-left: 3px solid darken($state-success-bg, 10%);
   }

--- a/app/assets/stylesheets/color_themes/_color_theme_override_dark.scss
+++ b/app/assets/stylesheets/color_themes/_color_theme_override_dark.scss
@@ -3,7 +3,7 @@
 body {
   .publisher {
     form {
-      #publisher_textarea_wrapper { background-color: $gray; }
+      #publisher-textarea-wrapper { background-color: $gray; }
       .btn.btn-link.question_mark:hover .entypo-cog { color: $gray-light; }
     }
     .publisher-buttonbar .btn.btn-link:hover i { color: $gray-light; }

--- a/app/assets/stylesheets/color_themes/_color_theme_override_origwhite.scss
+++ b/app/assets/stylesheets/color_themes/_color_theme_override_origwhite.scss
@@ -1,5 +1,5 @@
 body {
-  #main_stream .stream-element {
+  #main-stream .stream-element {
     border: 0;
     border-bottom: 1px solid $border-grey;
     margin-bottom: 10px;

--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -53,11 +53,11 @@
     }
     padding-left: 12px;
   }
-  .comment_box {
+  .comment-box {
     height: 35px;
     resize: none;
   }
-  textarea.comment_box:focus, textarea.comment_box:valid, textarea.comment_box:active {
+  textarea.comment-box:focus, textarea.comment-box:valid, textarea.comment-box:active {
     border-color: $border-dark-grey;
     box-shadow: none;
   }

--- a/app/assets/stylesheets/contacts.scss
+++ b/app/assets/stylesheets/contacts.scss
@@ -21,7 +21,7 @@
 }
 
 #contacts_container {
-  #people_stream.contacts {
+  #people-stream.contacts {
     .header {
       #change_aspect_name { cursor: pointer; }
       #aspect_name_form {

--- a/app/assets/stylesheets/conversations.scss
+++ b/app/assets/stylesheets/conversations.scss
@@ -148,7 +148,7 @@
     }
   }
 
-  .stream_container .conversation-participants {
+  .stream-container .conversation-participants {
     margin-bottom: 20px;
 
     .hide_conversation, .delete_conversation {

--- a/app/assets/stylesheets/conversations.scss
+++ b/app/assets/stylesheets/conversations.scss
@@ -65,7 +65,7 @@
 
     &:hover:not(.selected), &.selected {
       .subject,
-      .last_author,
+      .last-author,
       .last_message {
         color: $white;
       }
@@ -86,14 +86,14 @@
     &.unread { background-color: $background-grey; }
     &.selected { background-color: $brand-primary; }
 
-    .last_author, .last_message {
+    .last-author, .last_message {
       font-size: 12px;
       line-height: 15px;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
     }
-    .last_author { color: $text-dark-grey; }
+    .last-author { color: $text-dark-grey; }
 
     .message-count, .unread-message-count {
       margin-left: 3px;

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -94,7 +94,7 @@
           margin-right: 10px;
           opacity: 1;
         }
-        & > .pull-right > .aspect_membership_dropdown { display: none; }
+        & > .pull-right > .aspect-membership-dropdown { display: none; }
       }
       .ajax-loader {
         border-bottom: 1px solid $border-grey;

--- a/app/assets/stylesheets/hovercard.scss
+++ b/app/assets/stylesheets/hovercard.scss
@@ -65,7 +65,7 @@
     margin-bottom: 5px;
   }
 
-  .btn-group.aspect_membership_dropdown { margin: 0 !important; }
+  .btn-group.aspect-membership-dropdown { margin: 0 !important; }
 }
 
 #hovercard_container {

--- a/app/assets/stylesheets/interactions.scss
+++ b/app/assets/stylesheets/interactions.scss
@@ -22,7 +22,7 @@
   }
 }
 
-.stream_container,
+.stream-container,
 .single-post-interactions {
   .control-icons {
     float: right;

--- a/app/assets/stylesheets/mobile/mobile.scss
+++ b/app/assets/stylesheets/mobile/mobile.scss
@@ -486,7 +486,7 @@ select {
   margin-bottom: 5px;
 }
 
-.last_author {
+.last-author {
   position: relative;
   margin: 10px 10px 2px;
   float: right;

--- a/app/assets/stylesheets/mobile/mobile.scss
+++ b/app/assets/stylesheets/mobile/mobile.scss
@@ -694,7 +694,7 @@ select#aspect_ids_ {
   .entypo-camera { margin-right: 0; }
 }
 
-#publisher_textarea_wrapper {
+#publisher-textarea-wrapper {
   border-radius: 2px;
   margin: 12px 0px;
   background: $framed-background;

--- a/app/assets/stylesheets/mobile/mobile.scss
+++ b/app/assets/stylesheets/mobile/mobile.scss
@@ -83,7 +83,7 @@ h3 {  margin-top: 0; }
 
   > .content, .reshare > .content { padding: 6px; }
   .info{ margin-top: 0; }
-  .photo_attachments{ margin-top: 6px; }
+  .photo-attachments{ margin-top: 6px; }
   .timeago{ font-weight: normal; }
 }
 
@@ -172,7 +172,7 @@ footer {
     padding: 0;
   }
 
-  .photo_attachments {
+  .photo-attachments {
     border-radius: 3px 3px 0 0;
 
     border: {
@@ -194,7 +194,7 @@ footer {
   }
 }
 
-.photo_attachments {
+.photo-attachments {
   position: relative;
   left: 0;
   top: 0;

--- a/app/assets/stylesheets/mobile/mobile.scss
+++ b/app/assets/stylesheets/mobile/mobile.scss
@@ -206,7 +206,7 @@ footer {
     padding: 0; } }
 
 
-#main_stream {
+#main-stream {
   .from {
     white-space: nowrap;
     overflow: hidden;

--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -96,6 +96,6 @@
       opacity: 0;
     }
 
-    .btn-group.aspect_membership_dropdown { margin: 5px 0; }
+    .btn-group.aspect-membership-dropdown { margin: 5px 0; }
   }
 }

--- a/app/assets/stylesheets/people.scss
+++ b/app/assets/stylesheets/people.scss
@@ -5,7 +5,7 @@
   }
   #invitations-button { padding-left: 0; }
 }
-#people_stream {
+#people-stream {
   .media, .media-body {
     overflow: visible;
   }

--- a/app/assets/stylesheets/people.scss
+++ b/app/assets/stylesheets/people.scss
@@ -20,7 +20,7 @@
       width: 50px;
       height: 50px;
     }
-    .btn-group.aspect_membership_dropdown { margin: 12px 0; }
+    .btn-group.aspect-membership-dropdown { margin: 12px 0; }
     .thats_you {
       line-height: 50px;
       margin-right: 10px;

--- a/app/assets/stylesheets/post-content.scss
+++ b/app/assets/stylesheets/post-content.scss
@@ -1,7 +1,7 @@
 .message-content,
 .post-content {
   img { max-width: 100%; }
-  .photo_attachments {
+  .photo-attachments {
     margin-top: 7px;
     padding-bottom: 10px;
     text-align: center;

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -8,7 +8,7 @@
     margin-top: -20px;
     box-shadow: $card-shadow;
 
-    #edit_profile, #unblock_user_button, .aspect_dropdown {
+    #edit_profile, #unblock_user_button, .aspect-dropdown {
       margin-top: 15px;
     }
 

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -137,7 +137,7 @@
 
   }
 
-  .stream_container > .pagination { text-align: center; }
+  .stream-container > .pagination { text-align: center; }
 
   #people_stream {
     background-color: $white;

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -139,7 +139,7 @@
 
   .stream-container > .pagination { text-align: center; }
 
-  #people_stream {
+  #people-stream {
     background-color: $white;
     box-shadow: $card-shadow;
   }

--- a/app/assets/stylesheets/publisher.scss
+++ b/app/assets/stylesheets/publisher.scss
@@ -14,7 +14,7 @@
       display: none !important;
     }
 
-    #publisher_textarea_wrapper { border: 1px solid $border-grey !important; }
+    #publisher-textarea-wrapper { border: 1px solid $border-grey !important; }
   }
 
   .container-fluid{ padding: 0; }
@@ -64,7 +64,7 @@
       }
     }
 
-    #publisher_textarea_wrapper {
+    #publisher-textarea-wrapper {
       background-color: white;
       border-radius: 3px;
       border: 1px solid $border-dark-grey;

--- a/app/assets/stylesheets/publisher.scss
+++ b/app/assets/stylesheets/publisher.scss
@@ -53,8 +53,8 @@
         .btn-toolbar {
           width: 100%;
           display: flex;
-          .btn, .aspect_dropdown{ flex-grow: 1; }
-          .aspect_dropdown .btn { width: 100%; }
+          .btn, .aspect-dropdown{ flex-grow: 1; }
+          .aspect-dropdown .btn { width: 100%; }
         }
         .btn-group:first-child { margin: 0; }
         .dropdown-menu.pull-right {
@@ -183,7 +183,7 @@
     }
   }
 
-  .aspect_dropdown {
+  .aspect-dropdown {
     .radio {
       min-height: 0;
       padding-left: 0;

--- a/app/assets/stylesheets/stream.scss
+++ b/app/assets/stylesheets/stream.scss
@@ -1,4 +1,4 @@
-.stream_container {
+.stream-container {
   .stream-title {
     margin: 12px 0;
   }

--- a/app/assets/stylesheets/stream_element.scss
+++ b/app/assets/stylesheets/stream_element.scss
@@ -61,7 +61,7 @@
   }
 }
 
-#main_stream .stream-element {
+#main-stream .stream-element {
   margin-bottom: 20px;
   border: 1px solid $border-grey;
   box-shadow: $card-shadow;

--- a/app/assets/stylesheets/tag.scss
+++ b/app/assets/stylesheets/tag.scss
@@ -30,7 +30,7 @@ h1.tag {
         line-height: 1.1;
       }
 
-      .side_stream #people_stream {
+      .side_stream #people-stream {
         .name { display: block; }
         .name, .diaspora_handle {
           word-break: break-all;

--- a/app/assets/templates/comment-stream_tpl.jst.hbs
+++ b/app/assets/templates/comment-stream_tpl.jst.hbs
@@ -28,7 +28,7 @@
       <form accept-charset="UTF-8" action="/posts/{{id}}/comments"
             class="new-comment" id="new-comment-on-{{id}}" method="post">
 
-        <textarea class="comment_box form-control mention-textarea"
+        <textarea class="comment-box form-control mention-textarea"
                   id="comment_text_on_{{id}}" name="text" rows="1" required placeholder="{{t "stream.comment"}}" />
         <div class="typeahead-mention-box-wrap">
           <input class="typeahead-mention-box hidden" type="text">

--- a/app/assets/templates/profile_header_tpl.jst.hbs
+++ b/app/assets/templates/profile_header_tpl.jst.hbs
@@ -33,7 +33,7 @@
         {{else}} {{#if is_blocked}}
           <a href="#" id="unblock_user_button" class="btn btn-danger">{{t 'people.stop_ignoring'}}</a>
         {{else}}
-          <div class="placeholder aspect_membership_dropdown"></div>
+          <div class="placeholder aspect-membership-dropdown"></div>
         {{/if}}{{/if}}
       </div>
     {{/if}}

--- a/app/assets/templates/status-message_tpl.jst.hbs
+++ b/app/assets/templates/status-message_tpl.jst.hbs
@@ -23,7 +23,7 @@
 </div>
 
 {{#if largePhoto}}
-  <div class="photo_attachments nsfw-hidden">
+  <div class="photo-attachments nsfw-hidden">
     {{#with largePhoto}}
       <a href="{{sizes.large}}" class="stream-photo-link gallery-picture">
         <img src="{{sizes.large}}" class="stream-photo big_stream_photo">

--- a/app/views/aspect_memberships/_aspect_membership_dropdown.haml
+++ b/app/views/aspect_memberships/_aspect_membership_dropdown.haml
@@ -1,1 +1,1 @@
-.placeholder.aspect_membership_dropdown
+.placeholder.aspect-membership-dropdown

--- a/app/views/aspect_memberships/_aspect_membership_dropdown.mobile.haml
+++ b/app/views/aspect_memberships/_aspect_membership_dropdown.mobile.haml
@@ -1,5 +1,5 @@
 %div
-  %select.aspect_dropdown.form-control.user_aspects{"name" => "user_aspects", "data-person-id" => @person.id}
+  %select.aspect-dropdown.form-control.user_aspects{"name" => "user_aspects", "data-person-id" => @person.id}
     %option{value: 'list_cover', class: 'list_cover', disabled: 'true', selected: 'true'}
       = t("contacts.index.add_contact")
     - contact = current_user.contact_for(@person)

--- a/app/views/aspects/_aspect_dropdown.html.haml
+++ b/app/views/aspects/_aspect_dropdown.html.haml
@@ -6,7 +6,7 @@
     dropdown_css["data-content"] = t("shared.public_explain.visibility_dropdown")
   end
 
-.btn-group.aspect_dropdown
+.btn-group.aspect-dropdown
   %button.btn.btn-default.dropdown-toggle{dropdown_css}
     - if public_selected?(selected_aspects)
       %i.entypo-globe.small#visibility-icon

--- a/app/views/aspects/_aspect_stream.haml
+++ b/app/views/aspects/_aspect_stream.haml
@@ -8,10 +8,10 @@
   = render "publisher/publisher", publisher_aspects_for(stream)
 
 - if current_user.getting_started?
-  .stream#main_stream{:title => popover_with_close_html("3. #{t('.stay_updated')}"),
+  .stream#main-stream{:title => popover_with_close_html("3. #{t('.stay_updated')}"),
     "data-content" => t(".stay_updated_explanation")}
 - else
-  .stream#main_stream
+  .stream#main-stream
 
 #paginate
   .loader.hidden

--- a/app/views/comments/_new_comment.mobile.haml
+++ b/app/views/comments/_new_comment.mobile.haml
@@ -9,7 +9,7 @@
       %fieldset
         = hidden_field_tag :post_id, post_id, id: "post-id-on-#{post_id}"
         .form-group.clearfix
-          = text_area_tag :text, nil, class: "col-md-12 comment_box form-control",
+          = text_area_tag :text, nil, class: "col-md-12 comment-box form-control",
               id: "comment-text-on-#{post_id}", placeholder: t(".comment")
         = submit_tag t(".comment"), :id => "comment-submit-#{post_id}", "data-disable-with" => t(".commenting"),
             "data-reset-with" => t(".comment"), :class => "btn btn-primary btn-block comment-button"

--- a/app/views/contacts/index.html.haml
+++ b/app/views/contacts/index.html.haml
@@ -8,7 +8,7 @@
         = render "contacts/sidebar"
 
     .col-md-9
-      .stream.contacts.framed-content#people_stream
+      .stream.contacts.framed-content#people-stream
         = render "contacts/header"
 
         - if @contacts_size > 0

--- a/app/views/contacts/index.mobile.haml
+++ b/app/views/contacts/index.mobile.haml
@@ -9,7 +9,7 @@
   %h2
     = t(".title")
 
-#people_stream.stream.contacts
+#people-stream.stream.contacts
   - if @contacts.size > 0
     - for contact in @contacts
       = render "people/person", person: contact.person, contact: contact

--- a/app/views/contacts/spotlight.haml
+++ b/app/views/contacts/spotlight.haml
@@ -8,7 +8,7 @@
         = render "contacts/sidebar"
 
     .col-md-9
-      .stream.contacts.framed-content#people_stream
+      .stream.contacts.framed-content#people-stream
         .header.clearfix
           - if AppConfig.settings.community_spotlight.suggest_email.present?
             .pull-right

--- a/app/views/conversations/_conversation.haml
+++ b/app/views/conversations/_conversation.haml
@@ -26,7 +26,7 @@
             = conversation.subject
         .timestamp
           = timeago(conversation.updated_at)
-        .last_author
+        .last-author
           - if conversation.last_author.present?
             = conversation.last_author.name
         .last_message

--- a/app/views/conversations/_conversation.mobile.haml
+++ b/app/views/conversations/_conversation.mobile.haml
@@ -9,7 +9,7 @@
         = render partial: "conversation_subject",
                  locals:  { conversation: conversation, unread_count: visibility.unread }
 
-        .last_author
+        .last-author
           .timestamp
             = timeago(conversation.updated_at)
 

--- a/app/views/conversations/index.haml
+++ b/app/views/conversations/index.haml
@@ -22,7 +22,7 @@
               = will_paginate @visibilities, previous_label: "&laquo;", next_label: "&raquo;", inner_window: 1,
                   renderer: WillPaginate::ActionView::BootstrapLinkRenderer
     .col-md-8
-      .conversations-form-container.stream_container
+      .conversations-form-container.stream-container
         #conversation-show{class: @conversation ? "" : "hidden"}
           - if @conversation
             = render 'conversations/show', conversation: @conversation

--- a/app/views/devise/passwords/edit.mobile.haml
+++ b/app/views/devise/passwords/edit.mobile.haml
@@ -2,7 +2,7 @@
 -#   licensed under the Affero General Public License version 3 or later.  See
 -#   the COPYRIGHT file.
 
-#main_stream.stream
+#main-stream.stream
   .login-form
     .login-container
       = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|

--- a/app/views/devise/passwords/new.mobile.haml
+++ b/app/views/devise/passwords/new.mobile.haml
@@ -2,7 +2,7 @@
 -#   licensed under the Affero General Public License version 3 or later.  See
 -#   the COPYRIGHT file.
 
-#main_stream.stream
+#main-stream.stream
   .login-form
     .login-container
       = form_for(resource, :as => resource_name, :url => password_path(resource_name)) do |f|

--- a/app/views/notifications/_notification.haml
+++ b/app/views/notifications/_notification.haml
@@ -6,7 +6,7 @@
     - if note.target.present?
       - gon_load_contact(note.contact)
       .pull-right
-        .aspect_membership_dropdown.placeholder{data: {person_id: note.target.id}}
+        .aspect-membership-dropdown.placeholder{data: {person_id: note.target.id}}
 
   .media-object.pull-left
     = person_image_link note.actors.first, :size => :thumb_small, :class => 'hovercardable'

--- a/app/views/people/_index.html.haml
+++ b/app/views/people/_index.html.haml
@@ -1,4 +1,4 @@
-#people_stream
+#people-stream
   - people.each do |person|
     .media.stream-element{id: person.id}
       .media-object.pull-left

--- a/app/views/people/_relationship_action.haml
+++ b/app/views/people/_relationship_action.haml
@@ -1,5 +1,5 @@
 - unless person == current_user.person
-  .aspect_membership_dropdown.placeholder{data: {person_id: person.id}}
+  .aspect-membership-dropdown.placeholder{data: {person_id: person.id}}
 -else
   %span.thats_you
     = t("people.person.thats_you")

--- a/app/views/people/contacts.haml
+++ b/app/views/people/contacts.haml
@@ -11,7 +11,7 @@
       .profile_header
         -# more JS
 
-      .stream_container
+      .stream-container
         #people_stream.stream
           - @hashes.each do |hash|
             = render partial: 'people/person', locals: hash

--- a/app/views/people/contacts.haml
+++ b/app/views/people/contacts.haml
@@ -12,7 +12,7 @@
         -# more JS
 
       .stream-container
-        #people_stream.stream
+        #people-stream.stream
           - @hashes.each do |hash|
             = render partial: 'people/person', locals: hash
         = will_paginate @contacts_of_contact, renderer: WillPaginate::ActionView::BootstrapLinkRenderer

--- a/app/views/people/index.html.haml
+++ b/app/views/people/index.html.haml
@@ -14,7 +14,7 @@
       = search_header
   .row
     .col-md-8
-      #people_stream.stream
+      #people-stream.stream
         - if @hashes.empty?
           %p
             - if @background_query.present?

--- a/app/views/people/index.mobile.haml
+++ b/app/views/people/index.mobile.haml
@@ -23,7 +23,7 @@
       =t('.no_one_found')
 
   - else
-    #people_stream.stream
+    #people-stream.stream
       - for hash in @hashes
         = render :partial => 'people/person', :locals => hash
 

--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -23,7 +23,7 @@
         - if user_signed_in? && current_user.person.id == @person.id && !current_page?(person_photos_path(@person))
           = render 'publisher/publisher', publisher_aspects_for(nil)
 
-        .stream.clearfix#main_stream
+        .stream.clearfix#main-stream
           -# JS
 
         #paginate

--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -18,7 +18,7 @@
       .profile_header
         -# more JS
 
-      .stream_container
+      .stream-container
 
         - if user_signed_in? && current_user.person.id == @person.id && !current_page?(person_photos_path(@person))
           = render 'publisher/publisher', publisher_aspects_for(nil)

--- a/app/views/people/show.mobile.haml
+++ b/app/views/people/show.mobile.haml
@@ -19,7 +19,7 @@
 - if @post_type == :photos
   = render "photos/index", photos: @posts
 - else
-  .stream#main_stream
+  .stream#main-stream
     - if @stream.stream_posts.length > 0
       = render "shared/stream", posts: @stream.stream_posts
       = render "shared/stream_more_button"

--- a/app/views/photos/_index.mobile.haml
+++ b/app/views/photos/_index.mobile.haml
@@ -2,6 +2,6 @@
 -#   licensed under the Affero General Public License version 3 or later.  See
 -#   the COPYRIGHT file.
 
-#main_stream
+#main-stream
   - for photo in photos
     = link_to image_tag(photo.url(:thumb_large)), person_photo_path(photo.author, photo), class: "thumbnail"

--- a/app/views/publisher/_publisher.html.haml
+++ b/app/views/publisher/_publisher.html.haml
@@ -3,7 +3,7 @@
     = form_for(StatusMessage.new) do |status|
       = status.error_messages
       %params
-        .publisher-textarea-wrapper#publisher_textarea_wrapper
+        .publisher-textarea-wrapper#publisher-textarea-wrapper
           - if current_user.getting_started?
             = status.text_area :text, :rows => 2, :value => h(publisher_formatted_text),
               :tabindex => 1, :placeholder => "#{t('contacts.index.start_a_conversation')}...",

--- a/app/views/publisher/_publisher.mobile.haml
+++ b/app/views/publisher/_publisher.mobile.haml
@@ -27,7 +27,7 @@
           = "· #{aspect.name}"
 
     .clear
-    #publisher_textarea_wrapper
+    #publisher-textarea-wrapper
       %ul#photodropzone
     #fileInfo-publisher
 

--- a/app/views/registrations/new.mobile.haml
+++ b/app/views/registrations/new.mobile.haml
@@ -2,7 +2,7 @@
 -#   licensed under the Affero General Public License version 3 or later.  See
 -#   the COPYRIGHT file.
 
-.stream#main_stream
+.stream#main-stream
   - flash.each do |name, msg|
     .expose#flash-container
       .flash-message{class: "message alert alert-#{flash_class name}", role: "alert"}

--- a/app/views/sessions/new.mobile.haml
+++ b/app/views/sessions/new.mobile.haml
@@ -2,7 +2,7 @@
 -#   licensed under the Affero General Public License version 3 or later.  See
 -#   the COPYRIGHT file.
 
-.stream#main_stream
+.stream#main-stream
   - flash.each do |name, msg|
     .expose#flash-container
       .flash-message{class: "message alert alert-#{flash_class name}", role: "alert"}

--- a/app/views/shared/_photo_area.mobile.haml
+++ b/app/views/shared/_photo_area.mobile.haml
@@ -5,7 +5,7 @@
 .photo_area
   - if post.is_a?(StatusMessage)
     -if post.photos.size > 0
-      .photo_attachments
+      .photo-attachments
         = link_to person_photo_path(post.author, post.photos.first), class: "stream-photo-link" do
           - if post.photos.size > 1
             .additional_photo_count

--- a/app/views/status_messages/_status_message.mobile.haml
+++ b/app/views/status_messages/_status_message.mobile.haml
@@ -6,7 +6,7 @@
   .photo_area
     - if post.is_a?(StatusMessage)
       -if post.photos.size > 0
-        .photo_attachments
+        .photo-attachments
           - if post.photos.size > 1
             .additional_photo_count
               = "+ #{post.photos.size-1}"

--- a/app/views/streams/main_stream.html.haml
+++ b/app/views/streams/main_stream.html.haml
@@ -176,7 +176,7 @@
               = link_to t("layouts.application.powered_by"), "https://diasporafoundation.org"
 
     .col-md-9
-      .stream_container#aspect_stream_container
+      .stream-container#aspect-stream-container
         = render "aspects/aspect_stream", stream: @stream
 
       %a.entypo-chevron-up.back-to-top#back-to-top{title: "#{t('layouts.application.back_to_top')}", href: "#"}

--- a/app/views/streams/main_stream.mobile.haml
+++ b/app/views/streams/main_stream.mobile.haml
@@ -2,6 +2,6 @@
 -#   licensed under the Affero General Public License version 3 or later.  See
 -#   the COPYRIGHT file.
 
-#main_stream.stream
+#main-stream.stream
   = render 'shared/stream', posts: @stream.stream_posts
   = render 'shared/stream_more_button'

--- a/app/views/tags/show.haml
+++ b/app/views/tags/show.haml
@@ -20,7 +20,7 @@
           = render partial: "people/index", locals: {people: @stream.tagged_people}
 
     .col-md-9
-      .stream_container
+      .stream-container
         #author_info
           %h2
             = @stream.display_tag_name

--- a/app/views/tags/show.haml
+++ b/app/views/tags/show.haml
@@ -28,7 +28,7 @@
         - if current_user
           = render "publisher/publisher", publisher_aspects_for(@stream)
 
-        #main_stream.stream
+        #main-stream.stream
 
         #paginate
           .loader.hidden

--- a/app/views/tags/show.mobile.haml
+++ b/app/views/tags/show.mobile.haml
@@ -12,7 +12,7 @@
     .btn.btn-danger.tag_following_action{data: {name: @stream.tag_name}}
       = t(".stop_following", tag: @stream.tag_name)
 
-#main_stream.stream
+#main-stream.stream
   = render 'shared/stream', :posts => @stream.stream_posts
   = render 'shared/stream_more_button'
 

--- a/features/desktop/change_settings.feature
+++ b/features/desktop/change_settings.feature
@@ -36,7 +36,7 @@ Feature: Change settings
   Scenario: Change my post default aspects
     When I go to the stream page
     And I expand the publisher
-    Then I should see "All aspects" within ".aspect_dropdown"
+    Then I should see "All aspects" within ".aspect-dropdown"
     When I go to the edit user page
     And I press the aspect dropdown
     And I toggle the aspect "Family"
@@ -44,7 +44,7 @@ Feature: Change settings
     And I press "Change" within "#post-default-aspects"
     And I go to the stream page
     And I expand the publisher
-    Then I should see "Family" within ".aspect_dropdown"
+    Then I should see "Family" within ".aspect-dropdown"
 
   Scenario: Change my post default to public
     When I press the aspect dropdown
@@ -52,7 +52,7 @@ Feature: Change settings
     And I press "Change" within "#post-default-aspects"
     And I go to the stream page
     And I expand the publisher
-    Then I should see "Public" within ".aspect_dropdown"
+    Then I should see "Public" within ".aspect-dropdown"
 
   Scenario: exporting profile data
     When I click on the first selector "#account_data a"

--- a/features/desktop/connects_users.feature
+++ b/features/desktop/connects_users.feature
@@ -30,7 +30,7 @@ Feature: following and being followed
     When I sign in as "alice@alice.alice"
     And I am on "bob@bob.bob"'s page
 
-    And I press the first ".aspect_membership_dropdown .dropdown-toggle"
+    And I press the first ".aspect-membership-dropdown .dropdown-toggle"
     And I press the first "a" within ".add_aspect"
 
     And I fill in "aspect_name" with "Super People" in the aspect creation modal

--- a/features/desktop/contacts.feature
+++ b/features/desktop/contacts.feature
@@ -25,8 +25,8 @@ Feature: show contacts
     Then I should see "Contacts" within "#profile-horizontal-bar"
 
     When I press the first "#contacts_link"
-    Then I should see "Bob Jones" within "#people_stream .media-body"
-    When I add the person to my "Besties" aspect within "#people_stream"
+    Then I should see "Bob Jones" within "#people-stream .media-body"
+    When I add the person to my "Besties" aspect within "#people-stream"
     Then I should see a flash message containing "You have started sharing with Bob Jones!"
 
   Scenario: don't see contacts of an invisible aspect list

--- a/features/desktop/conversations.feature
+++ b/features/desktop/conversations.feature
@@ -24,12 +24,12 @@ Feature: private conversations
     And I should see "less than a minute ago" within "#conversation-show"
     And I should see "Alice Awesome" as a participant
     And "Alice Awesome" should be part of active conversation
-    And I should see "hello, alice!" within ".stream_container"
+    And I should see "hello, alice!" within ".stream-container"
     When I sign in as "alice@alice.alice"
     Then I should have 1 unread private message
     And I should have 1 email delivery
     When I reply with "hey, how you doing?"
-    Then I should see "hey, how you doing?" within ".stream_container"
+    Then I should see "hey, how you doing?" within ".stream-container"
 
   Scenario: send a message using keyboard shortcuts
     When I sign in as "bob@bob.bob"
@@ -37,9 +37,9 @@ Feature: private conversations
     Then I should see "Greetings" within "#conversation-inbox"
     And I should see "Greetings" within "#conversation-show"
     And "Alice Awesome" should be part of active conversation
-    And I should see "hello, alice!" within ".stream_container"
+    And I should see "hello, alice!" within ".stream-container"
     When I reply with "hey, how you doing?" using keyboard shortcuts
-    Then I should see "hey, how you doing?" within ".stream_container"
+    Then I should see "hey, how you doing?" within ".stream-container"
     When I sign in as "alice@alice.alice"
     Then I should have 2 unread private messages
     And I should have 2 email delivery
@@ -54,7 +54,7 @@ Feature: private conversations
     Then I should see "Greetings" within "#conversation-inbox"
     And I should see "Greetings" within "#conversation-show"
     And "Alice Awesome" should be part of active conversation
-    And I should see "hello, alice!" within ".stream_container"
+    And I should see "hello, alice!" within ".stream-container"
 
   Scenario: delete a conversation
     When I sign in as "bob@bob.bob"
@@ -66,7 +66,7 @@ Feature: private conversations
     Then I should have 1 unread private message
     And I should have 1 email delivery
     When I reply with "hey, how you doing?"
-    Then I should see "hey, how you doing?" within ".stream_container"
+    Then I should see "hey, how you doing?" within ".stream-container"
     When I sign in as "bob@bob.bob"
     Then I should have 1 email delivery
     And I should have no unread private messages

--- a/features/desktop/hovercards.feature
+++ b/features/desktop/hovercards.feature
@@ -24,12 +24,12 @@ Feature: Hovercards
   Scenario: Hovercards on the main stream in reshares
     Given I sign in as "alice@alice.alice"
     And I am on "bob@bob.bob"'s page
-    Then I should see "Alice" within "#main_stream"
-    When I hover "Alice" within "#main_stream"
+    Then I should see "Alice" within "#main-stream"
+    When I hover "Alice" within "#main-stream"
     Then I should not see a hovercard
     When I am on "alice@alice.alice"'s page
-    Then I should see "Bob Jones" within "#main_stream"
-    When I hover "Bob Jones" within "#main_stream"
+    Then I should see "Bob Jones" within "#main-stream"
+    When I hover "Bob Jones" within "#main-stream"
     Then I should see a hovercard
 
   Scenario: Hovercards on the tag stream as a logged out user

--- a/features/desktop/likes.feature
+++ b/features/desktop/likes.feature
@@ -17,12 +17,12 @@ Feature: Liking posts
     Then I should not have activated notifications for the post
     When I like the post "I like unicorns" in the stream
     Then I should see "Unlike" within ".stream-element .feedback"
-    And I should see a ".likes .media" within "#main_stream .stream-element"
+    And I should see a ".likes .media" within "#main-stream .stream-element"
     And I should have activated notifications for the post
 
     When I unlike the post "I like unicorns" in the stream
     Then I should see "Like" within ".stream-element .feedback"
-    And I should not see a ".likes .media" within "#main_stream .stream-element"
+    And I should not see a ".likes .media" within "#main-stream .stream-element"
 
 
   Scenario: Liking and unliking a post from a single post page
@@ -39,4 +39,4 @@ Feature: Liking posts
     When I like the post "I like unicorns" in the stream
     And I sign out
     And I sign in as "bob@bob.bob"
-    Then I should see a ".likes" within "#main_stream .stream-element"
+    Then I should see a ".likes" within "#main-stream .stream-element"

--- a/features/desktop/post_preview.feature
+++ b/features/desktop/post_preview.feature
@@ -46,7 +46,7 @@ Feature: preview posts in the stream
       When I fill in the following:
           | status_message_text    | Look at this dog    |
       And I preview the post
-      Then I should see a "img" within ".md-preview .stream-element .photo_attachments"
+      Then I should see a "img" within ".md-preview .stream-element .photo-attachments"
       And I should see "Look at this dog" within ".md-preview .stream-element"
       And I close the publisher
 

--- a/features/desktop/posts_from_main_page.feature
+++ b/features/desktop/posts_from_main_page.feature
@@ -78,12 +78,12 @@ Feature: posting from the main page
       When I write the status message "Look at this dog"
       And I submit the publisher
       And I go to the aspects page
-      Then I should see a "img" within ".stream-element div.photo_attachments"
+      Then I should see a "img" within ".stream-element div.photo-attachments"
       And I should see "Look at this dog" within ".stream-element"
       When I log out
       And I sign in as "alice@alice.alice"
       And I go to "bob@bob.bob"'s page
-      Then I should see a "img" within ".stream-element div.photo_attachments"
+      Then I should see a "img" within ".stream-element div.photo-attachments"
       And I should see "Look at this dog" within ".stream-element"
 
     Scenario: post a photo without text
@@ -91,13 +91,13 @@ Feature: posting from the main page
       And I attach "spec/fixtures/button.png" to the publisher
       Then I should see an uploaded image within the photo drop zone
       When I press "Share"
-      Then I should see a "img" within ".stream-element div.photo_attachments"
+      Then I should see a "img" within ".stream-element div.photo-attachments"
       When I go to the aspects page
-      Then I should see a "img" within ".stream-element div.photo_attachments"
+      Then I should see a "img" within ".stream-element div.photo-attachments"
       When I log out
       And I sign in as "alice@alice.alice"
       And I go to "bob@bob.bob"'s page
-      Then I should see a "img" within ".stream-element div.photo_attachments"
+      Then I should see a "img" within ".stream-element div.photo-attachments"
 
     Scenario: back out of posting a photo-only post
       Given I expand the publisher

--- a/features/desktop/posts_from_profile_page.feature
+++ b/features/desktop/posts_from_profile_page.feature
@@ -39,7 +39,7 @@ Feature: posting from own profile page
       And I submit the publisher
 
       When I go to the home page
-      Then I should see a "img" within ".stream-element div.photo_attachments"
+      Then I should see a "img" within ".stream-element div.photo-attachments"
       And I should see "who am I?" within ".stream-element"
 
     Scenario: back out of posting a photo-only post

--- a/features/desktop/profile_photos.feature
+++ b/features/desktop/profile_photos.feature
@@ -31,8 +31,8 @@ Feature: show photos
 
     Scenario: I delete a photo
       When I am on "robert@grimm.grimm"'s photos page
-      Then I should see a ".thumbnail" within "#main_stream"
+      Then I should see a ".thumbnail" within "#main-stream"
       When I confirm the alert after I delete a photo
-      Then I should not see a ".thumbnail" within "#main_stream"
+      Then I should not see a ".thumbnail" within "#main-stream"
       When I am on "robert@grimm.grimm"'s page
       Then I should not see "Photos" within "#profile-horizontal-bar"

--- a/features/desktop/search.feature
+++ b/features/desktop/search.feature
@@ -31,7 +31,7 @@ Scenario: search for a user in background
   And I search for "user@pod.tld"
   And a person with ID "user@pod.tld" has been discovered
   Then I should see "user@pod.tld" within ".stream .info.diaspora_handle"
-  And I should see a ".aspect_dropdown" within ".stream"
+  And I should see a ".aspect-dropdown" within ".stream"
 
 Scenario: search for a not searchable user
   When I sign in as "carol@example.com"

--- a/features/desktop/signs_up.feature
+++ b/features/desktop/signs_up.feature
@@ -42,7 +42,7 @@ Feature: new user registration
     When I confirm the alert after I follow "awesome_button"
     Then I should be on the stream page
     And the publisher should be expanded
-    And I should see "Public" within ".aspect_dropdown"
+    And I should see "Public" within ".aspect-dropdown"
 
   Scenario: new user without any tags posts first status message
     When I confirm the alert after I follow "awesome_button"

--- a/features/mobile/drawer.feature
+++ b/features/mobile/drawer.feature
@@ -58,11 +58,11 @@ Feature: Navigate between pages using the header menu and the drawer
     And I click on "My aspects" in the drawer
     And I click on "All aspects" in the drawer
     Then I should be on the aspects page
-    And I should see "Hi you!" within "#main_stream"
+    And I should see "Hi you!" within "#main-stream"
     When I open the drawer
     And I click on "My aspects" in the drawer
     And I click on "Unicorns" in the drawer
-    And I should not see "Hi you!" within "#main_stream"
+    And I should not see "Hi you!" within "#main-stream"
 
   Scenario: navigate to the followed tags page
     When I follow the "boss" tag

--- a/features/mobile/posts_from_main_page.feature
+++ b/features/mobile/posts_from_main_page.feature
@@ -35,11 +35,11 @@ Feature: posting from the mobile main page
     And I should see an uploaded image within the photo drop zone
     When I press "Share"
     When I go to the stream page
-    Then I should see a "img" within ".stream-element div.photo_attachments"
+    Then I should see a "img" within ".stream-element div.photo-attachments"
     When I log out
     And I sign in as "alice@alice.alice" on the mobile website
     When I go to the stream page
-    Then I should see a "img" within ".stream-element div.photo_attachments"
+    Then I should see a "img" within ".stream-element div.photo-attachments"
 
   Scenario: back out of posting a photo-only post
     Given I visit the mobile publisher page

--- a/features/mobile/stream.feature
+++ b/features/mobile/stream.feature
@@ -13,4 +13,4 @@ Feature: Viewing the main stream mobile page
     When I sign in as "bob@bob.bob" on the mobile website
     And I go to the stream page
     Then I should see "Hello! I am #newhere" within ".ltr"
-    And I should see "less than a minute ago" within "#main_stream"
+    And I should see "less than a minute ago" within "#main-stream"

--- a/features/step_definitions/aspects_steps.rb
+++ b/features/step_definitions/aspects_steps.rb
@@ -46,7 +46,7 @@ end
 
 When /^I select only "([^"]*)" aspect$/ do |aspect_name|
   click_link "My aspects"
-  expect(find("#aspect_stream_container")).to have_css(".loader.hidden", visible: false)
+  expect(find("#aspect-stream-container")).to have_css(".loader.hidden", visible: false)
   within("#aspects_list") do
     all(".selected").each do |node|
       aspect_item = node.find(:xpath, "..")

--- a/features/step_definitions/aspects_steps.rb
+++ b/features/step_definitions/aspects_steps.rb
@@ -1,6 +1,6 @@
 module AspectCukeHelpers
   def click_aspect_dropdown
-    find(".aspect_dropdown .dropdown-toggle").trigger "click"
+    find(".aspect-dropdown .dropdown-toggle").trigger "click"
   end
 
   def toggle_aspect(a_name)
@@ -9,7 +9,7 @@ module AspectCukeHelpers
            else
              @me.aspects.where(name: a_name).pluck(:id).first
            end
-    aspect_css = ".aspect_dropdown li[data-aspect_id='#{a_id}']"
+    aspect_css = ".aspect-dropdown li[data-aspect_id='#{a_id}']"
     expect(page).to have_selector(aspect_css)
     find(aspect_css).click
   end

--- a/features/step_definitions/aspects_steps.rb
+++ b/features/step_definitions/aspects_steps.rb
@@ -15,13 +15,13 @@ module AspectCukeHelpers
   end
 
   def toggle_aspect_via_ui(aspect_name)
-    aspects_dropdown = find(".aspect_membership_dropdown .dropdown-toggle", match: :first)
+    aspects_dropdown = find(".aspect-membership-dropdown .dropdown-toggle", match: :first)
     aspects_dropdown.trigger "click"
-    selected_aspect_count = all(".aspect_membership_dropdown.open .dropdown-menu li.selected").length
-    aspect = find(".aspect_membership_dropdown.open .dropdown-menu li", text: aspect_name)
+    selected_aspect_count = all(".aspect-membership-dropdown.open .dropdown-menu li.selected").length
+    aspect = find(".aspect-membership-dropdown.open .dropdown-menu li", text: aspect_name)
     aspect_selected = aspect["class"].include? "selected"
     aspect.trigger "click"
-    expect(find(".aspect_membership_dropdown .dropdown-menu", visible: false)).to have_no_css(".loading")
+    expect(find(".aspect-membership-dropdown .dropdown-menu", visible: false)).to have_no_css(".loading")
 
     # close dropdown
     page.should have_no_css('#profile.loading')
@@ -31,7 +31,7 @@ module AspectCukeHelpers
   end
 
   def aspect_dropdown_visible?
-    expect(find('.aspect_membership_dropdown.open')).to be_visible
+    expect(find('.aspect-membership-dropdown.open')).to be_visible
   end
 end
 World(AspectCukeHelpers)

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -40,5 +40,5 @@ Given /^"([^"]*)" has commented a lot on "([^"]*)"$/ do |email, post_text|
 end
 
 When /^I enter "([^"]*)" in the comment field$/ do |comment_text|
-  find("textarea.comment_box.mention-textarea").native.send_keys(comment_text)
+  find("textarea.comment-box.mention-textarea").native.send_keys(comment_text)
 end

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -3,12 +3,12 @@ When /^I focus the comment field$/ do
 end
 
 Then /^the first comment field should be open/ do
-  find("#main_stream .stream-element .new-comment").should be_visible
+  find("#main-stream .stream-element .new-comment").should be_visible
 end
 
 Then /^the first comment field should be closed$/ do
   page.should have_css(".stream-element .media")
-  page.should_not have_selector("#main_stream .stream-element .new-comment", match: :first)
+  page.should_not have_selector("#main-stream .stream-element .new-comment", match: :first)
 end
 
 When /^I make a show page comment "([^"]*)"$/ do |comment_text|

--- a/features/step_definitions/custom_web_steps.rb
+++ b/features/step_definitions/custom_web_steps.rb
@@ -73,7 +73,7 @@ Then /^the publisher should be expanded$/ do
 end
 
 Then /^the text area wrapper mobile should be with attachments$/ do
-  find("#publisher_textarea_wrapper")["class"].should include("with_attachments")
+  find("#publisher-textarea-wrapper")["class"].should include("with_attachments")
 end
 
 And /^I want to mention (?:him|her) from the profile$/ do

--- a/features/step_definitions/custom_web_steps.rb
+++ b/features/step_definitions/custom_web_steps.rb
@@ -205,7 +205,7 @@ Then /^the "([^"]*)" field(?: within "([^"]*)")? should be filled with "([^"]*)"
 end
 
 Then /^I should see (\d+) contacts$/ do |n_posts|
-  has_css?("#people_stream .stream-element", count: n_posts.to_i).should be true
+  has_css?("#people-stream .stream-element", count: n_posts.to_i).should be true
 end
 
 And /^I scroll down$/ do

--- a/features/step_definitions/custom_web_steps.rb
+++ b/features/step_definitions/custom_web_steps.rb
@@ -221,11 +221,11 @@ When /^I resize my window to 800x600$/ do
 end
 
 Then 'I should see an image attached to the post' do
-  step %(I should see a "img" within ".stream-element div.photo_attachments")
+  step %(I should see a "img" within ".stream-element div.photo-attachments")
 end
 
 Then 'I press the attached image' do
-  step %(I press the 1st "img" within ".stream-element div.photo_attachments")
+  step %(I press the 1st "img" within ".stream-element div.photo-attachments")
 end
 
 And "I wait for the popovers to appear" do

--- a/features/step_definitions/keyboard_navigation_steps.rb
+++ b/features/step_definitions/keyboard_navigation_steps.rb
@@ -1,5 +1,5 @@
 When /^I press the "([^\"]*)" key somewhere$/ do |key|
-  within("#main_stream") do
+  within("#main-stream") do
     find("div.stream-element", match: :first).native.send_keys(key)
   end
 end

--- a/features/step_definitions/notifications_steps.rb
+++ b/features/step_definitions/notifications_steps.rb
@@ -7,7 +7,7 @@ When "I filter notifications by mentions" do
 end
 
 Then /^I should( not)? have activated notifications for the post( in the single post view)?$/ do |negate, spv|
-  selector = spv ? "#single-post-moderation" : "#main_stream .stream-element"
+  selector = spv ? "#single-post-moderation" : "#main-stream .stream-element"
   if negate
     expect(find(selector, match: :first)).to have_no_css(".destroy_participation", visible: false)
     expect(find(selector, match: :first)).to have_css(".create_participation", visible: false)

--- a/features/step_definitions/oembed_steps.rb
+++ b/features/step_definitions/oembed_steps.rb
@@ -125,10 +125,10 @@ end
 Then /^I should see a video player$/ do
   visit aspects_path
   find('.post-content .oembed')
-  find('.stream_container').should have_css('.post-content .oembed img')
+  find('.stream-container').should have_css('.post-content .oembed img')
 end
 
 Then /^I should not see a video player$/ do
-  find('.stream_container').should_not have_css('.post-content .oembed img')
+  find('.stream-container').should_not have_css('.post-content .oembed img')
 end
 

--- a/features/step_definitions/posts_steps.rb
+++ b/features/step_definitions/posts_steps.rb
@@ -128,7 +128,7 @@ end
 
 When /^I select "([^"]*)" on the aspect dropdown$/ do |text|
   page.execute_script(
-    "$('#publisher .dropdown .dropdown_list, #publisher .aspect_dropdown .dropdown-menu')
+    "$('#publisher .dropdown .dropdown_list, #publisher .aspect-dropdown .dropdown-menu')
       .find('li').each(function(i,el){
       var elem = $(el);
       if ('" + text + "' == $.trim(elem.text()) ) {

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -233,7 +233,7 @@ end
 
 And /^I should be able to friend "([^\"]*)"$/ do |email|
   user = User.find_by_email(email)
-  step 'I should see a ".aspect_dropdown"'
+  step 'I should see a ".aspect-dropdown"'
   step "I should see \"#{user.name}\""
 end
 

--- a/features/support/publishing_cuke_helpers.rb
+++ b/features/support/publishing_cuke_helpers.rb
@@ -30,7 +30,7 @@ module PublishingCukeHelpers
     # wait for the publisher to be closed
     expect(find("#publisher")["class"]).to include("closed")
     # wait for the content to appear
-    expect(find("#main_stream")).to have_content(txt)
+    expect(find("#main-stream")).to have_content(txt)
   end
 
   def click_and_post(text)

--- a/features/support/publishing_cuke_helpers.rb
+++ b/features/support/publishing_cuke_helpers.rb
@@ -12,7 +12,7 @@ module PublishingCukeHelpers
 
   def upload_file_with_publisher(path)
     page.execute_script(%q{$("input[name='qqfile']").css("opacity", '1');})
-    with_scope("#publisher_textarea_wrapper") do
+    with_scope("#publisher-textarea-wrapper") do
       attach_file("qqfile", Rails.root.join(path).to_s)
       # wait for the image to be ready
       page.assert_selector(".publisher_photo.loading", count: 0)

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -119,7 +119,7 @@ describe NotificationsController, :type => :controller do
         eve.share_with(alice.person, eve.aspects.first)
         get :index, params: {per_page: 5}
 
-        expect(Nokogiri(response.body).css(".aspect_membership_dropdown")).not_to be_empty
+        expect(Nokogiri(response.body).css(".aspect-membership-dropdown")).not_to be_empty
       end
 
       it 'succeeds on mobile' do

--- a/spec/integration/profile_spec.rb
+++ b/spec/integration/profile_spec.rb
@@ -10,7 +10,7 @@ describe PeopleController, type: :request do
       expect(response.status).to eq(200)
       # make sure we are signed in
       expect(response.body).not_to match(/a class="login"/)
-      expect(response.body).to match(/div class='publisher-textarea-wrapper' id='publisher_textarea_wrapper'/)
+      expect(response.body).to match(/div class='publisher-textarea-wrapper' id='publisher-textarea-wrapper'/)
     end
 
     it "displays the publisher for people path" do
@@ -19,7 +19,7 @@ describe PeopleController, type: :request do
       expect(response.status).to eq(200)
       # make sure we are signed in
       expect(response.body).not_to match(/a class="login"/)
-      expect(response.body).to match(/div class='publisher-textarea-wrapper' id='publisher_textarea_wrapper'/)
+      expect(response.body).to match(/div class='publisher-textarea-wrapper' id='publisher-textarea-wrapper'/)
     end
 
     it "doesn't display the publisher for people photos path" do
@@ -28,7 +28,7 @@ describe PeopleController, type: :request do
       expect(response.status).to eq(200)
       # make sure we are signed in
       expect(response.body).not_to match(/a class="login"/)
-      expect(response.body).not_to match(/div class='publisher-textarea-wrapper' id='publisher_textarea_wrapper'/)
+      expect(response.body).not_to match(/div class='publisher-textarea-wrapper' id='publisher-textarea-wrapper'/)
     end
   end
 
@@ -43,7 +43,7 @@ describe PeopleController, type: :request do
       expect(response.status).to eq(200)
       # make sure we are signed in
       expect(response.body).not_to match(/a class="login"/)
-      expect(response.body).not_to match(/div class='publisher-textarea-wrapper' id='publisher_textarea_wrapper'/)
+      expect(response.body).not_to match(/div class='publisher-textarea-wrapper' id='publisher-textarea-wrapper'/)
     end
 
     it "doesn't display the publisher for people path" do
@@ -52,7 +52,7 @@ describe PeopleController, type: :request do
       expect(response.status).to eq(200)
       # make sure we are signed in
       expect(response.body).not_to match(/a class="login"/)
-      expect(response.body).not_to match(/div class='publisher-textarea-wrapper' id='publisher_textarea_wrapper'/)
+      expect(response.body).not_to match(/div class='publisher-textarea-wrapper' id='publisher-textarea-wrapper'/)
     end
   end
 
@@ -63,7 +63,7 @@ describe PeopleController, type: :request do
       expect(response.status).to eq(200)
       # make sure we aren't signed in
       expect(response.body).to match(/a class="login"/)
-      expect(response.body).not_to match(/div class='publisher-textarea-wrapper' id='publisher_textarea_wrapper'/)
+      expect(response.body).not_to match(/div class='publisher-textarea-wrapper' id='publisher-textarea-wrapper'/)
     end
 
     it "doesn't display the publisher for people path" do
@@ -72,7 +72,7 @@ describe PeopleController, type: :request do
       expect(response.status).to eq(200)
       # make sure we aren't signed in
       expect(response.body).to match(/a class="login"/)
-      expect(response.body).not_to match(/div class='publisher-textarea-wrapper' id='publisher_textarea_wrapper'/)
+      expect(response.body).not_to match(/div class='publisher-textarea-wrapper' id='publisher-textarea-wrapper'/)
     end
   end
 end

--- a/spec/javascripts/app/views/aspects_dropdown_view_spec.js
+++ b/spec/javascripts/app/views/aspects_dropdown_view_spec.js
@@ -1,7 +1,7 @@
 describe("app.views.AspectsDropdown", function(){
   beforeEach(function() {
     spec.loadFixture("bookmarklet");
-    this.view = new app.views.AspectsDropdown({el: $('.aspect_dropdown')});
+    this.view = new app.views.AspectsDropdown({el: $('.aspect-dropdown')});
   });
 
   context('_toggleCheckbox', function() {

--- a/spec/javascripts/app/views/comment_stream_view_spec.js
+++ b/spec/javascripts/app/views/comment_stream_view_spec.js
@@ -51,7 +51,7 @@ describe("app.views.CommentStream", function(){
       this.view.commentBox = undefined;
       this.view.postRenderTemplate();
       expect(this.view.commentBox).toBeDefined();
-      expect(this.view.commentBox).toEqual(this.view.$(".comment_box"));
+      expect(this.view.commentBox).toEqual(this.view.$(".comment-box"));
     });
 
     it("sets commentSubmitButton", function() {
@@ -124,7 +124,7 @@ describe("app.views.CommentStream", function(){
 
     context("submission", function() {
       beforeEach(function() {
-        this.view.$(".comment_box").val('a new comment');
+        this.view.$(".comment-box").val('a new comment');
         this.view.createComment();
 
         this.request = jasmine.Ajax.requests.mostRecent();

--- a/spec/javascripts/app/views/publisher_view_spec.js
+++ b/spec/javascripts/app/views/publisher_view_spec.js
@@ -112,7 +112,7 @@ describe("app.views.Publisher", function() {
         expect("#publisher").not.toHaveClass("closed");
         $("#publisher").find(".publisher-textarea-wrapper").click();
         expect("#publisher").not.toHaveClass("closed");
-        $("#publisher").find(".aspect_dropdown button").click();
+        $("#publisher").find(".aspect-dropdown button").click();
         expect("#publisher").not.toHaveClass("closed");
       });
 
@@ -121,10 +121,10 @@ describe("app.views.Publisher", function() {
         // that take the whole page when it detects a mobile.
         // Clicking on this element should not close the publisher.
         // See https://github.com/diaspora/diaspora/issues/6979.
-        $("#publisher").find(".aspect_dropdown").append("<div class='dropdown-backdrop'></div>")
+        $("#publisher").find(".aspect-dropdown").append("<div class='dropdown-backdrop'></div>")
           .css({position: "fixed", left: 0, right: 0, bottom: 0, top: 0, "z-index": 990});
         expect("#publisher").not.toHaveClass("closed");
-        $("#publisher").find(".aspect_dropdown button").click();
+        $("#publisher").find(".aspect-dropdown button").click();
         expect("#publisher").not.toHaveClass("closed");
         $("#publisher").find(".dropdown-backdrop").click();
         expect("#publisher").not.toHaveClass("closed");
@@ -403,13 +403,13 @@ describe("app.views.Publisher", function() {
 
     describe("toggles the selected entry visually", function(){
       it("click on the first aspect", function(){
-        this.view.$(".aspect_dropdown li.aspect_selector:first").click();
+        this.view.$(".aspect-dropdown li.aspect_selector:first").click();
         expect($("#publisher #visibility-icon")).not.toHaveClass("entypo-globe");
         expect($("#publisher #visibility-icon")).toHaveClass("entypo-lock");
       });
 
       it("click on public", function(){
-        this.view.$(".aspect_dropdown li.public").click();
+        this.view.$(".aspect-dropdown li.public").click();
         expect($("#publisher #visibility-icon")).toHaveClass("entypo-globe");
         expect($("#publisher #visibility-icon")).not.toHaveClass("entypo-lock");
       });
@@ -430,7 +430,7 @@ describe("app.views.Publisher", function() {
         expect(selected.length).toBe(1);
         expect(selected.first().val()).toBe('all_aspects');
 
-        var evt = $.Event("click", { target: $('.aspect_dropdown li.aspect_selector:last') });
+        var evt = $.Event("click", { target: $('.aspect-dropdown li.aspect_selector:last') });
         this.view.viewAspectSelector.toggleAspect(evt);
 
         selected = $('input[name="aspect_ids[]"]');
@@ -441,20 +441,20 @@ describe("app.views.Publisher", function() {
       it("toggles the same item", function() {
         expect($('input[name="aspect_ids[]"][value="42"]').length).toBe(0);
 
-        var evt = $.Event("click", { target: $('.aspect_dropdown li.aspect_selector:last') });
+        var evt = $.Event("click", { target: $('.aspect-dropdown li.aspect_selector:last') });
         this.view.viewAspectSelector.toggleAspect(evt);
         expect($('input[name="aspect_ids[]"][value="42"]').length).toBe(1);
 
-        evt = $.Event("click", { target: $('.aspect_dropdown li.aspect_selector:last') });
+        evt = $.Event("click", { target: $('.aspect-dropdown li.aspect_selector:last') });
         this.view.viewAspectSelector.toggleAspect(evt);
         expect($('input[name="aspect_ids[]"][value="42"]').length).toBe(0);
       });
 
       it("keeps other fields with different values", function() {
         $('.dropdown-menu').append('<li data-aspect_id="99" class="aspect_selector" />');
-        var evt = $.Event("click", { target: $('.aspect_dropdown li.aspect_selector:eq(-2)') });
+        var evt = $.Event("click", { target: $('.aspect-dropdown li.aspect_selector:eq(-2)') });
         this.view.viewAspectSelector.toggleAspect(evt);
-        evt = $.Event("click", { target: $('.aspect_dropdown li.aspect_selector:eq(-1)') });
+        evt = $.Event("click", { target: $('.aspect-dropdown li.aspect_selector:eq(-1)') });
         this.view.viewAspectSelector.toggleAspect(evt);
 
         expect($('input[name="aspect_ids[]"][value="42"]').length).toBe(1);

--- a/spec/javascripts/app/views/publisher_view_spec.js
+++ b/spec/javascripts/app/views/publisher_view_spec.js
@@ -519,7 +519,7 @@ describe("app.views.Publisher", function() {
       setFixtures(
         '<div id="publisher">'+
         '  <div class="content_creation"><form>'+
-        '    <div id="publisher_textarea_wrapper"></div>'+
+        '    <div id="publisher-textarea-wrapper"></div>'+
         '    <div id="photodropzone"></div>'+
         '    <input type="submit" />'+
         '  </form></div>'+


### PR DESCRIPTION
This pull request changes the most common class names that don't follow our styleguide. They appear in a lot of different files and thus would be often ignored in pull requests.

Pronto warnings are ignored in this pull request on purpose.