### PR TITLE
Don't truncate ar_internal_metadata after cucumber scenarios

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -51,6 +51,9 @@ Capybara.default_max_wait_time = 30
 # of your scenarios, as this makes it hard to discover errors in your application.
 ActionController::Base.allow_rescue = false
 
+# TODO: Temporary fix for rails 5, remove the next line after a new version of database_cleaner is released.
+# See https://github.com/DatabaseCleaner/database_cleaner/issues/445
+Cucumber::Rails::Database.javascript_strategy = :truncation, {except: %w[ar_internal_metadata]}
 Cucumber::Rails::Database.autorun_database_cleaner = true
 Cucumber::Rails::World.use_transactional_tests = false
 


### PR DESCRIPTION
This is an internal active record table and shouldn't be touched. When this is truncated you need to fix it again by running `bin/rails db:environment:set RAILS_ENV=test`.

This is a temporary fix until there is a new version of
database_cleaner. See DatabaseCleaner/database_cleaner#445.