### PR TITLE
Fix database issues for export

### DIFF
--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -3,8 +3,8 @@ class Poll < ApplicationRecord
   include Diaspora::Fields::Guid
 
   belongs_to :status_message
-  has_many :poll_answers, -> { order 'id ASC' }
-  has_many :poll_participations
+  has_many :poll_answers, -> { order "id ASC" }, dependent: :destroy
+  has_many :poll_participations, dependent: :destroy
   has_one :author, through: :status_message
 
   #forward some requests to status message, because a poll is just attached to a status message and is not sharable itself

--- a/app/models/status_message.rb
+++ b/app/models/status_message.rb
@@ -18,7 +18,7 @@ class StatusMessage < Post
   has_many :photos, :dependent => :destroy, :foreign_key => :status_message_guid, :primary_key => :guid
 
   has_one :location
-  has_one :poll, autosave: true
+  has_one :poll, autosave: true, dependent: :destroy
   has_many :poll_participations, through: :poll
 
   attr_accessor :oembed_url

--- a/db/migrate/20170914202650_cleanup_invalid_likes.rb
+++ b/db/migrate/20170914202650_cleanup_invalid_likes.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CleanupInvalidLikes < ActiveRecord::Migration[5.1]
+  class Like < ApplicationRecord
+  end
+
+  def up
+    Like.where(target_type: "Post").joins("LEFT OUTER JOIN posts ON posts.id = likes.target_id")
+        .where("posts.id IS NULL").delete_all
+    Like.where(target_type: "Comment").joins("LEFT OUTER JOIN comments ON comments.id = likes.target_id")
+        .where("comments.id IS NULL").delete_all
+  end
+end

--- a/db/migrate/20170914212336_cleanup_invalid_polls.rb
+++ b/db/migrate/20170914212336_cleanup_invalid_polls.rb
@@ -1,0 +1,19 @@
+class CleanupInvalidPolls < ActiveRecord::Migration[5.1]
+  class Poll < ApplicationRecord
+    has_many :poll_answers, dependent: :destroy
+    has_many :poll_participations, dependent: :destroy
+  end
+  class PollAnswer < ApplicationRecord
+    belongs_to :poll
+    has_many :poll_participations
+  end
+  class PollParticipation < ApplicationRecord
+    belongs_to :poll
+    belongs_to :poll_answer
+  end
+
+  def up
+    Poll.joins("LEFT OUTER JOIN posts ON posts.id = polls.status_message_id")
+        .where("posts.id IS NULL").destroy_all
+  end
+end

--- a/spec/models/status_message_spec.rb
+++ b/spec/models/status_message_spec.rb
@@ -231,6 +231,23 @@ describe StatusMessage, type: :model do
     end
   end
 
+  describe "poll" do
+    it "destroys the poll (with all answers and participations) when the status message is destroyed" do
+      poll = FactoryGirl.create(:poll_participation).poll
+      status_message = poll.status_message
+
+      poll_id = poll.id
+      poll_answers = poll.poll_answers.map(&:id)
+      poll_participations = poll.poll_participations.map(&:id)
+
+      status_message.destroy
+
+      expect(Poll.where(id: poll_id)).not_to exist
+      poll_answers.each {|id| expect(PollAnswer.where(id: id)).not_to exist }
+      poll_participations.each {|id| expect(PollParticipation.where(id: id)).not_to exist }
+    end
+  end
+
   describe "validation" do
     let(:status_message) { build(:status_message, text: @message_text) }
 


### PR DESCRIPTION
I fixed some database issues also blocking the profile export. So the PR contains DB-migrations, but since it's for the export I think it's important that they are in the minor release.

Times (with a local copy of a new backup of my production DB):
```
== 20170914202650 CleanupInvalidLikes: migrated (28.7232s) ====================
== 20170914212336 CleanupInvalidPolls: migrated (2.9790s) =====================
```

I also already added the `# frozen_string_literal: true` comment from #7595 here.