### PR TITLE
Add camo to NodeInfo

### DIFF
--- a/app/presenters/node_info_presenter.rb
+++ b/app/presenters/node_info_presenter.rb
@@ -22,6 +22,7 @@ class NodeInfoPresenter
     doc.open_registrations       = open_registrations?
     doc.metadata["nodeName"]     = name
     doc.metadata["xmppChat"]     = chat_enabled?
+    doc.metadata["camo"]         = camo_config
     doc.metadata["adminAccount"] = admin_account
   end
 
@@ -69,6 +70,14 @@ class NodeInfoPresenter
 
   def chat_enabled?
     AppConfig.chat.enabled?
+  end
+
+  def camo_config
+    {
+      markdown:    AppConfig.privacy.camo.proxy_markdown_images?,
+      opengraph:   AppConfig.privacy.camo.proxy_opengraph_thumbnails?,
+      remote_pods: AppConfig.privacy.camo.proxy_remote_pod_images?
+    }
   end
 
   def admin_account

--- a/spec/presenters/node_info_presenter_spec.rb
+++ b/spec/presenters/node_info_presenter_spec.rb
@@ -37,7 +37,12 @@ describe NodeInfoPresenter do
         },
         "metadata"          => {
           "nodeName" => AppConfig.settings.pod_name,
-          "xmppChat" => AppConfig.chat.enabled?
+          "xmppChat" => AppConfig.chat.enabled?,
+          "camo"     => {
+            "markdown"    => AppConfig.privacy.camo.proxy_markdown_images?,
+            "opengraph"   => AppConfig.privacy.camo.proxy_opengraph_thumbnails?,
+            "remote_pods" => AppConfig.privacy.camo.proxy_remote_pod_images?
+          }
         }
       )
     end
@@ -129,6 +134,22 @@ describe NodeInfoPresenter do
       end
     end
 
+    context "when camo is enabled" do
+      before do
+        AppConfig.privacy.camo.proxy_markdown_images = true
+        AppConfig.privacy.camo.proxy_opengraph_thumbnails = true
+        AppConfig.privacy.camo.proxy_remote_pod_images = true
+      end
+
+      it "should list enabled camo options in the metadata as true" do
+        expect(hash).to include "metadata" => include("camo" => {
+                                                        "markdown"    => true,
+                                                        "opengraph"   => true,
+                                                        "remote_pods" => true
+                                                      })
+      end
+    end
+
     context "when admin account is set" do
       before do
         AppConfig.admins.account = "podmin"
@@ -158,7 +179,12 @@ describe NodeInfoPresenter do
           },
           "metadata"          => {
             "nodeName" => AppConfig.settings.pod_name,
-            "xmppChat" => AppConfig.chat.enabled?
+            "xmppChat" => AppConfig.chat.enabled?,
+            "camo"     => {
+              "markdown"    => AppConfig.privacy.camo.proxy_markdown_images?,
+              "opengraph"   => AppConfig.privacy.camo.proxy_opengraph_thumbnails?,
+              "remote_pods" => AppConfig.privacy.camo.proxy_remote_pod_images?
+            }
           }
         )
       end


### PR DESCRIPTION
We have the `xmppChat` in the `metadata` too, and I think camo is also something that can be important when selecting a pod. After this is merged this can be used/displayed by [podupti.me](https://podupti.me/) or [the-federation.info](https://the-federation.info/).