### PR TITLE
Delete invalid oEmbed caches with binary titles

### DIFF
--- a/db/migrate/20170917163640_cleanup_invalid_o_embed_caches.rb
+++ b/db/migrate/20170917163640_cleanup_invalid_o_embed_caches.rb
@@ -1,0 +1,12 @@
+class CleanupInvalidOEmbedCaches < ActiveRecord::Migration[5.1]
+  class OEmbedCache < ApplicationRecord
+  end
+  class Post < ApplicationRecord
+  end
+
+  def up
+    ids = OEmbedCache.where("data LIKE '%!binary%'").ids
+    Post.where(o_embed_cache_id: ids).update_all(o_embed_cache_id: nil) # rubocop:disable Rails/SkipsModelValidations
+    OEmbedCache.where(id: ids).delete_all
+  end
+end


### PR DESCRIPTION
There are a few old oEmbed caches which have the title saved in binary (because they contain Chinese characters). This fails with `ActionView::Template::Error ("\xE5" from ASCII-8BIT to UTF-8)`. Since I found only very old OEmbed caches with this problem (newest from 2012), I think we can just remove these. When I create a new oEmbed cache for the same URL it creates it without `!binary`.

`== 20170917163640 CleanupInvalidOEmbedCaches: migrated (14.2081s) =============`