### PR TITLE
Don't change the filename of the export everytime the user is touched

### DIFF
--- a/app/uploaders/exported_photos.rb
+++ b/app/uploaders/exported_photos.rb
@@ -5,7 +5,6 @@
 #   the COPYRIGHT file.
 
 class ExportedPhotos < SecureUploader
-
   def store_dir
     "uploads/users"
   end
@@ -13,7 +12,4 @@ class ExportedPhotos < SecureUploader
   def filename
     "#{model.username}_photos_#{secure_token}.zip" if original_filename.present?
   end
-
-
-
 end

--- a/app/uploaders/exported_user.rb
+++ b/app/uploaders/exported_user.rb
@@ -14,6 +14,6 @@ class ExportedUser < SecureUploader
   end
 
   def filename
-    "#{model.username}_diaspora_data_#{secure_token}.json.gz"
+    "#{model.username}_diaspora_data_#{secure_token}.json.gz" if original_filename.present?
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -981,6 +981,17 @@ describe User, :type => :model do
     end
   end
 
+  describe "#export" do
+    it "doesn't change the filename when the user is saved" do
+      user = FactoryGirl.create(:user)
+
+      filename = user.export.filename
+      user.save!
+
+      expect(User.find(user.id).export.filename).to eq(filename)
+    end
+  end
+
   describe "queue_export" do
     it "queues up a job to perform the export" do
       user = FactoryGirl.create(:user)


### PR DESCRIPTION
Otherwise the filename is reseted when the user tries to download it, because `last_seen` time is touched ... and the user can't download the archive because the new filename doesn't exist anymore ...