### PR TITLE
Delete invalid diaspora IDs from friendica

### DIFF
--- a/app/models/aspect_membership.rb
+++ b/app/models/aspect_membership.rb
@@ -5,7 +5,6 @@
 #   the COPYRIGHT file.
 
 class AspectMembership < ApplicationRecord
-
   belongs_to :aspect
   belongs_to :contact
   has_one :user, :through => :contact

--- a/app/models/notification_actor.rb
+++ b/app/models/notification_actor.rb
@@ -5,8 +5,6 @@
 #   the COPYRIGHT file.
 
 class NotificationActor < ApplicationRecord
-
   belongs_to :notification
   belongs_to :person
-
 end

--- a/db/migrate/20170928233609_cleanup_invalid_diaspora_ids.rb
+++ b/db/migrate/20170928233609_cleanup_invalid_diaspora_ids.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class CleanupInvalidDiasporaIds < ActiveRecord::Migration[5.1]
+  def up
+    ids = Person.where("diaspora_handle LIKE '%@%/%'").ids
+    return if ids.empty?
+
+    AspectMembership.joins(:contact).where(contacts: {person_id: ids}).delete_all
+
+    Person.where(id: ids).each do |person|
+      destroy_notifications_for_person(person)
+      person.destroy
+    end
+  end
+
+  def destroy_notifications_for_person(person)
+    Notification.joins(:notification_actors).where(notification_actors: {person_id: person.id}).each do |notification|
+      if notification.notification_actors.count > 1
+        notification.notification_actors.where(person_id: person.id).delete_all
+      else
+        notification.destroy
+      end
+    end
+  end
+end


### PR DESCRIPTION
Friendica allows to be installed in a subfolder, but diaspora doesn't support this. In the past receive worked (send never worked), today diaspora is more strict and blocks these entities completely. But because of that we have now still some entities from the past in the database which can fail the export. The best solution is just to delete the invalid people (the can't be recreated with the current validations), because otherwise people could always create new invalid data.

I didn't create migration models for this migration, because otherwise I would have needed to copy all models (and even add some hacks for polymorphic relations, because migration models are namespaced) ...

On a newer pod this migration will just do nothing and exit.

```
== 20170928233609 CleanupInvalidDiasporaIds: migrated (13.2132s) ==============
```