### PR TITLE
Reduce account deletion memory usage

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,13 @@
 
 # 0.7.1.0
 
+## Ensure account deletions are run
+
+There were some issues causing accounts deletions to not properly perform in some cases, see
+[#7631](https://github.com/diaspora/diaspora/issues/7631) and [#7639](https://github.com/diaspora/diaspora/pull/7639).
+To ensure these are reexecuted properly, please run `RAILS_ENV=production bin/rake migrations:run_account_deletions`
+after you've upgraded.
+
 ## Refactor
 * Remove title from profile photo upload button [#7551](https://github.com/diaspora/diaspora/pull/7551)
 * Remove Internet Explorer workarounds [#7557](https://github.com/diaspora/diaspora/pull/7557)

--- a/lib/account_deleter.rb
+++ b/lib/account_deleter.rb
@@ -48,21 +48,16 @@ class AccountDeleter
        notifications blocks authorizations o_auth_applications pairwise_pseudonymous_identifiers]
   end
 
-  def special_ar_user_associations
-    %i[person profile contacts auto_follow_back_aspect]
-  end
-
-  def ignored_ar_user_associations
-    %i[followed_tags invited_by invited_users contact_people aspect_memberships
-       ignored_people share_visibilities conversation_visibilities conversations reports]
-  end
-
   def delete_standard_user_associations
     normal_ar_user_associates_to_delete.each do |asso|
       user.send(asso).ids.each_slice(20) do |ids|
         User.reflect_on_association(asso).class_name.constantize.where(id: ids).destroy_all
       end
     end
+  end
+
+  def normal_ar_person_associates_to_delete
+    %i[posts photos mentions participations roles blocks conversation_visibilities]
   end
 
   def delete_standard_person_associations
@@ -94,15 +89,6 @@ class AccountDeleter
 
   def delete_contacts_of_me
     Contact.all_contacts_of_person(person).find_each(batch_size: 20, &:destroy)
-  end
-
-  def normal_ar_person_associates_to_delete
-    %i[posts photos mentions participations roles blocks conversation_visibilities]
-  end
-
-  def ignored_or_special_ar_person_associations
-    %i[comments likes poll_participations contacts notification_actors notifications owner profile
-       pod conversations messages]
   end
 
   def mark_account_deletion_complete

--- a/lib/account_deleter.rb
+++ b/lib/account_deleter.rb
@@ -26,7 +26,6 @@ class AccountDeleter
   def perform!
     # close person
     delete_standard_person_associations
-    remove_conversation_visibilities
     delete_contacts_of_me
     tombstone_person_and_profile
 
@@ -84,10 +83,6 @@ class AccountDeleter
     ShareVisibility.for_a_user(user).find_each(batch_size: 20, &:destroy)
   end
 
-  def remove_conversation_visibilities
-    ConversationVisibility.where(:person_id => person.id).destroy_all
-  end
-
   def tombstone_person_and_profile
     person.lock_access!
     person.clear_profile!
@@ -102,12 +97,12 @@ class AccountDeleter
   end
 
   def normal_ar_person_associates_to_delete
-    %i[posts photos mentions participations roles blocks]
+    %i[posts photos mentions participations roles blocks conversation_visibilities]
   end
 
   def ignored_or_special_ar_person_associations
     %i[comments likes poll_participations contacts notification_actors notifications owner profile
-       conversation_visibilities pod conversations messages]
+       pod conversations messages]
   end
 
   def mark_account_deletion_complete

--- a/lib/account_deleter.rb
+++ b/lib/account_deleter.rb
@@ -25,17 +25,15 @@ class AccountDeleter
   end
 
   def perform!
-    ActiveRecord::Base.transaction do
-      #person
-      delete_standard_person_associations
-      remove_conversation_visibilities
-      delete_contacts_of_me
-      tombstone_person_and_profile
+    # close person
+    delete_standard_person_associations
+    remove_conversation_visibilities
+    delete_contacts_of_me
+    tombstone_person_and_profile
 
-      close_user if user
+    close_user if user
 
-      mark_account_deletion_complete
-    end
+    mark_account_deletion_complete
   end
 
   # user deletion methods

--- a/lib/diaspora/federation/receive.rb
+++ b/lib/diaspora/federation/receive.rb
@@ -10,7 +10,11 @@ module Diaspora
       end
 
       def self.account_deletion(entity)
-        AccountDeletion.create!(person: author_of(entity))
+        person = author_of(entity)
+        AccountDeletion.create!(person: person) unless AccountDeletion.where(person: person).exists?
+      rescue => e # rubocop:disable Lint/RescueWithoutErrorClass
+        raise e unless AccountDeletion.where(person: person).exists?
+        logger.warn "ignoring error on receive AccountDeletion:#{entity.author}: #{e.class}: #{e.message}"
       end
 
       def self.account_migration(entity)

--- a/lib/tasks/migrations.rake
+++ b/lib/tasks/migrations.rake
@@ -59,4 +59,15 @@ namespace :migrations do
       queue.clear
     end
   end
+
+  desc "Run uncompleted account deletions"
+  task run_account_deletions: :environment do
+    if AccountDeletion.uncompleted.count > 0
+      puts "Running account deletions.."
+      AccountDeletion.uncompleted.find_each(&:perform!)
+      puts "OK."
+    else
+      puts "No acccount deletions to run."
+    end
+  end
 end

--- a/spec/lib/account_deleter_spec.rb
+++ b/spec/lib/account_deleter_spec.rb
@@ -175,14 +175,20 @@ describe AccountDeleter do
     end
   end
 
-  it 'has all user association keys accounted for' do
-    all_keys = (@account_deletion.normal_ar_user_associates_to_delete + @account_deletion.special_ar_user_associations + @account_deletion.ignored_ar_user_associations)
-    expect(all_keys.sort{|x, y| x.to_s <=> y.to_s}).to eq(User.reflections.keys.sort{|x, y| x.to_s <=> y.to_s}.map(&:to_sym))
+  it "has all user association keys accounted for" do
+    special_ar_user_associations = %i[person profile contacts auto_follow_back_aspect]
+    ignored_ar_user_associations = %i[followed_tags invited_by invited_users contact_people aspect_memberships
+                                      ignored_people share_visibilities conversation_visibilities conversations reports]
+    all_keys = @account_deletion.normal_ar_user_associates_to_delete +
+      special_ar_user_associations + ignored_ar_user_associations
+    expect(all_keys.sort_by(&:to_s)).to eq(User.reflections.keys.sort_by(&:to_s).map(&:to_sym))
   end
 
-  it 'has all person association keys accounted for' do
-    all_keys = (@account_deletion.normal_ar_person_associates_to_delete + @account_deletion.ignored_or_special_ar_person_associations)
-    expect(all_keys.sort{|x, y| x.to_s <=> y.to_s}).to eq(Person.reflections.keys.sort{|x, y| x.to_s <=> y.to_s}.map(&:to_sym))
+  it "has all person association keys accounted for" do
+    ignored_or_special_ar_person_associations = %i[comments likes poll_participations contacts notification_actors
+                                                   notifications owner profile pod conversations messages]
+    all_keys = @account_deletion.normal_ar_person_associates_to_delete + ignored_or_special_ar_person_associations
+    expect(all_keys.sort_by(&:to_s)).to eq(Person.reflections.keys.sort_by(&:to_s).map(&:to_sym))
   end
 end
 

--- a/spec/lib/account_deleter_spec.rb
+++ b/spec/lib/account_deleter_spec.rb
@@ -20,7 +20,6 @@ describe AccountDeleter do
       delete_contacts_of_me
       delete_standard_person_associations
       tombstone_person_and_profile
-      remove_conversation_visibilities
     ]
 
     context "user deletion" do
@@ -155,14 +154,6 @@ describe AccountDeleter do
       it 'calls lock_access! on person' do
         expect(@account_deletion.person).to receive(:lock_access!)
         @account_deletion.tombstone_person_and_profile
-      end
-    end
-     describe "#remove_conversation_visibilities" do
-      it "removes the conversation visibility for the deleted user" do
-        vis = double
-        expect(ConversationVisibility).to receive(:where).with(hash_including(:person_id => bob.person.id)).and_return(vis)
-        expect(vis).to receive(:destroy_all)
-        @account_deletion.remove_conversation_visibilities
       end
     end
   end


### PR DESCRIPTION
This massively reduces the memory usage for account deletions (which could cause OOMs when deleting many big accounts in parallel). With this PR the sidekiq process uses only 180MB ram after deleting a rss-bot account with 17k posts (after start sidekiq uses 150MB, so this is only 30MB more than after start). Without this PR the same account deletion used 1.8GB ram.

I also did some cleanups in the `AccountDeleter` and added a check for duplicate account deletions.