### PR TITLE
Handle duplicate account migrations

### DIFF
--- a/spec/integration/federation/receive_federation_messages_spec.rb
+++ b/spec/integration/federation/receive_federation_messages_spec.rb
@@ -58,11 +58,12 @@ describe "Receive federation messages feature" do
           expect(AccountMigration.find_by(old_person: sender.person, new_person: new_user.person)).to be_performed
         end
 
-        it "doesn't accept the same migration for the second time" do
+        it "doesn't run the same migration for the second time" do
           run_migration
-          expect {
-            run_migration
-          }.to raise_error(ActiveRecord::RecordInvalid)
+          expect_any_instance_of(AccountMigration).not_to receive(:perform!)
+          run_migration
+          expect(AccountMigration.where(old_person: sender.person, new_person: new_user.person).count).to eq(1)
+          expect(AccountMigration.find_by(old_person: sender.person, new_person: new_user.person)).to be_performed
         end
 
         it "doesn't accept second migration for the same sender" do

--- a/spec/lib/diaspora/federation/receive_spec.rb
+++ b/spec/lib/diaspora/federation/receive_spec.rb
@@ -26,6 +26,27 @@ describe Diaspora::Federation::Receive do
 
       expect(AccountMigration.exists?(old_person: sender, new_person: new_person)).to be_truthy
     end
+
+    it "ignores duplicate the account migrations" do
+      AccountMigration.create(old_person: sender, new_person: new_person)
+
+      expect(AccountMigration).not_to receive(:create!)
+
+      expect(Diaspora::Federation::Receive.account_migration(account_migration_entity)).to be_nil
+
+      expect(AccountMigration.exists?(old_person: sender, new_person: new_person)).to be_truthy
+    end
+
+    it "handles race conditions on parallel receive" do
+      expect(AccountMigration).to receive(:create!) do
+        AccountMigration.create(old_person: sender, new_person: new_person)
+        raise "Some database error"
+      end
+
+      expect(Diaspora::Federation::Receive.account_migration(account_migration_entity)).to be_nil
+
+      expect(AccountMigration.exists?(old_person: sender, new_person: new_person)).to be_truthy
+    end
   end
 
   describe ".comment" do


### PR DESCRIPTION
This adds the same checks for account migrations that I also added for account deletions in #7639