### PR TITLE
Do not autocomplete change password and close account password input fields

### DIFF
--- a/app/views/users/_close_account_modal.haml
+++ b/app/views/users/_close_account_modal.haml
@@ -34,7 +34,8 @@
           = f.error_messages
           .form-group
             = f.label :close_account_password, t("users.edit.current_password"), for: :close_account_password
-            = f.password_field :current_password, id: :close_account_password, class: "form-control"
+            = f.password_field :current_password, id: :close_account_password, class: "form-control",
+              autocomplete: "current-password"
         .modal-footer
           .btn.btn-default{type: "button", data: {dismiss: "modal"}, aria: {hidden: "true"}}
             = t("cancel")

--- a/app/views/users/_edit.haml
+++ b/app/views/users/_edit.haml
@@ -39,18 +39,18 @@
             = f.label :current_password, t(".current_password"), class: "col-sm-6 control-label"
             .col-sm-6
               = f.password_field :current_password, placeholder: t(".current_password_expl"),
-                class: "form-control"
+                class: "form-control", autocomplete: "current-password"
           .form-group
             = f.label :password, t(".new_password"), class: "col-sm-6 control-label"
             .col-sm-6
               = f.password_field :password, placeholder: t(".character_minimum_expl"),
-                class: "form-control"
+                class: "form-control", autocomplete: "new-password"
           .form-group
             = f.label :password_confirmation, t("registrations.new.password_confirmation"),
               class: "col-sm-6 control-label"
             .col-sm-6
               = f.password_field :password_confirmation, placeholder: t(".character_minimum_expl"),
-                class: "form-control"
+                class: "form-control", autocomplete: "new-password"
 
           .clearfix
             = f.submit t(".change_password"), class: "btn btn-primary pull-right", name: "change_password"


### PR DESCRIPTION
Fixes #7633 

This adds autocomplete="off" to the input fields. This is how [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/password#Allowing_autocomplete) indicates it should be done but weirdly it didn't work for me: Firefox is still autocompleting the input and Chromium never was... Can anyone else please test?