### PR TITLE
Add some progress indicators to the account deletions rake task

### DIFF
--- a/lib/tasks/migrations.rake
+++ b/lib/tasks/migrations.rake
@@ -63,11 +63,22 @@ namespace :migrations do
   desc "Run uncompleted account deletions"
   task run_account_deletions: :environment do
     if AccountDeletion.uncompleted.count > 0
-      puts "Running account deletions.."
-      AccountDeletion.uncompleted.find_each(&:perform!)
+      puts "Running account deletions..."
+      AccountDeletion.uncompleted.find_each do |account_deletion|
+        print "Deleting #{account_deletion.person.diaspora_handle} ..."
+        progress = Thread.new {
+          loop {
+            sleep 10
+            print "."
+          }
+        }
+        account_deletion.perform!
+        progress.kill
+        puts " Done"
+      end
       puts "OK."
     else
-      puts "No acccount deletions to run."
+      puts "No account deletions to run."
     end
   end
 end


### PR DESCRIPTION
@Flaburgan asked if the rake task is stuck, because it doesn't output anything until it's finished (which can take a while when there are multiple accounts or big accounts needed to be deleted). So I thought it's maybe a good idea to print some stuff.