### PR TITLE
Group notifications by updated_at

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -40,7 +40,7 @@ class NotificationsController < ApplicationController
 
       pager.replace(result)
     end
-    @group_days = @notifications.group_by{|note| note.created_at.strftime('%Y-%m-%d')}
+    @group_days = @notifications.group_by {|note| note.updated_at.strftime("%Y-%m-%d") }
 
     @unread_notification_count = current_user.unread_notifications.count
 


### PR DESCRIPTION
The notifications need to be grouped by the same date as they are sorted, otherwise the date used for the group doesn't match all timestamps in the group and also the groups are sorted by the wrong date.

This fixes #7647, a regression of #7568.