### PR TITLE
Fix compatibility with Bundler 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,13 +24,11 @@ branches:
     - 'develop'
 
 before_install:
-  - gem install bundler
+  - script/ci/prepare.sh
   - mkdir travis-phantomjs
   - wget http://cifiles.diasporafoundation.org/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
   - tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs
   - export PATH=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
-
-bundler_args: "--deployment --without development --with mysql postgresql --jobs 3 --retry 3"
 
 script: "./script/ci/build.sh"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
   - tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs
   - export PATH=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
 
-script: "./script/ci/build.sh"
+script: "bin/rake --trace ci:travis:${BUILD_TYPE}"
 
 notifications:
   irc:

--- a/config/application.rb
+++ b/config/application.rb
@@ -4,9 +4,11 @@ require_relative 'boot'
 
 require 'rails/all'
 
+require_relative "bundler_helper"
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
-Bundler.require(*Rails.groups(*Bundler.settings.with))
+Bundler.require(*Rails.groups(BundlerHelper.database))
 
 # Do not dump the limit of boolean fields on MySQL,
 # since that generates a db/schema.rb that's incompatible

--- a/config/bundler_helper.rb
+++ b/config/bundler_helper.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+module BundlerHelper
+  def self.rails_env
+    @rails_env ||= ENV["RAILS_ENV"] ||
+      parse_value_from_file("diaspora.yml", "configuration", "server", "rails_environment") ||
+      parse_value_from_file("defaults.yml", "defaults", "server", "rails_environment")
+  end
+
+  def self.database
+    @adapter ||= parse_value_from_file("database.yml", rails_env, "adapter")
+
+    raise "No database adapter found, please fix your config/database.yml!" unless @adapter
+
+    @adapter.sub("mysql2", "mysql")
+  end
+
+  private_class_method def self.parse_value_from_file(file, *keys)
+    path = File.join(__dir__, file)
+    return YAML.load_file(path).dig(*keys) if File.file?(path)
+
+    puts "Configuration file #{path} not found, ensure it's present" # rubocop:disable Rails/Output
+  end
+end

--- a/script/ci/build.sh
+++ b/script/ci/build.sh
@@ -1,13 +1,5 @@
 #!/bin/sh
 
-
-# Create a database.yml for the right database
-echo "Setting up database.yml for $DB"
-cp config/database.yml.example config/database.yml
-if [ "$DB" = "mysql" ]; then
-  sed -i 's/*common/*mysql/' config/database.yml
-fi
-
 command="bundle exec rake --trace ci:travis:${BUILD_TYPE}"
 
 exec xvfb-run --auto-servernum --server-num=1 --server-args="-screen 0 1280x1024x8" $command

--- a/script/ci/build.sh
+++ b/script/ci/build.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-command="bundle exec rake --trace ci:travis:${BUILD_TYPE}"
-
-exec xvfb-run --auto-servernum --server-num=1 --server-args="-screen 0 1280x1024x8" $command

--- a/script/ci/prepare.sh
+++ b/script/ci/prepare.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Create a database.yml for the right database
+echo "Setting up database.yml for ${DB}"
+cp config/database.yml.example config/database.yml
+if [ "${DB}" = "mysql" ]; then
+  sed -i 's/*common/*mysql/' config/database.yml
+fi
+
+gem install bundler
+script/configure_bundler

--- a/script/configure_bundler
+++ b/script/configure_bundler
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../config/bundler_helper"
+
+rails_env = BundlerHelper.rails_env
+database = BundlerHelper.database
+
+puts "Configuring Bundler for #{rails_env} environment and #{database} database."
+
+def config(option)
+  puts "$ bin/bundle config --local #{option}"
+  system("#{File.join(__dir__, '../bin/bundle')} config --local #{option}")
+end
+
+config("jobs #{`nproc`}")
+config("with #{database}")
+
+if rails_env == "production"
+  config("without test:development")
+elsif rails_env == "test"
+  config("without development")
+end
+
+if rails_env != "development"
+  config("path vendor/bundle")
+  config("frozen 1")
+  config("disable_shared_gems true")
+end
+
+if `gcc -dumpversion`.split(".").first.to_i >= 5
+  config("build.sigar \"--with-cppflags='-fgnu89-inline'\"")
+end
+
+puts "Bundler configured! Please run 'bin/bundle install' now."


### PR DESCRIPTION
Stop using `Bundler.settings.with`, because it will be removed from Bundler 1.6.

Also, as described in #7653, we could use `Bundler.settings[:with]`, but that would be internal API again, so it probably breaks again in the future. That's why I added a `BundlerHelper` module to parse the required optional group from our config files, without the use of any internal Bundler API. That only breaks when we change something in our configs, but then we can change the `BundlerHelper` too, and we're not surprised any more by any new Bundler versions.

The `BundlerHelper` is also used for the new `script/configure_bundler` script to generate the correct config needed for `bin/bundle install`.