### PR TITLE
Fix deformed avatar in hovercards

### DIFF
--- a/app/assets/stylesheets/hovercard.scss
+++ b/app/assets/stylesheets/hovercard.scss
@@ -12,16 +12,10 @@
   font-size: small;
 
   .avatar {
-    position: relative;
     float: left;
-    height: 70px !important;
-    width: 70px !important;
-    top: 0 !important;
-
-    margin: {
-      right: 10px;
-      left: 0;
-    }
+    height: 70px;
+    object-fit: cover;
+    width: 70px;
   }
 
   $image_width: 80px; /* including margin */


### PR DESCRIPTION
So, from the [different options](https://github.com/diaspora/diaspora/issues/6039#issuecomment-339945467), I went the safest way: keep the avatar to 70x70 and truncate the image as done for the `small` avatar everywhere else. The "truncation" is not really one: I simply set the image as a background one and center center in a 70x70 container.

Fixes #6039 