### PR TITLE
 Rearrange userdata-export section and cleanup old archives

### DIFF
--- a/app/assets/stylesheets/settings.scss
+++ b/app/assets/stylesheets/settings.scss
@@ -36,3 +36,7 @@
   max-width: 100%;
   min-width: 100%;
 }
+
+.account-data h6 {
+  color: $text-grey;
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -539,6 +539,8 @@ class User < ApplicationRecord
      :post_default_public].each do |field|
       self[field] = false
     end
+    self.remove_export = true
+    self.remove_exported_photos_file = true
     self[:disable_mail] = true
     self[:strip_exif] = true
     self[:email] = "deletedaccount_#{self[:id]}@example.org"
@@ -579,7 +581,7 @@ class User < ApplicationRecord
     attributes.keys - %w(id username encrypted_password created_at updated_at locked_at
                          serialized_private_key getting_started
                          disable_mail show_community_spotlight_in_stream
-                         strip_exif email remove_after export exporting exported_at
-                         exported_photos_file exporting_photos exported_photos_at)
+                         strip_exif email remove_after export exporting
+                         exported_photos_file exporting_photos)
   end
 end

--- a/app/views/users/_edit.haml
+++ b/app/views/users/_edit.haml
@@ -181,35 +181,33 @@
       %hr
 
     .row
-      .col-md-6#account_data
+      .col-md-6.account-data
         %h3= t(".export_data")
+        %h4= t("profile")
         .form-group
           - if current_user.exporting
             .export-in-progress= t(".export_in_progress")
           - elsif current_user.export.present?
-            = link_to t(".request_export_update"), export_profile_user_path, method: :post,
-              class: "btn btn-default"
-            .small-horizontal-spacer
             = link_to t(".download_export"), download_profile_user_path,
               class: "btn btn-success"
-            .small-horizontal-spacer
+            = link_to t(".request_export_update"), export_profile_user_path, method: :post,
+              class: "btn btn-default"
             %h6
-              = t(".last_exported_at", timestamp: current_user.exported_at)
+              = t(".last_exported_html", timeago: timeago(current_user.exported_at))
           - else
             = link_to t(".request_export"), export_profile_user_path, method: :post,
               class: "btn btn-default"
 
+        %h4= t("javascripts.profile.photos")
         .form-group
           - if current_user.exporting_photos
             .export-in-progress= t(".export_photos_in_progress")
           - elsif current_user.exported_photos_file.present?
+            = link_to t(".download_export_photos"), download_photos_user_path, class: "btn btn-success"
             = link_to t(".request_export_photos_update"), export_photos_user_path, method: :post,
               class: "btn btn-default"
-            .small-horizontal-spacer
-            = link_to t(".download_export_photos"), download_photos_user_path, class: "btn btn-success"
-            .small-horizontal-spacer
             %h6
-              = t(".last_exported_at", timestamp: current_user.exported_photos_at)
+              = t(".last_exported_html", timeago: timeago(current_user.exported_photos_at))
           - else
             = link_to t(".request_export_photos"), export_photos_user_path, method: :post,
               class: "btn btn-default"

--- a/app/workers/cleanup_old_exports.rb
+++ b/app/workers/cleanup_old_exports.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Workers
+  class CleanupOldExports < Base
+    sidekiq_options queue: :low
+
+    def perform
+      User.where("exported_at < ?", 14.days.ago).each do |user|
+        user.remove_export = true
+        user.exported_at = nil
+        user.save
+      end
+
+      User.where("exported_photos_at < ?", 14.days.ago).each do |user|
+        user.remove_exported_photos_file = true
+        user.exported_photos_at = nil
+        user.save
+      end
+    end
+  end
+end

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -1228,7 +1228,7 @@ en:
       request_export_update: "Refresh my profile data"
       export_data: "Export data"
       export_in_progress: "We are currently processing your data. Please check back in a few moments."
-      last_exported_at: "(Last updated at %{timestamp})"
+      last_exported_html: "(Last updated %{timeago})"
       download_export_photos: "Download my photos"
       request_export_photos: "Request my photos"
       request_export_photos_update: "Refresh my photos"

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -17,3 +17,7 @@ recheck_scheduled_pods:
 check_birthday:
   cron: "0 0 * * *"
   class: "Workers::CheckBirthday"
+
+cleanup_old_exports:
+  cron: "0 0 * * *"
+  class: "Workers::CleanupOldExports"

--- a/features/desktop/change_settings.feature
+++ b/features/desktop/change_settings.feature
@@ -55,6 +55,6 @@ Feature: Change settings
     Then I should see "Public" within ".aspect-dropdown"
 
   Scenario: exporting profile data
-    When I click on the first selector "#account_data a"
+    When I click on the first selector ".account-data a"
     Then I should see "Download my profile"
     And I should have 1 email delivery

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -944,6 +944,17 @@ describe User, :type => :model do
         expect(@user.reload.show_community_spotlight_in_stream).to be false
         expect(@user.reload.post_default_public).to be false
       end
+
+      it "removes export archives" do
+        @user.perform_export!
+        @user.perform_export_photos!
+        @user.clear_account!
+        @user.reload
+        expect(@user.export).not_to be_present
+        expect(@user.exported_at).to be_nil
+        expect(@user.exported_photos_file).not_to be_present
+        expect(@user.exported_photos_at).to be_nil
+      end
     end
 
     describe "#clearable_attributes" do
@@ -970,6 +981,8 @@ describe User, :type => :model do
             last_seen
             color_theme
             post_default_public
+            exported_at
+            exported_photos_at
           )
         )
       end

--- a/spec/workers/cleanup_old_exports_spec.rb
+++ b/spec/workers/cleanup_old_exports_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+describe Workers::CleanupOldExports do
+  let(:user) { FactoryGirl.create(:user) }
+
+  context "with profile data" do
+    before do
+      user.perform_export!
+    end
+
+    it "removes old archives" do
+      Timecop.travel(Time.zone.today + 15.days) do
+        Workers::CleanupOldExports.new.perform
+        user.reload
+        expect(user.export).not_to be_present
+        expect(user.exported_at).to be_nil
+      end
+    end
+
+    it "does not remove new archives" do
+      Timecop.travel(Time.zone.today + 1.day) do
+        Workers::CleanupOldExports.new.perform
+        user.reload
+        expect(user.export).to be_present
+        expect(user.exported_at).to be_present
+      end
+    end
+  end
+
+  context "with photos" do
+    before do
+      user.perform_export_photos!
+    end
+
+    it "removes old archives" do
+      Timecop.travel(Time.zone.today + 15.days) do
+        Workers::CleanupOldExports.new.perform
+        user.reload
+        expect(user.exported_photos_file).not_to be_present
+        expect(user.exported_photos_at).to be_nil
+      end
+    end
+
+    it "does not remove new archives" do
+      Timecop.travel(Time.zone.today + 1.day) do
+        Workers::CleanupOldExports.new.perform
+        user.reload
+        expect(user.exported_photos_file).to be_present
+        expect(user.exported_photos_at).to be_present
+      end
+    end
+  end
+end


### PR DESCRIPTION
I changed the position of the export/download buttons to make it clear what belongs together.
I also replaced the timestamps with the age of the archive.
![](https://user-images.githubusercontent.com/14131225/34425601-a440a6d0-ec2d-11e7-871b-ee724c5822dc.png)

I added a cronjob to remove old archives, this saves space on the servers. The data is older than 2 weeks anyway.

Existing archives are also removed when closing an account.

This fixes #5727.
