### PR TITLE
Fix notifications when people remove their birthday date

### DIFF
--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -17,7 +17,7 @@ module NotificationsHelper
             .include?(note.type)
         opts.merge!(opts_for_post(note.linked_object))
       elsif note.is_a?(Notifications::ContactsBirthday)
-        opts.merge!(opts_for_birthday(note.linked_object))
+        opts.merge!(opts_for_birthday(note))
       end
     end
     translation(target_type, opts)
@@ -46,8 +46,8 @@ module NotificationsHelper
     }
   end
 
-  def opts_for_birthday(person)
-    {date: locale_date(person.birthday.to_s)}
+  def opts_for_birthday(note)
+    {date: I18n.l(note.created_at, format: I18n.t("date.formats.fullmonth_day"))}
   end
 
   def notification_people_link(note, people=nil)

--- a/spec/helpers/notifications_helper_spec.rb
+++ b/spec/helpers/notifications_helper_spec.rb
@@ -123,6 +123,22 @@ describe NotificationsHelper, type: :helper do
         expect(link).to include("#{post_path(status_message)}##{comment.guid}")
       end
     end
+
+    context "for a birthday" do
+      let(:notification) { Notifications::ContactsBirthday.create(recipient: alice, target: bob.person) }
+
+      it "contains the date" do
+        bob.profile.update_attributes(birthday: Time.zone.today)
+        link = object_link(notification, notification_people_link(notification))
+        expect(link).to include(I18n.l(Time.zone.today, format: I18n.t("date.formats.fullmonth_day")))
+      end
+
+      it "doesn't break, when the person removes the birthday date" do
+        bob.profile.update_attributes(birthday: nil)
+        link = object_link(notification, notification_people_link(notification))
+        expect(link).to include(I18n.l(Time.zone.today, format: I18n.t("date.formats.fullmonth_day")))
+      end
+    end
   end
 
   describe '#display_year?' do


### PR DESCRIPTION
Some people may remove their birthday date after the notification was sent, which then breaks the notification page for other users. Let's just display the date when the notification was created, and not display the users updated birthday date. When users update from date A to B it always looks weird anyway, when we display the same new date B twice on different days, or display two different dates for the same user.

We could remove notifications when users change or remove their birthday, but that would be way more complex and also we usually don't remove notifications (not even for deleted posts).

Fixes #7689