### PR TITLE
Bump diaspora federation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,8 @@ gem "unicorn-worker-killer", "0.4.4"
 
 # Federation
 
-gem "diaspora_federation-json_schema", "0.2.2"
-gem "diaspora_federation-rails", "0.2.2"
+gem "diaspora_federation-json_schema", "0.2.3"
+gem "diaspora_federation-rails", "0.2.3"
 
 # API and JSON
 
@@ -292,7 +292,7 @@ group :test do
   gem "timecop",            "0.9.1"
   gem "webmock",            "3.0.1", require: false
 
-  gem "diaspora_federation-test", "0.2.2"
+  gem "diaspora_federation-test", "0.2.3"
 
   # Coverage
   gem "coveralls", "0.8.21", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,18 +166,18 @@ GEM
       devise
       rails (>= 3.0.4)
     diaspora-prosody-config (0.0.7)
-    diaspora_federation (0.2.2)
-      faraday (>= 0.9.0, < 0.14.0)
+    diaspora_federation (0.2.3)
+      faraday (>= 0.9.0, < 0.15.0)
       faraday_middleware (>= 0.10.0, < 0.13.0)
       nokogiri (~> 1.6, >= 1.6.8)
       typhoeus (~> 1.0)
       valid (~> 1.0)
-    diaspora_federation-json_schema (0.2.2)
-    diaspora_federation-rails (0.2.2)
+    diaspora_federation-json_schema (0.2.3)
+    diaspora_federation-rails (0.2.3)
       actionpack (>= 4.2, < 6)
-      diaspora_federation (= 0.2.2)
-    diaspora_federation-test (0.2.2)
-      diaspora_federation (= 0.2.2)
+      diaspora_federation (= 0.2.3)
+    diaspora_federation-test (0.2.3)
+      diaspora_federation (= 0.2.3)
       fabrication (~> 2.16)
       uuid (~> 2.3, >= 2.3.8)
     diff-lcs (1.3)
@@ -194,7 +194,7 @@ GEM
       rake
     et-orbi (1.0.5)
       tzinfo
-    ethon (0.10.1)
+    ethon (0.11.0)
       ffi (>= 1.3.0)
     excon (0.59.0)
     execjs (2.7.0)
@@ -204,7 +204,7 @@ GEM
       sigar (~> 0.7.3)
       state_machines
       thor
-    fabrication (2.16.3)
+    fabrication (2.20.1)
     factory_girl (4.8.0)
       activesupport (>= 3.0.0)
     factory_girl_rails (4.8.0)
@@ -783,9 +783,9 @@ DEPENDENCIES
   devise (= 4.3.0)
   devise_lastseenable (= 0.0.6)
   diaspora-prosody-config (= 0.0.7)
-  diaspora_federation-json_schema (= 0.2.2)
-  diaspora_federation-rails (= 0.2.2)
-  diaspora_federation-test (= 0.2.2)
+  diaspora_federation-json_schema (= 0.2.3)
+  diaspora_federation-rails (= 0.2.3)
+  diaspora_federation-test (= 0.2.3)
   entypo-rails (= 3.0.0)
   eye (= 0.9.2)
   factory_girl_rails (= 4.8.0)
@@ -904,4 +904,4 @@ DEPENDENCIES
   will_paginate (= 3.1.6)
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -15,4 +15,9 @@ class Block < ApplicationRecord
       errors[:person_id] << "stop blocking yourself!"
     end
   end
+
+  # @return [Array<Person>] The recipient of the block
+  def subscribers
+    [person]
+  end
 end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -9,12 +9,7 @@ class Conversation < ApplicationRecord
   has_many :participants, class_name: "Person", through: :conversation_visibilities, source: :person
   has_many :messages, -> { order("created_at ASC") }, inverse_of: :conversation
 
-  validate :max_participants
   validate :local_recipients
-
-  def max_participants
-    errors.add(:max_participants, "too many participants") if participants.count > 20
-  end
 
   def local_recipients
     recipients.each do |recipient|

--- a/app/workers/send_base.rb
+++ b/app/workers/send_base.rb
@@ -9,7 +9,7 @@ module Workers
     protected
 
     def schedule_retry(retry_count, sender_id, obj_str, failed_urls)
-      if retry_count < MAX_RETRIES
+      if retry_count < (obj_str.start_with?("Contact") ? MAX_RETRIES + 10 : MAX_RETRIES)
         yield(seconds_to_delay(retry_count), retry_count)
       else
         logger.warn "status=abandon sender=#{sender_id} obj=#{obj_str} failed_urls='[#{failed_urls.join(', ')}]'"

--- a/lib/diaspora/federated/contact_retraction.rb
+++ b/lib/diaspora/federated/contact_retraction.rb
@@ -6,11 +6,11 @@ class ContactRetraction < Retraction
   end
 
   def self.retraction_data_for(target)
-    Diaspora::Federation::Entities.contact(target).to_h
+    Diaspora::Federation::Entities.build(target).to_h
   end
 
   def self.for(target)
-    target.receiving = false
+    target.receiving = false if target.is_a?(Contact)
     super
   end
 

--- a/lib/diaspora/federation/entities.rb
+++ b/lib/diaspora/federation/entities.rb
@@ -31,6 +31,16 @@ module Diaspora
         )
       end
 
+      def self.block(block)
+        DiasporaFederation::Entities::Contact.new(
+          author:    block.user.diaspora_handle,
+          recipient: block.person.diaspora_handle,
+          sharing:   false,
+          following: false,
+          blocking:  Block.exists?(user: block.user, person: block.person)
+        )
+      end
+
       def self.comment(comment)
         DiasporaFederation::Entities::Comment.new(
           {
@@ -52,7 +62,8 @@ module Diaspora
           author:    contact.user.diaspora_handle,
           recipient: contact.person.diaspora_handle,
           sharing:   contact.receiving,
-          following: contact.receiving
+          following: contact.receiving,
+          blocking:  Block.exists?(user: contact.user, person: contact.person)
         )
       end
 

--- a/lib/diaspora/federation/mappings.rb
+++ b/lib/diaspora/federation/mappings.rb
@@ -29,6 +29,7 @@ module Diaspora
         case diaspora_entity
         when AccountMigration  then :account_migration
         when AccountDeletion   then :account_deletion
+        when Block             then :block
         when Comment           then :comment
         when Contact           then :contact
         when Conversation      then :conversation

--- a/spec/models/block_spec.rb
+++ b/spec/models/block_spec.rb
@@ -1,10 +1,17 @@
 # frozen_string_literal: true
 
-describe Block, :type => :model do
+describe Block, type: :model do
   describe "validations" do
     it "doesnt allow you to block yourself" do
       block = alice.blocks.create(person: alice.person)
       expect(block.errors[:person_id].size).to eq(1)
+    end
+  end
+
+  describe "#subscribers" do
+    it "returns an array with recipient of the block" do
+      block = alice.blocks.create(person: eve.person)
+      expect(block.subscribers).to match_array([eve.person])
     end
   end
 end

--- a/spec/workers/send_base_spec.rb
+++ b/spec/workers/send_base_spec.rb
@@ -8,13 +8,13 @@ describe Workers::SendBase do
   end
 
   it "increases the interval for each retry" do
-    expect(Workers::SendBase.new.send(:seconds_to_delay, 2)).to be >= 625
-    expect(Workers::SendBase.new.send(:seconds_to_delay, 3)).to be >= 1_296
-    expect(Workers::SendBase.new.send(:seconds_to_delay, 4)).to be >= 2_401
-    expect(Workers::SendBase.new.send(:seconds_to_delay, 5)).to be >= 4_096
-    expect(Workers::SendBase.new.send(:seconds_to_delay, 6)).to be >= 6_561
-    expect(Workers::SendBase.new.send(:seconds_to_delay, 7)).to be >= 10_000
-    expect(Workers::SendBase.new.send(:seconds_to_delay, 8)).to be >= 14_641
+    (2..19).each do |count|
+      expect(Workers::SendBase.new.send(:seconds_to_delay, count)).to be >= ((count + 3)**4)
+    end
+
+    # lets make some tests with explicit numbers to make sure the formula above works correctly
+    # and increases the delay with the expected result
     expect(Workers::SendBase.new.send(:seconds_to_delay, 9)).to be >= 20_736
+    expect(Workers::SendBase.new.send(:seconds_to_delay, 19)).to be >= 234_256
   end
 end


### PR DESCRIPTION
Update `diaspora_federation` gem to [0.2.3](https://github.com/diaspora/diaspora_federation/releases/tag/v0.2.3) and do some related changes:

* Remove participants limits for conversations (second part of diaspora/diaspora_federation#91)
* Start sending the `blocking` flag, and increase retries for `Contact` entity (second part of diaspora/diaspora_federation#80)
 (Receiving the `blocking` flag would need a place to store it, so this needs a migration, but we can add this later in develop-branch and benefit from older releases already sending it)