### PR TITLE
Send participation after receiving a public post

### DIFF
--- a/spec/integration/federation/receive_federation_messages_spec.rb
+++ b/spec/integration/federation/receive_federation_messages_spec.rb
@@ -116,6 +116,11 @@ describe "Receive federation messages feature" do
           alice, instance_of(Reshare)
         ).and_return(double(create!: true))
 
+        expect(Diaspora::Federation::Dispatcher).to receive(:build) do |_user, participation, _opts|
+          expect(participation.target.guid).to eq(reshare.guid)
+          instance_double(:dispatch)
+        end
+
         post_message(generate_payload(reshare, sender))
 
         expect(Reshare.exists?(root_guid: post.guid)).to be_truthy

--- a/spec/integration/federation/shared_receive_stream_items.rb
+++ b/spec/integration/federation/shared_receive_stream_items.rb
@@ -8,6 +8,15 @@ shared_examples_for "messages which are indifferent about sharing fact" do
   it "treats status message receive correctly" do
     entity = Fabricate(:status_message_entity, author: sender_id, public: public)
 
+    if public
+      expect(Diaspora::Federation::Dispatcher).to receive(:build) do |_user, participation, _opts|
+        expect(participation.target.guid).to eq(entity.guid)
+        instance_double(:dispatch)
+      end
+    else
+      expect(Diaspora::Federation::Dispatcher).not_to receive(:build)
+    end
+
     post_message(generate_payload(entity, sender, recipient), recipient)
 
     expect(StatusMessage.exists?(guid: entity.guid)).to be_truthy

--- a/spec/lib/diaspora/federation/receive_spec.rb
+++ b/spec/lib/diaspora/federation/receive_spec.rb
@@ -541,6 +541,10 @@ describe Diaspora::Federation::Receive do
     it_behaves_like "it ignores existing object received twice", Reshare do
       let(:entity) { reshare_entity }
     end
+
+    it_behaves_like "it sends a participation to the author" do
+      let(:entity) { reshare_entity }
+    end
   end
 
   describe ".retraction" do
@@ -765,6 +769,18 @@ describe Diaspora::Federation::Receive do
 
         expect(status_message.photos.map(&:guid)).to include(photo1.guid, photo2.guid)
         expect(status_message.photos.map(&:text)).to include(received_photo.text, photo2.text)
+      end
+
+      it_behaves_like "it sends a participation to the author" do
+        let(:entity) { status_message_entity }
+      end
+
+      it "doesn't send participations for a private post" do
+        status_message_entity = Fabricate(:status_message_entity, author: sender.diaspora_handle, public: false)
+
+        expect(Diaspora::Federation::Dispatcher).not_to receive(:build)
+
+        Diaspora::Federation::Receive.perform(status_message_entity)
       end
     end
   end


### PR DESCRIPTION
I'm currently working on a PR to improve the situation described in #6806 and #6436. The main work is bigger (and not finished yet) and includes big migrations, so it's something for 0.8.0.0. But I thought it would be useful if older pods already start sending participations, so we can make use of them later. So I thought lets make this commit a last minute PR for 0.7.3.0 ;)

It already improves the situation only with this commit, because it lets the owner of the post know, that this pod is interested in updates about this post. This improves for incomplete threads of a post (but it will be better after the second part is done), and it also deletes a post on all pods that received it (so this fixes #6436, at least for public posts).

The sending user is only used to verify that the participation was sent from this pod, but lets use an admin/podmin account if available.