### PR TITLE
Fix followed tags posts in stream for posts with multiple tags

### DIFF
--- a/app/models/status_message.rb
+++ b/app/models/status_message.rb
@@ -46,7 +46,7 @@ class StatusMessage < Post
   end
 
   def self.public_tag_stream(tag_ids)
-    all_public.tag_stream(tag_ids)
+    all_public.select("DISTINCT #{table_name}.*").tag_stream(tag_ids)
   end
 
   def self.tag_stream(tag_ids)

--- a/spec/models/status_message_spec.rb
+++ b/spec/models/status_message_spec.rb
@@ -51,6 +51,14 @@ describe StatusMessage, type: :model do
         it "returns public status messages tagged with the tag" do
           expect(StatusMessage.public_tag_stream([@tag_id])).to eq([@status_message_1])
         end
+
+        it "returns a post with two tags only once" do
+          status_message = FactoryGirl.create(:status_message, text: "#hashtag #test", public: true)
+          test_tag_id = ActsAsTaggableOn::Tag.where(name: "test").first.id
+
+          expect(StatusMessage.public_tag_stream([@tag_id, test_tag_id]))
+            .to match_array([@status_message_1, status_message])
+        end
       end
 
       describe ".user_tag_stream" do


### PR DESCRIPTION
When there were posts with many followed tags they were returned multiple times, resulting in less than 15 unique posts. That resulted in some posts to be missed in the stream.

Fixes #4503