### PR TITLE
Make script/server work on readonly filesystems

### DIFF
--- a/script/server
+++ b/script/server
@@ -99,7 +99,7 @@ fi
 # Setup environment
 if [ -z "$RAILS_ENV" ]
 then
-  RAILS_ENV=$(bin/bundle exec ruby ./script/get_config.rb server.rails_environment)
+  RAILS_ENV=$(bin/bundle exec ruby ./script/get_config.rb server.rails_environment | grep -vE "is not writable|as your home directory temporarily" )
   on_failure "Couldn't parse config/diaspora.yml!"
   export RAILS_ENV
 fi
@@ -113,7 +113,8 @@ vars=$(bin/bundle exec ruby ./script/get_config.rb \
   chat=chat.enabled \
   chat_server=chat.server.enabled \
   chat_bosh_proxy=chat.server.bosh.proxy \
-  redis_url=environment.redis
+  redis_url=environment.redis \
+  | grep -vE "is not writable|as your home directory temporarily"
 )
 on_failure "Couldn't parse config/diaspora.yml!"
 eval "$vars"
@@ -170,7 +171,7 @@ then
   then
     redis_param="url: '$redis_url'"
   fi 
-  if [ "$(bin/bundle exec ruby -e "require 'redis'; puts Redis.new($redis_param).ping" 2> /dev/null)" != "PONG" ]
+  if [ "$(bin/bundle exec ruby -e "require 'redis'; puts Redis.new($redis_param).ping" 2> /dev/null | grep -vE "is not writable|as your home directory temporarily" )" != "PONG" ]
   then
     fatal "Can't connect to redis. Please check if it's running and if environment.redis is configured correctly in config/diaspora.yml."
   fi


### PR DESCRIPTION
I run [my Diaspora pod](https://diaspora.koehn.com) on a readonly filesystem inside Docker (but any readonly filesystem would work the same way). 

There's a problem with the `script/server` startup script in how it interacts with `bin/bundle`. On a readonly filesystem, `bin/bundle` outputs a warning to stdout about the readonly volume:
```
`/home/diaspora` is not writable.
Bundler will use `/tmp/bundler/home/unknown' as your home directory temporarily.
```
This in turn causes the `eval` of the results of `bin/bundle exec` to fail, when the shell attempts to execute these warnings as commands. 

This PR filters out the warnings from `bin/bundle` commands to suppress the warnings. I recognize that there may be better ways to accomplish this and I'm happy to accept improvements. I had initially tried to send `2> /dev/null` but to no avail.

Once I added these filters, I was able to run Diaspora from a readonly filesystem, with a few directories mounted as either external volumes or as tmpfs volumes (FYI only; not part of the PR):

TMPFS:
* `/home/diaspora/.eye`
* `/home/diaspora/diaspora/tmp` (note: you need to create `pids` and `cache` subdirectories prior to startup)
* `/tmp`

External Volumes:
* `/home/diaspora/diaspora/public/uploads/images`
* `/home/diaspora/diaspora/config/oidc_key.pem`
* `/home/diaspora/diaspora/logs`