### PR TITLE
Profile tags order

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -11,7 +11,7 @@ class Profile < ApplicationRecord
   include Diaspora::Taggable
 
   attr_accessor :tag_string
-  acts_as_taggable_on :tags
+  acts_as_ordered_taggable
   extract_tags_from :tag_string
   validates :tag_list, :length => { :maximum => 5 }
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -119,13 +119,8 @@ describe Comment, type: :model do
   end
 
   describe "tags" do
-    let(:object) { build(:comment) }
-
-    before do
-      # shared_behaviors/taggable.rb is still using instance variables, so we need to define them here.
-      # Suggestion: refactor all specs using shared_behaviors/taggable.rb to use "let"
-      @object = object
+    it_should_behave_like "it is taggable" do
+      let(:object) { build(:comment) }
     end
-    it_should_behave_like "it is taggable"
   end
 end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -245,30 +245,31 @@ describe Profile, :type => :model do
     end
   end
 
-  describe 'tags' do
-    before do
-      person = FactoryGirl.build(:person)
-      @object = person.profile
-    end
-    it 'allows 5 tags' do
-      @object.tag_string = '#one #two #three #four #five'
+  describe "tags" do
+    let(:object) { FactoryGirl.build(:person).profile }
 
-      @object.valid?
-      @object.errors.full_messages
+    it "allows 5 tags" do
+      object.tag_string = "#one #two #three #four #five"
 
-      expect(@object).to be_valid
+      object.valid?
+      object.errors.full_messages
+
+      expect(object).to be_valid
     end
-    it 'strips more than 5 tags' do
-      @object.tag_string = '#one #two #three #four #five #six'
-      @object.save
-      expect(@object.tags.count).to eq(5)
+
+    it "strips more than 5 tags" do
+      object.tag_string = "#one #two #three #four #five #six"
+      object.save
+      expect(object.tags.count).to eq(5)
     end
-    it 'should require tag name not be more than 255 characters long' do
-      @object.tag_string = "##{'a' * (255+1)}"
-      @object.save
-      expect(@object).not_to be_valid
+
+    it "should require tag name not be more than 255 characters long" do
+      object.tag_string = "##{'a' * (255 + 1)}"
+      object.save
+      expect(object).not_to be_valid
     end
-    it_should_behave_like 'it is taggable'
+
+    it_should_behave_like "it is taggable"
   end
 
   describe "#tombstone!" do

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -269,6 +269,17 @@ describe Profile, :type => :model do
       expect(object).not_to be_valid
     end
 
+    it "keeps the order of the tag_string" do
+      ActsAsTaggableOn::Tag.create(name: "test2")
+      ActsAsTaggableOn::Tag.create(name: "test1")
+
+      string = "#test1 #test2"
+      object.tag_string = string
+      object.save
+
+      expect(Profile.find(object.id).tag_string).to eq(string)
+    end
+
     it_should_behave_like "it is taggable"
   end
 

--- a/spec/models/status_message_spec.rb
+++ b/spec/models/status_message_spec.rb
@@ -171,10 +171,9 @@ describe StatusMessage, type: :model do
   end
 
   describe "tags" do
-    before do
-      @object = FactoryGirl.build(:status_message)
+    it_should_behave_like "it is taggable" do
+      let(:object) { build(:status_message) }
     end
-    it_should_behave_like "it is taggable"
 
     it "associates different-case tags to the same tag entry" do
       assert_equal ActsAsTaggableOn.force_lowercase, true

--- a/spec/shared_behaviors/taggable.rb
+++ b/spec/shared_behaviors/taggable.rb
@@ -25,14 +25,14 @@ shared_examples_for "it is taggable" do
 
     before do
       @str = tag_list.map {|tag| "##{tag}" }.join(" ")
-      @object.send(@object.class.field_with_tags_setter, @str)
-      @object.build_tags
-      @object.save!
+      object.send(object.class.field_with_tags_setter, @str)
+      object.build_tags
+      object.save!
     end
 
     it "supports non-ascii characters" do
       tag_list.each do |tag|
-        expect(@object.tags.reload.map(&:name)).to include(tag)
+        expect(object.tags.reload.map(&:name)).to include(tag)
       end
     end
 
@@ -97,12 +97,12 @@ shared_examples_for "it is taggable" do
 
   describe '#build_tags' do
     it 'builds the tags' do
-      @object.send(@object.class.field_with_tags_setter, '#what')
-      @object.build_tags
-      expect(@object.tag_list).to eq(['what'])
+      object.send(object.class.field_with_tags_setter, "#what")
+      object.build_tags
+      expect(object.tag_list).to eq(["what"])
       expect {
-        @object.save
-      }.to change{@object.tags.count}.by(1)
+        object.save
+      }.to change { object.tags.count }.by(1)
     end
   end
 
@@ -111,8 +111,8 @@ shared_examples_for "it is taggable" do
       str = '#what #hey #that"smybike. #@hey ##boo # #THATWASMYBIKE #vöglein #hey#there #135440we #abc/23 ### #h!gh #ok? #see: #re:publica'
       arr = ['what', 'hey', 'that', 'THATWASMYBIKE', 'vöglein', '135440we', 'abc', 'h', 'ok', 'see', 're']
 
-      @object.send(@object.class.field_with_tags_setter, str)
-      expect(@object.tag_strings).to match_array(arr)
+      object.send(object.class.field_with_tags_setter, str)
+      expect(object.tag_strings).to match_array(arr)
     end
 
     it 'extracts tags despite surrounding text' do
@@ -154,9 +154,9 @@ shared_examples_for "it is taggable" do
         "\u202a#\u200eUSA\u202c" => 'USA'
       }
 
-      expected.each do |text,hashtag|
-        @object.send  @object.class.field_with_tags_setter, text
-        expect(@object.tag_strings).to eq([hashtag].compact)
+      expected.each do |text, hashtag|
+        object.send(object.class.field_with_tags_setter, text)
+        expect(object.tag_strings).to eq([hashtag].compact)
       end
     end
 
@@ -164,16 +164,16 @@ shared_examples_for "it is taggable" do
       str = '#what #what #what #whaaaaaaaaaat'
       arr = ['what','whaaaaaaaaaat']
 
-      @object.send(@object.class.field_with_tags_setter, str)
-      expect(@object.tag_strings).to match_array(arr)
+      object.send(object.class.field_with_tags_setter, str)
+      expect(object.tag_strings).to match_array(arr)
     end
 
     it 'is case insensitive' do
       str = '#what #wHaT #WHAT'
       arr = ['what']
 
-      @object.send(@object.class.field_with_tags_setter, str)
-      expect(@object.tag_strings).to match_array(arr)
+      object.send(object.class.field_with_tags_setter, str)
+      expect(object.tag_strings).to match_array(arr)
     end
   end
 end


### PR DESCRIPTION
I already saw [this spec](https://travis-ci.org/diaspora/diaspora/jobs/346058334#L1703) fail multiple times, and I now debugged why this happens. The tag order in a profile depends on the order in which the `tags` (not `taggings`) were created on the pod, so when for some reason `#two` is created first in the database, it's always the first tag in the list. This isn't a big problem (since we don't offer a way to sort the profile tags), but I also don't know if it's intended that the profile tags are different on each pod.

However `acts-as-taggable-on` has the feature to keep the order, and I think it's useful to enable it for profile tags. That way people can order their tags by removing them and add them in the order they like, and maybe we can add a feature in the future to order them in a simpler way. And I didn't find any other way to make this test not randomly fail. :(

I also refactored the shared taggable tests to use `let` instead of `@object`, that makes the usage a big simpler and I didn't want to add the hack with `before` a second time like it was in [`comment_spec.rb`](https://github.com/diaspora/diaspora/pull/7724/files#diff-33939bbe6ae0e01f344f9254b1c86bb0L125).