### PR TITLE
Add app notifications

### DIFF
--- a/app/views/users/_edit.haml
+++ b/app/views/users/_edit.haml
@@ -117,9 +117,9 @@
 
     = render partial: "post_default"
 
-    - if AppConfig.mail.enable?
-      .row
-        .col-md-12
+    .row
+      - if AppConfig.mail.enable?
+        .col-md-6
           %h3
             = t(".receive_email_notifications")
           = form_for "user", url: edit_user_path, html: {method: :put} do |f|
@@ -176,9 +176,66 @@
                   = type.check_box :contacts_birthday, {checked: email_prefs["contacts_birthday"]}, false, true
                   = t(".birthday")
                 .small-horizontal-spacer
+      .col-md-6
+        %h3
+          = t(".receive_app_notifications")
+        = form_for "user", url: edit_user_path, html: {method: :put} do |f|
+          = f.fields_for :email_preferences do |type|
+            #email_prefs
+              - if current_user.admin?
+                = type.label :someone_reported, class: "checkbox-inline" do
+                  = type.check_box :someone_reported, {checked: email_prefs["someone_reported"]}, false, true
+                  = t(".someone_reported")
 
-            .clearfix= f.submit t(".change"), class: "btn btn-primary pull-right", id: "change_email_preferences"
-      %hr
+              .small-horizontal-spacer
+
+              = type.label :started_sharing, class: "checkbox-inline" do
+                = type.check_box :started_sharing, {checked: email_prefs["started_sharing"]}, false, true
+                = t(".started_sharing")
+              .small-horizontal-spacer
+
+              = type.label :mentioned, class: "checkbox-inline" do
+                = type.check_box :mentioned, {checked: email_prefs["mentioned"]}, false, true
+                = t(".mentioned")
+              .small-horizontal-spacer
+
+              = type.label :mentioned_in_comment, class: "checkbox-inline" do
+                = type.check_box :mentioned_in_comment, {checked: email_prefs["mentioned_in_comment"]}, false, true
+                = t(".mentioned_in_comment")
+              .small-horizontal-spacer
+
+              = type.label :liked, class: "checkbox-inline" do
+                = type.check_box :liked, {checked: email_prefs["liked"]}, false, true
+                = t(".liked")
+              .small-horizontal-spacer
+
+              = type.label :reshared, class: "checkbox-inline" do
+                = type.check_box :reshared, {checked: email_prefs["reshared"]}, false, true
+                = t(".reshared")
+              .small-horizontal-spacer
+
+              = type.label :comment_on_post, class: "checkbox-inline" do
+                = type.check_box :comment_on_post, {checked: email_prefs["comment_on_post"]}, false, true
+                = t(".comment_on_post")
+              .small-horizontal-spacer
+
+              = type.label :also_commented, class: "checkbox-inline" do
+                = type.check_box :also_commented, {checked: email_prefs["also_commented"]}, false, true
+                = t(".also_commented")
+              .small-horizontal-spacer
+
+              = type.label :private_message, class: "checkbox-inline" do
+                = type.check_box :private_message, {checked: email_prefs["private_message"]}, false, true
+                = t(".private_message")
+              .small-horizontal-spacer
+
+              = type.label :contacts_birthday, class: "checkbox-inline" do
+                = type.check_box :contacts_birthday, {checked: email_prefs["contacts_birthday"]}, false, true
+                = t(".birthday")
+              .small-horizontal-spacer
+
+          .clearfix= f.submit t(".change"), class: "btn btn-primary pull-right", id: "change_email_preferences"
+    %hr
 
     .row
       .col-md-6.account-data

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -1213,6 +1213,7 @@ en:
       auto_follow_aspect: "Aspect for users you automatically share with:"
       default_post_visibility: "Default aspects selected for posting"
       receive_email_notifications: "Receive email notifications when:"
+      receive_app_notifications: "Receive app notifications when:"
       started_sharing: "someone starts sharing with you"
       someone_reported: "someone sends a report"
       mentioned: "you are mentioned in a post"


### PR DESCRIPTION
This PR will add a symmetrical set of options for in-app notifications, as is currently available for email.

- [x] HAML form
- [ ] User settings controller
- [ ] Control in-app notifications conditionally