### PR TITLE
Add /camo/ to robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -8,3 +8,4 @@
 User-Agent: *
 Disallow: /people/
 Disallow: /u/
+Disallow: /camo/


### PR DESCRIPTION
I almost forgot to PR this. I added this a while ago on my pod after some (porn gif) /camo/ urls suddenly got popular on google and the traffic exploded. Camo only proxies images hosted somewhere else, so it doesn't make sense to add the proxied versions to search engines. It only creates traffic for camo when /camo/* urls are in search results.

Here is an image of the traffic from before, after some "magic SEO" happened and then after I added this to the robots.txt and some days delay (crawlers first need to find the new robots.txt) it was even lower than before.

![image](https://user-images.githubusercontent.com/458548/36702307-de500c0a-1b56-11e8-89a0-e8992138f135.png)