### PR TITLE
Add the back-to-top button to the single post view

### DIFF
--- a/app/assets/javascripts/app/pages/single-post-viewer.js
+++ b/app/assets/javascripts/app/pages/single-post-viewer.js
@@ -3,23 +3,23 @@
 app.pages.SinglePostViewer = app.views.Base.extend({
   templateName: "single-post-viewer",
 
-  subviews : {
-    "#single-post-content" : "singlePostContentView",
-    '#single-post-interactions' : 'singlePostInteractionsView'
+  subviews: {
+    "#single-post-content": "singlePostContentView",
+    "#single-post-interactions": "singlePostInteractionsView"
   },
 
-  initialize : function() {
+  initialize: function() {
     this.model = new app.models.Post(gon.post);
     this.initViews();
   },
 
-  initViews : function() {
+  initViews: function() {
     this.singlePostContentView = new app.views.SinglePostContent({model: this.model});
     this.singlePostInteractionsView = new app.views.SinglePostInteractions({model: this.model});
     this.render();
   },
 
-  postRenderTemplate : function() {
+  postRenderTemplate: function() {
     if(this.model.get("title")){
       // formats title to html...
       var html_title = app.helpers.textFormatter(this.model.get("title"), this.model.get("mentioned_people"));

--- a/app/assets/javascripts/app/views/back_to_top_view.js
+++ b/app/assets/javascripts/app/views/back_to_top_view.js
@@ -12,7 +12,7 @@ app.views.BackToTop = Backbone.View.extend({
 
   backToTop: function(evt) {
     evt.preventDefault();
-    $("html, body").animate({scrollTop: 0});
+    $("html, body").animate({scrollTop: 0}, this.toggleVisibility);
   },
 
   toggleVisibility: function() {

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -70,20 +70,29 @@ pre { word-wrap: break-word; }
   height: 50px;
   line-height: 50px;
   opacity: 0;
+  pointer-events: none;
   position: fixed;
   right: 20px;
+  text-decoration: none;
   transition: opacity ease 400ms;
   width: 50px;
   z-index: 49;
 
   &:hover,
-  &.visible:hover {
+  &:focus,
+  &:active {
     color: $white;
-    opacity: .85;
     text-decoration: none;
   }
 
-  &.visible { opacity: .5; }
+  &.visible {
+    opacity: .5;
+    pointer-events: auto;
+
+    &:hover {
+      opacity: .85;
+    }
+  }
 }
 
 .noscript {

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -38,3 +38,5 @@
       %ol.indicator
 
     #flash-container= flash_messages
+
+    %a.entypo-chevron-up.back-to-top#back-to-top{title: t("layouts.application.back_to_top"), href: "#"}

--- a/app/views/people/contacts.haml
+++ b/app/views/people/contacts.haml
@@ -17,8 +17,6 @@
             = render partial: 'people/person', locals: hash
         = will_paginate @contacts_of_contact, renderer: WillPaginate::ActionView::BootstrapLinkRenderer
 
-      %a.entypo-chevron-up.back-to-top#back-to-top{title: "#{t('layouts.application.back_to_top')}", href: "#"}
-
 -if user_signed_in? && @person
   #new_status_message_pane
     = render 'shared/modal',

--- a/app/views/people/index.html.haml
+++ b/app/views/people/index.html.haml
@@ -29,8 +29,6 @@
 
           = will_paginate @people, renderer: WillPaginate::ActionView::BootstrapLinkRenderer
 
-        %a.entypo-chevron-up.back-to-top#back-to-top{title: "#{t('layouts.application.back_to_top')}", href: "#"}
-
     .col-md-4
       - if AppConfig.settings.invitations.open?
         %h4

--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -30,8 +30,6 @@
           .loader.hidden
             .spinner
 
-      %a.entypo-chevron-up.back-to-top#back-to-top{title: "#{t('layouts.application.back_to_top')}", href: "#"}
-
 -if user_signed_in? && @person
   #new_status_message_pane
     = render 'shared/modal',

--- a/app/views/streams/main_stream.html.haml
+++ b/app/views/streams/main_stream.html.haml
@@ -178,5 +178,3 @@
     .col-md-9
       .stream-container#aspect-stream-container
         = render "aspects/aspect_stream", stream: @stream
-
-      %a.entypo-chevron-up.back-to-top#back-to-top{title: "#{t('layouts.application.back_to_top')}", href: "#"}

--- a/app/views/tags/show.haml
+++ b/app/views/tags/show.haml
@@ -33,5 +33,3 @@
         #paginate
           .loader.hidden
             .spinner
-
-      %a.entypo-chevron-up.back-to-top#back-to-top{title: "#{t('layouts.application.back_to_top')}", href: "#"}

--- a/spec/javascripts/app/views/back_to_top_view_spec.js
+++ b/spec/javascripts/app/views/back_to_top_view_spec.js
@@ -17,7 +17,7 @@ describe("app.views.BackToTop", function() {
     it("scrolls to the top of the page", function() {
       var spy = spyOn($.fn, "animate");
       this.view.backToTop($.Event());
-      expect(spy).toHaveBeenCalledWith({scrollTop: 0});
+      expect(spy).toHaveBeenCalledWith({scrollTop: 0}, jasmine.any(Function));
     });
   });
 


### PR DESCRIPTION
This would fix #7727.

Note that I added the back-to-top thingy on the same level as the content container, not inside it. This needs to be done, since we overwrite the contents of the container entirely, and that would override the link as well. Since the button is `position: fixed;` it won't matter anyway.