### PR TITLE
Allow blob: URIs to be used as a content source in CSP header

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -3,21 +3,23 @@
 SecureHeaders::Configuration.default do |config|
   config.hsts = SecureHeaders::OPT_OUT # added by Rack::SSL
 
+  # rubocop:disable Lint/PercentStringArray
   csp = {
-    default_src:     %w('none'),
-    child_src:       %w('self' www.youtube.com w.soundcloud.com twitter.com platform.twitter.com syndication.twitter.com
+    default_src:     %w['none'],
+    child_src:       %w['self' www.youtube.com w.soundcloud.com twitter.com platform.twitter.com syndication.twitter.com
                         player.vimeo.com www.mixcloud.com www.dailymotion.com media.ccc.de bandcamp.com
-                        www.instagram.com),
-    connect_src:     %w('self' embedr.flickr.com geo.query.yahoo.com nominatim.openstreetmap.org api.github.com),
-    font_src:        %w('self'),
-    form_action:     %w('self' platform.twitter.com syndication.twitter.com),
-    frame_ancestors: %w('self'),
-    img_src:         %w('self' data: *),
-    media_src:       %w(https:),
-    script_src:      %w('self' 'unsafe-eval' platform.twitter.com cdn.syndication.twimg.com widgets.flickr.com
-                        embedr.flickr.com platform.instagram.com 'unsafe-inline'),
-    style_src:       %w('self' 'unsafe-inline' platform.twitter.com *.twimg.com)
+                        www.instagram.com],
+    connect_src:     %w['self' embedr.flickr.com geo.query.yahoo.com nominatim.openstreetmap.org api.github.com],
+    font_src:        %w['self'],
+    form_action:     %w['self' platform.twitter.com syndication.twitter.com],
+    frame_ancestors: %w['self'],
+    img_src:         %w['self' data: blob: *],
+    media_src:       %w[https:],
+    script_src:      %w['self' 'unsafe-eval' platform.twitter.com cdn.syndication.twimg.com widgets.flickr.com
+                        embedr.flickr.com platform.instagram.com 'unsafe-inline'],
+    style_src:       %w['self' 'unsafe-inline' platform.twitter.com *.twimg.com]
   }
+  # rubocop:enable Lint/PercentStringArray
 
   if AppConfig.environment.assets.host.present?
     asset_host = Addressable::URI.parse(AppConfig.environment.assets.host.get).host


### PR DESCRIPTION
This PR fixes the not working profile image upload when CSP header is enabled on the pod.