### PR TITLE
Include Handlebars templates to main.js

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -6,7 +6,6 @@
 //= link bookmarklet.js
 //= link mobile/bookmarklet.js
 //= link mobile/mobile.js
-//= link templates.js
 //= link error_pages.css
 //= link admin.css
 //= link rtl.css

--- a/app/assets/javascripts/app/helpers/handlebars-partials.js
+++ b/app/assets/javascripts/app/helpers/handlebars-partials.js
@@ -1,7 +1,4 @@
 // @license magnet:?xt=urn:btih:0b31508aeb0634b347b8270c7bee4d411b5d4109&dn=agpl-3.0.txt AGPL-v3-or-Later
 
-/* we need to wrap this in a document ready to ensure JST is accessible */
-$(function(){
-  Handlebars.registerPartial('status-message', HandlebarsTemplates['status-message_tpl']);
-});
+Handlebars.registerPartial("status-message", HandlebarsTemplates["status-message_tpl"]);
 // @license-end

--- a/app/assets/javascripts/jasmine-load-all.js
+++ b/app/assets/javascripts/jasmine-load-all.js
@@ -1,6 +1,5 @@
 //= require jquery3
 //= require handlebars.runtime
-//= require templates
 //= require main
 //= require fine-uploader/fine-uploader.core
 //= require mobile/mobile

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -18,6 +18,7 @@
 //= require jquery.autoSuggest.custom
 //= require fine-uploader/fine-uploader.core
 //= require handlebars.runtime
+//= require_tree ../templates
 //= require posix-bracket-expressions
 //= require markdown-it
 //= require markdown-it-diaspora-mention

--- a/app/assets/javascripts/templates.js
+++ b/app/assets/javascripts/templates.js
@@ -1,5 +1,0 @@
-/*   Copyright (c) 2010-2011, Diaspora Inc.  This file is
- *   licensed under the Affero General Public License version 3 or later.  See
- *   the COPYRIGHT file.
- */
-//= require_tree ../templates

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -8,7 +8,7 @@
     %meta{name: "viewport", content: "width=device-width, initial-scale=1"}/
 
     - content_for :javascript do
-      = javascript_include_tag :main, :templates
+      = javascript_include_tag :main
       = load_javascript_locales
 
     = include_color_theme


### PR DESCRIPTION
This is needed to properly initialize Handlebars partials without a document ready handler.

ref #7739 