### PR TITLE
Bump mysql2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ gem "sprockets-rails",        "3.2.1"
 # Database
 
 group :mysql, optional: true do
-  gem "mysql2", "0.4.9"
+  gem "mysql2", "0.4.10"
 end
 group :postgresql, optional: true do
   gem "pg",     "0.21.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -391,7 +391,7 @@ GEM
     multi_test (0.1.2)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
-    mysql2 (0.4.9)
+    mysql2 (0.4.10)
     naught (1.1.0)
     nenv (0.3.0)
     nio4r (2.1.0)
@@ -831,7 +831,7 @@ DEPENDENCIES
   mini_magick (= 4.8.0)
   minitest
   mobile-fu (= 1.4.0)
-  mysql2 (= 0.4.9)
+  mysql2 (= 0.4.10)
   nokogiri (= 1.8.2)
   omniauth (= 1.6.1)
   omniauth-facebook (= 4.0.0)


### PR DESCRIPTION
Hi,

during test installation of diaspora on openSUSE 15.0beta I discovered a compilation issue with the `mysql2` gem. This problem was already [solved upstream](https://github.com/brianmario/mysql2/releases/tag/0.4.10). 

I bumped mysql2 to 0.4.10 and fired up a quick test and the compilation issue is gone :)

Jonathan