### PR TITLE
Show more explicit error messages on failed login

### DIFF
--- a/config/locales/devise/devise.en.yml
+++ b/config/locales/devise/devise.en.yml
@@ -12,10 +12,10 @@ en:
     failure:
       already_authenticated: You are already signed in.
       inactive: Your account is not activated yet.
-      invalid: Invalid %{authentication_keys} or password.
+      invalid: Invalid password.
       locked: Your account is locked.
       last_attempt: You have one more attempt before your account is locked.
-      not_found_in_database: Invalid %{authentication_keys} or password.
+      not_found_in_database: Invalid %{authentication_keys}.
       timeout: Your session expired. Please sign in again to continue.
       unauthenticated: You need to sign in or sign up before continuing.
       unconfirmed: You have to confirm your email address before continuing.


### PR DESCRIPTION
Related to #3540. We already have different error messages for unknown usernames and invalid passwords in some languages. As far as I can tell there is also no way to login using an email address, so I don't see any privacy or security issues related to this change.