### PR TITLE
Enable Content-Security-Policy header by default

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -150,7 +150,7 @@ defaults:
       title: 'diaspora* social network'
       description: 'diaspora* is the online social world where you are in control.'
     csp:
-      report_only: true
+      report_only: false
       report_uri:
   services:
     facebook:

--- a/config/diaspora.yml.example
+++ b/config/diaspora.yml.example
@@ -571,10 +571,10 @@ configuration: ## Section
     ## is blocked by CSP.
     csp:
 
-      ## Report-Only header (default=true)
-      ## By default diaspora* adds only a "Content-Security-Policy-Report-Only" header. If you set
-      ## this to false, the "Content-Security-Policy" header is added instead.
-      #report_only: false
+      ## Report-Only header (default=false)
+      ## By default diaspora* adds a "Content-Security-Policy" header. If you set
+      ## this to true, the "Content-Security-Policy-Report-Only" header is added instead.
+      #report_only: true
 
       ## CSP report URI (default=)
       ## You can set an URI here, where the user agent reports violations as JSON document via a POST request.


### PR DESCRIPTION
After 0.7.4.1 I think it's a good time to enable this by default ;) It's working without any problems in productions for a long time now, so I think it's save to enable it everywhere. Since this is a config-change and some podmins may have customization which could be blocked by this, I think we should still only change it in the next major release.