### PR TITLE
Fix link to "Make yourself an admin" and simplify /podmin redirect

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -21,7 +21,7 @@ class HomeController < ApplicationController
           partial_dir.join("_show.html.erb").exist? ||
           partial_dir.join("_show.haml").exist?
       render :show
-    elsif User.count > 1 && Role.where(name: "admin").any?
+    elsif Role.admins.any?
       render :default
     else
       redirect_to podmin_path

--- a/app/views/home/podmin.haml
+++ b/app/views/home/podmin.haml
@@ -31,7 +31,7 @@
           %span.entypo-key
           = t(".make_yourself_an_admin")
         != t(".make_yourself_an_admin_info",
-             wiki: link_to("diaspora* wiki", "https://wiki.diasporafoundation.org/FAQ_for_pod_maintainers#What_are_roles_and_how_do_I_use_them.3F_.2F_Make_yourself_an_admin"),
+             wiki: link_to("diaspora* wiki", "https://wiki.diasporafoundation.org/Permalink:FAQ_-_Add_admin"),
              admin_dashboard: link_to(t("javascripts.header.admin"), admin_dashboard_path))
 
   .row

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -6,31 +6,14 @@
 
 describe HomeController, type: :controller do
   describe "#show" do
-    it "does not redirect for :html if there are at least 2 users and an admin" do
-      allow(User).to receive(:count).and_return(2)
-      allow(Role).to receive_message_chain(:where, :any?).and_return(true)
-      allow(Role).to receive_message_chain(:where, :exists?).and_return(true)
+    it "does not redirect for :html if there is at least one admin" do
+      expect(Role).to receive_message_chain(:admins, :any?).and_return(true)
       get :show
       expect(response).not_to be_redirect
     end
 
-    it "redirects to the podmin page for :html if there are less than 2 users" do
-      allow(User).to receive(:count).and_return(1)
-      allow(Role).to receive_message_chain(:where, :any?).and_return(true)
-      get :show
-      expect(response).to redirect_to(podmin_path)
-    end
-
     it "redirects to the podmin page for :html if there is no admin" do
-      allow(User).to receive(:count).and_return(2)
-      allow(Role).to receive_message_chain(:where, :any?).and_return(false)
-      get :show
-      expect(response).to redirect_to(podmin_path)
-    end
-
-    it "redirects to the podmin page for :html if there are less than 2 users and no admin" do
-      allow(User).to receive(:count).and_return(0)
-      allow(Role).to receive_message_chain(:where, :any?).and_return(false)
+      expect(Role).to receive_message_chain(:admins, :any?).and_return(false)
       get :show
       expect(response).to redirect_to(podmin_path)
     end


### PR DESCRIPTION
The link to "Make yourself an admin" is broken, because the title changed. I created now a redirect in the wiki which redirects to this section. That way we can simply change the target of the redirect once something changes again and don't need to change the link here again (which needs a release).

Also I changed how the redirect to /podmin works because some podmins were confuse how they can disable this redirect and I think the rule with two users can actually be a little confusing. I think the
main goal of this page to give the podmin a little start and I think after they configured everything, the pod works and they found the link to the wiki to make themself an admin, it is OK to remove the redirect.

Also it's bad for single-user pods where this page always stays active, even if they are an admin, but have only one user. It's more useful for single-user pods to have the login on the home page.