### PR TITLE
Remove backporting of mention syntax

### DIFF
--- a/lib/diaspora/mentionable.rb
+++ b/lib/diaspora/mentionable.rb
@@ -71,20 +71,6 @@ module Diaspora::Mentionable
     }
   end
 
-  # Regex to find mentions with new syntax, only used for backporting to old syntax
-  NEW_SYNTAX_REGEX = /@\{[^\} ]+\}/
-
-  # replaces new syntax with old syntax, to be compatible with old pods
-  # @deprecated remove when most of the posts can handle the new syntax
-  def self.backport_mention_syntax(text)
-    text.to_s.gsub(NEW_SYNTAX_REGEX) do |match_str|
-      _, diaspora_id = mention_attrs(match_str)
-      person = find_or_fetch_person_by_identifier(diaspora_id)
-      old_syntax = "@{#{person.name.delete('{}')}; #{diaspora_id}}" if person
-      old_syntax || match_str
-    end
-  end
-
   private_class_method def self.find_or_fetch_person_by_identifier(identifier)
     Person.find_or_fetch_by_identifier(identifier) if Validation::Rule::DiasporaId.new.valid_value?(identifier)
   rescue DiasporaFederation::Discovery::DiscoveryError

--- a/lib/diaspora/mentions_container.rb
+++ b/lib/diaspora/mentions_container.rb
@@ -5,11 +5,6 @@ module Diaspora
     extend ActiveSupport::Concern
 
     included do
-      before_create do
-        # TODO: remove when most of the posts can handle the new syntax
-        self.text = Diaspora::Mentionable.backport_mention_syntax(text) if text && author.local?
-      end
-
       after_create :create_mentions
       has_many :mentions, as: :mentions_container, dependent: :destroy
     end

--- a/spec/integration/mentioning_spec.rb
+++ b/spec/integration/mentioning_spec.rb
@@ -205,7 +205,6 @@ describe "mentioning", type: :request do
 
     expect(status_msg).not_to be_nil
     expect(status_msg.public?).to be true
-    expect(status_msg.text).to include(user3.name)
     expect(status_msg.text).to include(user3.diaspora_handle)
 
     expect(user3).to be_mentioned_in(status_msg)
@@ -220,7 +219,6 @@ describe "mentioning", type: :request do
 
     expect(status_msg).not_to be_nil
     expect(status_msg.public?).to be false
-    expect(status_msg.text).to include(user2.name)
     expect(status_msg.text).to include(user2.diaspora_handle)
 
     expect(user2).to be_mentioned_in(status_msg)

--- a/spec/lib/diaspora/mentionable_spec.rb
+++ b/spec/lib/diaspora/mentionable_spec.rb
@@ -209,44 +209,4 @@ STR
       expect(txt).to eq "mentioning @non_existing_user@example.org"
     end
   end
-
-  describe ".backport_mention_syntax" do
-    it "replaces the new syntax with the old syntax" do
-      text = "mention @{#{people[0].diaspora_handle}} text"
-      expected_text = "mention @{#{people[0].name}; #{people[0].diaspora_handle}} text"
-      expect(Diaspora::Mentionable.backport_mention_syntax(text)).to eq(expected_text)
-    end
-
-    it "replaces the new syntax with the old syntax for immediately consecutive mentions" do
-      text = "mention @{#{people[0].diaspora_handle}}@{#{people[1].diaspora_handle}} text"
-      expected_text = "mention @{#{people[0].name}; #{people[0].diaspora_handle}}" \
-        "@{#{people[1].name}; #{people[1].diaspora_handle}} text"
-      expect(Diaspora::Mentionable.backport_mention_syntax(text)).to eq(expected_text)
-    end
-
-    it "removes curly braces from name of the mentioned person when adding it" do
-      profile = FactoryGirl.build(:profile, first_name: "{Alice}", last_name: "(Smith) [123]")
-      person = FactoryGirl.create(:person, profile: profile)
-      text = "mention @{#{person.diaspora_handle}} text"
-      expected_text = "mention @{Alice (Smith) [123]; #{person.diaspora_handle}} text"
-      expect(Diaspora::Mentionable.backport_mention_syntax(text)).to eq(expected_text)
-    end
-
-    it "does not change the text, when the mention includes a name" do
-      text = "mention @{#{names[0]}; #{people[0].diaspora_handle}} text"
-      expect(Diaspora::Mentionable.backport_mention_syntax(text)).to eq(text)
-    end
-
-    it "does not change the text, when the person is not found" do
-      text = "mention @{non_existing_user@example.org} text"
-      expect(Person).to receive(:find_or_fetch_by_identifier).with("non_existing_user@example.org").and_return(nil)
-      expect(Diaspora::Mentionable.backport_mention_syntax(text)).to eq(text)
-    end
-
-    it "does not change the text, when the diaspora ID is invalid" do
-      text = "mention @{invalid_diaspora_id} text"
-      expect(Person).not_to receive(:find_or_fetch_by_identifier)
-      expect(Diaspora::Mentionable.backport_mention_syntax(text)).to eq(text)
-    end
-  end
 end

--- a/spec/shared_behaviors/mentions_container.rb
+++ b/spec/shared_behaviors/mentions_container.rb
@@ -12,23 +12,6 @@ shared_examples_for "it is mentions container" do
     target
   }
 
-  describe ".before_create" do
-    it "backports mention syntax to old syntax" do
-      text = "mention @{#{people[0].diaspora_handle}} text"
-      expected_text = "mention @{#{people[0].name}; #{people[0].diaspora_handle}} text"
-      obj = FactoryGirl.build(described_class.to_s.underscore.to_sym, text: text, author: alice.person)
-      obj.save
-      expect(obj.text).to eq(expected_text)
-    end
-
-    it "doesn't backport mention syntax if author is not local" do
-      text = "mention @{#{people[0].diaspora_handle}} text"
-      obj = FactoryGirl.build(described_class.to_s.underscore.to_sym, text: text, author: remote_raphael)
-      obj.save
-      expect(obj.text).to eq(text)
-    end
-  end
-
   describe ".after_create" do
     it "calls create_mentions" do
       expect(target).to receive(:create_mentions).and_call_original


### PR DESCRIPTION
I think enough pods support the new syntax now, and for those which don't, they should immediately upgrade anyway because of security hotfixes.

fixes #7276, #7392 and #7640 