### PR TITLE
Add completed_at to account_migrations

### DIFF
--- a/app/models/account_migration.rb
+++ b/app/models/account_migration.rb
@@ -40,10 +40,11 @@ class AccountMigration < ApplicationRecord
 
     dispatch if locally_initiated?
     dispatch_contacts if remotely_initiated?
+    update(completed_at: Time.zone.now)
   end
 
   def performed?
-    old_person.closed_account?
+    !completed_at.nil?
   end
 
   # We assume that migration message subscribers are people that are subscribed to a new user profile updates.

--- a/db/migrate/20180430134444_add_completed_at_to_account_migration.rb
+++ b/db/migrate/20180430134444_add_completed_at_to_account_migration.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddCompletedAtToAccountMigration < ActiveRecord::Migration[5.1]
+  def change
+    add_column :account_migrations, :completed_at, :datetime, default: nil
+
+    reversible do |change|
+      change.up do
+        set_completed_at_for_closed_accounts
+      end
+    end
+  end
+
+  def set_completed_at_for_closed_accounts
+    # rubocop:disable Rails/SkipsModelValidations
+    AccountMigration.joins(:old_person).where(people: {closed_account: true}).update_all(completed_at: Time.zone.now)
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+end

--- a/spec/models/account_migration_spec.rb
+++ b/spec/models/account_migration_spec.rb
@@ -61,9 +61,14 @@ describe AccountMigration, type: :model do
       }.to change(account_migration, :performed?).to be_truthy
     end
 
-    it "calls old_person.closed_account?" do
-      expect(account_migration.old_person).to receive(:closed_account?)
-      account_migration.performed?
+    it "is truthy when completed_at is set" do
+      expect(FactoryGirl.create(:account_migration, completed_at: Time.zone.now).performed?).to be_truthy
+    end
+
+    it "is falsey when completed_at is null" do
+      account_migration = FactoryGirl.create(:account_migration, completed_at: nil)
+      account_migration.old_person.lock_access!
+      expect(account_migration.performed?).to be_falsey
     end
   end
 


### PR DESCRIPTION
Use completed_at datetime field as an indication of a performed migration