### PR TITLE
Support fetching StatusMessage by Poll guid

### DIFF
--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -15,6 +15,8 @@ class Poll < ApplicationRecord
   validate :enough_poll_answers
   validates :question, presence: true
 
+  scope :all_public, -> { joins(:status_message).where(posts: {public: true}) }
+
   self.include_root_in_json = false
 
   def enough_poll_answers

--- a/config/initializers/diaspora_federation.rb
+++ b/config/initializers/diaspora_federation.rb
@@ -117,8 +117,13 @@ DiasporaFederation.configure do |config|
     end
 
     on :fetch_public_entity do |entity_type, guid|
-      entity = Diaspora::Federation::Mappings.model_class_for(entity_type).find_by(guid: guid, public: true)
-      Diaspora::Federation::Entities.post(entity) if entity.is_a? Post
+      entity = Diaspora::Federation::Mappings.model_class_for(entity_type).all_public.find_by(guid: guid)
+      case entity
+      when Post
+        Diaspora::Federation::Entities.post(entity)
+      when Poll
+        Diaspora::Federation::Entities.status_message(entity.status_message)
+      end
     end
 
     on :fetch_person_url_to do |diaspora_id, path|

--- a/spec/federation_callbacks_spec.rb
+++ b/spec/federation_callbacks_spec.rb
@@ -430,6 +430,26 @@ describe "diaspora federation callbacks" do
       expect(entity.author).to eq(alice.diaspora_handle)
     end
 
+    it "fetches a StatusMessage by a Poll guid" do
+      post = FactoryGirl.create(:status_message, author: alice.person, public: true)
+      poll = FactoryGirl.create(:poll, status_message: post)
+      entity = DiasporaFederation.callbacks.trigger(:fetch_public_entity, "Poll", poll.guid)
+
+      expect(entity.guid).to eq(post.guid)
+      expect(entity.author).to eq(alice.diaspora_handle)
+      expect(entity.public).to be_truthy
+      expect(entity.poll.guid).to eq(poll.guid)
+      expect(entity.poll.question).to eq(poll.question)
+    end
+
+    it "doesn't fetch a private StatusMessage by a Poll guid" do
+      post = FactoryGirl.create(:status_message, author: alice.person, public: false)
+      poll = FactoryGirl.create(:poll, status_message: post)
+      expect(
+        DiasporaFederation.callbacks.trigger(:fetch_public_entity, "Poll", poll.guid)
+      ).to be_nil
+    end
+
     it "does not fetch a private post" do
       post = FactoryGirl.create(:status_message, author: alice.person, public: false)
 


### PR DESCRIPTION
When public fetch is requested with Poll guid, return parent StatusMessage for it, which includes the Poll in its turn.

ref #7660 