### PR TITLE
Escape asterisks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# diaspora*
+# diaspora\*
 ### A privacy-aware, distributed, open source social network
 
 **master:** [![Build Status master](https://secure.travis-ci.org/diaspora/diaspora.svg?branch=master)](http://travis-ci.org/diaspora/diaspora)
@@ -17,9 +17,9 @@
 
 ## Installation
 
-You don't have to install diaspora* to use the network. There are many servers connected to diaspora*s network which are open to anyone, and you can create an account on one of these servers. Have a look at our [tips for finding a home](https://wiki.diasporafoundation.org/Choosing_a_pod), or you can just go straight to the [list of open servers](http://podupti.me) to sign up.
+You don't have to install diaspora\* to use the network. There are many servers connected to diaspora\*s network which are open to anyone, and you can create an account on one of these servers. Have a look at our [tips for finding a home](https://wiki.diasporafoundation.org/Choosing_a_pod), or you can just go straight to the [list of open servers](http://podupti.me) to sign up.
 
-Want to own your data and install diaspora*? Whether you just want to try it out, want to install it on your server or want to contribute and need a development setup, our [installation guides](https://wiki.diasporafoundation.org/Installation) will get you started!
+Want to own your data and install diaspora\*? Whether you just want to try it out, want to install it on your server or want to contribute and need a development setup, our [installation guides](https://wiki.diasporafoundation.org/Installation) will get you started!
 
 ## Questions?
 


### PR DESCRIPTION
Unescaped asterisks can cause markdown text to be misinterpreted. Also
syntax highlighters (e.g. in sublime text) freak out.

References: [markdown specification](https://daringfireball.net/projects/markdown/syntax#em)