### PR TITLE
Add a welcome email with address verification

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -16,7 +16,7 @@ class RegistrationsController < Devise::RegistrationsController
       flash[:notice] = t("registrations.create.success")
       @user.process_invite_acceptence(invite) if invite.present?
       @user.seed_aspects
-      @user.send_welcome_message
+      @user.send_welcome_email
       sign_in_and_redirect(:user, @user)
       logger.info "event=registration status=successful user=#{@user.diaspora_handle}"
     else

--- a/app/mailers/welcome_mailer.rb
+++ b/app/mailers/welcome_mailer.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class WelcomeMailer < ApplicationMailer
+  def send_welcome_email(user)
+    @user = user
+    @podmin_message = podmin_message
+    mail(to: @user.email, reply_to: AppConfig.admins.podmin_email.presence,
+         subject: I18n.t("registrations.welcome_email.subject")) do |format|
+      format.text { render "registrations/welcome_email" }
+      format.html { render "registrations/welcome_email" }
+    end
+  end
+
+  private
+
+  def podmin_message
+    return unless AppConfig.settings.welcome_message.enabled?
+    AppConfig.settings.welcome_message.text.get
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -228,8 +228,17 @@ class User < ApplicationRecord
 
   def confirm_email(token)
     return false if token.blank? || token != confirm_email_token
-    self.email = unconfirmed_email
+
+    self.email = unconfirmed_email if unconfirmed_email.present?
+    self.confirm_email_token = nil
     save
+  end
+
+  # The address is considered verified while no confirmation is pending: both
+  # the welcome email (registration) and the change-email flow set this token
+  # and clear it once the link is followed
+  def email_verified?
+    confirm_email_token.blank?
   end
 
   ######## Posting ########
@@ -351,6 +360,7 @@ class User < ApplicationRecord
   ######### Mailer #######################
   def mail(job, *args)
     return unless job.present?
+
     pref = job.to_s.gsub("Mail::", "").underscore.sub(/_worker\z/, "")
     if(self.disable_mail == false && !self.user_preferences.exists?(:email_type => pref))
       job.perform_async(*args)
@@ -453,18 +463,9 @@ class User < ApplicationRecord
     aq
   end
 
-  def send_welcome_message
-    return unless AppConfig.settings.welcome_message.enabled? && AppConfig.admins.account?
-    sender_username = AppConfig.admins.account.get
-    sender = User.find_by(username: sender_username)
-    return if sender.nil?
-    conversation = sender.build_conversation(
-      participant_ids: [sender.person.id, person.id],
-      subject:         AppConfig.settings.welcome_message.subject.get,
-      message:         {text: AppConfig.settings.welcome_message.text.get % {username: username}}
-    )
-
-    Diaspora::Federation::Dispatcher.build(sender, conversation).dispatch if conversation.save
+  def send_welcome_email
+    update!(confirm_email_token: SecureRandom.hex(15))
+    WelcomeMailer.send_welcome_email(self).deliver_now
   end
 
   def encryption_key

--- a/app/views/registrations/welcome_email.html.erb
+++ b/app/views/registrations/welcome_email.html.erb
@@ -1,0 +1,70 @@
+<style>
+body {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  background-color: #eee;
+  padding: 1rem;
+}
+main {
+  margin: auto;
+  padding: 2rem;
+  background-color: #fff;
+  max-width: 800px;
+  border-radius: 10px;
+}
+h1 {
+  font-size: 1.4rem;
+  text-align: center;
+  margin-top: 0;
+  margin-bottom: 2rem;
+}
+strong {
+  white-space: nowrap;
+}
+.button-container {
+  text-align: center;
+  margin: 1.5rem;
+}
+.button-container a {
+  border-radius: 5px;
+  color: #fff;
+  background-color: #0088e6;
+  padding: 8px 16px;
+}
+p:last-child {
+  margin-bottom: 0;
+}
+</style>
+
+<main>
+  <h1>
+    <%= t("registrations.welcome_email.member") %>
+  </h1>
+  <p>
+    <% pod_url = AppConfig.pod_uri.site %>
+    <%= t("registrations.welcome_email.part_of_network",
+      pod_url: link_to(pod_url, pod_url), username: content_tag(:strong, @user.username)).html_safe %>
+  </p>
+  <p>
+    <%= t("registrations.welcome_email.your_id", id: content_tag(:strong, @user.person.diaspora_handle)).html_safe %>
+  </p>
+  <p>
+    <%= t("registrations.welcome_email.verify") %>
+  </p>
+  <p class="button-container">
+    <%= link_to t("registrations.welcome_email.verify_link"), confirm_email_url(token: @user.confirm_email_token) %>
+  </p>
+  <% if @podmin_message.present? %>
+  <p>
+    <%= @podmin_message %>
+  </p>
+  <% end %>
+  <p>
+    <%= t("registrations.welcome_email.help",
+      tutorials_link: link_to(
+        t("registrations.welcome_email.tutorials_link_text"), "https://diasporafoundation.org/tutorials")
+    ).html_safe %>
+  </p>
+  <p>
+    <em><%= t("registrations.welcome_email.welcome") %></em>
+  </p>
+</main>

--- a/app/views/registrations/welcome_email.text.erb
+++ b/app/views/registrations/welcome_email.text.erb
@@ -1,0 +1,19 @@
+<%= t("registrations.welcome_email.member") %>
+
+<%= t("registrations.welcome_email.part_of_network", pod_url: AppConfig.pod_uri.site, username: @user.username) %>
+
+<%= t("registrations.welcome_email.your_id", id: @user.person.diaspora_handle) %>
+
+<%= t("registrations.welcome_email.verify") %>
+
+<%= confirm_email_url(token: @user.confirm_email_token) %>
+
+<% if @podmin_message.present? %>
+<%= @podmin_message %>
+<% end %>
+
+<% tutorials_text = t("registrations.welcome_email.tutorials_link_text") %>
+<%= t("registrations.welcome_email.help",
+      tutorials_link: "#{tutorials_text} (https://diasporafoundation.org/tutorials)") %>
+
+<%= t("registrations.welcome_email.welcome") %>

--- a/app/views/users/_edit.haml
+++ b/app/views/users/_edit.haml
@@ -27,7 +27,9 @@
               = f.text_field :email, value: @user.unconfirmed_email || @user.email, class: "form-control"
           .clearfix= f.submit t(".change_email"), class: "btn btn-primary pull-right"
         - if @user.unconfirmed_email.present?
-          %div= t(".email_awaiting_confirmation", email: @user.email, unconfirmed_email: @user.unconfirmed_email)
+          %div= t(".email_awaiting_confirmation", unconfirmed_email: @user.unconfirmed_email)
+        - unless @user.email_verified?
+          %div= t(".email_not_verified")
     %hr
 
     .row

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -74,8 +74,7 @@ defaults:
     autofollow_on_join_user: 'hq@pod.diaspora.software'
     welcome_message:
       enabled: false
-      subject: 'Welcome Message'
-      text: 'Hello %{username}, welcome to diaspora*.'
+      text: 'Welcome to diaspora*.'
     invitations:
       open: true
       count: 25

--- a/config/diaspora.toml.example
+++ b/config/diaspora.toml.example
@@ -327,22 +327,12 @@
 ## Welcome Message settings
 [configuration.settings.welcome_message]
 
-## Welcome Message on registration (default=false)
-## Send a message to new users after registration
-## to tell them about your pod and how things
-## are handled on it.
+## Add your own message to the welcome email (default=false) that new users
+## receive after registration.
 #enabled = false
 
-## Welcome Message subject (default="Welcome Message")
-## The subject of the conversation that is started
-## by your welcome message.
-#subject = "Welcome Message"
-
-## Welcome Message text (default="Hello %{username}, welcome to diaspora*.")
-## The content of your welcome message.
-## The placeholder "%{username}" will be replaced by the username
-## of the new user.
-#text = "Hello %{username}, welcome to diaspora*."
+## Welcome Message text (default="Welcome to diaspora*.")
+#text = "Welcome to diaspora*."
 
 ## Invitation settings
 [configuration.settings.invitations]

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -1114,7 +1114,16 @@ en:
       find_pods: "There’s a list of pods you can sign up to at %{fediverse_observer}."
       other_questions: "If you have any other questions regarding choosing a pod, check out our %{wiki}."
     invalid_invite: "The invite link you provided is no longer valid!"
-
+    welcome_email:
+      subject: "Welcome to the diaspora* community!"
+      member: "Congratulations! You now are a member of the diaspora* community!"
+      part_of_network: "You have registered with %{pod_url}, one of the many nodes (called a “pod”) in the diaspora* network. To access the diaspora* network, you will need to sign in to that same pod using your username, %{username}, and password. Once signed in, you will be able to reach the whole diaspora* network, even people registered with other pods."
+      your_id: "Your diaspora* id is %{id}. This includes your home pod name and helps diaspora*'s software to locate you in the network. Share this with everyone you want to connect with in diaspora*."
+      verify: "Please confirm that this is really your email address. Until you do, we won’t send you any notification emails."
+      verify_link: "Verify my email address"
+      help: "If you need any help, have a look at our %{tutorials_link} or the in-app help section, which can be found via the user menu in the header bar. If you don’t find the information you need there, post a public message with the #question tag so that members of our amazing community can help you."
+      tutorials_link_text: "tutorials for new community members"
+      welcome: "Welcome aboard, and enjoy diaspora*!"
   reshares:
     create:
       error: "Failed to reshare."
@@ -1248,7 +1257,8 @@ en:
       your_email: "Your email"
       your_email_private: "Your email will never be seen by other users"
       change_email: "Change email"
-      email_awaiting_confirmation: "We have sent you an activation link to %{unconfirmed_email}. Until you follow this link and activate the new address, we will continue to use your original address %{email}."
+      email_awaiting_confirmation: "We have sent you an activation link to %{unconfirmed_email}. You will not receive any notifications until you follow this link and activate the new address."
+      email_not_verified: "Your email address is not verified. You will not receive notification emails from diaspora* until you verify it."
       change_password: "Change password"
       new_password: "New password"
       current_password: "Current password"

--- a/features/desktop/registrations.feature
+++ b/features/desktop/registrations.feature
@@ -4,12 +4,23 @@ Feature: New user registration
   As a desktop user
   I want to register an account
 
-  Scenario: user signs up and goes to getting started
-    Given I am on the new user registration page
+  Scenario: user signs up, goes to getting started and receives a welcome email verifying their address
+    Given the podmin contact address is "podmin@example.org"
+    And the podmin welcome message is "Welcome to my little pod!"
+    And I am on the new user registration page
     When I fill in the new user form
     And I press "Create account"
     Then I should be on the getting started page
     And I should see the 'getting started' contents
+    And I should have 1 email delivery
+    And "ohai@example.com" should have received an email with subject "Welcome to the diaspora* community!"
+    And I should see "ohai" in the last sent email
+    And I should see "Welcome to my little pod!" in the last sent email
+    And the last sent email should have a plain text and an HTML part
+    And the last sent email should have the reply-to address "podmin@example.org"
+    And my email address should not be verified
+    When I follow the "Verify my email address" link from the last sent email
+    Then my email address should be verified
 
   Scenario: registrations are closed, user is informed
     Given the registrations are closed

--- a/features/step_definitions/session_steps.rb
+++ b/features/step_definitions/session_steps.rb
@@ -79,6 +79,15 @@ Given /^the registrations are closed$/ do
   AppConfig.settings.enable_registrations = false
 end
 
+Given /^the podmin contact address is "([^"]*)"$/ do |address|
+  AppConfig.admins.podmin_email = address
+end
+
+Given /^the podmin welcome message is "([^"]*)"$/ do |message|
+  AppConfig.settings.welcome_message.enabled = true
+  AppConfig.settings.welcome_message.text = message
+end
+
 When /^I fill in the new user form$/ do
   fill_in_new_user_form
 end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -183,6 +183,25 @@ Then /^"([^"]*)" should have received an email with subject "([^"]*)"$/ do |user
   expect(email.subject).to have_content(subject)
 end
 
+Then /^the last sent email should have a plain text and an HTML part$/ do
+  email = ActionMailer::Base.deliveries.last
+  expect(email.text_part).to be_present
+  expect(email.html_part).to be_present
+end
+
+Then /^the last sent email should have the reply-to address "([^"]*)"$/ do |address|
+  expect(ActionMailer::Base.deliveries.last.reply_to).to include(address)
+end
+
+Then /^my email address should( not)? be verified$/ do |negate|
+  user = User.find_by(username: @username)
+  if negate
+    expect(user).not_to be_email_verified
+  else
+    expect(user).to be_email_verified
+  end
+end
+
 When /^"([^\"]+)" has posted a (public )?status message with a photo$/ do |email, public_status|
   user = User.find_for_database_authentication(username: email)
   post = FactoryBot.create(

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -817,57 +817,34 @@ describe User, type: :model do
     end
   end
 
-  describe "#send_welcome_message" do
+  describe "#send_welcome_email" do
     let(:user) { FactoryBot.create(:user) }
-    let(:podmin) { FactoryBot.create(:user) }
 
-    context "with welcome message enabled" do
-      before do
-        AppConfig.settings.welcome_message.enabled = true
-      end
-
-      it "should send welcome message from podmin account" do
-        AppConfig.admins.account = podmin.username
-        expect {
-          user.send_welcome_message
-        }.to change(user.conversations, :count).by(1)
-        expect(user.conversations.first.author.owner.username).to eq podmin.username
-      end
-
-      it "should send welcome message text from config" do
-        AppConfig.admins.account = podmin.username
-        AppConfig.settings.welcome_message.text = "Hello %{username}, welcome!" # rubocop:disable Style/FormatStringToken
-        user.send_welcome_message
-        expect(user.conversations.first.messages.first.text).to eq "Hello #{user.username}, welcome!"
-      end
-
-      it "should use subject from config" do
-        AppConfig.settings.welcome_message.subject = "Welcome Message"
-        AppConfig.admins.account = podmin.username
-        user.send_welcome_message
-        expect(user.conversations.first.subject).to eq "Welcome Message"
-      end
-
-      it "should send no welcome message if no podmin is specified" do
-        AppConfig.admins.account = ""
-        user.send_welcome_message
-        expect(user.conversations.count).to eq 0
-      end
-
-      it "should send no welcome message if podmin is invalid" do
-        AppConfig.admins.account = "invalid"
-        user.send_welcome_message
-        expect(user.conversations.count).to eq 0
-      end
+    it "sends the welcome email to the address the user registered with" do
+      expect { user.send_welcome_email }.to change(ActionMailer::Base.deliveries, :count).by(1)
+      expect(ActionMailer::Base.deliveries.last.to).to eq [user.email]
     end
 
-    context "with welcome message disabled" do
-      it "shouldn't send a welcome message" do
-        AppConfig.settings.welcome_message.enabled = false
-        AppConfig.admins.account = podmin.username
-        user.send_welcome_message
-        expect(user.conversations.count).to eq 0
-      end
+    it "verifies the address once the user follows the link, and lets mail through" do
+      user.send_welcome_email
+      expect(user.confirm_email(user.reload.confirm_email_token)).to be true
+      expect(user.reload).to be_email_verified
+      expect(Mail::MentionedWorker).to receive(:perform_async)
+      user.mail(Mail::MentionedWorker, user.id, user.id, user.id)
+    end
+
+    it "keeps address unverified when an unverified user requests an email change instead" do
+      user.send_welcome_email
+      user.update!(unconfirmed_email: "changed-but-never-confirmed@example.org")
+      expect(user.reload).not_to be_email_verified
+    end
+
+    it "adds the podmin's message when they configured some" do
+      AppConfig.settings.welcome_message.enabled = true
+      AppConfig.settings.welcome_message.text = "Message from your podmin"
+      user.send_welcome_email
+      expect(ActionMailer::Base.deliveries.last.text_part.body.raw_source)
+        .to include("Message from your podmin")
     end
   end
 


### PR DESCRIPTION
So as discussed [on discourse](https://discourse.diasporafoundation.org/t/from-hearing-about-diaspora-to-becoming-a-recurrent-user/1356/17?u=flaburgan), this pull request adds a welcome email sent to the users once they filled the first form (with email and username). I only put the very basics in it, here is how it looks:

Subject is "Welcome aboard!"
Body:
```
You now are a member of the diaspora* community!

https://diaspora-fr.org is the diaspora* server (called a pod) where you registered. Log in there using your username, testwelcomeemail14. Once logged, you will be able to reach the whole diaspora* network, even users registered on other pods.

Your diaspora* id is testwelcomeemail14@diaspora-fr.org, share it with everyone so they can find you in the network.

If you need help, have a look at the tutorials or the help section. If you don't find anything, then post a public message with the #question tag so people can help you.

Welcome aboard, enjoy diaspora*!
```

@goobertron I'd love some feedback on the content, and what we could write.

I also still need to add links to the tutorials and help section text.

I guess I also need to write some tests...