### PR TITLE
Allow fonts to be served from asset host in CSP.

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -23,6 +23,7 @@ SecureHeaders::Configuration.default do |config|
 
   if AppConfig.environment.assets.host.present?
     asset_host = Addressable::URI.parse(AppConfig.environment.assets.host.get).host
+    csp[:font_src] << asset_host
     csp[:script_src] << asset_host
     csp[:style_src] << asset_host
   end


### PR DESCRIPTION
Closes #7796.

I bumped into this setting up my pod (where I was brave / foolish and turned on CSP enforcement) and noticed that web fonts were being blocked by CSP. Seems like a simple fix.