### PR TITLE
Get processor count with ruby (on linux and mac)

### DIFF
--- a/script/configure_bundler
+++ b/script/configure_bundler
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require_relative "../config/bundler_helper"
+require "etc"
 
 rails_env = BundlerHelper.rails_env
 database = BundlerHelper.database
@@ -13,7 +14,7 @@ def config(option)
   system("#{File.join(__dir__, '../bin/bundle')} config --local #{option}")
 end
 
-config("jobs #{`nproc`}")
+config("jobs #{Etc.nprocessors}")
 config("with #{database}")
 
 if rails_env == "production"


### PR DESCRIPTION
`nproc` doesn't work on mac, but this ruby solution works since ruby 2.2 ([see documentation](http://ruby-doc.org/stdlib-2.2.0/libdoc/etc/rdoc/Etc.html#method-c-nprocessors)) and should work on linux and mac. Obviously I can only test this on linux, so maybe somebody with a mac can test if that works there too :)