### PR TITLE
Install web+diaspora:// handler only when the user is logged in

### DIFF
--- a/app/assets/javascripts/protocol-handler.js
+++ b/app/assets/javascripts/protocol-handler.js
@@ -12,6 +12,6 @@ function registerDiasporaLinksProtocol() {
   window.navigator.registerProtocolHandler("web+diaspora", host.concat("/link?q=%s"), document.title);
 }
 
-if (typeof (window.navigator.registerProtocolHandler) === "function") {
+if (typeof (window.navigator.registerProtocolHandler) === "function" && window.gon.user) {
   registerDiasporaLinksProtocol();
 }


### PR DESCRIPTION
I just realized that it even asks to install the handler when the user is not logged in, which I think is bad, because people should install the handler for their pod, not for every pod (when people view posts on other pods).