### PR TITLE
Use podname for web+diaspora:// protocol handler

### DIFF
--- a/app/assets/javascripts/helpers/protocol_handler.js
+++ b/app/assets/javascripts/helpers/protocol_handler.js
@@ -10,7 +10,7 @@ Diaspora.ProtocolHandler = {
       window.navigator.registerProtocolHandler(
         "web+diaspora",
         [window.location.protocol, "//", window.location.host, "/link?q=%s"].join(""),
-        document.title
+        gon.appConfig.settings.podname
       );
     } catch (_) {
       return false;


### PR DESCRIPTION
`document.title` is a bad idea on the user edit page ;)