### PR TITLE
Include PostsHelper in NotifierHelper

### DIFF
--- a/app/helpers/notifier_helper.rb
+++ b/app/helpers/notifier_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module NotifierHelper
+  include PostsHelper
 
   # @param post [Post] The post object.
   # @param opts [Hash] Optional hash.  Accepts :length parameters.
@@ -9,7 +10,7 @@ module NotifierHelper
     if post.respond_to? :message
       post.message.try(:plain_text_without_markdown).presence || post_page_title(post)
     else
-      I18n.translate 'notifier.a_post_you_shared'
+      I18n.translate "notifier.a_post_you_shared"
     end
   end
 
@@ -19,7 +20,7 @@ module NotifierHelper
     if comment.post.public?
       comment.message.plain_text_without_markdown
     else
-      I18n.translate 'notifier.a_limited_post_comment'
+      I18n.translate "notifier.a_limited_post_comment"
     end
   end
 end

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -214,6 +214,14 @@ describe Notifier, type: :mailer do
       like = reshare.likes.create!(author: bob.person)
       Notifier.send_notification("liked", alice.id, like.author.id, like.id)
     end
+
+    it "can handle status_messages without text" do
+      photo = FactoryGirl.create(:photo, public: true)
+      status = FactoryGirl.create(:status_message, author: alice.person, text: nil, photos: [photo], public: true)
+      like = status.likes.create!(author: bob.person)
+      mail = Notifier.send_notification("liked", alice.id, like.author.id, like.id)
+      expect(mail.body.encoded).to include(I18n.t("posts.show.photos_by", count: 1, author: alice.name))
+    end
   end
 
   describe ".reshared" do


### PR DESCRIPTION
@SuperTux88 ideally, this needs tests. However, this seems to only fail in the context of Sidekiq runs, see https://github.com/diaspora/diaspora/issues/7852#issuecomment-418221263. Any idea off the top of your head on how to either test this or how to make Sidekiq behave the same as the fronted?