### PR TITLE
Fix i18n fallbacks

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,10 +74,6 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
-  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
-
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 


### PR DESCRIPTION
It looks like the new i18n-1.1.0 has breaking changes, which was automatically updated in #7856 because it is only a new minor version and we didn't lock it in the Gemfile. The old version sets English as default fallback for all languages, the new version doesn't set a default fallback anymore.

This setting was only set in production (that's why it didn't cause any issues in tests and dev-environments) and it looks like it resets all fallbacks which are setup in [config/initializers/locale.rb](https://github.com/diaspora/diaspora/blob/e82690963dc55d10491b8da6b4fc0b6f397bea6d/config/initializers/locale.rb) (where we already set English as default fallback for all languages).

Fixes #7860