### PR TITLE
Remove reference to statistics.json

### DIFF
--- a/config/diaspora.yml.example
+++ b/config/diaspora.yml.example
@@ -308,7 +308,7 @@ configuration: ## Section
 
     ## Statistics
     ## Your pod will report its name, software version and whether
-    ## or not registrations are open via /statistics.json.
+    ## or not registrations are open via /statistics and NodeInfo.
     ## Uncomment the options below to enable more statistics.
     statistics: ## Section
 


### PR DESCRIPTION
The `/statistics.json` is not a thing anymore (#7399), but it was still mentioned in the `diaspora.yml`.