### PR TITLE
Don't depend on the database content when loading the tests

### DIFF
--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -336,16 +336,16 @@ describe UsersController, :type => :controller do
     end
 
     context "with inviter" do
-      [bob, eve].each do |inviter|
-        sharing = !alice.contact_for(inviter.person).nil?
+      it "preloads data using gon for the aspect memberships dropdown when sharing with the inviter" do
+        alice.invited_by = bob
+        get :getting_started
+        expect_gon_preloads_for_aspect_membership_dropdown(:inviter, true)
+      end
 
-        context sharing ? "when sharing" : "when don't share" do
-          it "preloads data using gon for the aspect memberships dropdown" do
-            alice.invited_by = inviter
-            get :getting_started
-            expect_gon_preloads_for_aspect_membership_dropdown(:inviter, sharing)
-          end
-        end
+      it "preloads data using gon for the aspect memberships dropdown when not sharing with the inviter" do
+        alice.invited_by = eve
+        get :getting_started
+        expect_gon_preloads_for_aspect_membership_dropdown(:inviter, false)
       end
     end
   end


### PR DESCRIPTION
This failed with:
```
An error occurred while loading ./spec/controllers/users_controller_spec.rb.
Failure/Error: sharing = !alice.contact_for(inviter.person).nil?

NoMethodError:
  undefined method `person' for nil:NilClass
```
when the database was empty and bob and eve didn't exist. The fixtures are only inserted into the db after the tests are loaded before the first test runs.

Thanks to @CSammy for finding and reporting it :cookie: 