### PR TITLE
Bump unicode-display_width

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -730,7 +730,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
-    unicode-display_width (1.3.0)
+    unicode-display_width (1.4.0)
     unicorn (5.4.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)


### PR DESCRIPTION
After I saw this deprecation warning multiple times today, lets get rid of it:
```
NOTE: Gem.gunzip is deprecated; use Gem::Util.gunzip instead. It will be removed on or after 2018-12-01.
Gem.gunzip called from /srv/diaspora/vendor/bundle/ruby/2.4.0/gems/unicode-display_width-1.3.0/lib/unicode/display_width/index.rb:5.
```