### PR TITLE
Added quotation marks for postgresql parameters.

### DIFF
--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -1,9 +1,9 @@
 postgresql: &postgresql
   adapter: postgresql
-  host: localhost
+  host: "localhost"
   port: 5432
-  username: postgres
-  password:
+  username: "postgres"
+  password: ""
   encoding: unicode
 
 mysql: &mysql


### PR DESCRIPTION
As a new, novice user, I ran into an issue where my postgresql
password contained special characters.  After a brief conversation
with DenSchub on #diaspora, it was noted that the example
database configuration had quotes added for mysql but not for
postgresql, and it was suggested this be improved.