### PR TITLE
Add to string when pass integer to person model function

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -104,7 +104,7 @@ class Person < ApplicationRecord
   # @param [String] search substring
   # @return [Person::ActiveRecord_Relation]
   scope :find_by_substring, ->(search_str) {
-    search_str = search_str.strip
+    search_str = search_str.to_s.strip
     if search_str.blank? || search_str.size < 2
       none
     else


### PR DESCRIPTION
Fixing function find_by_substring in Person model. When pass a integer to the function, that method doesnt, because, strip is a string method. 