### PR TITLE
Move comment timestamp next to author name, add permalink

### DIFF
--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -44,6 +44,19 @@
     }
   }
 
+  .permalink {
+    @include transition(opacity);
+    opacity: 0;
+  }
+
+  .comment:hover .permalink {
+    opacity: .8;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+
   .comment.new-comment-form-wrapper { padding-bottom: 0; }
 
   .submit-button {

--- a/app/assets/stylesheets/stream_element.scss
+++ b/app/assets/stylesheets/stream_element.scss
@@ -122,9 +122,12 @@
     opacity: 0;
   }
 
-  &:hover .permalink {
+  &:hover .post-timestamp .permalink {
     opacity: .8;
-    &:hover { opacity: 1; }
+
+    &:hover {
+      opacity: 1;
+    }
   }
 
   div.reshare {

--- a/app/assets/templates/comment_tpl.jst.hbs
+++ b/app/assets/templates/comment_tpl.jst.hbs
@@ -20,18 +20,21 @@
     {{/if}}
     </div>
 
-    {{#linkToAuthor author}}
-      {{name}}
-    {{/linkToAuthor}}
-
-    <div class="collapsible comment-content markdown-content">
-      {{{text}}}
-    </div>
-
-    <div class="info">
+    <div>
+      {{#linkToAuthor author}}
+        {{name}}
+      {{/linkToAuthor}}
+      -
       <a href="/posts/{{parent.id}}#{{guid}}" class="permalink_comment">
         <time class="timeago" data-original-title="{{{localTime created_at}}}" datetime="{{created_at}}"/>
       </a>
+      <a href="/posts/{{parent.guid}}#{{guid}}" class="permalink gray" title="{{t "stream.permalink"}}">
+        <i class="entypo-link"></i>
+      </a>
+    </div>
+
+    <div class="collapsible comment-content markdown-content">
+      {{{text}}}
     </div>
   </div>
 </div>

--- a/app/assets/templates/stream-element_tpl.jst.hbs
+++ b/app/assets/templates/stream-element_tpl.jst.hbs
@@ -19,7 +19,7 @@
           {{~name~}}
         {{/linkToAuthor}}
 
-        <span class="details gray">
+        <span class="details gray post-timestamp">
           -
           <a href="/posts/{{id}}">
             <time class="timeago" data-original-title="{{{localTime created_at}}}" datetime="{{created_at}}" />


### PR DESCRIPTION
When checking how to add likes to comment, I noticed that comment timestamp was displayed at the bottom, not next to the author like for posts. This PR moves it next to the author name, as I plan to add the "like" action at the bottom, like for posts.

**Before:**
![screenshot_2018-10-23 diaspora](https://user-images.githubusercontent.com/930064/47387203-ef5a8100-d70e-11e8-999b-09f7b7186a78.png)
![screenshot_2018-10-23 et si ce site de test me servait de journal intime](https://user-images.githubusercontent.com/930064/47387204-eff31780-d70e-11e8-8283-600a9a621c06.png)


**After:**
![screenshot_2018-10-23 diaspora 1](https://user-images.githubusercontent.com/930064/47387082-a30f4100-d70e-11e8-804d-1798517c59b1.png)
![screenshot_2018-10-23 et si ce site de test me servait de journal intime 1](https://user-images.githubusercontent.com/930064/47387081-a276aa80-d70e-11e8-9ebd-25cc84da995d.png)
