### PR TITLE
Reword the web handler setting

### DIFF
--- a/app/views/users/_edit.haml
+++ b/app/views/users/_edit.haml
@@ -184,7 +184,8 @@
       .col-md-12
         %h3#protocol-handler
           = t(".protocol_handler.title")
-        %p= t(".protocol_handler.description")
+        %p= t(".protocol_handler.description", pod_url: AppConfig.pod_uri.site)
+        %p= t(".protocol_handler.browser")
         .form-group
           %button.btn.btn-default#register-protocol-handler
             = t(".protocol_handler.register")

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -1261,8 +1261,9 @@ en:
 
       protocol_handler:
         title: "web+diaspora:// protocol handler"
-        description: "Clicking this button will ask your browser to install a handler that allows us to open web+diaspora:// URLs on your home pod. This is currently experimental and interactions will depend on your browser."
-        register: "Register"
+        description: "web+diaspora:// is a new web protocol that we have introduced. Any link to a diaspora* page on an external website that uses this protocol can be opened in the pod on which your diaspora* account is registered. Click the button below to set your browser to use %{pod_url} to recognise external web+diaspora:// links."
+        browser: "This protocol is currently in the experimental stage and the success of interactions using it will depend on your browser. If you want to manage or remove this handler, you will do this via your browser settings. The button below will always be enabled, and you need to set the handler separately in each browser you use."
+        register: "Register web+diaspora:// handler on this browser"
 
     privacy_settings:
       title: "Privacy settings"


### PR DESCRIPTION
I tried to reword the web handler instruction a bit. It's hard to keep it short but clear at the same time. I was wondering if there should be an example, explaining the problem it solves: a link "joindiaspora.com/posts/xxx" would not allow users of other pods to be logged in and comment on it, the new syntax should be used instead. But it was too much. Maybe there should be a section in the help page, and which could be linked there?

Please check the english here, it can surely be improved.

Fixes https://github.com/diaspora/diaspora/issues/7838