### PR TITLE
Save a screenshot of the page in tmp/capybara when a cucumber test is failing

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -77,3 +77,8 @@ Before do |scenario|
   # Reset overridden settings
   AppConfig.reset_dynamic!
 end
+
+After do |scenario|
+  Capybara.save_path = ENV["SCREENSHOT_PATH"]
+  page.save_screenshot("#{Time.now.utc} #{scenario.name}.png", full: true) if scenario.failed? && ENV["SCREENSHOT_PATH"]
+end


### PR DESCRIPTION
Not sure if I have to add something to avoid the CI doing it.