### PR TITLE
Fix script domain for instagram in CSP header

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -16,7 +16,7 @@ SecureHeaders::Configuration.default do |config|
     img_src:         %w['self' data: blob: *],
     media_src:       %w[https:],
     script_src:      %w['self' blob: 'unsafe-eval' platform.twitter.com cdn.syndication.twimg.com widgets.flickr.com
-                        embedr.flickr.com platform.instagram.com 'unsafe-inline'],
+                        embedr.flickr.com www.instagram.com 'unsafe-inline'],
     style_src:       %w['self' 'unsafe-inline' platform.twitter.com *.twimg.com]
   }
   # rubocop:enable Lint/PercentStringArray


### PR DESCRIPTION
I just noticed that a post embedding an instagram post wasn't displayed correctly and it looks like instagram changed the domain where the script is loaded.