### PR TITLE
Ignore invalid URLs for camo

### DIFF
--- a/lib/diaspora/camo.rb
+++ b/lib/diaspora/camo.rb
@@ -17,7 +17,11 @@ module Diaspora
       return unless url
       return url unless self.url_eligible?(url)
 
-      url = Addressable::URI.encode(Addressable::URI.unencode(url))
+      begin
+        url = Addressable::URI.encode(Addressable::URI.unencode(url))
+      rescue Addressable::URI::InvalidURIError
+        return url
+      end
 
       digest = OpenSSL::HMAC.hexdigest(
         OpenSSL::Digest.new('sha1'),

--- a/spec/lib/diaspora/camo_spec.rb
+++ b/spec/lib/diaspora/camo_spec.rb
@@ -48,6 +48,10 @@ describe Diaspora::Camo do
         expect(Diaspora::Camo.image_url("https://example.com/%C3%A1%C3%A9%C3%B3?foo=%C3%A4%C3%BC%C3%B6&bar=a%CC%80"))
           .to eq(camo_image_url)
       end
+
+      it "ignores invalid urls" do
+        expect(Diaspora::Camo.image_url("https://")).to eq("https://")
+      end
     end
   end
 


### PR DESCRIPTION
When people only write `![foobar](https://)` this would fail with `Addressable::URI::InvalidURIError: Absolute URI missing hierarchical segment: 'https://'`.