### PR TITLE
Sharpen small and medium thumbnails

### DIFF
--- a/app/uploaders/processed_image.rb
+++ b/app/uploaders/processed_image.rb
@@ -20,10 +20,10 @@ class ProcessedImage < CarrierWave::Uploader::Base
   end
 
   version :thumb_small do
-    process resize_to_fill: [50, 50]
+    process resize_to_fill: [50, 50, combine_options: {unsharp: "1.5x1+0.7+0.02"}]
   end
   version :thumb_medium do
-    process resize_to_limit: [100, 100]
+    process resize_to_limit: [100, 100, combine_options: {unsharp: "1.5x1+0.7+0.02"}]
   end
   version :thumb_large do
     process resize_to_limit: [300, 1500]


### PR DESCRIPTION
I noticed profile icons appeared fuzzy on Diaspora. Resizing images [often results in apparent blurring](http://www.imagemagick.org/Usage/filter/#blurring). This commit adds sharpening to 50 and 100px thumbnail sizes in order to compensate for perceived loss of detail. It uses [unsharpening](https://en.wikipedia.org/wiki/Unsharp_masking) parameters of `1.5x1+0.7+0.02` referenced in a section dedicated to the subject on  [ImageMagick's resize page](http://www.imagemagick.org/Usage/resize/#resize_unsharp).

### Examples
|Before|After|
|-|-|
| ![hq_small_default](https://user-images.githubusercontent.com/151138/47958820-c9e03980-df90-11e8-9f64-a79ae17c8797.png) | ![hq_small_unsharp](https://user-images.githubusercontent.com/151138/47958821-cd73c080-df90-11e8-890b-11b0d084175f.png) |
| ![sistine_small_default](https://user-images.githubusercontent.com/151138/47958824-d95f8280-df90-11e8-8bad-cfaffcf7b9ff.jpg) | ![sistine_small_unsharp](https://user-images.githubusercontent.com/151138/47958825-dd8ba000-df90-11e8-9a35-48d998877ff2.jpg) |
| ![author_small_default](https://user-images.githubusercontent.com/151138/47958830-fbf19b80-df90-11e8-9c1a-93f6e186b388.png) |  ![author_small_unsharp](https://user-images.githubusercontent.com/151138/47958831-feec8c00-df90-11e8-9881-da1f09db57f9.png) |

|Before|After|
|-|-|
| ![hq_medium_default](https://user-images.githubusercontent.com/151138/47958833-0f9d0200-df91-11e8-877a-60cdc6aeff18.png) |  ![hq_medium_unsharp](https://user-images.githubusercontent.com/151138/47958834-13308900-df91-11e8-8a81-ec9e0af15ea1.png) |
| ![sistine_medium_default](https://user-images.githubusercontent.com/151138/47958835-1b88c400-df91-11e8-96f6-1a96bb8e7bdc.jpg) |  ![sistine_medium_unsharp](https://user-images.githubusercontent.com/151138/47958836-1e83b480-df91-11e8-80c9-b2254bb10f81.jpg) |
| ![author_medium_default](https://user-images.githubusercontent.com/151138/47958837-2a6f7680-df91-11e8-8c2f-c38a93374849.png) | ![author_medium_unsharp](https://user-images.githubusercontent.com/151138/47958838-2cd1d080-df91-11e8-8feb-0f2731492783.png) |

#### Original Images

[1](https://user-images.githubusercontent.com/151138/47958995-5e4c9b00-df95-11e8-8562-d97fbe749ed9.png), [2](https://user-images.githubusercontent.com/151138/47958997-699fc680-df95-11e8-948b-c91c0e2ded15.jpg), [3](https://user-images.githubusercontent.com/151138/47958998-6dcbe400-df95-11e8-929a-cc468038060d.png)







