### PR TITLE
Change the port exposed by Docker to 3000

### DIFF
--- a/docker/develop/docker-compose.yml
+++ b/docker/develop/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - dia_data_tmp:/diaspora/tmp
       - dia_data_bundle:/diaspora/vendor/bundle
     ports:
-      - 8080:3000
+      - ${DIASPORA_DOCKER_PORT:-3000}:3000
     depends_on:
       - "${DIASPORA_DOCKER_DB}"
 


### PR DESCRIPTION
I see no reason to use port `8080`, and since changing the `diaspora.yml` is more painful, let's just expose port `3000` to the world. :)

Fixes #7927.