### PR TITLE
Speed up public stream and remove obsolete indexes

### DIFF
--- a/db/migrate/20181227235201_clean_up_posts_indexes.rb
+++ b/db/migrate/20181227235201_clean_up_posts_indexes.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class CleanUpPostsIndexes < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :posts, %i[id type created_at]
+    remove_index :posts, :tweet_id
+    add_index :posts, %i[created_at id]
+  end
+end


### PR DESCRIPTION
Speeds up the public stream by a factor of 1000 on a production PostgreSQL database, it's lightning fast now. MySQL shows improvement as well.