### PR TITLE
Improve web+diaspora:// protocol handler

### DIFF
--- a/app/services/diaspora_link_service.rb
+++ b/app/services/diaspora_link_service.rb
@@ -10,7 +10,9 @@ class DiasporaLinkService
   end
 
   def find_or_fetch_entity
-    entity_finder.find || fetch_entity
+    if type && guid
+      entity_finder.find || fetch_entity
+    end
   end
 
   private
@@ -38,8 +40,8 @@ class DiasporaLinkService
   def parse
     normalize
     match = DiasporaFederation::Federation::DiasporaUrlParser::DIASPORA_URL_REGEX.match(link)
-    @author = match[1]
-    @type = match[2]
-    @guid = match[3]
+    if match
+      @author, @type, @guid = match.captures
+    end
   end
 end

--- a/spec/services/diaspora_link_service_spec.rb
+++ b/spec/services/diaspora_link_service_spec.rb
@@ -52,5 +52,21 @@ describe DiasporaLinkService do
         expect(service.find_or_fetch_entity).to be_nil
       end
     end
+
+    context "with only a diaspora ID" do
+      let(:person) { FactoryGirl.create(:person) }
+      let(:link) { "diaspora://#{person.diaspora_handle}" }
+
+      it "returns the person" do
+        expect(service.find_or_fetch_entity).to eq(person)
+      end
+
+      it "returns nil when person is non fetchable" do
+        expect(Person).to receive(:find_or_fetch_by_identifier)
+          .with(person.diaspora_handle).and_raise(DiasporaFederation::Discovery::DiscoveryError)
+
+        expect(service.find_or_fetch_entity).to be_nil
+      end
+    end
   end
 end

--- a/spec/services/diaspora_link_service_spec.rb
+++ b/spec/services/diaspora_link_service_spec.rb
@@ -40,5 +40,17 @@ describe DiasporaLinkService do
         expect(service.find_or_fetch_entity).to be_nil
       end
     end
+
+    context "with invalid links" do
+      it "returns nil when the link is invalid" do
+        service = described_class.new("web+diaspora://something_invalid")
+        expect(service.find_or_fetch_entity).to be_nil
+      end
+
+      it "returns nil when the author is valid, but rest of the link is invalid" do
+        service = described_class.new("web+diaspora://#{alice.diaspora_handle}/foo/bar")
+        expect(service.find_or_fetch_entity).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
Don't throw 500er for invalid links and allow to link to a profile with only the diaspora ID (so you can link your profile from a blog).