### PR TITLE
Remove password reset and sign up link below two factor form

### DIFF
--- a/app/views/sessions/two_factor.html.haml
+++ b/app/views/sessions/two_factor.html.haml
@@ -29,11 +29,3 @@
       = f.button t("devise.sessions.new.sign_in"),
       type: :submit,
       class: "btn btn-large btn-block btn-primary"
-
-  .text-center
-    - if display_password_reset_link?
-      = link_to t("devise.shared.links.forgot_your_password"),
-        new_password_path(resource_name), id: "forgot_password_link"
-      %br
-    - if display_registration_link?
-      = link_to t("devise.shared.links.sign_up"), new_registration_path(resource_name)


### PR DESCRIPTION
They don't make sense on that page, because at this stage, the user already has an account and also has already entered their password.

As pointed out by @goobertron in https://github.com/diaspora/diaspora/pull/8004#issuecomment-487766771