### PR TITLE
Use password to disable 2FA instead of a token

### DIFF
--- a/app/controllers/two_factor_authentications_controller.rb
+++ b/app/controllers/two_factor_authentications_controller.rb
@@ -37,12 +37,12 @@ class TwoFactorAuthenticationsController < ApplicationController
   end
 
   def destroy
-    if acceptable_code?
+    if current_user.valid_password?(params[:two_factor_authentication][:password])
       current_user.otp_required_for_login = false
       current_user.save!
       flash[:notice] = t("two_factor_auth.flash.success_deactivation")
     else
-      flash.now[:alert] = t("two_factor_auth.flash.error_token")
+      flash[:alert] = t("users.destroy.wrong_password")
     end
     redirect_to two_factor_authentication_path
   end
@@ -51,10 +51,5 @@ class TwoFactorAuthenticationsController < ApplicationController
 
   def verify_otp_required
     redirect_to two_factor_authentication_path if current_user.otp_required_for_login?
-  end
-
-  def acceptable_code?
-    current_user.validate_and_consume_otp!(params[:two_factor_authentication][:code]) ||
-      current_user.invalidate_otp_backup_code!(params[:two_factor_authentication][:code])
   end
 end

--- a/app/views/two_factor_authentications/_deactivate.haml
+++ b/app/views/two_factor_authentications/_deactivate.haml
@@ -13,10 +13,9 @@
       = form_for "two_factor_authentication", url: two_factor_authentication_path,
         html: {method: :delete, class: "form-horizontal"} do |f|
         .form-group
-          = f.label :code, t("two_factor_auth.input_token.label"), class: "control-label col-sm-6"
+          = f.label :password, t("users.edit.current_password"), class: "control-label col-sm-6"
           .col-sm-6
-            = f.text_field :code, placeholder: t("two_factor_auth.input_token.placeholder"), class: "form-control"
-            = t("two_factor_auth.recovery.reminder")
+            = f.password_field :password, class: "form-control"
         .clearfix= f.submit t("two_factor_auth.activated.change_button"), class: "btn btn-primary pull-right"
 
       %hr

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -1316,7 +1316,7 @@ en:
     explanation: "Two-factor authentication is a powerful way to ensure you are the only one able to sign in to your account. When signing in, you will enter a 6-digit code along with your password to prove your identity. Be careful though: if you lose your phone and the recovery codes created when you activate this feature, access to your diaspora* account will be blocked forever."
     activated:
       status: "Two-factor authentication activated"
-      change_label: "Deactivate two-factor authentication by entering a TOTP token."
+      change_label: "Deactivate two-factor authentication by entering your password"
       change_button: "Deactivate"
     deactivated:
       status: "Two-factor authentication not activated"

--- a/features/desktop/two_factor_authentication.feature
+++ b/features/desktop/two_factor_authentication.feature
@@ -51,40 +51,30 @@ Feature: Two-factor autentication
 
   Scenario: Regenerating recovery codes
     Given a user with email "alice@test.com"
-    When I sign in as "alice@test.com"
     And 2fa is activated for "alice@test.com"
+    When I sign in as "alice@test.com"
     When I go to the two-factor authentication page
     Then I should see "Generate new recovery codes"
     When I press the recovery code generate button
     Then I should see a list of recovery codes
 
-  Scenario: Deactivating 2fa with correct token
+  Scenario: Deactivating 2fa with correct password
     Given a user with email "alice@test.com"
-    When I sign in as "alice@test.com"
     And 2fa is activated for "alice@test.com"
+    When I sign in as "alice@test.com"
     When I go to the two-factor authentication page
     Then I should see "Deactivate"
-    When I fill in a valid TOTP token to deactivate for "alice@test.com"
+    When I put in my password in "two_factor_authentication_password"
     And I press "Deactivate"
     Then I should see "Two-factor authentication not activated"
 
-  Scenario: Deactivating 2fa with recovery token
+  Scenario: Trying to deactivate with incorrect password
     Given a user with email "alice@test.com"
-    When I sign in as "alice@test.com"
     And 2fa is activated for "alice@test.com"
+    When I sign in as "alice@test.com"
     When I go to the two-factor authentication page
     Then I should see "Deactivate"
-    When I fill in a recovery code to deactivate from "alice@test.com"
-    And I press "Deactivate"
-    Then I should see "Two-factor authentication not activated"
-
-  Scenario: Trying to deactivate with incorrect token
-    Given a user with email "alice@test.com"
-    When I sign in as "alice@test.com"
-    And 2fa is activated for "alice@test.com"
-    When I go to the two-factor authentication page
-    Then I should see "Deactivate"
-    When I fill in an invalid TOTP token to deactivate
+    When I fill in "two_factor_authentication_password" with "incorrect"
     And I press "Deactivate"
     Then I should see "Two-factor authentication activated"
     And I should see "Deactivate"

--- a/features/step_definitions/session_steps.rb
+++ b/features/step_definitions/session_steps.rb
@@ -31,7 +31,7 @@ When /^I (?:sign|log) in with password "([^"]*)"( on the mobile website)?$/ do |
 end
 
 When /^I put in my password in "([^"]*)"$/ do |field|
- step %(I fill in "#{field}" with "#{@me.password}")
+  step %(I fill in "#{field}" with "#{@me.password}")
 end
 
 When /^I fill out change password section with my password and "([^"]*)" and "([^"]*)"$/ do |new_pass, confirm_pass|

--- a/features/step_definitions/two_factor_steps.rb
+++ b/features/step_definitions/two_factor_steps.rb
@@ -14,27 +14,11 @@ When /^I fill in an invalid TOTP token$/ do
   fill_in "user_otp_attempt", with: "c0ffee"
 end
 
-When /^I fill in a valid TOTP token to deactivate for "([^"]*)"$/ do |username|
-  @me = find_user username
-  fill_in "two_factor_authentication_code", with: @me.current_otp
-end
-
-When /^I fill in an invalid TOTP token to deactivate$/ do
-  fill_in "two_factor_authentication_code", with: "c0ffee"
-end
-
 When /^I fill in a recovery code from "([^"]*)"$/ do |username|
   @me = find_user username
   @codes = @me.generate_otp_backup_codes!
   @me.save!
   fill_in "user_otp_attempt", with: @codes.first
-end
-
-When /^I fill in a recovery code to deactivate from "([^"]*)"$/ do |username|
-  @me = find_user username
-  @codes = @me.generate_otp_backup_codes!
-  @me.save!
-  fill_in "two_factor_authentication_code", with: @codes.first
 end
 
 When /^I confirm activation$/ do

--- a/spec/controllers/two_factor_authentications_controller_spec.rb
+++ b/spec/controllers/two_factor_authentications_controller_spec.rb
@@ -19,7 +19,6 @@ describe TwoFactorAuthenticationsController, type: :controller do
       get :show
       expect(response.body).to match I18n.t("two_factor_auth.title")
       expect(response.body).to match I18n.t("two_factor_auth.activated.status")
-      expect(response.body).to match I18n.t("two_factor_auth.input_token.label")
       expect(response.body).to match I18n.t("two_factor_auth.recovery.button")
       expect(@user).to have_attributes(otp_required_for_login: true)
     end
@@ -90,16 +89,16 @@ describe TwoFactorAuthenticationsController, type: :controller do
     before do
       activate_2fa
     end
-    it "deactivates 2fa if token is correct" do
-      delete :destroy, params: {two_factor_authentication: {code: @user.current_otp}}
+    it "deactivates 2fa if password is correct" do
+      delete :destroy, params: {two_factor_authentication: {password: @user.password}}
       expect(response).to be_redirect
       expect(flash[:notice]).to match I18n.t("two_factor_auth.flash.success_deactivation")
     end
 
-    it "does nothing if token is wrong" do
-      delete :destroy, params: {two_factor_authentication: {code: "a wrong code"}}
+    it "does nothing if password is wrong" do
+      delete :destroy, params: {two_factor_authentication: {password: "a wrong password"}}
       expect(response).to be_redirect
-      expect(flash[:alert]).to match I18n.t("two_factor_auth.flash.error_token")
+      expect(flash[:alert]).to match I18n.t("users.destroy.wrong_password")
     end
   end
 


### PR DESCRIPTION
Using token doesn't make much sense when you can generate new tokens right below.