### PR TITLE
Fix archive import for reshares of down pods

### DIFF
--- a/lib/archive_importer/entity_importer.rb
+++ b/lib/archive_importer/entity_importer.rb
@@ -15,6 +15,7 @@ class ArchiveImporter
     rescue DiasporaFederation::Entities::Signable::SignatureVerificationFailed,
            DiasporaFederation::Discovery::InvalidDocument,
            DiasporaFederation::Discovery::DiscoveryError,
+           DiasporaFederation::Federation::Fetcher::NotFetchable,
            ActiveRecord::RecordInvalid => e
       logger.warn "#{self}: #{e}"
     end

--- a/lib/archive_importer/own_entity_importer.rb
+++ b/lib/archive_importer/own_entity_importer.rb
@@ -25,7 +25,7 @@ class ArchiveImporter
     end
 
     def real_author
-      instance.author.diaspora_handle
+      instance.try(:author).try(:diaspora_handle)
     end
   end
 end

--- a/spec/lib/archive_importer/post_importer_spec.rb
+++ b/spec/lib/archive_importer/post_importer_spec.rb
@@ -113,5 +113,34 @@ describe ArchiveImporter::PostImporter do
         end
       end
     end
+
+    context "with reshare" do
+      let(:guid) { UUID.generate(:compact) }
+      let(:entity_json) { JSON.parse(<<~JSON) }
+        {
+          "entity_data" : {
+             "created_at" : "2015-10-19T13:58:16Z",
+             "guid" : "#{guid}",
+             "author" : "#{new_user.diaspora_handle}",
+             "root_author" : "author@example.com",
+             "root_guid" : "#{UUID.generate(:compact)}"
+          },
+          "entity_type" : "reshare"
+        }
+      JSON
+
+      context "with unknown root author" do
+        it "handles missing person" do
+          allow(DiasporaFederation::Federation::Fetcher).to receive(:fetch_public)
+            .and_raise(DiasporaFederation::Federation::Fetcher::NotFetchable)
+
+          expect {
+            instance.import
+          }.not_to raise_error
+
+          expect(Reshare.find_by(guid: guid)).to be_nil
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Got this beauty trying to run the migration on my profile:

```
rake aborted!
DiasporaFederation::Federation::Fetcher::NotFetchable: Failed to fetch Post:4acfd5c387185c99 from vcuculo@diaspora.eigenlab.org: DiasporaFederation::Discovery::DiscoveryError: Failed to fetch http://diaspora.eige$
lab.org/.well-known/host-meta for vcuculo@diaspora.eigenlab.org: RuntimeError: Failed to fetch http://diaspora.eigenlab.org/.well-known/host-meta: 403
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/federation/fetcher.rb:15:in `rescue in fetch_public'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/federation/fetcher.rb:10:in `fetch_public'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/entities/related_entity.rb:43:in `fetch'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/entities/reshare.rb:54:in `validate_root'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/entities/reshare.rb:66:in `tap'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/entities/reshare.rb:66:in `from_hash'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/entity.rb:124:in `from_json'
/home/diaspora/diaspora/lib/archive_importer/entity_importer.rb:27:in `entity'
/home/diaspora/diaspora/lib/archive_importer/entity_importer.rb:14:in `import'
/home/diaspora/diaspora/lib/archive_importer/own_entity_importer.rb:7:in `import'
/home/diaspora/diaspora/lib/archive_importer/post_importer.rb:8:in `import'
/home/diaspora/diaspora/lib/archive_importer.rb:89:in `block in import_collection'
/home/diaspora/diaspora/lib/archive_importer.rb:88:in `each'
/home/diaspora/diaspora/lib/archive_importer.rb:88:in `import_collection'
/home/diaspora/diaspora/lib/archive_importer.rb:76:in `import_posts'
/home/diaspora/diaspora/lib/archive_importer.rb:17:in `import'
/home/diaspora/diaspora/app/services/migration_service.rb:37:in `import_archive'
/home/diaspora/diaspora/app/services/migration_service.rb:20:in `perform!'
/home/diaspora/diaspora/lib/tasks/accounts.rake:22:in `block (2 levels) in <top (required)>'

Caused by:
DiasporaFederation::Discovery::DiscoveryError: Failed to fetch http://diaspora.eigenlab.org/.well-known/host-meta for vcuculo@diaspora.eigenlab.org: RuntimeError: Failed to fetch http://diaspora.eigenlab.org/.well
-known/host-meta: 403
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/discovery/discovery.rb:53:in `rescue in get'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/discovery/discovery.rb:46:in `get'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/discovery/discovery.rb:71:in `legacy_webfinger_url_from_host_meta'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/discovery/discovery.rb:83:in `rescue in webfinger'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/discovery/discovery.rb:75:in `webfinger'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/discovery/discovery.rb:37:in `validate_diaspora_id'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/discovery/discovery.rb:22:in `fetch_and_save'
/home/diaspora/diaspora/app/models/person.rb:325:in `find_or_fetch_by_identifier'
/home/diaspora/diaspora/config/initializers/diaspora_federation.rb:130:in `block (3 levels) in <top (required)>'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/callbacks.rb:47:in `trigger'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/federation/fetcher.rb:29:in `fetch_from_url'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/federation/fetcher.rb:13:in `fetch_public'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/entities/related_entity.rb:43:in `fetch'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/entities/reshare.rb:54:in `validate_root'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/entities/reshare.rb:66:in `tap'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/entities/reshare.rb:66:in `from_hash'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/entity.rb:124:in `from_json'
/home/diaspora/diaspora/lib/archive_importer/entity_importer.rb:27:in `entity'
/home/diaspora/diaspora/lib/archive_importer/entity_importer.rb:14:in `import'
/home/diaspora/diaspora/lib/archive_importer/own_entity_importer.rb:7:in `import'
/home/diaspora/diaspora/lib/archive_importer/post_importer.rb:8:in `import'
/home/diaspora/diaspora/lib/archive_importer.rb:89:in `block in import_collection'
/home/diaspora/diaspora/lib/archive_importer.rb:88:in `each'
/home/diaspora/diaspora/lib/archive_importer.rb:88:in `import_collection'
/home/diaspora/diaspora/lib/archive_importer.rb:76:in `import_posts'
/home/diaspora/diaspora/lib/archive_importer.rb:17:in `import'
/home/diaspora/diaspora/app/services/migration_service.rb:37:in `import_archive'
/home/diaspora/diaspora/app/services/migration_service.rb:20:in `perform!'
/home/diaspora/diaspora/lib/tasks/accounts.rake:22:in `block (2 levels) in <top (required)>'

Caused by:
Failed to fetch http://diaspora.eigenlab.org/.well-known/host-meta: 403
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/discovery/discovery.rb:49:in `get'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/discovery/discovery.rb:71:in `legacy_webfinger_url_from_host_meta'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/discovery/discovery.rb:83:in `rescue in webfinger'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/discovery/discovery.rb:75:in `webfinger'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/discovery/discovery.rb:37:in `validate_diaspora_id'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/discovery/discovery.rb:22:in `fetch_and_save'
/home/diaspora/diaspora/app/models/person.rb:325:in `find_or_fetch_by_identifier'
/home/diaspora/diaspora/config/initializers/diaspora_federation.rb:130:in `block (3 levels) in <top (required)>'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/callbacks.rb:47:in `trigger'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/federation/fetcher.rb:29:in `fetch_from_url'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/federation/fetcher.rb:13:in `fetch_public'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/entities/related_entity.rb:43:in `fetch'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/entities/reshare.rb:54:in `validate_root'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/entities/reshare.rb:66:in `tap'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/entities/reshare.rb:66:in `from_hash'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/entity.rb:124:in `from_json'
/home/diaspora/diaspora/lib/archive_importer/entity_importer.rb:27:in `entity'
/home/diaspora/diaspora/lib/archive_importer/entity_importer.rb:14:in `import'
/home/diaspora/diaspora/lib/archive_importer/own_entity_importer.rb:7:in `import'
/home/diaspora/diaspora/lib/archive_importer/post_importer.rb:8:in `import'
/home/diaspora/diaspora/lib/archive_importer.rb:89:in `block in import_collection'
/home/diaspora/diaspora/lib/archive_importer.rb:88:in `each'
/home/diaspora/diaspora/lib/archive_importer.rb:88:in `import_collection'
/home/diaspora/diaspora/lib/archive_importer.rb:76:in `import_posts'
/home/diaspora/diaspora/lib/archive_importer.rb:17:in `import'
/home/diaspora/diaspora/app/services/migration_service.rb:37:in `import_archive'
/home/diaspora/diaspora/app/services/migration_service.rb:20:in `perform!'
/home/diaspora/diaspora/lib/tasks/accounts.rake:22:in `block (2 levels) in <top (required)>'

Caused by:
DiasporaFederation::Discovery::DiscoveryError: Failed to fetch https://diaspora.eigenlab.org/.well-known/webfinger?resource=acct:vcuculo@diaspora.eigenlab.org for vcuculo@diaspora.eigenlab.org: Faraday::Connection
Failed: SSL peer certificate or SSH remote key was not OK
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/discovery/discovery.rb:53:in `rescue in get'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/discovery/discovery.rb:46:in `get'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/discovery/discovery.rb:80:in `webfinger'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/discovery/discovery.rb:37:in `validate_diaspora_id'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/discovery/discovery.rb:22:in `fetch_and_save'
/home/diaspora/diaspora/app/models/person.rb:325:in `find_or_fetch_by_identifier'
/home/diaspora/diaspora/config/initializers/diaspora_federation.rb:130:in `block (3 levels) in <top (required)>'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/callbacks.rb:47:in `trigger'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/federation/fetcher.rb:29:in `fetch_from_url'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/federation/fetcher.rb:13:in `fetch_public'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/entities/related_entity.rb:43:in `fetch'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/entities/reshare.rb:54:in `validate_root'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/entities/reshare.rb:66:in `tap'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/entities/reshare.rb:66:in `from_hash'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/entity.rb:124:in `from_json'
/home/diaspora/diaspora/lib/archive_importer/entity_importer.rb:27:in `entity'
/home/diaspora/diaspora/lib/archive_importer/entity_importer.rb:14:in `import'
/home/diaspora/diaspora/lib/archive_importer/own_entity_importer.rb:7:in `import'
/home/diaspora/diaspora/lib/archive_importer/post_importer.rb:8:in `import'
/home/diaspora/diaspora/lib/archive_importer.rb:89:in `block in import_collection'
/home/diaspora/diaspora/lib/archive_importer.rb:88:in `each'
/home/diaspora/diaspora/lib/archive_importer.rb:88:in `import_collection'
/home/diaspora/diaspora/lib/archive_importer.rb:76:in `import_posts'
/home/diaspora/diaspora/lib/archive_importer.rb:17:in `import'
/home/diaspora/diaspora/app/services/migration_service.rb:37:in `import_archive'
/home/diaspora/diaspora/app/services/migration_service.rb:20:in `perform!'
/home/diaspora/diaspora/lib/tasks/accounts.rake:22:in `block (2 levels) in <top (required)>'

Caused by:
Faraday::ConnectionFailed: SSL peer certificate or SSH remote key was not OK
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/typhoeus-1.3.1/lib/typhoeus/adapters/faraday.rb:106:in `block in request'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/typhoeus-1.3.1/lib/typhoeus/request/callbacks.rb:146:in `block in execute_callbacks'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/typhoeus-1.3.1/lib/typhoeus/request/callbacks.rb:145:in `each'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/typhoeus-1.3.1/lib/typhoeus/request/callbacks.rb:145:in `execute_callbacks'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/typhoeus-1.3.1/lib/typhoeus/request/operations.rb:35:in `finish'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/typhoeus-1.3.1/lib/typhoeus/easy_factory.rb:164:in `block in set_callback'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/ethon-0.12.0/lib/ethon/easy/response_callbacks.rb:68:in `block in complete'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/ethon-0.12.0/lib/ethon/easy/response_callbacks.rb:68:in `each'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/ethon-0.12.0/lib/ethon/easy/response_callbacks.rb:68:in `complete'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/ethon-0.12.0/lib/ethon/easy/operations.rb:33:in `perform'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/typhoeus-1.3.1/lib/typhoeus/request/operations.rb:16:in `run'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/typhoeus-1.3.1/lib/typhoeus/request/cacheable.rb:18:in `run'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/typhoeus-1.3.1/lib/typhoeus/request/block_connection.rb:31:in `run'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/typhoeus-1.3.1/lib/typhoeus/request/stubbable.rb:25:in `run'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/typhoeus-1.3.1/lib/typhoeus/request/before.rb:26:in `run'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/typhoeus-1.3.1/lib/typhoeus/adapters/faraday.rb:82:in `perform_request'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/typhoeus-1.3.1/lib/typhoeus/adapters/faraday.rb:72:in `call'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/faraday_middleware-0.12.2/lib/faraday_middleware/response/follow_redirects.rb:78:in `perform_with_redirection'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/faraday_middleware-0.12.2/lib/faraday_middleware/response/follow_redirects.rb:66:in `call'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/faraday-0.15.4/lib/faraday/rack_builder.rb:143:in `build_response'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/faraday-0.15.4/lib/faraday/connection.rb:387:in `run_request'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/faraday-0.15.4/lib/faraday/connection.rb:138:in `get'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/http_client.rb:15:in `get'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/discovery/discovery.rb:48:in `get'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/discovery/discovery.rb:80:in `webfinger'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/discovery/discovery.rb:37:in `validate_diaspora_id'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/discovery/discovery.rb:22:in `fetch_and_save'
/home/diaspora/diaspora/app/models/person.rb:325:in `find_or_fetch_by_identifier'
/home/diaspora/diaspora/config/initializers/diaspora_federation.rb:130:in `block (3 levels) in <top (required)>'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/callbacks.rb:47:in `trigger'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/federation/fetcher.rb:29:in `fetch_from_url'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/federation/fetcher.rb:13:in `fetch_public'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/entities/related_entity.rb:43:in `fetch'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/entities/reshare.rb:54:in `validate_root'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/entities/reshare.rb:66:in `tap'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/entities/reshare.rb:66:in `from_hash'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/diaspora_federation-0.2.6/lib/diaspora_federation/entity.rb:124:in `from_json'
/home/diaspora/diaspora/lib/archive_importer/entity_importer.rb:27:in `entity'
/home/diaspora/diaspora/lib/archive_importer/entity_importer.rb:14:in `import'
/home/diaspora/diaspora/lib/archive_importer/own_entity_importer.rb:7:in `import'
/home/diaspora/diaspora/lib/archive_importer/post_importer.rb:8:in `import'
/home/diaspora/diaspora/lib/archive_importer.rb:89:in `block in import_collection'
/home/diaspora/diaspora/lib/archive_importer.rb:88:in `each'
/home/diaspora/diaspora/lib/archive_importer.rb:88:in `import_collection'
/home/diaspora/diaspora/lib/archive_importer.rb:76:in `import_posts'
/home/diaspora/diaspora/lib/archive_importer.rb:17:in `import'
/home/diaspora/diaspora/app/services/migration_service.rb:37:in `import_archive'
/home/diaspora/diaspora/app/services/migration_service.rb:20:in `perform!'
/home/diaspora/diaspora/lib/tasks/accounts.rake:22:in `block (2 levels) in <top (required)>'
Tasks: TOP => accounts:migration
(See full trace by running task with --trace)
````

This hopefully fixes that