### PR TITLE
Pass normalized URI to OpenGraphReader

### DIFF
--- a/app/models/open_graph_cache.rb
+++ b/app/models/open_graph_cache.rb
@@ -33,7 +33,9 @@ class OpenGraphCache < ApplicationRecord
   end
 
   def fetch_and_save_opengraph_data!
-    object = OpenGraphReader.fetch!(self.url)
+    uri = URI.parse(url.start_with?("http") ? url : "http://#{url}")
+    uri.normalize!
+    object = OpenGraphReader.fetch!(uri)
 
     return unless object
 


### PR DESCRIPTION
This ensures the hostname is downcase and thus subsequent third party library
assumptions hold, namely http-cookie (pulled through faraday-cookie_jar) doesn't
raise.

Had this nice little puzzle turn up:

```
RuntimeError: domain is missing
  from app/models/open_graph_cache.rb:36:in `fetch_and_save_opengraph_data!'
  from app/models/open_graph_cache.rb:31:in `find_or_create_by'
  from app/workers/gather_open_graph_data.rb:14:in `perform'
```
Digging a full backtrace:
```
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/http-cookie-1.0.3/lib/http/cookie.rb:572:in `acceptable?'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/http-cookie-1.0.3/lib/http/cookie.rb:320:in `block (2 levels) in parse'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/http-cookie-1.0.3/lib/http/cookie/scanner.rb:214:in `scan_set_cookie'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/http-cookie-1.0.3/lib/http/cookie.rb:281:in `block in parse'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/http-cookie-1.0.3/lib/http/cookie.rb:280:in `tap'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/http-cookie-1.0.3/lib/http/cookie.rb:280:in `parse'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/http-cookie-1.0.3/lib/http/cookie_jar.rb:191:in `parse'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/faraday-cookie_jar-0.0.6/lib/faraday/cookie_jar.rb:25:in `block in call'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/faraday-0.15.4/lib/faraday/response.rb:61:in `on_complete'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/faraday-cookie_jar-0.0.6/lib/faraday/cookie_jar.rb:22:in `call'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/faraday_middleware-0.12.2/lib/faraday_middleware/response/follow_redirects.rb:78:in `perform_with_redirection'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/faraday_middleware-0.12.2/lib/faraday_middleware/response/follow_redirects.rb:66:in `call'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/faraday-0.15.4/lib/faraday/rack_builder.rb:143:in `build_response'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/faraday-0.15.4/lib/faraday/connection.rb:387:in `run_request'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/faraday-0.15.4/lib/faraday/connection.rb:138:in `head'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/open_graph_reader-0.6.2/lib/open_graph_reader/fetcher.rb:60:in `fetch_headers'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/open_graph_reader-0.6.2/lib/open_graph_reader/fetcher.rb:81:in `html?'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/open_graph_reader-0.6.2/lib/open_graph_reader.rb:26:in `fetch!'
/home/diaspora/diaspora/vendor/bundle/ruby/2.4.0/gems/open_graph_reader-0.6.2/lib/open_graph_reader.rb:29:in `fetch!'
```

`OpenGraphCache#url` was `"Wetter.com"` for this case and somewhere rejected as valid domain for the cookie, or something like that. Anyway, this fixes this.