### PR TITLE
Fix some 2FA login problems

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -19,14 +19,14 @@ class SessionsController < Devise::SessionsController
 
   def authenticate_with_2fa
     self.resource = find_user
-    u = find_user
 
-    return true unless u&.otp_required_for_login?
+    return true unless resource&.otp_required_for_login?
 
     if params[:user][:otp_attempt].present? && session[:otp_user_id]
-      authenticate_with_two_factor_via_otp(u)
-    elsif u&.valid_password?(params[:user][:password])
-      prompt_for_two_factor(u)
+      authenticate_with_two_factor_via_otp(resource)
+    else
+      strategy = Warden::Strategies[:database_authenticatable].new(warden.env, :user)
+      prompt_for_two_factor(strategy.user) if strategy.valid? && strategy._run!.successful?
     end
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,9 +12,9 @@ class SessionsController < Devise::SessionsController
   # rubocop:enable Rails/LexicallyScopedActionFilter
 
   def find_user
-    return User.find(session[:otp_user_id]) if session[:otp_user_id]
+    return User.find_for_authentication(username: params[:user][:username]) if params[:user][:username]
 
-    User.find_for_authentication(username: params[:user][:username]) if params[:user][:username]
+    User.find(session[:otp_user_id]) if session[:otp_user_id]
   end
 
   def authenticate_with_2fa

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -591,6 +591,10 @@ class User < ApplicationRecord
     end
   end
 
+  def remember_me
+    true
+  end
+
   private
 
   def clearable_fields

--- a/app/views/devise/passwords/edit.haml
+++ b/app/views/devise/passwords/edit.haml
@@ -37,7 +37,6 @@
                            autocorrect:    "off",
                            aria:           {labelledby: "passwordConfirmationLabel"}
 
-      = hidden_field(:user, :remember_me, value: 1)
       = f.submit t("devise.passwords.edit.change_password"), class: "btn btn-block btn-primary"
 
     .text-center

--- a/app/views/sessions/_form.haml
+++ b/app/views/sessions/_form.haml
@@ -40,5 +40,4 @@
                        autocorrect: "off",
                        aria: {labelledby: "passwordLabel"}
 
-  = f.hidden_field :remember_me, value: 1
   = f.submit t("devise.sessions.new.sign_in"), class: "btn btn-large btn-block btn-primary"

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -15,11 +15,6 @@ end
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
-  config.warden do |manager|
-    manager.default_strategies(scope: :user).unshift :two_factor_authenticatable
-    manager.default_strategies(scope: :user).unshift :two_factor_backupable
-  end
-
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.


### PR DESCRIPTION
* Fixes  #8023
* Fixes that `remove_after` isn't cleared after a successful login if the user has 2FA enabled.
* Fixes weird behaviour when half logging in with an OTP user and then trying to login with a different user.