### PR TITLE
8018 Do not show getting started after account import

### DIFF
--- a/lib/archive_importer.rb
+++ b/lib/archive_importer.rb
@@ -25,10 +25,12 @@ class ArchiveImporter
       email strip_exif show_community_spotlight_in_stream language disable_mail auto_follow_back
     ]
     data = convert_keys(archive_hash["user"], allowed_keys)
+    # setting getting_started to false as the user doesn't need to see the getting started wizard
     data.merge!(
       username:              attr[:username],
       password:              attr[:password],
       password_confirmation: attr[:password],
+      getting_started:       false,
       person:                {
         profile_attributes: profile_attributes
       }

--- a/spec/lib/archive_importer_spec.rb
+++ b/spec/lib/archive_importer_spec.rb
@@ -155,6 +155,7 @@ describe ArchiveImporter do
       expect(archive_importer.user.language).to eq("ru")
       expect(archive_importer.user.disable_mail).to eq(false)
       expect(archive_importer.user.auto_follow_back).to eq(true)
+      expect(archive_importer.user.getting_started).to be_falsey
 
       expect(archive_importer.user.profile.first_name).to eq("First")
       expect(archive_importer.user.profile.last_name).to eq("Last")


### PR DESCRIPTION
Copy 'getting_started' value for user when he is being migrated. 
https://github.com/diaspora/diaspora/issues/8018