### PR TITLE
Remove commentable functionality from photos

### DIFF
--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -6,7 +6,6 @@
 
 class Photo < ApplicationRecord
   include Diaspora::Federated::Base
-  include Diaspora::Commentable
   include Diaspora::Shareable
 
   # NOTE API V1 to be extracted

--- a/db/migrate/20190701234716_photos_remove_comment_count.rb
+++ b/db/migrate/20190701234716_photos_remove_comment_count.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class PhotosRemoveCommentCount < ActiveRecord::Migration[5.1]
+  class Comment < ApplicationRecord
+  end
+
+  def change
+    remove_column :photos, :comments_count, :integer
+
+    reversible do |change|
+      change.up { Comment.where(commentable_type: "Photo").delete_all }
+    end
+  end
+end


### PR DESCRIPTION
This is not (and as far as I know, was never) used. If we want to make standalone photos commentable, we can always add it back, but it would also need to change federation for it to work, because comments support only posts there. But for now it makes the code cleaner and easier to remove it.