### PR TITLE
Cleanup pending photos which were never posted with cronjob

### DIFF
--- a/app/workers/cleanup_pending_photos.rb
+++ b/app/workers/cleanup_pending_photos.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Workers
+  class CleanupPendingPhotos < Base
+    sidekiq_options queue: :low
+
+    def perform
+      Photo.where(pending: true).where("created_at < ?", 1.day.ago).destroy_all
+    end
+  end
+end

--- a/config/initializers/sidekiq_scheduled.rb
+++ b/config/initializers/sidekiq_scheduled.rb
@@ -29,6 +29,11 @@ def default_job_config
       "class": "Workers::CleanupOldExports"
     },
 
+    cleanup_pending_photos:  {
+      "cron":  "#{random_minute.call} #{random_hour.call} * * *",
+      "class": "Workers::CleanupPendingPhotos"
+    },
+
     queue_users_for_removal: {
       "cron":  "#{random_minute.call} #{random_hour.call} * * *",
       "class": "Workers::QueueUsersForRemoval"

--- a/spec/workers/cleanup_pending_photos_spec.rb
+++ b/spec/workers/cleanup_pending_photos_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+describe Workers::CleanupPendingPhotos do
+  let!(:photo) { FactoryGirl.create(:photo, author: alice.person, pending: true) }
+
+  it "removes pending photos" do
+    Timecop.travel(25.hours) do
+      Workers::CleanupPendingPhotos.new.perform
+      expect(Photo).not_to exist(photo.id)
+    end
+  end
+
+  it "does not remove pending photos newer than one day" do
+    Timecop.travel(1.hour) do
+      Workers::CleanupPendingPhotos.new.perform
+      expect(Photo).to exist(photo.id)
+    end
+  end
+
+  it "does not remove posted photos" do
+    StatusMessageCreationService.new(alice).create(
+      status_message: {text: "Post with photo"},
+      public:         true,
+      photos:         [photo.id]
+    )
+    Timecop.travel(25.hours) do
+      Workers::CleanupPendingPhotos.new.perform
+      expect(Photo).to exist(photo.id)
+    end
+  end
+end


### PR DESCRIPTION
Only delete photos older than a day, so we don't delete photos for posts which were uploaded 10 minutes ago and the author is still writing the post for it.