### PR TITLE
Migrate pending profile photos and fix upload to unpend profile photos

### DIFF
--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -153,12 +153,7 @@ class PhotosController < ApplicationController
         current_user.dispatch_post(@photo, to: photo_params[:aspect_ids])
       end
 
-      if photo_params[:set_profile_photo]
-        profile_params = {image_url:        @photo.url(:thumb_large),
-                          image_url_medium: @photo.url(:thumb_medium),
-                          image_url_small:  @photo.url(:thumb_small)}
-        current_user.update_profile(profile_params)
-      end
+      current_user.update_profile(photo: @photo) if photo_params[:set_profile_photo]
 
       respond_to do |format|
         format.json { render(layout: false, json: {"success" => true, "data" => @photo}.to_json) }

--- a/db/migrate/20190703231700_fix_pending_profile_photos.rb
+++ b/db/migrate/20190703231700_fix_pending_profile_photos.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class FixPendingProfilePhotos < ActiveRecord::Migration[5.1]
+  def up
+    Photo.where(pending: true).each do |photo|
+      photo.update(pending: false) if Profile.where(image_url: photo.url(:thumb_large)).exists?
+    end
+  end
+end

--- a/spec/controllers/photos_controller_spec.rb
+++ b/spec/controllers/photos_controller_spec.rb
@@ -44,7 +44,7 @@ describe PhotosController, :type => :controller do
   describe '#create' do
     before do
       allow(@controller).to receive(:file_handler).and_return(uploaded_photo)
-      @params = {:photo => {:user_file => uploaded_photo, :aspect_ids => "all"} }
+      @params = {photo: {user_file: uploaded_photo, aspect_ids: "all", pending: true}}
     end
 
     it "creates a photo" do
@@ -67,11 +67,13 @@ describe PhotosController, :type => :controller do
       expect(Photo.last.author).to eq(alice.person)
     end
 
-    it 'can set the photo as the profile photo' do
+    it "can set the photo as the profile photo and unpends the photo" do
       old_url = alice.person.profile.image_url
       @params[:photo][:set_profile_photo] = true
       post :create, params: @params
-      expect(alice.reload.person.profile.image_url).not_to eq(old_url)
+      new_url = alice.reload.person.profile.image_url
+      expect(new_url).not_to eq(old_url)
+      expect(Photo.find_by(remote_photo_name: new_url.rpartition("_").last).pending).to be_falsey
     end
   end
 


### PR DESCRIPTION
fixes #8043

(I actually tested that profile photos aren't deleted, but I saved my profile after uploading the photos, but this only happened when you didn't save but only upload a new photo m( )