### PR TITLE
Update open_graph_reader to 0.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ cache:
     - app/assets/images
     - tmp/cache/assets
 
+addons:
+  apt:
+    packages: libidn11-dev
+
 branches:
   only:
     - 'master'

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,9 @@ cache:
 
 addons:
   apt:
-    packages: libidn11-dev
+    packages: 
+      - libidn11-dev
+      - ghostscript
 
 services:
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ addons:
   apt:
     packages: libidn11-dev
 
+services:
+  - postgresql
+  - mysql
+
 branches:
   only:
     - 'master'

--- a/Gemfile
+++ b/Gemfile
@@ -147,7 +147,7 @@ gem "leaflet-rails",       "1.5.1"
 # Parsing
 
 gem "nokogiri",          "1.10.3"
-gem "open_graph_reader", "0.6.2" # also update User-Agent in features/support/webmock.rb
+gem "open_graph_reader", "0.7.0" # also update User-Agent in features/support/webmock.rb
 gem "redcarpet",         "3.4.0"
 gem "ruby-oembed",       "0.12.0"
 gem "twitter-text",      "3.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -444,7 +444,7 @@ GEM
       rack
     omniauth-wordpress (0.2.2)
       omniauth-oauth2 (>= 1.1.0)
-    open_graph_reader (0.6.2)
+    open_graph_reader (0.7.0)
       faraday (>= 0.9.0)
       nokogiri (~> 1.6)
     openid_connect (1.1.8)
@@ -855,7 +855,7 @@ DEPENDENCIES
   omniauth-tumblr (= 1.2)
   omniauth-twitter (= 1.4.0)
   omniauth-wordpress (= 0.2.2)
-  open_graph_reader (= 0.6.2)
+  open_graph_reader (= 0.7.0)
   openid_connect (= 1.1.8)
   pg (= 1.1.4)
   poltergeist (= 1.18.1)

--- a/features/support/webmock.rb
+++ b/features/support/webmock.rb
@@ -7,7 +7,7 @@ Before do
   stub_request(:head, /.+/).with(
     headers: {
       "Accept"     => "text/html",
-      "User-Agent" => "OpenGraphReader/0.6.2 (+https://github.com/jhass/open_graph_reader)"
+      "User-Agent" => "OpenGraphReader/0.7.0 (+https://github.com/jhass/open_graph_reader)"
     }
   ).to_return(status: 200, body: "", headers: {"Content-Type" => "text/plain"})
 end

--- a/spec/models/open_graph_cache_spec.rb
+++ b/spec/models/open_graph_cache_spec.rb
@@ -63,7 +63,7 @@ describe OpenGraphCache, type: :model do
         stub_request(:head, "http:///wetter.com")
           .with(headers: {
                   "Accept"     => "text/html",
-                  "User-Agent" => "OpenGraphReader/0.6.2 (+https://github.com/jhass/open_graph_reader)"
+                  "User-Agent" => "OpenGraphReader/0.7.0 (+https://github.com/jhass/open_graph_reader)"
                 })
           .to_return(status: 200, body: "", headers:
             {"Set-Cookie" => "Dabgroup=A;path=/;Expires=Thu, 23 May 2019 16:12:01 GMT;httpOnly"})


### PR DESCRIPTION
This should fix 
```
undefined method `og' for #<OpenGraphReader::Base:0x00007f73c53f2308 @bases={}>
```
for sites that have OpenGraph tags of other namespaces but no actual OpenGraph core tags