### PR TITLE
Handle missing parent when deleting comment

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -47,8 +47,8 @@ class Comment < ApplicationRecord
   end
 
   after_destroy do
-    self.parent.update_comments_counter
-    participation = author.participations.find_by(target_id: post.id)
+    parent&.update_comments_counter
+    participation = author.participations.find_by(target_id: commentable_id)
     participation.unparticipate! if participation.present?
   end
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -24,6 +24,14 @@ describe Comment, type: :model do
       participations = Participation.where(target_id: comment_alice.commentable_id, author_id: comment_alice.author_id)
       expect(participations.first.count).to eq(1)
     end
+
+    it "should work if parent is gone" do
+      comment_alice.parent.delete
+      comment_alice.reload
+      expect {
+        comment_alice.destroy
+      }.to_not raise_error
+    end
   end
 
   describe "#subscribers" do


### PR DESCRIPTION
When a post is deleted, a comment retraction might race with a post retraction,
causing the comment deletion to raise because of a missing parent.

Fixes
```
NoMethodError: undefined method `update_comments_counter' for nil:NilClass
  from app/models/comment.rb:50:in `block in <class:Comment>'
  from lib/diaspora/federation/receive.rb:177:in `retraction'
  from config/initializers/diaspora_federation.rb:112:in `block (3 levels) in <top (required)>'
  from app/workers/receive_private.rb:13:in `block in perform'
  from app/workers/receive_base.rb:11:in `filter_errors_for_retry'
  from app/workers/receive_private.rb:10:in `perform'