### PR TITLE
Handle processing a mention in a comment of an already deleted post

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -138,7 +138,9 @@ class Person < ApplicationRecord
   # @param [Post] the post for which we query mentionable in comments people
   # @return [Person::ActiveRecord_Relation]
   scope :allowed_to_be_mentioned_in_a_comment_to, ->(post) {
-    allowed = if post.public?
+    allowed = if post.nil?
+                none
+              elsif post.public?
                 all
               else
                 left_join_visible_post_interactions_on_authorship(post.id)

--- a/spec/models/notifications/mentioned_spec.rb
+++ b/spec/models/notifications/mentioned_spec.rb
@@ -63,5 +63,16 @@ describe Notifications::Mentioned do
       expect(TestNotification).not_to receive(:create_notification)
       TestNotification.notify(status_message, nil)
     end
+
+    it "doesn't create a notification for a mention in a comment of an already deleted post" do
+      post = FactoryGirl.create(:status_message, public: true)
+      comment = FactoryGirl.create(:comment, commentable: post, text: text_mentioning(alice))
+      post.delete
+      comment.reload
+
+      expect {
+        Notifications::MentionedInComment.notify(comment, [alice])
+      }.to_not change(Notification, :count)
+    end
   end
 end


### PR DESCRIPTION
```
NoMethodError: undefined method `public?' for nil:NilClass
  from app/models/person.rb:141:in `block in <class:Person>'
  from app/models/notifications/mentioned_in_comment.rb:16:in `filter_mentions'
  from app/models/notifications/mentioned.rb:14:in `notify'
  from app/services/notification_service.rb:15:in `block in notify'
  from app/services/notification_service.rb:15:in `each'
  from app/services/notification_service.rb:15:in `notify'
  from app/workers/receive_local.rb:12:in `perform'
```