### PR TITLE
Drop rails-assets.org dependency.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,7 @@ gem "js-routes",         "1.4.7"
 gem "js_image_paths",    "0.1.1"
 gem "sprockets-es6",     "0.9.2"
 
-source "https://rails-assets.org" do
+source "https://gems.diasporafoundation.org" do
   gem "rails-assets-jquery",                              "3.4.1" # Should be kept in sync with jquery-rails
   gem "rails-assets-jquery.ui",                           "1.11.4"
 
@@ -312,7 +312,7 @@ group :development, :test do
   # Jasmine (client side application tests (JS))
   gem "jasmine",                   "3.4.0"
   gem "jasmine-jquery-rails",      "2.0.3"
-  gem "rails-assets-jasmine-ajax", "4.0.0", source: "https://rails-assets.org"
+  gem "rails-assets-jasmine-ajax", "4.0.0", source: "https://gems.diasporafoundation.org"
   gem "sinon-rails",               "1.15.0"
 
   # For `assigns` in controller specs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GEM
   remote: https://rubygems.org/
-  remote: https://rails-assets.org/
+  remote: https://gems.diasporafoundation.org/
   specs:
     actioncable (5.1.7)
       actionpack (= 5.1.7)


### PR DESCRIPTION
... and replace it with our own Gem cache. This isn't pretty, as we have to manage that one ourselves, and pushing updates requires a core-team member, but rails-assets.org has become way too unreliable for us to be a viable option. This closes #8062.

We're currently into a already 20-hour long downtime (see https://github.com/tenex/rails-assets/issues/462), with no solution on the horizon. This is not only risking lots of trouble for people setting up new pods or updating existing, it is also actively blocking us from merging a PR at the moment, because we have no CI coverage.

This move is... kinda sad, especially since I made a significant financial contribution to rails-assets.org last year in the hopes of helping stabilizing the service. It only got worse, so this has to be done.

This solution is not perfect, as any asset changes now require manual action from the core team. Ideally, when rails-assets.org is back up, this is as easy as downloading the gem from there and pushing it to our host. But since the server requires authentication for uploads, this can only be done by someone with access to our infrastructure. I think that's fair, though, as we're in the process of merging the API and then eventually rebuilding our frontend anyway.

For whoever merges this (r? @jhass and/or @SuperTux88):

* I populated the cache with gems currently in use in `develop` *and* `master`/`next-minor`, so this can be uplifted to all branches. But please verify that, as gems can be... weird.
* I used Geraspora's gem cache as a source for populating the cache. If you SSH into `starsupport`, you can find all source files in `/srv/geminabox/gemsrc`.
* The server is running `geminabox`, see [this](https://github.com/geminabox/geminabox#client-usage) for instructions on how to push gems. However, uploading/changing things requires HTTP auth. Check `/srv/geminabox/config.ru` for details, and ping me if you need help.