### PR TITLE
Re-add sizes.raw to the photo JSON

### DIFF
--- a/app/presenters/photo_presenter.rb
+++ b/app/presenters/photo_presenter.rb
@@ -12,7 +12,8 @@ class PhotoPresenter < BasePresenter
       sizes:      {
         small:  url(:thumb_small),
         medium: url(:thumb_medium),
-        large:  url(:scaled_full)
+        large:  url(:scaled_full),
+        raw:    url
       }
     }
   end
@@ -26,7 +27,8 @@ class PhotoPresenter < BasePresenter
       sizes:      {
         small:  url(:thumb_small),
         medium: url(:thumb_medium),
-        large:  url(:scaled_full)
+        large:  url(:scaled_full),
+        raw:    url
       }
     }
 

--- a/lib/schemas/api_v1.json
+++ b/lib/schemas/api_v1.json
@@ -205,11 +205,12 @@
     "photo_sizes": {
       "type": "object",
       "properties": {
+        "raw": { "$ref": "#/definitions/url" },
         "large": { "$ref": "#/definitions/url" },
         "medium": { "$ref": "#/definitions/url" },
         "small": { "$ref": "#/definitions/url" }
       },
-      "required": ["large", "medium", "small"],
+      "required": ["raw", "large", "medium", "small"],
       "additionalProperties": true
     },
 

--- a/lib/schemas/api_v1.json
+++ b/lib/schemas/api_v1.json
@@ -211,7 +211,7 @@
         "small": { "$ref": "#/definitions/url" }
       },
       "required": ["raw", "large", "medium", "small"],
-      "additionalProperties": true
+      "additionalProperties": false
     },
 
     "photo_dimensions": {

--- a/spec/presenters/photo_presenter_spec.rb
+++ b/spec/presenters/photo_presenter_spec.rb
@@ -34,6 +34,7 @@ describe PhotoPresenter do
     expect(photo[:sizes][:small]).to be_truthy
     expect(photo[:sizes][:medium]).to be_truthy
     expect(photo[:sizes][:large]).to be_truthy
+    expect(photo[:sizes][:raw]).to be_truthy
   end
   # rubocop:enable Metrics/AbcSize
 end


### PR DESCRIPTION
... because we need it for showing the raw image in the lightbox. This got lost, as the photo extension was made after API development started.

There are no integration tests for the lightbox, and since I don't want to spend two days on hotfixing a regression, we won't have integration tests after this PR either. But at least we have spec coverage now, so.. yay?