### PR TITLE
API: ensure nsfw field in post is returned as a boolean

### DIFF
--- a/app/models/status_message.rb
+++ b/app/models/status_message.rb
@@ -58,7 +58,7 @@ class StatusMessage < Post
   end
 
   def nsfw
-    text.try(:match, /#nsfw/i) || super
+    !!(text.try(:match, /#nsfw/i) || super) # rubocop:disable Style/DoubleNegation
   end
 
   def comment_email_subject

--- a/spec/integration/api/posts_controller_spec.rb
+++ b/spec/integration/api/posts_controller_spec.rb
@@ -80,7 +80,7 @@ describe Api::V1::PostsController do
 
     context "access full post by post ID" do
       it "gets post" do
-        base_params = {status_message: {text: "myText"}, public: true}
+        base_params = {status_message: {text: "myText #nsfw"}, public: true}
         poll_params = {poll_question: "something?", poll_answers: %w[yes no maybe]}
         location_params = {location_address: "somewhere", location_coords: "1,2"}
         merged_params = base_params.merge(location_params)
@@ -694,7 +694,7 @@ describe Api::V1::PostsController do
     expect(post["post_type"]).to eq(reference_post.post_type)
     expect(post["provider_display_name"]).to eq(reference_post.provider_display_name)
     expect(post["public"]).to eq(reference_post.public)
-    expect(post["nsfw"]).to eq(reference_post.nsfw)
+    expect(post["nsfw"]).to eq(!!reference_post.nsfw) # rubocop:disable Style/DoubleNegation
   end
 
   def confirm_interactions(interactions, reference_post)


### PR DESCRIPTION
No idea why this wasn't catched by the JSON schema validation...