### PR TITLE
Use full references in API JSON schema

### DIFF
--- a/lib/schemas/api_v1.json
+++ b/lib/schemas/api_v1.json
@@ -2,23 +2,23 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "https://diaspora.software/api/v1/schema.json",
   "oneOf": [
-    {"$ref": "#/definitions/aspects"},
-    {"$ref": "#/definitions/aspect"},
-    {"$ref": "#/definitions/comments_or_messages"},
-    {"$ref": "#/definitions/users"},
-    {"$ref": "#/definitions/conversations"},
-    {"$ref": "#/definitions/conversation"},
-    {"$ref": "#/definitions/authored_content_references"},
-    {"$ref": "#/definitions/likes"},
-    {"$ref": "#/definitions/notifications"},
-    {"$ref": "#/definitions/notification"},
-    {"$ref": "#/definitions/photos"},
-    {"$ref": "#/definitions/photo"},
-    {"$ref": "#/definitions/post"},
-    {"$ref": "#/definitions/posts"},
-    {"$ref": "#/definitions/tags"},
-    {"$ref": "#/definitions/own_user"},
-    {"$ref": "#/definitions/user"}
+    {"$ref": "https://diaspora.software/api/v1/schema.json#/definitions/aspects"},
+    {"$ref": "https://diaspora.software/api/v1/schema.json#/definitions/aspect"},
+    {"$ref": "https://diaspora.software/api/v1/schema.json#/definitions/comments_or_messages"},
+    {"$ref": "https://diaspora.software/api/v1/schema.json#/definitions/users"},
+    {"$ref": "https://diaspora.software/api/v1/schema.json#/definitions/conversations"},
+    {"$ref": "https://diaspora.software/api/v1/schema.json#/definitions/conversation"},
+    {"$ref": "https://diaspora.software/api/v1/schema.json#/definitions/authored_content_references"},
+    {"$ref": "https://diaspora.software/api/v1/schema.json#/definitions/likes"},
+    {"$ref": "https://diaspora.software/api/v1/schema.json#/definitions/notifications"},
+    {"$ref": "https://diaspora.software/api/v1/schema.json#/definitions/notification"},
+    {"$ref": "https://diaspora.software/api/v1/schema.json#/definitions/photos"},
+    {"$ref": "https://diaspora.software/api/v1/schema.json#/definitions/photo"},
+    {"$ref": "https://diaspora.software/api/v1/schema.json#/definitions/post"},
+    {"$ref": "https://diaspora.software/api/v1/schema.json#/definitions/posts"},
+    {"$ref": "https://diaspora.software/api/v1/schema.json#/definitions/tags"},
+    {"$ref": "https://diaspora.software/api/v1/schema.json#/definitions/own_user"},
+    {"$ref": "https://diaspora.software/api/v1/schema.json#/definitions/user"}
   ],
 
   "definitions": {
@@ -41,10 +41,10 @@
     "short_profile": {
       "type": "object",
       "properties": {
-        "guid": { "$ref": "#/definitions/guid" },
+        "guid": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/guid" },
         "diaspora_id": { "type": "string" },
         "name": { "type": "string" },
-        "avatar": { "$ref": "#/definitions/url" }
+        "avatar": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/url" }
       },
       "required": ["guid", "diaspora_id", "name"],
       "additionalProperties": false
@@ -92,9 +92,9 @@
       "items": {
         "type": "object",
         "properties": {
-          "guid": { "$ref": "#/definitions/guid" },
-          "created_at": { "$ref": "#/definitions/timestamp" },
-          "author": { "$ref": "#/definitions/short_profile" },
+          "guid": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/guid" },
+          "created_at": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/timestamp" },
+          "author": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/short_profile" },
           "body": { "type": "string" }
         },
         "required": ["guid", "created_at", "author", "body"],
@@ -104,24 +104,24 @@
 
     "users": {
       "type": "array",
-      "items": { "$ref": "#/definitions/short_profile" }
+      "items": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/short_profile" }
     },
 
     "conversations": {
       "type": "array",
-      "items": { "$ref": "#/definitions/conversation" }
+      "items": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/conversation" }
     },
 
     "conversation": {
       "type": "object",
       "properties": {
-        "guid": { "$ref": "#/definitions/guid" },
+        "guid": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/guid" },
         "subject": { "type": "string" },
-        "created_at": { "$ref": "#/definitions/timestamp" },
+        "created_at": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/timestamp" },
         "read": { "type": "boolean" },
         "participants": {
           "type": "array",
-          "items": { "$ref": "#/definitions/short_profile" }
+          "items": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/short_profile" }
         }
       },
       "required": ["subject", "created_at", "read", "participants"],
@@ -130,10 +130,10 @@
 
     "authored_content_reference": {
       "type": "object",
-      "created_at": { "$ref": "#/definitions/timestamp" },
+      "created_at": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/timestamp" },
       "properties": {
-        "guid": { "$ref": "#/definitions/guid" },
-        "author": { "$ref": "#/definitions/short_profile" }
+        "guid": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/guid" },
+        "author": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/short_profile" }
       },
       "required": ["guid", "created_at", "author"],
       "additionalProperties": false
@@ -141,7 +141,7 @@
 
     "authored_content_references": {
       "type": "array",
-      "items": { "$ref": "#/definitions/authored_content_reference" }
+      "items": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/authored_content_reference" }
     },
 
     "likes": {
@@ -149,8 +149,8 @@
       "items": {
         "type": "object",
         "properties": {
-          "guid": { "$ref": "#/definitions/guid" },
-          "author": { "$ref": "#/definitions/short_profile" }
+          "guid": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/guid" },
+          "author": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/short_profile" }
         },
         "required": ["guid", "author"],
         "additionalProperties": false
@@ -159,13 +159,13 @@
 
     "notifications": {
       "type": "array",
-      "items": { "$ref": "#/definitions/notification" }
+      "items": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/notification" }
     },
 
     "notification": {
       "type": "object",
       "properties": {
-        "guid": { "$ref": "#/definitions/guid" },
+        "guid": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/guid" },
         "type": {
           "enum": [
             "also_commented",
@@ -179,18 +179,18 @@
           ]
         },
         "read": { "type": "boolean" },
-        "created_at": { "$ref": "#/definitions/timestamp" },
+        "created_at": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/timestamp" },
         "target": {
           "type": "object",
           "properties": {
-            "guid": { "$ref": "#/definitions/guid" },
-            "author": { "$ref": "#/definitions/short_profile" }
+            "guid": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/guid" },
+            "author": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/short_profile" }
           },
           "required": ["guid"]
         },
         "event_creators": {
           "type": "array",
-          "items": { "$ref": "#/definitions/short_profile" }
+          "items": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/short_profile" }
         }
       },
       "required": ["guid", "type", "read", "created_at", "target"],
@@ -199,15 +199,15 @@
 
     "photos": {
       "type": "array",
-      "items": { "$ref": "#/definitions/photo"}
+      "items": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/photo"}
     },
 
     "photo_sizes": {
       "type": "object",
       "properties": {
-        "large": { "$ref": "#/definitions/url" },
-        "medium": { "$ref": "#/definitions/url" },
-        "small": { "$ref": "#/definitions/url" }
+        "large": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/url" },
+        "medium": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/url" },
+        "small": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/url" }
       },
       "required": ["large", "medium", "small"],
       "additionalProperties": true
@@ -225,11 +225,11 @@
     "photo": {
       "type": "object",
       "properties": {
-        "guid": { "$ref": "#/definitions/guid" },
-        "post": { "$ref": "#/definitions/guid" },
-        "created_at": { "$ref": "#/definitions/timestamp" },
-        "dimensions": { "$ref": "#/definitions/photo_dimensions" },
-        "sizes": { "$ref": "#/definitions/photo_sizes" }
+        "guid": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/guid" },
+        "post": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/guid" },
+        "created_at": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/timestamp" },
+        "dimensions": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/photo_dimensions" },
+        "sizes": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/photo_sizes" }
       },
       "required": ["guid", "created_at", "dimensions", "sizes"],
       "additionalProperties": false
@@ -238,14 +238,14 @@
     "post_common": {
       "type": "object",
       "properties": {
-        "guid": { "$ref": "#/definitions/guid" },
-        "created_at": { "$ref": "#/definitions/timestamp" },
+        "guid": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/guid" },
+        "created_at": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/timestamp" },
         "title": { "type": "string" },
         "body": { "type": "string" },
         "provider_display_name": { "type": "string" },
         "public": { "type": "boolean" },
         "nsfw": { "type": "boolean" },
-        "author": { "$ref": "#/definitions/short_profile" },
+        "author": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/short_profile" },
         "interaction_counters": {
           "type": "object",
           "properties": {
@@ -258,15 +258,15 @@
         },
         "mentioned_people": {
           "type": "array",
-          "items": { "$ref": "#/definitions/short_profile" }
+          "items": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/short_profile" }
         },
         "photos": {
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
-              "dimensions": { "$ref": "#/definitions/photo_dimensions" },
-              "sizes": { "$ref": "#/definitions/photo_sizes" }
+              "dimensions": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/photo_dimensions" },
+              "sizes": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/photo_sizes" }
             },
             "required": ["dimensions", "sizes"]
           }
@@ -274,7 +274,7 @@
         "poll": {
           "type": "object",
           "properties": {
-            "guid": { "$ref": "#/definitions/guid" },
+            "guid": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/guid" },
             "participation_count": { "type": "integer" },
             "already_participated": { "type": "boolean" },
             "question": { "type": "string" },
@@ -313,7 +313,7 @@
       "anyOf": [
         {
           "allOf": [
-            { "$ref": "#/definitions/post_common" },
+            { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/post_common" },
             {
               "properties": {
                 "post_type": { "type": "string", "format": "^StatusMessage$" }
@@ -324,11 +324,11 @@
         },
         {
           "allOf": [
-            { "$ref": "#/definitions/post_common" },
+            { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/post_common" },
             {
               "properties": {
                 "post_type": { "type": "string", "format": "^Reshare$" },
-                "root": { "$ref": "#/definitions/authored_content_reference" }
+                "root": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/authored_content_reference" }
               },
               "required": ["post_type", "root"]
             }
@@ -342,9 +342,9 @@
       "items": {
         "type": "object",
         "properties": {
-          "guid":  { "$ref": "#/definitions/guid" },
-          "created_at": { "$ref": "#/definitions/timestamp" },
-          "author": { "$ref": "#/definitions/short_profile" }
+          "guid":  { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/guid" },
+          "created_at": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/timestamp" },
+          "author": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/short_profile" }
         },
         "required": ["guid", "created_at", "author"],
         "additionalProperties": false
@@ -353,7 +353,7 @@
 
     "posts": {
       "type": "array",
-      "items": { "$ref": "#/definitions/post" }
+      "items": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/post" }
     },
 
     "tags": {
@@ -366,22 +366,22 @@
     "user_data": {
       "type": "object",
       "properties": {
-        "guid": { "$ref": "#/definitions/guid" },
+        "guid": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/guid" },
         "diaspora_id": { "type": "string" },
         "name": { "type": "string" },
-        "birthday": { "$ref": "#/definitions/birthday" },
+        "birthday": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/birthday" },
         "gender": { "type": "string" },
         "location": { "type": "string" },
         "bio": { "type": "string" },
-        "avatar": { "$ref": "#/definitions/photo_sizes" },
-        "tags": { "$ref": "#/definitions/tags" }
+        "avatar": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/photo_sizes" },
+        "tags": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/tags" }
       },
       "required": ["guid", "diaspora_id", "tags"]
     },
 
     "own_user": {
       "allOf": [
-        { "$ref": "#/definitions/user_data" },
+        { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/user_data" },
         {
           "type": "object",
           "properties": {
@@ -395,7 +395,7 @@
 
     "user": {
       "allOf": [
-        { "$ref": "#/definitions/user_data" },
+        { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/user_data" },
         {
           "type": "object",
           "properties": {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -145,7 +145,6 @@ RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
 
   config.include JSON::SchemaMatchers
-  config.json_schemas[:archive_schema] = "lib/schemas/archive-format.json"
   config.json_schemas[:archive_schema] = ArchiveValidator::SchemaValidator::JSON_SCHEMA
   config.json_schemas[:api_v1_schema] = "lib/schemas/api_v1.json"
 


### PR DESCRIPTION
We load another schema, https://diaspora.github.io/diaspora_federation/schemas/federation_entities.json, that has overlapping definitions, namely #/definitions/post. When the definition from that schema is accessed first, the json-schema gem caches it and is not smart enough to give precedence to the definition within the schema document that contains the reference. So for now we have to disambiguate the references likes this