### PR TITLE
Re-add `raw` to a photo's json.

### DIFF
--- a/app/presenters/avatar_presenter.rb
+++ b/app/presenters/avatar_presenter.rb
@@ -6,7 +6,8 @@ class AvatarPresenter < BasePresenter
     avatar = {
       small:  small(with_default),
       medium: medium(with_default),
-      large:  large(with_default)
+      large:  large(with_default),
+      raw:    raw(with_default) # rubocop:disable Rails/OutputSafety
     }.compact
 
     avatar unless avatar.empty?
@@ -21,6 +22,11 @@ class AvatarPresenter < BasePresenter
   end
 
   def large(with_default=false)
+    image_url(size: :scaled_full, fallback_to_default: with_default)
+  end
+
+  def raw(with_default=false)
+    # TODO: Replace me with the actual raw photo.
     image_url(fallback_to_default: with_default)
   end
 end

--- a/app/presenters/photo_presenter.rb
+++ b/app/presenters/photo_presenter.rb
@@ -12,7 +12,8 @@ class PhotoPresenter < BasePresenter
       sizes:      {
         small:  url(:thumb_small),
         medium: url(:thumb_medium),
-        large:  url(:scaled_full)
+        large:  url(:scaled_full),
+        raw:    url
       }
     }
   end
@@ -26,7 +27,8 @@ class PhotoPresenter < BasePresenter
       sizes:      {
         small:  url(:thumb_small),
         medium: url(:thumb_medium),
-        large:  url(:scaled_full)
+        large:  url(:scaled_full),
+        raw:    url
       }
     }
 

--- a/lib/schemas/api_v1.json
+++ b/lib/schemas/api_v1.json
@@ -205,11 +205,12 @@
     "photo_sizes": {
       "type": "object",
       "properties": {
+        "raw": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/url" },
         "large": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/url" },
         "medium": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/url" },
         "small": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/url" }
       },
-      "required": ["large", "medium", "small"],
+      "required": ["raw", "large", "medium", "small"],
       "additionalProperties": true
     },
 

--- a/lib/schemas/api_v1.json
+++ b/lib/schemas/api_v1.json
@@ -211,7 +211,7 @@
         "small": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/url" }
       },
       "required": ["raw", "large", "medium", "small"],
-      "additionalProperties": true
+      "additionalProperties": false
     },
 
     "photo_dimensions": {

--- a/spec/presenters/avatar_presenter_spec.rb
+++ b/spec/presenters/avatar_presenter_spec.rb
@@ -5,7 +5,7 @@ describe AvatarPresenter do
     it "calls image_url() for the avatars" do
       profile = FactoryGirl.create(:profile_with_image_url, person: alice.person)
       presenter = AvatarPresenter.new(profile)
-      expect(profile).to receive(:image_url).exactly(3).times.and_call_original
+      expect(profile).to receive(:image_url).exactly(4).times.and_call_original
       expect(presenter.base_hash).to be_present
     end
 
@@ -13,6 +13,16 @@ describe AvatarPresenter do
       profile = FactoryGirl.create(:profile, person: alice.person)
       presenter = AvatarPresenter.new(profile)
       expect(presenter.base_hash).to be_nil
+    end
+
+    it "returns all relevant sizes" do
+      profile = FactoryGirl.create(:profile_with_image_url, person: alice.person)
+      base_hash = AvatarPresenter.new(profile).base_hash
+
+      expect(base_hash[:small]).to be_truthy
+      expect(base_hash[:medium]).to be_truthy
+      expect(base_hash[:large]).to be_truthy
+      expect(base_hash[:raw]).to be_truthy
     end
   end
 end

--- a/spec/presenters/photo_presenter_spec.rb
+++ b/spec/presenters/photo_presenter_spec.rb
@@ -34,6 +34,7 @@ describe PhotoPresenter do
     expect(photo[:sizes][:small]).to be_truthy
     expect(photo[:sizes][:medium]).to be_truthy
     expect(photo[:sizes][:large]).to be_truthy
+    expect(photo[:sizes][:raw]).to be_truthy
   end
   # rubocop:enable Metrics/AbcSize
 end


### PR DESCRIPTION
This fixes the current issue with lightboxes not working.

To make sure we don't acidentially drop it again, I added `raw` as a required field to the schema. Unfortunately, this broke CI, as we did not expose `raw` for profile pictures, which do reference the same API schema.

Initially, I wanted to expose the actual raw image on the API, and I still plan on doing this, but this change turns out to be a magical journey through all parts of diaspora, and will take me a bit of time. To get the lightboxes fixed in the meantime, this PR exposes the `scaled_full` version as the "raw" image.