### PR TITLE
API: return whether post or item was already reported or not

### DIFF
--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -104,7 +104,7 @@ module Api
       end
 
       def comment_as_json(comment)
-        CommentPresenter.new(comment).as_api_response
+        CommentPresenter.new(comment, current_user).as_api_response
       end
 
       def find_post

--- a/app/presenters/comment_presenter.rb
+++ b/app/presenters/comment_presenter.rb
@@ -18,7 +18,8 @@ class CommentPresenter < BasePresenter
       body:             message.plain_text_for_json,
       author:           PersonPresenter.new(author).as_api_json,
       created_at:       created_at,
-      mentioned_people: build_mentioned_people_json
+      mentioned_people: build_mentioned_people_json,
+      reported:         current_user.present? && reports.where(user: current_user).exists?
     }
   end
 

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -162,13 +162,15 @@ class PostPresenter < BasePresenter
       {
         liked:      @post.likes.where(author: current_user.person).exists?,
         reshared:   @post.reshares.where(author: current_user.person).exists?,
-        subscribed: participates?
+        subscribed: participates?,
+        reported:   @post.reports.where(user: current_user).exists?
       }
     else
       {
         liked:      false,
         reshared:   false,
-        subscribed: false
+        subscribed: false,
+        reported:   false
       }
     end
   end

--- a/lib/schemas/api_v1.json
+++ b/lib/schemas/api_v1.json
@@ -100,9 +100,10 @@
           "mentioned_people": {
             "type": "array",
             "items": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/short_profile" }
-          }
+          },
+          "reported": { "type": "boolean" }
         },
-        "required": ["guid", "created_at", "author", "body"],
+        "required": ["guid", "created_at", "author", "body", "reported"],
         "additionalProperties": false
       }
     },
@@ -282,9 +283,10 @@
           "properties": {
             "liked": { "type": "boolean" },
             "reshared": { "type": "boolean" },
-            "subscribed": { "type": "boolean" }
+            "subscribed": { "type": "boolean" },
+            "reported": { "type": "boolean" }
           },
-          "required": ["liked", "reshared", "subscribed"],
+          "required": ["liked", "reshared", "subscribed", "reported"],
           "additionalProperties": false
         },
         "mentioned_people": {

--- a/spec/integration/api/posts_controller_spec.rb
+++ b/spec/integration/api/posts_controller_spec.rb
@@ -109,6 +109,7 @@ describe Api::V1::PostsController do
       it "gets post" do
         auth.user.like!(@status)
         auth.user.reshare!(@status)
+        auth.user.reports.create!(item: @status, text: "Meh!")
         @status.reload
 
         get(
@@ -123,6 +124,7 @@ describe Api::V1::PostsController do
         expect(post["own_interaction_state"]["liked"]).to be true
         expect(post["own_interaction_state"]["reshared"]).to be true
         expect(post["own_interaction_state"]["subscribed"]).to be true
+        expect(post["own_interaction_state"]["reported"]).to be true
 
         expect(post.to_json).to match_json_schema(:api_v1_schema, fragment: "#/definitions/post")
       end
@@ -722,6 +724,7 @@ describe Api::V1::PostsController do
     expect(state["liked"]).to eq(reference_post.likes.where(author: auth.user.person).exists?)
     expect(state["reshared"]).to eq(reference_post.reshares.where(author: auth.user.person).exists?)
     expect(state["subscribed"]).to eq(reference_post.participations.where(author: auth.user.person).exists?)
+    expect(state["reported"]).to eq(reference_post.reports.where(user: auth.user).exists?)
   end
 
   def confirm_person_format(post_person, user)


### PR DESCRIPTION
I think that makes sense so clients can hide the button rather
than having to prompt the user to fill another report that's then 
rejected by the API.