### PR TITLE
API: Don't return notifications target unless it's a post

### DIFF
--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -15,7 +15,7 @@ module Api
         notification = service.get_by_guid(params[:id])
 
         if notification
-          render json: NotificationPresenter.new(notification).as_api_json(true)
+          render json: NotificationPresenter.new(notification).as_api_json
         else
           render_error 404, "Notification with provided guid could not be found"
         end

--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -3,6 +3,8 @@
 module Api
   module V1
     class NotificationsController < Api::V1::BaseController
+      BOOLEAN_TYPE = ActiveModel::Type::Boolean.new
+
       before_action do
         require_access_token %w[notifications]
       end
@@ -24,25 +26,25 @@ module Api
       def index
         after_date = Date.iso8601(params[:only_after]) if params.has_key?(:only_after)
 
-        notifications_query = service.index(params[:only_unread], after_date)
+        notifications_query = service.index(BOOLEAN_TYPE.cast(params[:only_unread]), after_date)
         notifications_page = time_pager(notifications_query).response
         notifications_page[:data] = notifications_page[:data].map do |note|
           NotificationPresenter.new(note, default_serializer_options).as_api_json
         end
         render_paged_api_response notifications_page
       rescue ArgumentError
-        render_error 422, "Couldnt process the notifications requestt process the notifications request"
+        render_error 422, "Could not process the notifications request"
       end
 
       def update
-        read = ActiveModel::Type::Boolean.new.cast(params.require(:read))
+        read = BOOLEAN_TYPE.cast(params.require(:read))
         if service.update_status_by_guid(params[:id], read)
           head :no_content
         else
-          render_error 422, "Couldnt process the notifications requestt process the notifications request"
+          render_error 422, "Could not process the notifications request"
         end
       rescue ActionController::ParameterMissing
-        render_error 422, "Couldnt process the notifications requestt process the notifications request"
+        render_error 422, "Could not process the notifications request"
       end
 
       private

--- a/app/presenters/notification_presenter.rb
+++ b/app/presenters/notification_presenter.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class NotificationPresenter < BasePresenter
-  def as_api_json(include_target=true)
+  def as_api_json
     data = base_hash
-    data = data.merge(target: target_json) if include_target && linked_object
+    data = data.merge(target: target_json) if target
     data
   end
 
@@ -20,8 +20,8 @@ class NotificationPresenter < BasePresenter
   end
 
   def target_json
-    json = {guid: linked_object.guid}
-    json[:author] = PersonPresenter.new(linked_object.author).as_api_json if linked_object.author
+    json = {guid: target.guid}
+    json[:author] = PersonPresenter.new(target.author).as_api_json if target.author
     json
   end
 
@@ -31,5 +31,10 @@ class NotificationPresenter < BasePresenter
 
   def type_as_json
     NotificationService::NOTIFICATIONS_REVERSE_JSON_TYPES[type]
+  end
+
+  def target
+    return linked_object if linked_object&.is_a?(Post)
+    return linked_object.post if linked_object&.respond_to?(:post)
   end
 end

--- a/lib/schemas/api_v1.json
+++ b/lib/schemas/api_v1.json
@@ -213,7 +213,7 @@
           "items": { "$ref": "https://diaspora.software/api/v1/schema.json#/definitions/short_profile" }
         }
       },
-      "required": ["guid", "type", "read", "created_at", "target"],
+      "required": ["guid", "type", "read", "created_at"],
       "additionalProperties": false
     },
 

--- a/spec/integration/api/notifications_controller_spec.rb
+++ b/spec/integration/api/notifications_controller_spec.rb
@@ -62,6 +62,20 @@ describe Api::V1::NotificationsController do
         expect(notification.length).to eq(1)
       end
 
+      it "with proper credentials and unread only explicitly false" do
+        @notification.set_read_state(true)
+        get(
+          api_v1_notifications_path,
+          params: {only_unread: false, access_token: access_token}
+        )
+        expect(response.status).to eq(200)
+        notifications = response_body_data(response)
+        expect(notifications.length).to eq(2)
+        confirm_notification_format(notifications[1], @notification, "also_commented", nil)
+
+        expect(notifications.to_json).to match_json_schema(:api_v1_schema, fragment: "#/definitions/notifications")
+      end
+
       it "with proper credentials and after certain date" do
         get(
           api_v1_notifications_path,
@@ -87,7 +101,7 @@ describe Api::V1::NotificationsController do
           api_v1_notifications_path,
           params: {only_after: "January 1, 2018", access_token: access_token}
         )
-        confirm_api_error(response, 422, "Couldnt process the notifications requestt process the notifications request")
+        confirm_api_error(response, 422, "Could not process the notifications request")
       end
 
       it "with insufficient credentials" do
@@ -190,7 +204,7 @@ describe Api::V1::NotificationsController do
           api_v1_notification_path("999_999_999"),
           params: {access_token: access_token}
         )
-        confirm_api_error(response, 422, "Couldnt process the notifications requestt process the notifications request")
+        confirm_api_error(response, 422, "Could not process the notifications request")
       end
 
       it "with proper missing read field" do
@@ -198,7 +212,7 @@ describe Api::V1::NotificationsController do
           api_v1_notification_path(@notification.guid),
           params: {access_token: access_token}
         )
-        confirm_api_error(response, 422, "Couldnt process the notifications requestt process the notifications request")
+        confirm_api_error(response, 422, "Could not process the notifications request")
       end
 
       it "with insufficient credentials" do

--- a/spec/presenters/notification_presenter_spec.rb
+++ b/spec/presenters/notification_presenter_spec.rb
@@ -1,31 +1,58 @@
 # frozen_string_literal: true
 
 describe NotificationPresenter do
-  before do
-    @post = FactoryGirl.create(:status_message)
-    @notification = FactoryGirl.create(:notification, recipient: alice, target: @post)
-  end
-
-  it "makes json with target when requested" do
-    json = NotificationPresenter.new(@notification).as_api_json(true)
-    expect(json[:guid]).to eq(@notification.guid)
+  it "makes json with target" do
+    post = FactoryGirl.create(:status_message)
+    notification = FactoryGirl.create(:notification, recipient: alice, target: post)
+    json = NotificationPresenter.new(notification).as_api_json
+    expect(json[:guid]).to eq(notification.guid)
     expect(json[:type]).to eq("also_commented")
     expect(json[:read]).to be_falsey
-    expect(json[:created_at]).to eq(@notification.created_at)
-    expect(json[:target][:guid]).to eq(@post.guid)
+    expect(json[:created_at]).to eq(notification.created_at)
+    expect(json[:target][:guid]).to eq(post.guid)
     expect(json[:event_creators].length).to eq(1)
   end
 
-  it "makes json with without target" do
-    json = NotificationPresenter.new(@notification).as_api_json(false)
-    expect(json.has_key?(:target)).to be_falsey
-  end
-
-  it "Makes target on mentioned" do
+  it "returns target on mentioned" do
     mentioned_post = FactoryGirl.create(:status_message_in_aspect, author: alice.person, text: text_mentioning(bob))
     Notifications::MentionedInPost.notify(mentioned_post, [bob.id])
     notification = Notifications::MentionedInPost.last
-    json = NotificationPresenter.new(notification).as_api_json(true)
+    json = NotificationPresenter.new(notification).as_api_json
     expect(json[:target][:guid]).to eq(mentioned_post.guid)
+  end
+
+  it "returns target on mentioned in comment" do
+    post = FactoryGirl.create(:status_message, public: true)
+    mentioned_comment = FactoryGirl.create(:comment, post: post, author: alice.person, text: text_mentioning(bob))
+    Notifications::MentionedInComment.notify(mentioned_comment, [bob.id])
+    notification = Notifications::MentionedInComment.last
+    json = NotificationPresenter.new(notification).as_api_json
+    expect(json[:target][:guid]).to eq(mentioned_comment.post.guid)
+  end
+
+  it "returns target on also_commented" do
+    post = FactoryGirl.create(:status_message)
+    bob.comment!(post, "cool")
+    comment2 = FactoryGirl.create(:comment, post: post)
+    Notifications::AlsoCommented.notify(comment2, [])
+    notification = Notifications::AlsoCommented.last
+    json = NotificationPresenter.new(notification).as_api_json
+    expect(json[:target][:guid]).to eq(post.guid)
+  end
+
+  it "returns no target on started_sharing" do
+    contact = FactoryGirl.create(:contact)
+    Notifications::StartedSharing.notify(contact, [bob.id])
+    notification = Notifications::StartedSharing.last
+    json = NotificationPresenter.new(notification).as_api_json
+    expect(json[:target]).to be_nil
+  end
+
+  it "returns no target on contacts_birthday" do
+    contact = FactoryGirl.create(:contact)
+    Notifications::ContactsBirthday.notify(contact, [bob.id])
+    notification = Notifications::ContactsBirthday.last
+    json = NotificationPresenter.new(notification).as_api_json
+    expect(json[:target]).to be_nil
   end
 end


### PR DESCRIPTION
API docs imply that's how it should be since the "target" can be inferred from
the event creator in the non post notifications case.

Also fixed the `only_unread` parameter to only listen to `true`. (Can send that separately if you prefer.)