### PR TITLE
API: Fix fetching explicitly not only unread conversations

### DIFF
--- a/app/controllers/api/v1/conversations_controller.rb
+++ b/app/controllers/api/v1/conversations_controller.rb
@@ -5,6 +5,8 @@ module Api
     class ConversationsController < Api::V1::BaseController
       include ConversationsHelper
 
+      BOOLEAN_TYPE = ActiveModel::Type::Boolean.new
+
       before_action do
         require_access_token %w[conversations]
       end
@@ -17,7 +19,7 @@ module Api
         mapped_params = {}
         mapped_params[:only_after] = params[:only_after] if params.has_key?(:only_after)
 
-        mapped_params[:unread] = params[:only_unread] if params.has_key?(:only_unread)
+        mapped_params[:unread] = BOOLEAN_TYPE.cast(params[:only_unread]) if params.has_key?(:only_unread)
 
         conversations_query = conversation_service.all_for_user(mapped_params)
         conversations_page = pager(conversations_query, "conversations.created_at").response

--- a/app/services/conversation_service.rb
+++ b/app/services/conversation_service.rb
@@ -15,7 +15,7 @@ class ConversationService
     visibility_filter = if filter[:unread]
                           {
                             person_id: @user.person_id,
-                            unread:    0
+                            unread:    1
                           }
                         else
                           {person_id: @user.person_id}

--- a/spec/integration/api/conversations_controller_spec.rb
+++ b/spec/integration/api/conversations_controller_spec.rb
@@ -173,7 +173,16 @@ describe Api::V1::ConversationsController do
         params: {only_unread: true, access_token: access_token}
       )
       expect(response.status).to eq(200)
-      expect(response_body(response).length).to eq(2)
+      expect(response_body(response).length).to eq(1)
+    end
+
+    it "returns all the user unread conversations with only_unread explicitly false" do
+      get(
+        api_v1_conversations_path,
+        params: {only_unread: false, access_token: access_token}
+      )
+      expect(response.status).to eq(200)
+      expect(response_body(response).length).to eq(3)
     end
 
     it "returns all the user conversations after a given date" do

--- a/spec/services/conversation_service_spec.rb
+++ b/spec/services/conversation_service_spec.rb
@@ -41,7 +41,7 @@ describe ConversationService do
       @conversation.conversation_visibilities[0].unread = true
       @conversation.conversation_visibilities[0].save!
       conversations = bob_conversation_service.all_for_user(unread: true)
-      expect(conversations.length).to eq(2)
+      expect(conversations.length).to eq(1)
     end
 
     it "returns conversation after a given date" do


### PR DESCRIPTION
and also the behavior with filtering in general, which was flipped to the actual intent.