### PR TITLE
API: add new route to search for tags

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -23,6 +23,12 @@ module Api
         render_paged_api_response posts_page
       end
 
+      def tag_index
+        tags_page = index_pager(tags_query).response
+        tags_page[:data] = tags_page[:data].pluck(:name)
+        render_paged_api_response tags_page
+      end
+
       private
 
       def time_pager(query, query_time_field, data_time_field)
@@ -52,6 +58,10 @@ module Api
         else
           Stream::Tag.new(nil, params.require(:tag)).posts
         end
+      end
+
+      def tags_query
+        ActsAsTaggableOn::Tag.autocomplete(params.require(:query))
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -259,6 +259,7 @@ Rails.application.routes.draw do
     resources :tag_followings, only: %i[index create destroy]
     get "search/users" => "search#user_index", :as => "user_index"
     get "search/posts" => "search#post_index", :as => "post_index"
+    get "search/tags" => "search#tag_index", :as => "tag_index"
     get "streams/activity" => "streams#activity", :as => "activity_stream"
     get "streams/main" => "streams#multi", :as => "stream"
     get "streams/tags" => "streams#followed_tags", :as => "followed_tags_stream"


### PR DESCRIPTION
I think that's missing to provide autocompletion for tags in clients