### PR TITLE
#8119 Add input validation for gender in profile

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -22,6 +22,7 @@ class Profile < ApplicationRecord
   validates :first_name, :length => { :maximum => 32 }
   validates :last_name, :length => { :maximum => 32 }
   validates :location, :length => { :maximum =>255 }
+  validates :gender, length: {maximum: 255}
 
   validates_format_of :first_name, :with => /\A[^;]+\z/, :allow_blank => true
   validates_format_of :last_name, :with => /\A[^;]+\z/, :allow_blank => true

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -124,6 +124,18 @@ describe Profile, :type => :model do
     end
   end
 
+  describe "of gender" do
+    it "can be 255 characters long" do
+      profile = FactoryGirl.build(:profile, gender: "a" * 255)
+      expect(profile).to be_valid
+    end
+
+    it "cannot be 256 characters" do
+      profile = FactoryGirl.build(:profile, gender: "a" * 256)
+      expect(profile).not_to be_valid
+    end
+  end
+
   describe "image_url setters" do
     %i(image_url image_url_small image_url_medium).each do |method|
       describe "##{method}=" do


### PR DESCRIPTION
In response to [issue 8119](https://github.com/diaspora/diaspora/issues/8119) this PR adds a new validation for the length of the gender field limiting it to 255 characters to avoid a nasty 500 error. This PR also  includes a couple of tests.