### PR TITLE
Allow CORS on all API routes.

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -10,8 +10,7 @@
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     origins "*"
-    resource "/api/openid_connect/user_info", methods: %i(get post)
-    resource "/api/v0/*", methods: %i(delete get post)
+    resource "/api/*", methods: :any
     resource "/.well-known/host-meta"
     resource "/.well-known/webfinger"
     resource "/.well-known/openid-configuration"

--- a/spec/integration/application_spec.rb
+++ b/spec/integration/application_spec.rb
@@ -51,4 +51,25 @@ describe ApplicationController, type: :request do
       end
     end
   end
+
+  describe "cross-origin resource sharing" do
+    before do
+      @headers = {
+        origin: "https://example.com"
+      }
+    end
+
+    it "does set permissive headers for API requests" do
+      get "/api/openid_connect/user_info", headers: @headers
+      expect(response.headers["Access-Control-Allow-Origin"]).to eq("*")
+      allow_methods = response.headers["Access-Control-Allow-Methods"].split(",").map(&:strip)
+      expect(allow_methods).to include("GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+    end
+
+    it "does allow CORS GET for the OpenID configuration" do
+      get "/.well-known/openid-configuration", headers: @headers
+      expect(response.headers["Access-Control-Allow-Origin"]).to eq("*")
+      expect(response.headers["Access-Control-Allow-Methods"]).to eq("GET")
+    end
+  end
 end


### PR DESCRIPTION
... and adds a test, because we had none.

Closes #8126.