### PR TITLE
OpenID Connect: Disable form-action CSP on authorization page

### DIFF
--- a/app/controllers/api/openid_connect/authorizations_controller.rb
+++ b/app/controllers/api/openid_connect/authorizations_controller.rb
@@ -120,6 +120,7 @@ module Api
         @scopes = endpoint.scopes
         save_request_parameters
         @app = UserApplicationPresenter.new @o_auth_application, @scopes
+        override_content_security_policy_directives(form_action: %w[])
         render :new
       end
 


### PR DESCRIPTION
Some browsers apply this CSP rule even to the redirect response
after the POST requests, blocking the redirect_uri redirect.

Appending `'unsafe-allow-redirct'` does not help, at least for the tested non http(s) redirect URIs.