### PR TITLE
Fix error in TagFollowingsController#create when duplicate is created

### DIFF
--- a/app/controllers/tag_followings_controller.rb
+++ b/app/controllers/tag_followings_controller.rb
@@ -17,7 +17,7 @@ class TagFollowingsController < ApplicationController
     tag = tag_followings_service.create(params["name"])
     render json: tag.to_json, status: :created
   rescue TagFollowingService::DuplicateTag
-    render json: tag_followings_service.find(params["name"]), status: created
+    render json: tag_followings_service.find(params["name"]), status: :created
   rescue StandardError
     head :forbidden
   end


### PR DESCRIPTION
Fixes:
```
ActionController::Base: Completed 500 Internal Server Error in 43ms (ActiveRecord: 2.7ms)
Rails: NameError (undefined local variable or method `created' for #<TagFollowingsController:0x00007f4de2e87560> Did you mean?  create):
	app/controllers/tag_followings_controller.rb:20:in `rescue in create'
	app/controllers/tag_followings_controller.rb:16:in `create'
```

Broken in #8091, so only in `develop`.