### PR TITLE
OpenID Connect: ensure consistent issuer URL

### DIFF
--- a/app/controllers/api/openid_connect/discovery_controller.rb
+++ b/app/controllers/api/openid_connect/discovery_controller.rb
@@ -28,7 +28,7 @@ module Api
     class DiscoveryController < ApplicationController
       def configuration
         render json: OpenIDConnect::Discovery::Provider::Config::Response.new(
-          issuer:                                      root_url,
+          issuer:                                      AppConfig.environment.url,
           registration_endpoint:                       api_openid_connect_clients_url,
           authorization_endpoint:                      new_api_openid_connect_authorization_url,
           token_endpoint:                              api_openid_connect_access_tokens_url,

--- a/lib/api/openid_connect/id_token.rb
+++ b/lib/api/openid_connect/id_token.rb
@@ -53,7 +53,7 @@ module Api
       def claims
         sub = build_sub
         @claims ||= {
-          iss:       Rails.application.routes.url_helpers.root_url,
+          iss:       AppConfig.environment.url,
           sub:       sub,
           aud:       @authorization.o_auth_application.client_id,
           exp:       @expires_at.to_i,

--- a/spec/controllers/api/openid_connect/discovery_controller_spec.rb
+++ b/spec/controllers/api/openid_connect/discovery_controller_spec.rb
@@ -8,7 +8,7 @@ describe Api::OpenidConnect::DiscoveryController, type: :controller do
 
     it "should have the issuer as the root url" do
       json_body = JSON.parse(response.body)
-      expect(json_body["issuer"]).to eq(root_url)
+      expect(json_body["issuer"]).to eq(AppConfig.environment.url)
     end
 
     it "should have the appropriate user info endpoint" do


### PR DESCRIPTION
root_url does not know the right protocol in all contexts,
some clients are strict when validating this.