### PR TITLE
Allow podmins to specify fog provider name

### DIFF
--- a/config/diaspora.toml.example
+++ b/config/diaspora.toml.example
@@ -122,6 +122,13 @@
 #bucket = "my_photos"
 #region = "us-east-1"
 
+# If you intend to use a provider other than AWS, you must
+# install that provider's corresponding fog support gem
+# A list of available providers may be found at https://fog.io/about/provider_documentation.html
+# Provider gems are typically named fog-provider, where
+# 'provider' is the name of the provider (e.g. "fog-digitalocean", "fog-google")
+#provider = "AWS"
+
 ## Use max-age header on Amazon S3 resources (default=true).
 ## When true, this allows locally cached images to be served for up to
 ## one year. This can improve load speed and save requests to the image

--- a/config/initializers/asset_sync.rb
+++ b/config/initializers/asset_sync.rb
@@ -3,12 +3,12 @@
 if defined? AssetSync
   AssetSync.configure do |config|
     config.enabled = true
-    
-    config.fog_provider = 'AWS'
+
+    config.fog_provider = AppConfig.environment.s3.provider.get
     config.aws_access_key_id = AppConfig.environment.s3.key.get
     config.aws_secret_access_key = AppConfig.environment.s3.secret.get
     config.fog_directory = AppConfig.environment.s3.bucket.get
-  
+
     # Increase upload performance by configuring your region
     config.fog_region = AppConfig.environment.s3.region.get
     #
@@ -18,7 +18,7 @@ if defined? AssetSync
     # Automatically replace files with their equivalent gzip compressed version
     # config.gzip_compression = true
     #
-    # Use the Rails generated 'manifest.yml' file to produce the list of files to 
+    # Use the Rails generated 'manifest.yml' file to produce the list of files to
     # upload instead of searching the assets directory.
     # config.manifest = true
     #

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -13,10 +13,10 @@ CarrierWave.configure do |config|
     config.storage = :fog
     config.cache_dir = Rails.root.join('tmp', 'uploads').to_s
     config.fog_credentials = {
-        provider:              'AWS',
-        aws_access_key_id:     AppConfig.environment.s3.key.get,
-        aws_secret_access_key: AppConfig.environment.s3.secret.get,
-        region:                AppConfig.environment.s3.region.get
+      provider:              AppConfig.environment.s3.provider.get,
+      aws_access_key_id:     AppConfig.environment.s3.key.get,
+      aws_secret_access_key: AppConfig.environment.s3.secret.get,
+      region:                AppConfig.environment.s3.region.get
     }
     if AppConfig.environment.s3.cache?
       config.fog_attributes['Cache-Control'] = 'max-age=31536000'


### PR DESCRIPTION
Implements the changes required to allow a fog provider name to be specified in diaspora's configuration file.

Closes #8175