### PR TITLE
Enlarge accept and deny buttons in open-id authorization

### DIFF
--- a/app/views/api/openid_connect/authorizations/new.haml
+++ b/app/views/api/openid_connect/authorizations/new.haml
@@ -1,16 +1,16 @@
 .row
-  .user-consent.col-md-10.col-md-offset-1
+  .user-consent.col-md-8.col-md-offset-2
     %ul.list-group
       %li.list-group-item.authorized-application.clearfix
         = render "grants_list", app: @app
 
         .row
-          .col-xs-6.text-left
+          .col-xs-2.col-xs-offset-2.col-sm-1.col-sm-offset-7
             = form_tag api_openid_connect_authorizations_path, class: "approval-button" do
               = submit_tag t(".deny"), class: "btn btn-lg btn-danger"
               = hidden_field_tag :approve, false
 
-          .col-xs-6.text-right
+          .col-xs-2.col-xs-offset-3.col-sm-1.col-sm-offset-1
             = form_tag api_openid_connect_authorizations_path, class: "approval-button" do
               = submit_tag t(".approve"),  class: "btn btn-lg btn-primary"
               = hidden_field_tag :approve, true

--- a/app/views/api/openid_connect/authorizations/new.haml
+++ b/app/views/api/openid_connect/authorizations/new.haml
@@ -4,11 +4,13 @@
       %li.list-group-item.authorized-application.clearfix
         = render "grants_list", app: @app
 
-        .clearfix.pull-right
-          = form_tag api_openid_connect_authorizations_path, class: "approval-button" do
-            = submit_tag t(".deny"), class: "btn btn-danger"
-            = hidden_field_tag :approve, false
+        .row
+          .col-xs-6.text-left
+            = form_tag api_openid_connect_authorizations_path, class: "approval-button" do
+              = submit_tag t(".deny"), class: "btn btn-lg btn-danger"
+              = hidden_field_tag :approve, false
 
-          = form_tag api_openid_connect_authorizations_path, class: "approval-button" do
-            = submit_tag t(".approve"),  class: "btn btn-primary"
-            = hidden_field_tag :approve, true
+          .col-xs-6.text-right
+            = form_tag api_openid_connect_authorizations_path, class: "approval-button" do
+              = submit_tag t(".approve"),  class: "btn btn-lg btn-primary"
+              = hidden_field_tag :approve, true


### PR DESCRIPTION
Will fix #8170 
New appearance: 
![Simulator Screen Shot - iPhone 11 - 2020-11-06 at 13 40 29](https://user-images.githubusercontent.com/501326/98367660-4ef60180-2036-11eb-8a15-0c05eb11ee88.png)

