### PR TITLE
Fix syntax error for default_color_theme in diaspora.toml.example

### DIFF
--- a/config/diaspora.toml.example
+++ b/config/diaspora.toml.example
@@ -325,7 +325,7 @@
 ## to enter the name of the theme's folder in "app/assets/stylesheets/color_themes/".
 ## ("original" for the theme in "app/assets/stylesheets/color_themes/original/", for
 ## example).
-#default_color_theme: "original"
+#default_color_theme = "original"
 
 ## CURL debug (default=false)
 ## Turn on extra verbose output when sending stuff. Note: you


### PR DESCRIPTION
I have no idea why, but this is the only one where the `:` wasn't replaced with a `=` in the example.