### PR TITLE
Delete user invitation code during account deletion

### DIFF
--- a/lib/account_deleter.rb
+++ b/lib/account_deleter.rb
@@ -58,7 +58,7 @@ class AccountDeleter
   end
 
   def delete_user_invitation_code
-    InvitationCode.find_by(user_id: user.id).destroy
+    InvitationCode.find_by(user_id: user.id).try(:destroy)
   end
 
   def normal_ar_person_associates_to_delete

--- a/lib/account_deleter.rb
+++ b/lib/account_deleter.rb
@@ -39,6 +39,7 @@ class AccountDeleter
     remove_share_visibilities_on_contacts_posts
     disconnect_contacts
     delete_standard_user_associations
+    delete_user_invitation_code
     tombstone_user
   end
 
@@ -54,6 +55,10 @@ class AccountDeleter
         User.reflect_on_association(asso).class_name.constantize.where(id: ids).destroy_all
       end
     end
+  end
+
+  def delete_user_invitation_code
+    InvitationCode.find_by(user_id: user.id).destroy
   end
 
   def normal_ar_person_associates_to_delete

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -85,6 +85,7 @@ FactoryGirl.define do
     after(:create) do |u|
       u.person.save
       u.person.profile.save
+      FactoryGirl.create(:invitation_code, user: u)
     end
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -85,7 +85,6 @@ FactoryGirl.define do
     after(:create) do |u|
       u.person.save
       u.person.profile.save
-      FactoryGirl.create(:invitation_code, user: u)
     end
   end
 

--- a/spec/lib/account_deleter_spec.rb
+++ b/spec/lib/account_deleter_spec.rb
@@ -76,6 +76,7 @@ describe AccountDeleter do
   describe "#close_user" do
     user_removal_methods = %i[
       delete_standard_user_associations
+      delete_user_invitation_code
       remove_share_visibilities_on_contacts_posts
       disconnect_contacts tombstone_user
     ]
@@ -92,7 +93,7 @@ describe AccountDeleter do
   end
 
   describe "#delete_standard_user_associations" do
-    it 'removes all standard user associaltions' do
+    it "removes all standard user associations" do
       @account_deletion.normal_ar_user_associates_to_delete.each do |asso|
         association_double = double
         expect(association_double).to receive(:ids).and_return([42])
@@ -107,11 +108,23 @@ describe AccountDeleter do
     end
   end
 
+  describe "#delete_user_invitation_code" do
+    it "deletes user invitation code" do
+      expect(bob.invitation_code).not_to be_nil
+      expect(bob.invitation_code).to eq(InvitationCode.find_by(user_id: bob.id))
+      invitation_code_double = double
+      expect(InvitationCode).to receive(:find_by).with(user_id: bob.id).and_return(invitation_code_double)
+      expect(invitation_code_double).to receive(:destroy)
+
+      @account_deletion.delete_user_invitation_code
+    end
+  end
+
   describe "#delete_standard_person_associations" do
     before do
       @account_deletion.person = bob.person
     end
-    it 'removes all standard person associaltions' do
+    it "removes all standard person associations" do
       @account_deletion.normal_ar_person_associates_to_delete.each do |asso|
         association_double = double
         expect(association_double).to receive(:ids).and_return([42])


### PR DESCRIPTION
Disclaimer: I've never written Ruby, so please let me know if there's a better way of doing this.

If a Podmin closes an account on an invite-only server and that account holder still knows their invitation code, they can currently recreate an account using that invitation code. This PR deletes the original invitation code for that user during account deletion so they can't create another account against a Podmin's will. I realize the user can still recreate an account if they themselves were invited by another user (and still have that user's code), but this at least helps in situations where a server might have previously allowed registrations but no longer does.