### PR TITLE
File selection dialog accepts only image types

### DIFF
--- a/app/assets/javascripts/helpers/post_photo_uploader.es6
+++ b/app/assets/javascripts/helpers/post_photo_uploader.es6
@@ -54,6 +54,7 @@ Diaspora.PostPhotoUploader = class {
         }
       },
       validation: {
+        acceptFiles: "image/png, image/jpeg, image/gif",
         allowedExtensions: ["jpg", "jpeg", "png", "gif"],
         sizeLimit: (window.Promise && qq.supportedFeatures.scaling ? null : this.sizeLimit)
       },

--- a/app/assets/javascripts/helpers/profile_photo_uploader.es6
+++ b/app/assets/javascripts/helpers/profile_photo_uploader.es6
@@ -38,6 +38,7 @@ Diaspora.ProfilePhotoUploader = class {
     this.fineUploader = new qq.FineUploaderBasic({
       element: this.fileInput,
       validation: {
+        acceptFiles: "image/png, image/jpeg",
         allowedExtensions: ["jpg", "jpeg", "png"]
       },
       request: {

--- a/app/assets/javascripts/mobile/mobile_profile_photo_uploader.js
+++ b/app/assets/javascripts/mobile/mobile_profile_photo_uploader.js
@@ -11,6 +11,7 @@ Diaspora.ProfilePhotoUploader.prototype = {
     new qq.FineUploaderBasic({
       element: document.getElementById("file-upload"),
       validation: {
+        acceptFiles: "image/png, image/jpeg, image/gif",
         allowedExtensions: ["jpg", "jpeg", "png"],
         sizeLimit: 4194304
       },


### PR DESCRIPTION
Fixes #8189 File Upload Dialog only accept image types PNG, JPG and GIF. 
Profile upload only JPG and PNG. 

Found reference here: https://docs.fineuploader.com/branch/master/api/options.html#validation.acceptFiles