### PR TITLE
Removing deprecated 'Heidelberg' tile map service.

### DIFF
--- a/app/assets/javascripts/app/helpers/locations.js
+++ b/app/assets/javascripts/app/helpers/locations.js
@@ -3,23 +3,21 @@
     getTiles: function() {
       // If the mapbox option is enabled in the diaspora.toml, the mapbox tiles with the podmin's credentials are used.
       if (gon.appConfig.map.mapbox.enabled) {
-        return L.tileLayer("https://api.mapbox.com/styles/v1/{style}/tiles/256/{z}/{x}/{y}?access_token={accessToken}", {
-          accessToken: gon.appConfig.map.mapbox.access_token,
-          style: gon.appConfig.map.mapbox.style,
-          attribution: "Map data &copy; <a href='https://openstreetmap.org'>OpenStreetMap</a> contributors, " +
-                       "<a href='https://creativecommons.org/licenses/by-sa/2.0/''>CC-BY-SA</a>, " +
-                       "Imagery © <a href='https://www.mapbox.com'>Mapbox</a>",
-          maxZoom: 18
-        });
+        return L.tileLayer(
+          "https://api.mapbox.com/styles/v1/{style}/tiles/256/{z}/{x}/{y}?access_token={accessToken}",
+          {
+            accessToken: gon.appConfig.map.mapbox.access_token,
+            style: gon.appConfig.map.mapbox.style,
+            attribution:
+              "Map data &copy; <a href='https://openstreetmap.org'>OpenStreetMap</a> contributors, " +
+              "<a href='http://opendatacommons.org/licenses/dbcl/1.0/'>Open Database License, ODbL 1.0</a>, " +
+              "Imagery © <a href='https://www.mapbox.com'>Mapbox</a>",
+            maxZoom: 18,
+            tileSize: 512,
+            zoomOffset: -1
+          }
+        );
       }
-
-      // maptiles from the Heidelberg University are used by default.
-      return L.tileLayer("http://korona.geog.uni-heidelberg.de/tiles/roads/x={x}&y={y}&z={z}", {
-        attribution: "Map data &copy; <a href='https://openstreetmap.org'>OpenStreetMap</a> contributors, " +
-                     "rendering <a href='http://giscience.uni-hd.de/'>" +
-                     "GIScience Research Group @ Heidelberg University</a>",
-        maxZoom: 18
-      });
     }
   };
 })();

--- a/app/assets/javascripts/app/views/single-post-viewer/single_post_content_view.js
+++ b/app/assets/javascripts/app/views/single-post-viewer/single_post_content_view.js
@@ -36,8 +36,9 @@ app.views.SinglePostContent = app.views.Base.extend({
 
     var map = L.map(mapContainer[0]).setView([location.lat, location.lng], 14);
     var tiles = app.helpers.locations.getTiles();
-
-    tiles.addTo(map);
+    if (tiles) {
+      tiles.addTo(map);
+    }
 
     // put marker on map
     L.marker(location).addTo(map);

--- a/config/diaspora.toml.example
+++ b/config/diaspora.toml.example
@@ -198,10 +198,9 @@
 ## increase environment.sidekiq.concurrency instead!
 #sidekiq_workers = 1
 
-## Displays the location of a post in a map. Per default we are using the map
-## tiles of the Heidelberg University (http://giscience.uni-hd.de).
-## You also have the possibility to use the map tiles of https://www.mapbox.com
-## which is probably more reliable. There you have to create an account to get
+## Displays the location of a post in a map.
+## If you enable this setting you use the map tiles of https://www.mapbox.com
+## which is reliable. There you have to create an account to get
 ## an access token which is limited. If you want to get an unlimited account
 ## you can write an email to team@diasporafoundation.org.
 ## Please enable mapbox and fill out your access_token.
@@ -209,7 +208,7 @@
 
 #enabled = false
 #access_token = "youraccesstoken"
-#style = "mapbox/streets-v9"
+#style = "mapbox/streets-v11"
 
 ## Settings potentially affecting the privacy of your users.
 [configuration.privacy]

--- a/spec/javascripts/app/helpers/locations_spec.js
+++ b/spec/javascripts/app/helpers/locations_spec.js
@@ -1,28 +1,15 @@
 describe("app.helpers.locations", function() {
   describe("getTiles", function() {
-    context("with mapbox disabled", function() {
-      beforeEach(function() {
-        gon.appConfig = {map: {mapbox: {enabled: false}}};
-      });
-
-      it("returns tiles from the Heidelberg University", function() {
-        var tiles = app.helpers.locations.getTiles();
-        expect(tiles._url).toMatch("http://korona.geog.uni-heidelberg.de/");
-        expect(tiles._url).not.toMatch("https://api.tiles.mapbox.com/");
-      });
-    });
-
     context("with mapbox enabled", function() {
       beforeEach(function() {
         /* eslint-disable camelcase */
-        gon.appConfig = {map: {mapbox: {enabled: true, style: "mapbox/streets-v9", access_token: "yourAccessToken"}}};
+        gon.appConfig = {map: {mapbox: {enabled: true, style: "mapbox/streets-v11", access_token: "yourAccessToken"}}};
         /* eslint-enable camelcase */
       });
 
       it("returns tiles from mapbox", function() {
         var tiles = app.helpers.locations.getTiles();
         expect(tiles._url).toMatch("https://api.mapbox.com/");
-        expect(tiles._url).not.toMatch("http://korona.geog.uni-heidelberg.de/");
       });
     });
   });


### PR DESCRIPTION
Updated settings for MapTiles as recommended by leaflet.js
Updating current licence text
Closes #8209 

I decided to remove 'Heidelberg' because the new service needs also to login and receive a API Token. So there is no benefit to let choose. 
If there is a free Map service without API-login, that can act as a new default, it can be added (later) 