### PR TITLE
Installing missing libffi6 in Git CI Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,10 @@ jobs:
     steps:
       - name: Install system dependencies
         run: sudo apt-get install -y build-essential curl git gsfonts imagemagick libcurl4-openssl-dev libidn11-dev libmagickwand-dev libssl-dev libxml2-dev libxslt1-dev
+      - name: Re-install libffi.so.6 a
+        run: |
+          wget http://mirrors.edge.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb
+          sudo apt-get install ./libffi6_3.2.1-8_amd64.deb
       - name: Start MySQL
         run: sudo systemctl start mysql.service
         if: matrix.db == 'mysql'


### PR DESCRIPTION
On Latest OS Version v6 of libffi is missing. This add it back to the CI