### PR TITLE
Adds ability to block a pod in Admin-View

### DIFF
--- a/app/assets/javascripts/app/models/pod.js
+++ b/app/assets/javascripts/app/models/pod.js
@@ -11,5 +11,6 @@ app.models.Pod = Backbone.Model.extend({
         self.set(newAttributes);
       });
   }
+
 });
 // @license-end

--- a/app/assets/javascripts/app/pages/admin_pods.js
+++ b/app/assets/javascripts/app/pages/admin_pods.js
@@ -31,7 +31,7 @@ app.pages.AdminPods = app.views.Base.extend({
     var msgs = document.createDocumentFragment();
     if (gon.totalCount && gon.totalCount > 0) {
       let totalPods = $("<div class='alert alert-info' role='alert' />")
-        .append(Diaspora.I18n.t("admin.pods.total", {count: gon.totalCount}));
+        .append(Diaspora.I18n.t("admin.pods.total", {count: gon.totalCount.toLocaleString()}));
       if (gon.activeCount) {
         if (gon.activeCount === 0) {
           totalPods
@@ -42,7 +42,7 @@ app.pages.AdminPods = app.views.Base.extend({
             .append(" " + Diaspora.I18n.t("admin.pods.all_active"));
         } else {
           totalPods
-            .append(" " + Diaspora.I18n.t("admin.pods.active", {count: gon.activeCount}));
+            .append(" " + Diaspora.I18n.t("admin.pods.active", {count: gon.activeCount.toLocaleString()}));
         }
       }
       msgs.appendChild(totalPods[0]);
@@ -50,18 +50,23 @@ app.pages.AdminPods = app.views.Base.extend({
 
     if( gon.uncheckedCount && gon.uncheckedCount > 0 ) {
       var unchecked = $("<div class='alert alert-info' role='alert' />")
-        .append(Diaspora.I18n.t("admin.pods.unchecked", {count: gon.uncheckedCount}));
+        .append(Diaspora.I18n.t("admin.pods.unchecked", {count: gon.uncheckedCount.toLocaleString()}));
       msgs.appendChild(unchecked[0]);
     }
     if( gon.versionFailedCount && gon.versionFailedCount > 0 ) {
       var versionFailed = $("<div class='alert alert-warning' role='alert' />")
-          .append(Diaspora.I18n.t("admin.pods.version_failed", {count: gon.versionFailedCount}));
+          .append(Diaspora.I18n.t("admin.pods.version_failed", {count: gon.versionFailedCount.toLocaleString()}));
       msgs.appendChild(versionFailed[0]);
     }
     if( gon.errorCount && gon.errorCount > 0 ) {
       var errors = $("<div class='alert alert-danger' role='alert' />")
-        .append(Diaspora.I18n.t("admin.pods.errors", {count: gon.errorCount}));
+        .append(Diaspora.I18n.t("admin.pods.errors", {count: gon.errorCount.toLocaleString()}));
         msgs.appendChild(errors[0]);
+    }
+    if (gon.blockedCount && gon.blockedCount > 0) {
+      var blocked = $("<div class='alert alert-danger' role='alert' />")
+        .append(Diaspora.I18n.t("admin.pods.blocked", {count: gon.blockedCount.toLocaleString()}));
+      msgs.appendChild(blocked[0]);
     }
 
     $("#pod-alerts").html(msgs);

--- a/app/assets/javascripts/app/views/pod_entry_view.js
+++ b/app/assets/javascripts/app/views/pod_entry_view.js
@@ -7,15 +7,18 @@ app.views.PodEntry = app.views.Base.extend({
 
   events: {
     "click .more": "toggleMore",
-    "click .recheck": "recheckPod"
+    "click .recheck": "recheckPod",
+    "click .pod-unblock": "unblockPod",
+    "click .pod-block": "blockPod"
   },
 
   tooltipSelector: ".ssl-status i, .actions i",
 
   className: function() {
-    if( this.model.get("offline") ) { return "bg-danger"; }
-    if( this.model.get("status")==="version_failed" ) { return "bg-warning"; }
-    if( this.model.get("status")==="no_errors" ) { return "bg-success"; }
+    if (this.model.get("blocked") === true) { return "bg-light"; }
+    if (this.model.get("offline")) { return "bg-danger"; }
+    if (this.model.get("status") === "version_failed") { return "bg-warning"; }
+    if (this.model.get("status") === "no_errors") { return "bg-success"; }
   },
 
   initialize: function(opts) {
@@ -26,15 +29,16 @@ app.views.PodEntry = app.views.Base.extend({
 
   presenter: function() {
     return _.extend({}, this.defaultPresenter(), {
-      /* jshint camelcase: false */
+      /* eslint-disable camelcase */
       is_unchecked: (this.model.get("status")==="unchecked"),
       has_no_errors: (this.model.get("status")==="no_errors"),
       has_errors: (this.model.get("status")!=="no_errors"),
+      is_blocked: (this.model.get("blocked")),
       status_text: Diaspora.I18n.t("admin.pods.states."+this.model.get("status")),
       pod_url: (this.model.get("ssl") ? "https" : "http") + "://" + this.model.get("host") +
                  (this.model.get("port") ? ":" + this.model.get("port") : ""),
       response_time_fmt: this._fmtResponseTime()
-      /* jshint camelcase: true */
+      /* eslint-disable camelcase */
     });
   },
 
@@ -52,9 +56,19 @@ app.views.PodEntry = app.views.Base.extend({
     return false;
   },
 
+  blockPod: function() {
+    this.model.set("blocked", true);
+    this.model.save();
+  },
+
+  unblockPod: function() {
+    this.model.set("blocked", false);
+    this.model.save();
+  },
+
   recheckPod: function() {
-    var self  = this;
     this.$el.addClass("checking");
+    var self = this;
 
     this.model.recheck()
       .done(function(){

--- a/app/assets/templates/pod_table_entry_tpl.jst.hbs
+++ b/app/assets/templates/pod_table_entry_tpl.jst.hbs
@@ -13,8 +13,12 @@
 </td>
 <td>
   {{#if has_no_errors}}
-    <i title="{{status_text}}" class="glyphicon glyphicon-ok"></i>
-    {{software}}
+    {{#if is_blocked}}
+      <i title="{{status_text}}" class="glyphicon glyphicon-ban-circle"></i> {{t 'admin.pods.is_blocked'}}
+    {{else}}
+      <i title="{{status_text}}" class="glyphicon glyphicon-ok"></i>
+      {{software}}
+    {{/if}}
   {{else}}
     {{status_text}}
   {{/if}}
@@ -34,6 +38,11 @@
   </pre>
 </td>
 <td class="actions">
+  {{#if is_blocked}}
+    <a class="pod-unblock" href="#"><i title="Sync pod again" class="entypo entypo-play"></i></a>
+  {{else}}
+    <a class="pod-block" href="#"><i title="Stop syncing pod and hide posts" class="entypo entypo-block"></i></a>
+  {{/if}}
   {{#unless is_unchecked}}
     <a class="more" href="#"><i title="{{t 'admin.pods.more_info'}}" class="entypo-circled-help"></i></a>
   {{/unless}}

--- a/app/controllers/admin/pods_controller.rb
+++ b/app/controllers/admin/pods_controller.rb
@@ -14,12 +14,24 @@ module Admin
           gon.unchecked_count = Pod.unchecked.count
           gon.version_failed_count = Pod.version_failed.count
           gon.error_count = Pod.check_failed.count
+          gon.blocked_count = Pod.blocked.count
           gon.active_count = Pod.active.count
           gon.total_count = Pod.count
           render "admins/pods"
         end
         format.mobile { render "admins/pods" }
         format.json { render json: pods_json }
+      end
+    end
+
+    def update
+      permitted = params.permit(:blocked)
+      pod = Pod.find(params[:id])
+      pod.update!(permitted)
+
+      respond_with do |format|
+        format.html { redirect_to admin_pods_path }
+        format.json { render json: PodPresenter.new(pod).as_json }
       end
     end
 

--- a/app/controllers/api/v1/streams_controller.rb
+++ b/app/controllers/api/v1/streams_controller.rb
@@ -50,6 +50,8 @@ module Api
       def stream_responder(stream_klass=nil, query_time_field="posts.created_at", data_time_field="created_at")
         @stream = stream_klass.present? ? stream_klass.new(current_user, max_time: stream_max_time) : @stream
         query = @stream.stream_posts
+        query = query.left_outer_joins(author: [:pod])
+        query = query.where("(pods.blocked = false or pods.blocked is null)")
         query = query.where(public: true) unless private_read?
         posts_page = pager(query, query_time_field, data_time_field).response
         posts_page[:data] = posts_page[:data].map {|post| PostPresenter.new(post, current_user).as_api_response }

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -43,12 +43,11 @@ class PeopleController < ApplicationController
         # only do it if it is a diaspora*-ID
         if diaspora_id?(search_query)
           @people = Person.left_outer_joins(:pod)
-                          .where("(pods.blocked = false or pods.blocked is null)")
                           .where(diaspora_handle: search_query.downcase, closed_account: false)
-
           # TODO: Dont make a background fetch, if search_query references a pod which is blocked
           background_search(search_query) if @people.empty?
         end
+        @people = @people.where("(pods.blocked = FALSE or pods.blocked is NULL)")
         @people = @people.paginate(:page => params[:page], :per_page => 15)
         @hashes = hashes_for_people(@people, @aspects)
       end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -336,6 +336,13 @@ class Person < ApplicationRecord
 
   # discovery (webfinger)
   def self.find_or_fetch_by_identifier(diaspora_id)
+    # pod blocked?
+    if diaspora_handle_from_blocked_pod?(diaspora_id)
+      logger.info "Rejecting #{diaspora_id}, from blocked pod"
+      raise DiasporaFederation::Discovery::DiscoveryError,
+            "Failed discovery for #{diaspora_id}: blocked pod"
+    end
+
     # exiting person?
     person = by_account_identifier(diaspora_id)
     return person if person.present? && person.profile.present?

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -336,7 +336,6 @@ class Person < ApplicationRecord
 
   # discovery (webfinger)
   def self.find_or_fetch_by_identifier(diaspora_id)
-
     return nil if diaspora_handle_from_blocked_pod?(diaspora_id)
 
     # exiting person?
@@ -348,7 +347,6 @@ class Person < ApplicationRecord
     DiasporaFederation::Discovery::Discovery.new(diaspora_id).fetch_and_save
 
     by_account_identifier(diaspora_id)
-
   rescue DiasporaFederation::Discovery::InvalidDocument
     logger.info "#{diaspora_id} returns not as a valid document"
     nil
@@ -393,6 +391,12 @@ class Person < ApplicationRecord
     self
   end
 
+  def self.diaspora_handle_from_blocked_pod?(diaspora_handle)
+    host = diaspora_handle.split("@").last
+    pod = Pod.find_by(host: host)
+    !pod.nil? && pod.blocked
+  end
+
   private
 
   def fix_profile
@@ -409,11 +413,4 @@ class Person < ApplicationRecord
     diaspora_id = Person.where(guid: guid).where.not(diaspora_handle: diaspora_handle).pluck(:diaspora_handle).first
     errors.add(:base, "Person with same GUID already exists: #{diaspora_id}") if diaspora_id
   end
-
-  def self.diaspora_handle_from_blocked_pod?(diaspora_handle)
-    host = diaspora_handle.split('@').last
-    pod = Pod.find_by_host(host)
-    return !pod.nil? && pod.blocked
-  end
-
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -336,8 +336,6 @@ class Person < ApplicationRecord
 
   # discovery (webfinger)
   def self.find_or_fetch_by_identifier(diaspora_id)
-    return nil if diaspora_handle_from_blocked_pod?(diaspora_id)
-
     # exiting person?
     person = by_account_identifier(diaspora_id)
     return person if person.present? && person.profile.present?

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -6,6 +6,7 @@
 
 class Person < ApplicationRecord
   include Diaspora::Fields::Guid
+  include Diaspora::Federation
 
   # NOTE API V1 to be extracted
   acts_as_api

--- a/app/models/pod.rb
+++ b/app/models/pod.rb
@@ -42,6 +42,8 @@ class Pod < ApplicationRecord
     where(arel_table[:status].gt(Pod.statuses[:no_errors])).where.not(status: Pod.statuses[:version_failed])
   }
 
+  scope :blocked, -> { where(blocked: true) }
+
   scope :active, -> {
     where(["offline_since is null or offline_since > ?", DateTime.now.utc - ACTIVE_DAYS])
   }
@@ -77,7 +79,7 @@ class Pod < ApplicationRecord
   end
 
   def offline?
-    Pod.offline_statuses.include?(Pod.statuses[status])
+    Pod.offline_statuses.include?(Pod.statuses[status]) || blocked
   end
 
   # a pod is active if it is online or was online recently
@@ -100,6 +102,10 @@ class Pod < ApplicationRecord
     transaction do
       update_from_result(result)
     end
+  rescue URI::InvalidComponentError
+    logger.error "Invalid pod host: #{host}"
+  rescue StandardError => e
+    logger.error "While updating pod: #{host}, #{e.inspect}"
   end
 
   # @param path [String]

--- a/app/presenters/pod_presenter.rb
+++ b/app/presenters/pod_presenter.rb
@@ -15,6 +15,7 @@ class PodPresenter < BasePresenter
       offline_since: offline_since,
       created_at:    created_at,
       software:      software,
+      blocked:       blocked,
       error:         error
     }
   end

--- a/app/workers/fetch_webfinger.rb
+++ b/app/workers/fetch_webfinger.rb
@@ -10,6 +10,8 @@ module Workers
 
     def perform(account)
       person = Person.find_or_fetch_by_identifier(account)
+      return if person.nil?
+      return if person.pod.blocked
 
       # also, schedule to fetch a few public posts from that person
       Diaspora::Fetcher::Public.queue_for(person)

--- a/app/workers/receive_base.rb
+++ b/app/workers/receive_base.rb
@@ -26,6 +26,7 @@ module Workers
            DiasporaFederation::Salmon::InvalidEncoding,
            Diaspora::Federation::AuthorIgnored,
            Diaspora::Federation::InvalidAuthor,
+            Diaspora::Federation::PodBlocked,
            Diaspora::Federation::RecipientClosed => e
       logger.warn "don't retry for error: #{e.class}"
     end

--- a/app/workers/receive_base.rb
+++ b/app/workers/receive_base.rb
@@ -26,7 +26,7 @@ module Workers
            DiasporaFederation::Salmon::InvalidEncoding,
            Diaspora::Federation::AuthorIgnored,
            Diaspora::Federation::InvalidAuthor,
-            Diaspora::Federation::PodBlocked,
+           Diaspora::Federation::PodBlocked,
            Diaspora::Federation::RecipientClosed => e
       logger.warn "don't retry for error: #{e.class}"
     end

--- a/config/initializers/diaspora_federation.rb
+++ b/config/initializers/diaspora_federation.rb
@@ -86,7 +86,10 @@ DiasporaFederation.configure do |config|
     end
 
     on :fetch_public_key do |diaspora_id|
-      Person.find_or_fetch_by_identifier(diaspora_id).public_key
+      person = Person.find_or_fetch_by_identifier(diaspora_id)
+      if person
+        person.public_key unless person.pod&.blocked
+      end
     end
 
     on :fetch_related_entity do |entity_type, guid|

--- a/config/initializers/diaspora_federation.rb
+++ b/config/initializers/diaspora_federation.rb
@@ -16,42 +16,47 @@ DiasporaFederation.configure do |config|
     on :fetch_person_for_webfinger do |diaspora_id|
       person = Person.where(diaspora_handle: diaspora_id, closed_account: false).where.not(owner: nil).first
       if person
-        DiasporaFederation::Discovery::WebFinger.new(
-          {
-            acct_uri:      "acct:#{person.diaspora_handle}",
-            hcard_url:     AppConfig.url_to(DiasporaFederation::Engine.routes.url_helpers.hcard_path(person.guid)),
-            seed_url:      AppConfig.pod_uri,
-            profile_url:   person.profile_url,
-            atom_url:      person.atom_url,
-            salmon_url:    person.receive_url,
-            subscribe_url: AppConfig.url_to("/people?q={uri}")
-          },
-          aliases: [AppConfig.url_to("/people/#{person.guid}")],
-          links:   [
+        unless person.pod&.blocked
+          DiasporaFederation::Discovery::WebFinger.new(
             {
-              rel:  OpenIDConnect::Discovery::Provider::Issuer::REL_VALUE,
-              href: Rails.application.routes.url_helpers.root_url
-            }
-          ]
-        )
+              acct_uri:      "acct:#{person.diaspora_handle}",
+              hcard_url:     AppConfig.url_to(DiasporaFederation::Engine.routes.url_helpers.hcard_path(person.guid)),
+              seed_url:      AppConfig.pod_uri,
+              profile_url:   person.profile_url,
+              atom_url:      person.atom_url,
+              salmon_url:    person.receive_url,
+              subscribe_url: AppConfig.url_to("/people?q={uri}")
+            },
+            aliases: [AppConfig.url_to("/people/#{person.guid}")],
+            links:   [
+              {
+                rel:  OpenIDConnect::Discovery::Provider::Issuer::REL_VALUE,
+                href: Rails.application.routes.url_helpers.root_url
+              }
+            ]
+          )
+        end
       end
     end
 
     on :fetch_person_for_hcard do |guid|
       person = Person.where(guid: guid, closed_account: false).where.not(owner: nil).take
       if person
-        DiasporaFederation::Discovery::HCard.new(
-          guid:             person.guid,
-          nickname:         person.username,
-          full_name:        "#{person.profile.first_name} #{person.profile.last_name}".strip,
-          photo_large_url:  person.image_url,
-          photo_medium_url: person.image_url(size: :thumb_medium),
-          photo_small_url:  person.image_url(size: :thumb_small),
-          public_key:       person.serialized_public_key,
-          searchable:       person.searchable,
-          first_name:       person.profile.first_name,
-          last_name:        person.profile.last_name
-        )
+        unless person.pod&.blocked
+          DiasporaFederation::Discovery::HCard.new(
+            guid:             person.guid,
+            nickname:         person.username,
+            full_name:        "#{person.profile.first_name} #{person.profile.last_name}".strip,
+            url:              AppConfig.pod_uri,
+            photo_large_url:  person.image_url,
+            photo_medium_url: person.image_url(size: :thumb_medium),
+            photo_small_url:  person.image_url(size: :thumb_small),
+            public_key:       person.serialized_public_key,
+            searchable:       person.searchable,
+            first_name:       person.profile.first_name,
+            last_name:        person.profile.last_name
+          )
+        end
       end
     end
 

--- a/config/initializers/diaspora_federation.rb
+++ b/config/initializers/diaspora_federation.rb
@@ -114,8 +114,10 @@ DiasporaFederation.configure do |config|
       when DiasporaFederation::Entities::Retraction
         Diaspora::Federation::Receive.retraction(entity, recipient_id)
       else
-        persisted = Diaspora::Federation::Receive.perform(entity)
-        Workers::ReceiveLocal.perform_async(persisted.class.to_s, persisted.id, [recipient_id].compact) if persisted
+        if Diaspora::Federation::Entities.should_perform(entity)
+          persisted = Diaspora::Federation::Receive.perform(entity)
+          Workers::ReceiveLocal.perform_async(persisted.class.to_s, persisted.id, [recipient_id].compact) if persisted
+        end
       end
     end
 

--- a/config/locales/javascript/javascript.de.yml
+++ b/config/locales/javascript/javascript.de.yml
@@ -23,6 +23,7 @@ de:
         no_info: "Zurzeit keine weiteren Informationen verfügbar"
         not_available: "nicht verfügbar"
         offline_since: "offline seit:"
+        blocked: "Blockiert"
         pod: "Pod"
         recheck:
           failure: "Die Überprüfung wurde nicht durchgeführt."
@@ -49,6 +50,13 @@ de:
         version_failed:
           one: "Es gibt einen Pod, der keine Version hat (alter Pod, kein NodeInfo)."
           other: "Es gibt <%= count %> Pods, die keine Version haben (alte Pods, kein NodeInfo)."
+        is_blocked: "Der Pod wurde blockiert"
+        blocked:
+          one: "Ein Pod wurde blockiert"
+          other: "<%= count %> Pods wurden blockiert"
+        total_pods: 
+          one: "Es gibt genau einen Pod."
+          other: "Es gibt insgesamt <%= count %> Pods."
     admins:
       dashboard:
         compare_versions: "Die neueste diaspora*-Version ist <%= latestVersion %>, dein Pod verwendet <%= podVersion %>."

--- a/config/locales/javascript/javascript.de.yml
+++ b/config/locales/javascript/javascript.de.yml
@@ -23,7 +23,6 @@ de:
         no_info: "Zurzeit keine weiteren Informationen verfügbar"
         not_available: "nicht verfügbar"
         offline_since: "offline seit:"
-        blocked: "Blockiert"
         pod: "Pod"
         recheck:
           failure: "Die Überprüfung wurde nicht durchgeführt."

--- a/config/locales/javascript/javascript.de_formal.yml
+++ b/config/locales/javascript/javascript.de_formal.yml
@@ -23,6 +23,7 @@ de_formal:
         no_info: "Zur Zeit sind keine weiteren Informationen verfügbar"
         not_available: "Nicht verfügbar"
         offline_since: "offline seit:"
+        blocked: "Blockiert"
         pod: "Pod"
         recheck:
           failure: "Die Überprüfung wurde nicht durchgeführt."

--- a/config/locales/javascript/javascript.de_moo.yml
+++ b/config/locales/javascript/javascript.de_moo.yml
@@ -23,6 +23,7 @@ de_moo:
         no_info: "Zurzeit sind keine weiteren Informationen verfügbar"
         not_available: "nicht verfügbar"
         offline_since: "offline seit:"
+        blocked: "Blockiert"
         pod: "Bauernhof"
         recheck:
           failure: "Die Überprüfung wurde nicht durchgeführt."

--- a/config/locales/javascript/javascript.en.yml
+++ b/config/locales/javascript/javascript.en.yml
@@ -55,6 +55,7 @@ en:
           unknown_error: "An unspecified error has happened during the check"
         actions: "Actions"
         offline_since: "offline since:"
+        blocked: "Blocked"
         last_check: "last check:"
         more_info: "show more information"
         check: "perform connection test"
@@ -87,7 +88,13 @@ en:
         errors:
           one: "The connection test returned an error for one pod."
           other: "The connection test returned an error for <%= count %> pods."
-
+        is_blocked: "Pod is blocked"
+        blocked:
+          one: "One pod is blocked"
+          other: "<%= count %> pods are blocked"
+        total_pods:
+          one: "There is only one pod."
+          other: "There are <%= count %> pods total."
     aspects:
       name: "Name"
       create:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,7 +147,7 @@ Rails.application.routes.draw do
   end
 
   namespace :admin do
-    resources :pods, only: :index do
+    resources :pods, only: %i[index update] do
       post :recheck
     end
 

--- a/lib/archive_importer/post_importer.rb
+++ b/lib/archive_importer/post_importer.rb
@@ -24,6 +24,8 @@ class ArchiveImporter
       json.fetch("subscribed_users_ids", []).each do |diaspora_id|
         begin
           person = Person.find_or_fetch_by_identifier(diaspora_id)
+          next if person.nil? # TODO: Side effect of 'disable_pods', but import needs rework anyway
+
           person = person.account_migration.newest_person unless person.account_migration.nil?
           next if person.closed_account?
           # TODO: unless person.nil? import subscription: subscription import is not supported yet

--- a/lib/diaspora/federation.rb
+++ b/lib/diaspora/federation.rb
@@ -13,6 +13,10 @@ module Diaspora
     # Raised, if the recipient account is closed already
     class RecipientClosed < RuntimeError
     end
+
+    # Raised if pod is blocked by admin
+    class PodBlocked < RuntimeError
+    end
   end
 end
 

--- a/lib/diaspora/federation/entities.rb
+++ b/lib/diaspora/federation/entities.rb
@@ -241,7 +241,7 @@ module Diaspora
       end
 
       def self.closed_account?(diaspora_handle)
-        return false if diaspora_handle.present?
+        return false if diaspora_handle.blank?
 
         person = Person.find_or_fetch_by_identifier(diaspora_handle)
         person&.closed?

--- a/lib/diaspora/federation/entities.rb
+++ b/lib/diaspora/federation/entities.rb
@@ -225,6 +225,27 @@ module Diaspora
           parent: entity.respond_to?(:parent) ? related_entity(entity.parent) : nil
         )
       end
+
+      def self.should_perform(entity)
+        author = entity.try(:diaspora_handle)
+        return false if author.present? && Person.diaspora_handle_from_blocked_pod(author.diaspora_id)
+
+        root_author = entity.try(:root_diaspora_id)
+        return false if root_author.present? && Person.diaspora_handle_from_blocked_pod(root_author)
+
+        return false if closed_account(author)
+
+        return false if closed_account(root_author)
+
+        true
+      end
+
+      def self.closed_account(diaspora_handle)
+        return false if diaspora_handle.nil?
+
+        person = Person.find_or_fetch_by_identifier(diaspora_handle)
+        person&.closed?
+      end
     end
   end
 end

--- a/lib/diaspora/federation/entities.rb
+++ b/lib/diaspora/federation/entities.rb
@@ -228,20 +228,20 @@ module Diaspora
 
       def self.should_perform(entity)
         author = entity.try(:diaspora_handle)
-        return false if author.present? && Person.diaspora_handle_from_blocked_pod(author.diaspora_id)
+        return false if author.present? && Person.diaspora_handle_from_blocked_pod?(author)
 
         root_author = entity.try(:root_diaspora_id)
-        return false if root_author.present? && Person.diaspora_handle_from_blocked_pod(root_author)
+        return false if root_author.present? && Person.diaspora_handle_from_blocked_pod?(root_author)
 
-        return false if closed_account(author)
+        return false if closed_account?(author)
 
-        return false if closed_account(root_author)
+        return false if closed_account?(root_author)
 
         true
       end
 
-      def self.closed_account(diaspora_handle)
-        return false if diaspora_handle.nil?
+      def self.closed_account?(diaspora_handle)
+        return false if diaspora_handle.present?
 
         person = Person.find_or_fetch_by_identifier(diaspora_handle)
         person&.closed?

--- a/lib/diaspora/fetcher/public.rb
+++ b/lib/diaspora/fetcher/public.rb
@@ -17,6 +17,10 @@ module Diaspora; module Fetcher; class Public
   Status_Unfetchable = 6
 
   def self.queue_for(person)
+    unless person.pod.nil?
+      return if person.pod.blocked
+    end
+
     Workers::FetchPublicPosts.perform_async(person.diaspora_handle) unless person.fetch_status > Status_Initial
   end
 
@@ -47,6 +51,10 @@ module Diaspora; module Fetcher; class Public
       if @person.local?
         set_fetch_status Public::Status_Unfetchable
         return false
+      end
+
+      unless @person.pod.nil?
+        return false if @person.pod.blocked
       end
 
       # this record is already being worked on

--- a/lib/diaspora/fetcher/public.rb
+++ b/lib/diaspora/fetcher/public.rb
@@ -17,9 +17,7 @@ module Diaspora; module Fetcher; class Public
   Status_Unfetchable = 6
 
   def self.queue_for(person)
-    unless person.pod.nil?
-      return if person.pod.blocked
-    end
+    return if person.pod&.blocked
 
     Workers::FetchPublicPosts.perform_async(person.diaspora_handle) unless person.fetch_status > Status_Initial
   end

--- a/lib/diaspora/fetcher/public.rb
+++ b/lib/diaspora/fetcher/public.rb
@@ -51,9 +51,7 @@ module Diaspora; module Fetcher; class Public
         return false
       end
 
-      unless @person.pod.nil?
-        return false if @person.pod.blocked
-      end
+      return false if @person.pod&.blocked
 
       # this record is already being worked on
       return false if @person.fetch_status > Public::Status_Initial

--- a/lib/stream/aspect.rb
+++ b/lib/stream/aspect.rb
@@ -39,6 +39,8 @@ class Stream::Aspect < Stream::Base
                                              :order => "#{order} DESC",
                                              :max_time => max_time
                    )
+    @posts = @posts.left_outer_joins(author: [:pod])
+                   .where("(pods.blocked = false or pods.blocked is null)")
   end
 
   # @return [ActiveRecord::Association<Person>] AR association of people within stream's given aspects

--- a/spec/controllers/admin/pods_controller_spec.rb
+++ b/spec/controllers/admin/pods_controller_spec.rb
@@ -18,6 +18,7 @@ describe Admin::PodsController, type: :controller do
 
     it "contains the preloads" do
       get :index
+      expect(response.body).to match(/totalPodCount=/im)
       expect(response.body).to match(/uncheckedCount=/im)
       expect(response.body).to match(/errorCount=/im)
       expect(response.body).to match(/preloads.*"pods"\s?\:/im)

--- a/spec/lib/diaspora/fetcher/public_spec.rb
+++ b/spec/lib/diaspora/fetcher/public_spec.rb
@@ -178,6 +178,19 @@ describe Diaspora::Fetcher::Public do
         }).to be false
       end
 
+      it "returns false if the person resides on a blocked pod" do
+        user = FactoryBot.create(:user)
+        pod = FactoryBot.create(:pod)
+        pod.blocked = true
+        user.person.pod = pod
+        user.person.save
+        expect(public_fetcher.instance_eval {
+          @person = user.person
+          qualifies_for_fetching?
+        }).to be false
+        expect(user.person.fetch_status).to eql Diaspora::Fetcher::Public::Status_Unfetchable
+      end
+
       it "returns true, if the user is remote and hasn't been fetched" do
         person = FactoryBot.create(:person, {diaspora_handle: "neo@theone.net"})
         expect(public_fetcher.instance_eval {

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -411,6 +411,8 @@ describe Person, type: :model do
       @casey_grippi = FactoryBot.build(:person)
       @invisible_person = FactoryBot.build(:person)
       @closed_account = FactoryBot.build(:person, closed_account: true)
+      @blocked_by_pod = FactoryBot.build(:person)
+      @pod = Pod.find_or_create_by(url: "https://example.org")
 
       @robert_grimm.profile.first_name = "Robert"
       @robert_grimm.profile.last_name = "Grimm"
@@ -442,6 +444,12 @@ describe Person, type: :model do
       @closed_account.profile.last_name = "Account"
       @closed_account.profile.save
       @closed_account.reload
+
+      @blocked_by_pod.pod = @pod
+      @blocked_by_pod.profile.first_name = "Blocked_pod"
+      @blocked_by_pod.profile.last_name = "Blocked"
+      @blocked_by_pod.profile.save
+      @blocked_by_pod.reload
     end
 
     it "orders results by last name" do
@@ -500,6 +508,18 @@ describe Person, type: :model do
       expect(Person.search("Closed", @user)).to be_empty
       expect(Person.search("Account", @user)).to be_empty
       expect(Person.search(@closed_account.diaspora_handle, @user)).to be_empty
+    end
+
+    it "doesn't display persons from blocked pods" do
+      @blocked_by_pod.pod.blocked = true
+      @blocked_by_pod.pod.save
+      expect(Person.search("blocked_pod", @user)).to be_empty
+    end
+
+    it "display persons from unblocked pods" do
+      @blocked_by_pod.pod.blocked = false
+      @blocked_by_pod.pod.save
+      expect(Person.search("blocked_pod", @user).first).to eq(@blocked_by_pod)
     end
 
     it "displays contacts that are not searchable" do


### PR DESCRIPTION
It uses the already existing 'blocked' information of Pods. 

On Adminview a 'blocked/unblock' UI element is added. 
A blocked pod is then filtered out in any stream views. No Database element is deleted or changed. 

This Feature was requested in Issue #6640 and also discussed/requested in https://discourse.diasporafoundation.org/t/add-better-spam-controls/296

Is this a viable approach? 
On https://societas.online this is already rolled out and ready to test. 

Block / Unblock
<img width="884" alt="Bildschirmfoto 2021-04-04 um 13 32 20" src="https://user-images.githubusercontent.com/501326/113507388-63d5b300-954a-11eb-846c-12f0b995d01d.png">

Added blocked pod count in pod list - header
<img width="680" alt="Bildschirmfoto 2021-04-04 um 13 31 56" src="https://user-images.githubusercontent.com/501326/113507405-718b3880-954a-11eb-976b-da59145790cb.png">

Any remarks / ideas or help is appreciated. 
