### PR TITLE
Update mimemagic (0.3.5 is removed from rubygems.org)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -404,7 +404,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)


### PR DESCRIPTION
Fix for #8229