### PR TITLE
7992 wrap local_posts from statistics in a cache

### DIFF
--- a/app/presenters/node_info_presenter.rb
+++ b/app/presenters/node_info_presenter.rb
@@ -100,17 +100,17 @@ class NodeInfoPresenter
   end
 
   def local_posts
-    Rails.cache.fetch("NodeInfoPresenter/local_posts", expires_in: 1.hours) do
+    Rails.cache.fetch("NodeInfoPresenter/local_posts", expires_in: 1.hour) do
       @local_posts ||= Post.where(type: "StatusMessage")
-                          .joins(:author)
-                          .where("owner_id IS NOT null")
-                          .count
+                           .joins(:author)
+                           .where.not(people: {owner_id: nil})
+                           .count
     end
   end
 
   def local_comments
     @local_comments ||= Comment.joins(:author)
-                               .where("owner_id IS NOT null")
+                               .where.not(people: {owner_id: nil})
                                .count
   end
 end

--- a/app/presenters/node_info_presenter.rb
+++ b/app/presenters/node_info_presenter.rb
@@ -100,10 +100,12 @@ class NodeInfoPresenter
   end
 
   def local_posts
-    @local_posts ||= Post.where(type: "StatusMessage")
-                         .joins(:author)
-                         .where("owner_id IS NOT null")
-                         .count
+    Rails.cache.fetch("NodeInfoPresenter/local_posts", expires_in: 1.hours) do
+      @local_posts ||= Post.where(type: "StatusMessage")
+                          .joins(:author)
+                          .where("owner_id IS NOT null")
+                          .count
+    end
   end
 
   def local_comments

--- a/app/presenters/node_info_presenter.rb
+++ b/app/presenters/node_info_presenter.rb
@@ -109,8 +109,10 @@ class NodeInfoPresenter
   end
 
   def local_comments
-    @local_comments ||= Comment.joins(:author)
-                               .where.not(people: {owner_id: nil})
-                               .count
+    Rails.cache.fetch("NodeInfoPresenter/local_comments", expires_in: 1.hour) do
+      @local_comments ||= Comment.joins(:author)
+                                 .where.not(people: {owner_id: nil})
+                                 .count
+    end
   end
 end


### PR DESCRIPTION
As requested in  #7992 it wraps get NodeInfoPresenter.local_posts in a 1 hour cache. 