### PR TITLE
8139 add a podmin mail to footer

### DIFF
--- a/app/views/shared/_links.haml
+++ b/app/views/shared/_links.haml
@@ -7,3 +7,5 @@
 %li= link_to t("layouts.application.switch_to_touch_optimized_mode"), toggle_mobile_path
 - if AppConfig.settings.terms.enable?
   %li= link_to t("_terms"), terms_path
+- unless AppConfig.admins.podmin_email.nil?
+  %li= mail_to AppConfig.admins.podmin_email, t("_podmin_mail")

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -32,6 +32,7 @@ en:
   no_results: "No results found"
   _contacts: "Contacts"
   _terms: "Terms"
+  _podmin_mail: "Podmin Mail"
   _statistics: "Statistics"
 
   # For reference translation; the real ActiveRecord English transations are actually

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -32,7 +32,7 @@ en:
   no_results: "No results found"
   _contacts: "Contacts"
   _terms: "Terms"
-  _podmin_mail: "Podmin Mail"
+  _podmin_mail: "Contact Podmin"
   _statistics: "Statistics"
 
   # For reference translation; the real ActiveRecord English transations are actually


### PR DESCRIPTION
As requested in #8139 it adds a podmin mail address to footer if set in configuration. 
<img width="382" alt="Footer screenshot" src="https://user-images.githubusercontent.com/501326/117565878-ec002880-b0b3-11eb-9682-e0e4ce96baf0.png">
