### PR TITLE
Let podmin send private messages to local users

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -20,7 +20,11 @@ class ContactsController < ApplicationController
       format.json {
         @people = if params[:q].present?
                     mutual = params[:mutual].present? && params[:mutual]
-                    Person.search(params[:q], current_user, only_contacts: true, mutual: mutual).limit(15)
+                    if current_user.admin?
+                      Person.search_for_admin(params[:q], current_user, only_contacts: true, mutual: mutual).limit(15)
+                    else
+                      Person.search(params[:q], current_user, only_contacts: true, mutual: mutual).limit(15)
+                    end
                   else
                     set_up_contacts_json
                   end

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -21,7 +21,7 @@ class ContactsController < ApplicationController
         @people = if params[:q].present?
                     mutual = params[:mutual].present? && params[:mutual]
                     if current_user.admin?
-                      Person.search_for_admin(params[:q], current_user, only_contacts: true, mutual: mutual).limit(15)
+                      Person.search_as_admin(params[:q], current_user, only_contacts: true, mutual: mutual).limit(15)
                     else
                       Person.search(params[:q], current_user, only_contacts: true, mutual: mutual).limit(15)
                     end

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -123,7 +123,7 @@ class ConversationsController < ApplicationController
   end
 
   def no_contacts?
-    # an admin always has at least all local contcts
+    # an admin always has at least all local contacts
     return false if current_user.admin?
 
     current_user.contacts.mutual.empty?

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -24,9 +24,8 @@ class ConversationsController < ApplicationController
     end
 
     gon.contacts = contacts_data
-
     respond_with do |format|
-      format.html { render "index", locals: {no_contacts: current_user.contacts.mutual.empty?} }
+      format.html { render "index", locals: {no_contacts: has_no_contacts?} }
       format.json { render json: @visibilities.map(&:conversation), status: 200 }
     end
   end
@@ -37,7 +36,12 @@ class ConversationsController < ApplicationController
     # This will have to be removed when mobile autocomplete is ported to Typeahead
     recipients_param, column = [%i(contact_ids id), %i(person_ids person_id)].find {|param, _| params[param].present? }
     if recipients_param
-      person_ids = current_user.contacts.mutual.where(column => params[recipients_param].split(",")).pluck(:person_id)
+      # As an admin, I want to send a message to all local user
+      if current_user.admin? 
+        person_ids = JSON.parse("[#{params[:person_ids]}]")
+      else
+        person_ids = current_user.contacts.mutual.where(column => params[recipients_param].split(",")).pluck(:person_id)
+      end
     end
 
     unless person_ids.present?
@@ -49,7 +53,7 @@ class ConversationsController < ApplicationController
     opts[:participant_ids] = person_ids
     opts[:message] = { text: params[:conversation][:text] }
     @conversation = current_user.build_conversation(opts)
-
+    puts "Built conversation: #{@conversation} "
     if @conversation.save
       Diaspora::Federation::Dispatcher.defer_dispatch(current_user, @conversation)
       flash[:notice] = I18n.t("conversations.create.sent")
@@ -117,5 +121,11 @@ class ConversationsController < ApplicationController
       .map {|contact_id, *name_attrs|
         {value: contact_id, name: ERB::Util.h(Person.name_from_attrs(*name_attrs)) }
       }
+  end
+
+  def has_no_contacts?
+    # an admin always has at least all local contcts
+    return false if current_user.admin?
+    current_user.contacts.mutual.empty? 
   end
 end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -15,7 +15,7 @@ class Conversation < ApplicationRecord
     recipients.each do |recipient|
       if recipient.local?
         unless recipient.owner.contacts.where(person_id: author.id).any? ||
-            (author.owner && author.owner.podmin_account?)
+            (author.owner && (author.owner.podmin_account? || author.owner.admin?))
           errors.add(:all_recipients, "recipient not allowed")
         end
       end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -248,7 +248,7 @@ class Person < ApplicationRecord
 
     [where_clause, q_tokens]
   end
- 
+
   # rubocop:disable Rails/DynamicFindBy
   def self.search(search_str, user, only_contacts: false, mutual: false)
     query = find_by_substring(search_str)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -248,7 +248,7 @@ class Person < ApplicationRecord
 
     [where_clause, q_tokens]
   end
-  
+ 
   # rubocop:disable Rails/DynamicFindBy
   def self.search(search_str, user, only_contacts: false, mutual: false)
     query = find_by_substring(search_str)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -105,6 +105,11 @@ class Person < ApplicationRecord
     joins(:contacts).where(contacts: {user_id: user.id})
   }
 
+  scope :contacts_of_for_admins, ->(user) {
+    left_outer_joins(:contacts).where(contacts: {user_id: user.id})
+    .or(Person.where("order_id > 0"))
+  }
+
   scope :profile_tagged_with, ->(tag_name) {
     joins(:profile => :tags)
       .where(:tags => {:name => tag_name})
@@ -247,17 +252,32 @@ class Person < ApplicationRecord
   def self.search(search_str, user, only_contacts: false, mutual: false)
     query = find_by_substring(search_str)
     return query if query.is_a?(ActiveRecord::NullRelation)
-
     query = if only_contacts
               query.contacts_of(user)
             else
               query.searchable(user)
             end
-
     query = query.where(contacts: {sharing: true, receiving: true}) if mutual
 
     query.where(closed_account: false)
          .order([Arel.sql("contacts.user_id IS NULL"), "profiles.last_name ASC", "profiles.first_name ASC"])
+  end
+
+  def self.search_for_admin(search_str, user, only_contacts: false, mutual: false)
+    query = find_by_substring(search_str)
+    return query if query.is_a?(ActiveRecord::NullRelation)
+    query = if only_contacts
+              query.where("exists (" + exists_in_contacts(user, mutual) + ") or people.owner_id is not null")
+            else
+              query.searchable(user)
+            end
+    query.where(closed_account: false)
+         .order(["profiles.last_name ASC", "profiles.first_name ASC"])
+  end
+  
+  def self.exists_in_contacts(user, mutual)
+    return "select 1 from contacts where contacts.user_id = #{user.id}" unless mutual
+    "select 1 from contacts where contacts.user_id = #{user.id} and sharing = true and receiving = true"
   end
 
   def name(opts = {})

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -264,7 +264,7 @@ class Person < ApplicationRecord
          .order([Arel.sql("contacts.user_id IS NULL"), "profiles.last_name ASC", "profiles.first_name ASC"])
   end
 
-  def self.search_for_admin(search_str, user, only_contacts: false, mutual: false)
+  def self.search_as_admin(search_str, user, only_contacts: false, mutual: false)
     query = find_by_substring(search_str)
     return query if query.is_a?(ActiveRecord::NullRelation)
 
@@ -279,10 +279,10 @@ class Person < ApplicationRecord
   # rubocop:enable Rails/DynamicFindBy
 
   def self.exists_in_contacts(user, mutual)
-    return "select 1 from contacts where contacts.person_id = people.id and contacts.user_id = #{user.id}" unless mutual
+    return "SELECT 1 FROM contacts WHERE contacts.person_id = people.id AND contacts.user_id = #{user.id}" unless mutual
 
-    "select 1 from contacts where contacts.person_id = people.id
-     and contacts.user_id = #{user.id} and sharing = true and receiving = true"
+    "SELECT 1 FROM contacts WHERE contacts.person_id = people.id
+     AND contacts.user_id = #{user.id} AND sharing = TRUE AND receiving = TRUE"
   end
 
   def name(opts = {})

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -368,7 +368,7 @@ class User < ApplicationRecord
   end
 
   ######### Posts and Such ###############
-  def cretract(target)
+  def retract(target)
     retraction = Retraction.for(target)
     retraction.defer_dispatch(self)
     retraction.perform

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -368,7 +368,7 @@ class User < ApplicationRecord
   end
 
   ######### Posts and Such ###############
-  def retract(target)
+  def cretract(target)
     retraction = Retraction.for(target)
     retraction.defer_dispatch(self)
     retraction.perform

--- a/spec/controllers/contacts_controller_spec.rb
+++ b/spec/controllers/contacts_controller_spec.rb
@@ -64,6 +64,22 @@ describe ContactsController, :type => :controller do
           get :index, params: {q: @person3.first_name, mutual: true}, format: :json
           expect(response.body).to eq([@person3].to_json)
         end
+
+        it "returns local contacts if admin" do
+          Role.add_admin bob.person
+          local_user = FactoryBot.create(:person)
+          local_user.owner_id = 42
+          local_user.save
+          get :index, params: {q: local_user.first_name, mutual: true}, format: :json
+          expect(response.body).to eq([local_user].to_json)
+        end
+
+        it "wont return remote user if admin" do
+          remote_user = FactoryBot.create(:person)
+          Role.add_admin bob.person
+          get :index, params: {q: remote_user.first_name, mutual: true}, format: :json
+          expect(response.body).to eq([].to_json)
+        end
       end
 
       context "for pagination on the contacts page" do


### PR DESCRIPTION
Hidden under this headline https://github.com/diaspora/diaspora/issues/7297 a podmin should be allowed to send a message to it's local users even when they don't share each others. 

Together with improved report system (see PR #8239 ), there are some cases when a podmin needs to get in contact for a specific topic to its users. 
There are also many other situations where a private message is very helpful between podmin and users. 


