### PR TITLE
Add missing closing tag of textarea, fix 'Comment' button not appearing for some browser

### DIFF
--- a/app/assets/templates/comment-stream_tpl.jst.hbs
+++ b/app/assets/templates/comment-stream_tpl.jst.hbs
@@ -29,7 +29,8 @@
             class="new-comment" id="new-comment-on-{{id}}" method="post">
 
         <textarea class="comment-box form-control mention-textarea"
-                  id="comment_text_on_{{id}}" name="text" rows="1" required placeholder="{{t "stream.comment"}}" />
+                  id="comment_text_on_{{id}}" name="text" rows="1" required placeholder="{{t "stream.comment"}}">
+        </textarea>
         <div class="typeahead-mention-box-wrap">
           <input class="typeahead-mention-box hidden" type="text">
         </div>


### PR DESCRIPTION
I just discovered [that post](https://diaspora-fr.org/posts/a2892a70e5800138a521448a5bd87df2) from @pravi

It was a bug, we used the textarea element this way: `<textarea />`, but that's a mistake, according to the W3C specification:

>Tag omission: None, both the starting and ending tag are mandatory.

This non closed tag resulted to the following HTML element (here, the "Comment" button) being considered as inside the textarea in some browser, so not displayed. This pull request correctly closes the HTML tag.

@pravi next time please ping me when this kind of things happen ;)