### PR TITLE
Migration: Fixing import  issues / Speed up repeated unknown pod detection

### DIFF
--- a/lib/archive_importer/entity_importer.rb
+++ b/lib/archive_importer/entity_importer.rb
@@ -15,12 +15,14 @@ class ArchiveImporter
     rescue DiasporaFederation::Entities::Signable::SignatureVerificationFailed,
            DiasporaFederation::Discovery::InvalidDocument,
            DiasporaFederation::Discovery::DiscoveryError,
+           DiasporaFederation::Federation::Fetcher::NotFetchable,
+           OwnRelayableImporter::NoParentError,
            ActiveRecord::RecordInvalid => e
       logger.warn "#{self}: #{e}"
+      self.persisted_object = nil
     end
 
-    attr_reader :json
-    attr_reader :user
+    attr_reader :json, :user
     attr_accessor :persisted_object
 
     def entity

--- a/lib/archive_importer/own_entity_importer.rb
+++ b/lib/archive_importer/own_entity_importer.rb
@@ -21,11 +21,13 @@ class ArchiveImporter
     attr_reader :old_author_id
 
     def persisted_object
-      @persisted_object ||= (instance if real_author == old_author_id)
+      return @persisted_object if defined?(@persisted_object)
+
+      @persisted_object = (instance if real_author == old_author_id)
     end
 
     def real_author
-      instance.author.diaspora_handle
+      instance&.author&.diaspora_handle
     end
   end
 end

--- a/lib/archive_importer/own_relayable_importer.rb
+++ b/lib/archive_importer/own_relayable_importer.rb
@@ -2,6 +2,8 @@
 
 class ArchiveImporter
   class OwnRelayableImporter < OwnEntityImporter
+    class NoParentError < RuntimeError; end
+
     def entity
       fetch_parent(symbolized_entity_data)
       entity_class.new(symbolized_entity_data)
@@ -19,6 +21,8 @@ class ArchiveImporter
         break entity_class::PARENT_TYPE if entity_class.const_defined?(:PARENT_TYPE)
       }
       entity = Diaspora::Federation::Mappings.model_class_for(type).find_by(guid: data.fetch(:parent_guid))
+      raise NoParentError if entity.nil?
+
       data[:parent] = Diaspora::Federation::Entities.related_entity(entity)
     end
   end

--- a/spec/lib/archive_importer/post_importer_spec.rb
+++ b/spec/lib/archive_importer/post_importer_spec.rb
@@ -113,5 +113,34 @@ describe ArchiveImporter::PostImporter do
         end
       end
     end
+
+    context "with reshare" do
+      let(:guid) { UUID.generate(:compact) }
+      let(:entity_json) { JSON.parse(<<~JSON) }
+        {
+          "entity_data" : {
+             "created_at" : "2015-10-19T13:58:16Z",
+             "guid" : "#{guid}",
+             "author" : "#{new_user.diaspora_handle}",
+             "root_author" : "author@example.com",
+             "root_guid" : "#{UUID.generate(:compact)}"
+          },
+          "entity_type" : "reshare"
+        }
+      JSON
+
+      context "with unknown root author" do
+        it "handles missing person" do
+          allow(DiasporaFederation::Federation::Fetcher).to receive(:fetch_public)
+            .and_raise(DiasporaFederation::Federation::Fetcher::NotFetchable)
+
+          expect {
+            instance.import
+          }.not_to raise_error
+
+          expect(Reshare.find_by(guid: guid)).to be_nil
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
It handles some migration issues listed in #8256, please check @cmrd-senya, @jhass, @Flaburgan .
(Import stops when posts comments or likes don't have a parent/author),
It handles #8019 (caching person fetches from remotes)

For this reason I changed the Person.find_or_fetch_by_identifier function. It now won't raise a NotFetchable exception, it just returns nil or the person object. Some callers rely on nil (which was never returned), some other rely on exception. IMHO this function should return an existing person from local store or by fetching, but never raise an exception. 
Now,  Person.find_or_fetch_by_identifier  returns a person, or nil. Callers are adapted to this behaviour.

@cmrd-senya : I left over a failing test, which I can't fix, maybe you have on eye on this? 
@jhass : can you check import - times with your archive file?