### PR TITLE
Don't export chat_enabled flag anymore

### DIFF
--- a/app/serializers/export/aspect_serializer.rb
+++ b/app/serializers/export/aspect_serializer.rb
@@ -2,6 +2,6 @@
 
 module Export
   class AspectSerializer < ActiveModel::Serializer
-    attributes :name, :chat_enabled
+    attributes :name
   end
 end

--- a/lib/schemas/archive-format.json
+++ b/lib/schemas/archive-format.json
@@ -35,8 +35,7 @@
           "items": {
             "type": "object",
             "properties": {
-              "name": { "type": "string" },
-              "chat_enabled": { "type": "boolean" }
+              "name": { "type": "string" }
             },
             "required": [
               "name"

--- a/spec/integration/exporter_spec.rb
+++ b/spec/integration/exporter_spec.rb
@@ -46,12 +46,10 @@ describe Diaspora::Exporter do
         user: {
           "contact_groups": [
             {
-              "name":             "generic",
-              "chat_enabled":     false
+              "name": "generic"
             },
             {
-              "name":             "Work",
-              "chat_enabled":     false
+              "name": "Work"
             }
           ]
         }

--- a/spec/serializers/export/aspect_serializer_spec.rb
+++ b/spec/serializers/export/aspect_serializer_spec.rb
@@ -6,8 +6,7 @@ describe Export::AspectSerializer do
 
   it "has aspect attributes" do
     expect(serializer.attributes).to eq(
-      name:         aspect.name,
-      chat_enabled: aspect.chat_enabled
+      name: aspect.name
     )
   end
 end


### PR DESCRIPTION
The chat is already removed for 0.8, so there is no need to still export this data since it can't be imported anyway.

Related to #8069