### PR TITLE
Allow points and dashes in the username

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -126,16 +126,10 @@ class PeopleController < ApplicationController
 
   def find_person
     username = params[:username]
-    @person = if diaspora_id?(username)
-        Person.where({
-          diaspora_handle: username.downcase
-        }).first
-      else
-        Person.find_from_guid_or_username({
-          id: params[:id] || params[:person_id],
-          username: username
-        })
-      end
+    @person = Person.find_from_guid_or_username(
+      id:       params[:id] || params[:person_id],
+      username: username
+    )
 
     raise ActiveRecord::RecordNotFound if @person.nil?
     raise Diaspora::AccountClosed if @person.closed_account?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,10 +36,8 @@ class User < ApplicationRecord
   before_validation :set_current_language, :on => :create
   before_validation :set_default_color_theme, on: :create
 
-  validates :username, :presence => true, :uniqueness => true
-  validates_format_of :username, :with => /\A[A-Za-z0-9_]+\z/
-  validates_length_of :username, :maximum => 32
-  validates_exclusion_of :username, :in => AppConfig.settings.username_blacklist
+  validates :username, presence: true, uniqueness: true, format: {with: /\A[A-Za-z0-9_.\-]+\z/},
+                       length: {maximum: 32}, exclusion: {in: AppConfig.settings.username_blacklist}
   validates_inclusion_of :language, :in => AVAILABLE_LANGUAGE_CODES
   validates :color_theme, inclusion: {in: AVAILABLE_COLOR_THEMES}, allow_blank: true
   validates_format_of :unconfirmed_email, :with  => Devise.email_regexp, :allow_blank => true

--- a/app/views/registrations/_form.haml
+++ b/app/views/registrations/_form.haml
@@ -32,7 +32,7 @@
                    placeholder: t("registrations.new.username"),
                    title:       t("registrations.new.enter_username"),
                    required:    true,
-                   pattern:     "[A-Za-z0-9_]+",
+                   pattern:     "[A-Za-z0-9_.\-]+",
                    aria:        {labelledby: "usernameLabel"}
 
     - if mobile

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -186,7 +186,11 @@ Rails.application.routes.draw do
       post 'by_handle' => :retrieve_remote, :as => 'person_by_handle'
     end
   end
-  get '/u/:username' => 'people#show', :as => 'user_profile', :constraints => { :username => /[^\/]+/ }
+
+  # Note: The contraint for this route's username parameter cannot be removed.
+  # This constraint turns off the format parameter, so that an username
+  # doctor.example would not try to render the user `doctor` in `example` format.
+  get "/u/:username" => "people#show", :as => "user_profile", :constraints => {username: %r{[^/]+}}
 
   # External
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -213,7 +213,7 @@ Rails.application.routes.draw do
   get 'help/:topic' => 'help#faq'
 
   #Protocol Url
-  get "protocol" => redirect("https://wiki.diasporafoundation.org/Federation_Protocol_Overview")
+  get "protocol" => redirect("https://diaspora.github.io/diaspora_federation/")
 
   # NodeInfo
   get ".well-known/nodeinfo", to: "node_info#jrd"

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -206,16 +206,6 @@ describe PeopleController, type: :controller do
       expect(assigns(:presenter).to_json).to eq(@presenter.to_json)
     end
 
-    it "404s if no person is found via diaspora handle" do
-      get :show, params: {username: "delicious@pod.net"}
-      expect(response.code).to eq("404")
-    end
-
-    it "finds a person via diaspora handle" do
-      get :show, params: {username: @person.diaspora_handle}
-      expect(assigns(:presenter).to_json).to eq(@presenter.to_json)
-    end
-
     it "redirects home for closed account" do
       @person = FactoryBot.create(:person, closed_account: true)
       get :show, params: {id: @person.to_param}

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -261,11 +261,6 @@ describe User, type: :model do
         expect(alice).not_to be_valid
       end
 
-      it "should not contain periods" do
-        alice.username = "kittens."
-        expect(alice).not_to be_valid
-      end
-
       it "can be 32 characters long" do
         alice.username = "hexagoooooooooooooooooooooooooon"
         expect(alice).to be_valid


### PR DESCRIPTION
and some drive-by fixes. See the commit messages for context.

Special thanks to the owner of a 11+ years old Geraspora account who sent me a support mail about being unable to reset their password because `User` validation failed.