### PR TITLE
Downgrade ethon because of https://github.com/typhoeus/ethon/issues/194

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,8 +237,8 @@ GEM
       rake
     et-orbi (1.2.4)
       tzinfo
-    ethon (0.14.0)
-      ffi (>= 1.15.0)
+    ethon (0.12.0)
+      ffi (>= 1.3.0)
     excon (0.82.0)
     execjs (2.8.1)
     eye (0.10.0)


### PR DESCRIPTION
There is no release with the "fix" (revert) yet, so just downgrading to "fix" the issue.