### PR TITLE
Person.find_or_fetch_by_identifier never return nil

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -442,8 +442,13 @@ class User < ApplicationRecord
     aq = self.aspects.create(:name => I18n.t('aspects.seed.acquaintances'))
 
     if AppConfig.settings.autofollow_on_join?
-      default_account = Person.find_or_fetch_by_identifier(AppConfig.settings.autofollow_on_join_user)
-      self.share_with(default_account, aq) if default_account
+      begin
+        default_account = Person.find_or_fetch_by_identifier(AppConfig.settings.autofollow_on_join_user)
+        share_with(default_account, aq)
+      rescue DiasporaFederation::Discovery::DiscoveryError
+        logger.warn "Error auto-sharing with #{AppConfig.settings.autofollow_on_join_user}
+                     fix autofollow_on_join_user in configuration."
+      end
     end
     aq
   end

--- a/app/workers/fetch_webfinger.rb
+++ b/app/workers/fetch_webfinger.rb
@@ -12,7 +12,9 @@ module Workers
       person = Person.find_or_fetch_by_identifier(account)
 
       # also, schedule to fetch a few public posts from that person
-      Diaspora::Fetcher::Public.queue_for(person) unless person.nil?
+      Diaspora::Fetcher::Public.queue_for(person)
+    rescue DiasporaFederation::Discovery::DiscoveryError
+      # Ignored
     end
   end
 end

--- a/lib/archive_validator/author_private_key_validator.rb
+++ b/lib/archive_validator/author_private_key_validator.rb
@@ -5,12 +5,11 @@ class ArchiveValidator
     include Diaspora::Logging
 
     def validate
-      return if person.nil?
       return if person.public_key.export == private_key.public_key.export
 
       messages.push("Private key in the archive doesn't match the known key of #{person.diaspora_handle}")
     rescue DiasporaFederation::Discovery::DiscoveryError
-      logger.info "#{self}: Archive author couldn't be fetched (old home pod is down?), will continue with data"\
+      logger.info "Archive author couldn't be fetched (old home pod is down?), will continue with data"\
         " import only"
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -797,10 +797,10 @@ describe User, type: :model do
       context "with autofollow sharing enabled" do
         it "should start sharing with autofollow account" do
           AppConfig.settings.autofollow_on_join = true
-          AppConfig.settings.autofollow_on_join_user = "one"
+          person = FactoryBot.build(:person)
+          AppConfig.settings.autofollow_on_join_user = person.diaspora_handle
 
-          expect(Person).to receive(:find_or_fetch_by_identifier).with("one")
-
+          expect(Person).to receive(:find_or_fetch_by_identifier).with(person.diaspora_handle).and_return(person)
           user.seed_aspects
         end
       end

--- a/spec/workers/fetch_webfinger_spec.rb
+++ b/spec/workers/fetch_webfinger_spec.rb
@@ -11,7 +11,7 @@ describe Workers::FetchWebfinger do
   end
 
   it "should webfinger and queue no job to fetch public posts if the person is not found" do
-    allow(Person).to receive(:find_or_fetch_by_identifier).and_return(nil)
+    allow(Person).to receive(:find_or_fetch_by_identifier).and_raise DiasporaFederation::Discovery::DiscoveryError
 
     expect(Diaspora::Fetcher::Public).not_to receive(:queue_for)
 


### PR DESCRIPTION
Person.find_or_fetch_by_identifier raises an exception if person is not found localy and not fetchable. It never returns nil. These code changes take care about this behaviour and changes specs and code to behave equally.

Its a very useful to keep in mind this for user-imports.