### PR TITLE
Using galleries default border radius for indicator images

### DIFF
--- a/app/assets/stylesheets/gallery.scss
+++ b/app/assets/stylesheets/gallery.scss
@@ -55,7 +55,6 @@ $margin: 15px;
 
     li {
       border: 0;
-      border-radius: $thumbnail-size / 2;
       height: $thumbnail-size;
       margin: $margin 6px;
       vertical-align: middle;


### PR DESCRIPTION
Small indicator images in image gallery are round ones, this doesn't correspond with preview shown in stream.
It also doesn't look good on real-world images. (may look OK for User profile images).
This PR restores the default image galleries' border radius for indicator images.

Before: 
![Bildschirmfoto 2021-07-24 um 10 31 39](https://user-images.githubusercontent.com/501326/126863787-0ae95ff6-5cb4-4b82-947d-74457b4fabb2.png)

After: 
![Bildschirmfoto 2021-07-24 um 11 08 49](https://user-images.githubusercontent.com/501326/126863831-7a4f2d62-53fe-4509-9089-885cd87a0dee.png)
