### PR TITLE
#7960 Add support for Markdown footnote syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,10 +105,11 @@ source "https://gems.diasporafoundation.org" do
 
   gem "rails-assets-highlightjs",                         "9.12.0"
   gem "rails-assets-markdown-it",                         "8.4.2"
-  gem "rails-assets-markdown-it-hashtag",                 "0.4.0"
   gem "rails-assets-markdown-it-diaspora-mention",        "1.2.0"
-  gem "rails-assets-markdown-it-sanitizer",               "0.4.3"
+  gem "rails-assets-markdown-it-footnote",                "3.0.3"
+  gem "rails-assets-markdown-it-hashtag",                 "0.4.0"
   gem "rails-assets-markdown-it--markdown-it-for-inline", "0.1.1"
+  gem "rails-assets-markdown-it-sanitizer",               "0.4.3"
   gem "rails-assets-markdown-it-sub",                     "1.0.0"
   gem "rails-assets-markdown-it-sup",                     "1.0.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -569,6 +569,7 @@ GEM
     rails-assets-markdown-it--markdown-it-for-inline (0.1.1)
     rails-assets-markdown-it (8.4.2)
     rails-assets-markdown-it-diaspora-mention (1.2.0)
+    rails-assets-markdown-it-footnote (3.0.3)
     rails-assets-markdown-it-hashtag (0.4.0)
     rails-assets-markdown-it-sanitizer (0.4.3)
     rails-assets-markdown-it-sub (1.0.0)
@@ -888,6 +889,7 @@ DEPENDENCIES
   rails-assets-markdown-it (= 8.4.2)!
   rails-assets-markdown-it--markdown-it-for-inline (= 0.1.1)!
   rails-assets-markdown-it-diaspora-mention (= 1.2.0)!
+  rails-assets-markdown-it-footnote (= 3.0.3)!
   rails-assets-markdown-it-hashtag (= 0.4.0)!
   rails-assets-markdown-it-sanitizer (= 0.4.3)!
   rails-assets-markdown-it-sub (= 1.0.0)!

--- a/app/assets/javascripts/app/helpers/text_formatter.js
+++ b/app/assets/javascripts/app/helpers/text_formatter.js
@@ -16,6 +16,9 @@
       typographer: true
     });
 
+    var footnote = window.markdownitFootnote;
+    md.use(footnote);
+
     var inlinePlugin = window.markdownitForInline;
     md.use(inlinePlugin, "utf8_symbols", "text", function (tokens, idx) {
       tokens[idx].content = tokens[idx].content.replace(/<->/g, "↔")

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -23,6 +23,7 @@
 //= require markdown-it
 //= require markdown-it-diaspora-mention
 //= require markdown-it-for-inline
+//= require markdown-it-footnote
 //= require markdown-it-hashtag
 //= require markdown-it-sanitizer
 //= require markdown-it-sub

--- a/lib/diaspora/message_renderer.rb
+++ b/lib/diaspora/message_renderer.rb
@@ -50,7 +50,10 @@ module Diaspora
       end
 
       def strip_markdown
-        renderer = Redcarpet::Markdown.new Redcarpet::Render::StripDown, options[:stripdown_options]
+        stripdown_options = options[:markdown_options]
+        # Footnotes are not supported in text-only outputs (mail, crossposts etc)
+        stripdown_options[:footnotes] = false
+        renderer = Redcarpet::Markdown.new Redcarpet::Render::StripDown, stripdown_options
         @message = renderer.render(message).strip
       end
 
@@ -114,14 +117,6 @@ module Diaspora
                 squish:                  false,
                 escape:                  true,
                 escape_tags:             false,
-                stripdown_options:       {
-                  autolink:            true,
-                  fenced_code_blocks:  true,
-                  space_after_headers: true,
-                  strikethrough:       true,
-                  tables:              true,
-                  no_intra_emphasis:   true
-                },
                 markdown_options:        {
                   autolink:            true,
                   fenced_code_blocks:  true,

--- a/lib/diaspora/message_renderer.rb
+++ b/lib/diaspora/message_renderer.rb
@@ -50,7 +50,7 @@ module Diaspora
       end
 
       def strip_markdown
-        renderer = Redcarpet::Markdown.new Redcarpet::Render::StripDown, options[:markdown_options]
+        renderer = Redcarpet::Markdown.new Redcarpet::Render::StripDown, options[:stripdown_options]
         @message = renderer.render(message).strip
       end
 
@@ -105,26 +105,35 @@ module Diaspora
       end
     end
 
-    DEFAULTS = {mentioned_people: [],
-                link_all_mentions: false,
-                disable_hovercards: false,
-                truncate: false,
-                append: nil,
-                append_after_truncate: nil,
-                squish: false,
-                escape: true,
-                escape_tags: false,
-                markdown_options: {
-                  autolink: true,
+    DEFAULTS = {mentioned_people:        [],
+                link_all_mentions:       false,
+                disable_hovercards:      false,
+                truncate:                false,
+                append:                  nil,
+                append_after_truncate:   nil,
+                squish:                  false,
+                escape:                  true,
+                escape_tags:             false,
+                stripdown_options:       {
+                  autolink:            true,
                   fenced_code_blocks:  true,
                   space_after_headers: true,
-                  strikethrough: true,
-                  tables: true,
-                  no_intra_emphasis: true,
+                  strikethrough:       true,
+                  tables:              true,
+                  no_intra_emphasis:   true
+                },
+                markdown_options:        {
+                  autolink:            true,
+                  fenced_code_blocks:  true,
+                  space_after_headers: true,
+                  strikethrough:       true,
+                  footnotes:           true,
+                  tables:              true,
+                  no_intra_emphasis:   true
                 },
                 markdown_render_options: {
-                  filter_html: true,
-                  hard_wrap: true,
+                  filter_html:     true,
+                  hard_wrap:       true,
                   safe_links_only: true
                 }}.freeze
 

--- a/lib/diaspora/message_renderer.rb
+++ b/lib/diaspora/message_renderer.rb
@@ -50,9 +50,8 @@ module Diaspora
       end
 
       def strip_markdown
-        stripdown_options = options[:markdown_options]
         # Footnotes are not supported in text-only outputs (mail, crossposts etc)
-        stripdown_options[:footnotes] = false
+        stripdown_options = options[:markdown_options].except(:footnotes)
         renderer = Redcarpet::Markdown.new Redcarpet::Render::StripDown, stripdown_options
         @message = renderer.render(message).strip
       end


### PR DESCRIPTION
It solves #7960 Add support for Markdown footnote syntax

A quick fix, but surely rarely used. 

It adds the possibility to add footnotes to posts. Syntax is defined here: https://pandoc.org/MANUAL.html#footnotes

Source example: 
![Bildschirmfoto 2021-07-31 um 08 01 17](https://user-images.githubusercontent.com/501326/127731790-a15a188c-09aa-40de-99be-6234c01f61f8.png)

The outcome: 
![Bildschirmfoto 2021-07-31 um 08 24 48](https://user-images.githubusercontent.com/501326/127731796-fc12db9a-1bb4-454e-b135-1c5b9b8eca8c.png)

It would be nice if this could then be added to the diaspora markdown - doc: 
https://diasporafoundation.org/formatting

