### PR TITLE
Support to search for multiple tags

### DIFF
--- a/app/helpers/stream_helper.rb
+++ b/app/helpers/stream_helper.rb
@@ -5,7 +5,7 @@
 #   the COPYRIGHT file.
 
 module StreamHelper
-  def next_page_path(opts ={})
+  def next_page_path(_opts={})
     if controller.instance_of?(TagsController)
       tag_path(name: @stream.tag_names, max_time: time_for_scroll(@stream))
     elsif controller.instance_of?(PeopleController)
@@ -22,6 +22,7 @@ module StreamHelper
   end
 
   private
+
   # rubocop:disable Rails/HelperInstanceVariable
   def next_stream_path
     if current_page?(:stream)
@@ -50,7 +51,7 @@ module StreamHelper
 
   def time_for_scroll(stream)
     if stream.stream_posts.empty?
-      (Time.now + 1).to_i
+      (Time.zone.now + 1).to_i
     else
       stream.stream_posts.last.send(stream.order.to_sym).to_i
     end

--- a/app/helpers/stream_helper.rb
+++ b/app/helpers/stream_helper.rb
@@ -7,13 +7,13 @@
 module StreamHelper
   def next_page_path(opts ={})
     if controller.instance_of?(TagsController)
-      tag_path(:name => @stream.tag_name, :max_time => time_for_scroll(@stream))
+      tag_path(name: @stream.tag_names, max_time: time_for_scroll(@stream))
     elsif controller.instance_of?(PeopleController)
-      local_or_remote_person_path(@person, :max_time => time_for_scroll(@stream))
+      local_or_remote_person_path(@person, max_time: time_for_scroll(@stream))
     elsif controller.instance_of?(StreamsController)
       next_stream_path
     else
-      raise 'in order to use pagination for this new controller, update next_page_path in stream helper'
+      raise "in order to use pagination for this new controller, update next_page_path in stream helper"
     end
   end
 
@@ -50,7 +50,7 @@ module StreamHelper
 
   def time_for_scroll(stream)
     if stream.stream_posts.empty?
-      (Time.now() + 1).to_i
+      (Time.now + 1).to_i
     else
       stream.stream_posts.last.send(stream.order.to_sym).to_i
     end

--- a/app/presenters/tag_stream_presenter.rb
+++ b/app/presenters/tag_stream_presenter.rb
@@ -7,7 +7,7 @@ class TagStreamPresenter < BasePresenter
 
   def metas_attributes
     {
-      keywords:       {name:     "keywords",       content: tag_name},
+      keywords:       {name:     "keywords",       content: tag_names},
       description:    {name:     "description",    content: description},
       og_url:         {property: "og:url",         content: url},
       og_title:       {property: "og:title",       content: title},
@@ -18,10 +18,10 @@ class TagStreamPresenter < BasePresenter
   private
 
   def description
-    I18n.t("streams.tags.title", tags: tag_name)
+    I18n.t("streams.tags.title", tags: tag_names)
   end
 
   def url
-    tag_url tag_name
+    tag_url tag_names
   end
 end

--- a/app/views/tags/show.mobile.haml
+++ b/app/views/tags/show.mobile.haml
@@ -5,13 +5,14 @@
 %h1
   = @stream.display_tag_name
 - if user_signed_in?
-  - unless tag_followed?
-    .btn.btn-success.tag_following_action{data: {name: @stream.tag_name}}
-      = t(".follow", tag: @stream.tag_name)
+  -# rubocop:disable Style/IdenticalConditionalBranches
+  - if tag_followed?
+    .btn.btn-danger.tag_following_action{data: {name: @stream.tag_names}}
+      = t(".stop_following", tag: @stream.tag_names)
   - else
-    .btn.btn-danger.tag_following_action{data: {name: @stream.tag_name}}
-      = t(".stop_following", tag: @stream.tag_name)
-
+    .btn.btn-success.tag_following_action{data: {name: @stream.tag_names}}
+      = t(".follow", tag: @stream.tag_names)
+  -# rubocop:enable Style/IdenticalConditionalBranches
 #main-stream.stream
   = render 'shared/stream', :posts => @stream.stream_posts
   = render 'shared/stream_more_button'

--- a/lib/evil_query.rb
+++ b/lib/evil_query.rb
@@ -73,7 +73,7 @@ module EvilQuery
 
     def followed_tags_posts!
       logger.debug("[EVIL-QUERY] followed_tags_posts!")
-      StatusMessage.public_tag_stream(@user.followed_tag_ids).excluding_hidden_content(@user)
+      StatusMessage.public_any_tag_stream(@user.followed_tag_ids).excluding_hidden_content(@user)
     end
 
     def mentioned_posts

--- a/lib/stream/followed_tag.rb
+++ b/lib/stream/followed_tag.rb
@@ -16,7 +16,12 @@ class Stream::FollowedTag < Stream::Base
 
   # @return [ActiveRecord::Association<Post>] AR association of posts
   def posts
-    @posts ||= StatusMessage.user_tag_stream(user, tag_ids)
+    if tag_ids.empty?
+      @posts = StatusMessage.none
+    else
+      @posts ||= StatusMessage.any_user_tag_stream(user, tag_ids)
+    end
+    @posts
   end
 
   private

--- a/lib/stream/tag.rb
+++ b/lib/stream/tag.rb
@@ -5,46 +5,43 @@
 #   the COPYRIGHT file.
 
 class Stream::Tag < Stream::Base
-  attr_accessor :tag_name, :people_page , :people_per_page
+  attr_accessor :tag_names, :people_page, :people_per_page
 
-  def initialize(user, tag_name, opts={})
-    self.tag_name = tag_name
+  def initialize(user, tag_names, opts={})
+    self.tag_names = tag_names.downcase.gsub("#", "")
     self.people_page = opts[:page] || 1
     self.people_per_page = 15
     super(user, opts)
   end
 
-  def tag
-    @tag ||= ActsAsTaggableOn::Tag.named(tag_name).first
+  def tags
+    @tags ||= ActsAsTaggableOn::Tag.named_any(tag_names.split(" "))
   end
 
   def display_tag_name
-    @display_tag_name ||= "##{tag_name}"
+    @display_tag_name ||= tag_names.split(" ").map {|t| "##{t}" }.join(" ")
   end
 
   def tagged_people
-    @people ||= ::Person.profile_tagged_with(tag_name).paginate(:page => people_page, :per_page => people_per_page)
+    @tagged_people ||= ::Person.profile_tagged_with(tag_names).paginate(page: people_page, per_page: people_per_page)
   end
 
   def tagged_people_count
-    @people_count ||= ::Person.profile_tagged_with(tag_name).count
+    @tagged_people_count ||= ::Person.profile_tagged_with(tag_names).count
   end
 
   def posts
     @posts ||= if user
-                 StatusMessage.user_tag_stream(user, tag.id)
+                 StatusMessage.user_tag_stream(user, tags.pluck(:id))
                else
-                 StatusMessage.public_tag_stream(tag.id)
+                 StatusMessage.public_all_tag_stream(tags.pluck(:id))
                end
   end
 
   def stream_posts
-    return [] unless tag
-    super
-  end
+    return [] unless tags
 
-  def tag_name=(tag_name)
-    @tag_name = tag_name.downcase.gsub('#', '')
+    super
   end
 
   private

--- a/spec/integration/api/streams_controller_spec.rb
+++ b/spec/integration/api/streams_controller_spec.rb
@@ -249,8 +249,8 @@ describe Api::V1::StreamsController do
         params: {access_token: access_token_public_only_read_only}
       )
       expect(response.status).to eq(200)
-      post = response_body_data(response)
-      expect(post.length).to eq(1)
+      posts = response_body_data(response)
+      expect(posts.any? {|post| post["public"] == true }).to be_truthy
     end
 
     it "fails with invalid credentials" do

--- a/spec/lib/stream/tag_spec.rb
+++ b/spec/lib/stream/tag_spec.rb
@@ -108,12 +108,12 @@ describe Stream::Tag do
   describe '#tag_name=' do
     it 'downcases the tag' do
       stream = Stream::Tag.new(nil, "WHAT")
-      expect(stream.tag_name).to eq('what')
+      expect(stream.tag_names).to eq("what")
     end
 
     it 'removes #es' do
       stream = Stream::Tag.new(nil, "#WHAT")
-      expect(stream.tag_name).to eq('what')
+      expect(stream.tag_names).to eq("what")
     end
   end
 

--- a/spec/models/status_message_spec.rb
+++ b/spec/models/status_message_spec.rb
@@ -41,22 +41,22 @@ describe StatusMessage, type: :model do
 
       describe ".tag_steam" do
         it "returns status messages tagged with the tag" do
-          tag_stream = StatusMessage.send(:tag_stream, [@tag_id])
+          tag_stream = StatusMessage.send(:all_tag_stream, [@tag_id])
           expect(tag_stream).to include @status_message1
           expect(tag_stream).to include @status_message2
         end
       end
 
-      describe ".public_tag_stream" do
+      describe ".public_any_tag_stream" do
         it "returns public status messages tagged with the tag" do
-          expect(StatusMessage.public_tag_stream([@tag_id])).to eq([@status_message1])
+          expect(StatusMessage.public_any_tag_stream([@tag_id])).to eq([@status_message1])
         end
 
         it "returns a post with two tags only once" do
           status_message = FactoryBot.create(:status_message, text: "#hashtag #test", public: true)
           test_tag_id = ActsAsTaggableOn::Tag.where(name: "test").first.id
 
-          expect(StatusMessage.public_tag_stream([@tag_id, test_tag_id]))
+          expect(StatusMessage.public_any_tag_stream([@tag_id, test_tag_id]))
             .to match_array([@status_message1, status_message])
         end
       end
@@ -65,9 +65,9 @@ describe StatusMessage, type: :model do
         it "returns tag stream thats owned or visible by" do
           relation = double
           expect(StatusMessage).to receive(:owned_or_visible_by_user).with(bob).and_return(relation)
-          expect(relation).to receive(:tag_stream).with([@tag_id])
+          expect(relation).to receive(:any_tag_stream).with([@tag_id])
 
-          StatusMessage.user_tag_stream(bob, [@tag_id])
+          StatusMessage.any_user_tag_stream(bob, [@tag_id])
         end
       end
     end


### PR DESCRIPTION
It allows to search for more than one tag in the search-field.

No frills, just search for "#cat #photos" or "#cat #painting" to see the feature. 

Can be tested on https://societas.online
