### PR TITLE
Fix running jasmine tests in docker

### DIFF
--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -20,6 +20,9 @@ RUN DEBIAN_FRONTEND=noninteractive \
         nodejs \
         gosu \
     && \
+    curl https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb -o ./google-chrome.deb && \
+    apt install -y -qq --no-install-recommends ./google-chrome.deb && \
+    rm ./google-chrome.deb && \
     rm -rf /var/lib/apt/lists/*
 
 

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -5,4 +5,7 @@ Jasmine.configure do |config|
   config.runner_browser = :chromeheadless
   config.chrome_startup_timeout = 20
   config.chrome_cli_options["autoplay-policy"] = "no-user-gesture-required"
+  config.chrome_cli_options["disable-gpu"] = nil
+  config.chrome_cli_options["disable-software-rasterizer"] = nil
+  config.chrome_cli_options["disable-dev-shm-usage"] = nil
 end


### PR DESCRIPTION
Google Chrome is now required to be installed to run jasmine tests