### PR TITLE
Fix sharing status of local contacts after an import

### DIFF
--- a/app/services/migration_service.rb
+++ b/app/services/migration_service.rb
@@ -49,7 +49,8 @@ class MigrationService
       old_person:             old_person,
       new_person:             archive_importer.user.person,
       old_private_key:        archive_importer.serialized_private_key,
-      old_person_diaspora_id: archive_importer.archive_author_diaspora_id
+      old_person_diaspora_id: archive_importer.archive_author_diaspora_id,
+      archive_contacts:       archive_importer.contacts
     )
   end
 

--- a/lib/archive_importer/contact_importer.rb
+++ b/lib/archive_importer/contact_importer.rb
@@ -13,6 +13,8 @@ class ArchiveImporter
     attr_reader :user
 
     def import
+      return unless json.fetch("receiving")
+
       @imported_contact = create_contact
       add_to_aspects
     rescue ActiveRecord::RecordInvalid => e
@@ -34,7 +36,8 @@ class ArchiveImporter
 
     def create_contact
       person = Person.by_account_identifier(json.fetch("account_id"))
-      user.contacts.create!(person_id: person.id, sharing: false, receiving: json.fetch("receiving"))
+      # see AccountMigration#dispatch_contacts for the other half of this when the contact is sharing with the user
+      user.contacts.create!(person_id: person.id, sharing: false, receiving: true)
     end
   end
 end

--- a/lib/archive_importer/contact_importer.rb
+++ b/lib/archive_importer/contact_importer.rb
@@ -34,7 +34,7 @@ class ArchiveImporter
 
     def create_contact
       person = Person.by_account_identifier(json.fetch("account_id"))
-      user.contacts.create!(person_id: person.id, sharing: json.fetch("sharing"), receiving: json.fetch("receiving"))
+      user.contacts.create!(person_id: person.id, sharing: false, receiving: json.fetch("receiving"))
     end
   end
 end

--- a/spec/integration/migration_service_spec.rb
+++ b/spec/integration/migration_service_spec.rb
@@ -287,17 +287,17 @@ describe MigrationService do
 
       contact = user.contacts.find_by(person: Person.by_account_identifier(contact1_diaspora_id))
       expect(contact).not_to be_nil
-      expect(contact.sharing).to be_truthy
+      expect(contact.sharing).to be_falsey
       expect(contact.receiving).to be_falsey
 
       contact = user.contacts.find_by(person: Person.by_account_identifier(contact2_diaspora_id))
       expect(contact).not_to be_nil
-      expect(contact.sharing).to be_truthy
+      expect(contact.sharing).to be_falsey
       expect(contact.receiving).to be_truthy
 
       contact = user.contacts.find_by(person: Person.by_account_identifier(migrated_contact_new_diaspora_id))
       expect(contact).not_to be_nil
-      expect(contact.sharing).to be_truthy
+      expect(contact.sharing).to be_falsey
       expect(contact.receiving).to be_truthy
 
       aspect = user.aspects.find_by(name: "Friends")

--- a/spec/integration/migration_service_spec.rb
+++ b/spec/integration/migration_service_spec.rb
@@ -128,7 +128,7 @@ describe MigrationService do
             "following": true,
             "followed": false,
             "account_id": "#{contact1_diaspora_id}",
-            "contact_groups_membership": ["Family"]
+            "contact_groups_membership": []
           },
           {
             "sharing": true,
@@ -286,9 +286,7 @@ describe MigrationService do
       expect(like.author).not_to eq(user.person)
 
       contact = user.contacts.find_by(person: Person.by_account_identifier(contact1_diaspora_id))
-      expect(contact).not_to be_nil
-      expect(contact.sharing).to be_falsey
-      expect(contact.receiving).to be_falsey
+      expect(contact).to be_nil
 
       contact = user.contacts.find_by(person: Person.by_account_identifier(contact2_diaspora_id))
       expect(contact).not_to be_nil

--- a/spec/models/account_migration_spec.rb
+++ b/spec/models/account_migration_spec.rb
@@ -93,6 +93,34 @@ describe AccountMigration, type: :model do
           expect(account_migration.subscribers).to be_empty
         end
       end
+
+      context "with contacts from the archive" do
+        it "includes contacts from the archive" do
+          archive_person = FactoryBot.create(:person)
+          remote_contact = DataGenerator.create(new_user, :remote_mutual_friend)
+          contacts = [
+            {
+              "sharing"                   => true,
+              "receiving"                 => false,
+              "following"                 => true,
+              "followed"                  => false,
+              "account_id"                => archive_person.diaspora_handle,
+              "contact_groups_membership" => []
+            },
+            {
+              "sharing"                   => true,
+              "receiving"                 => true,
+              "following"                 => true,
+              "followed"                  => true,
+              "account_id"                => remote_contact.person.diaspora_handle,
+              "contact_groups_membership" => []
+            }
+          ]
+          account_migration =
+            AccountMigration.create!(old_person: old_person, new_person: new_person, archive_contacts: contacts)
+          expect(account_migration.subscribers).to match_array([remote_contact.person, archive_person, old_person])
+        end
+      end
     end
   end
 


### PR DESCRIPTION
While checking if there still is a problem, with contacts sharing state after the import, I noticed that #8254 was actually the wrong fix for #8106, so I reverted that again. The problem in #8106 is only with contacts on the same pod as the user was imported to, all other contacts from other pods where working. Fixing that was actually pretty easy, so now also local contacts update the sharing status after the import.

#8254 trusted the content of the archive where it shouldn't be trusted, because the user can modify the archive, so it was intentionally ignored if somebody else was sharing with the imported user during the import, Contacts refresh their sharing status if they really share with the imported user after the import (and now also local contacts do this).

But unrelated to #8106, there were also "empty" contacts created, where both directions didn't share with each others. This created contacts in the database which neither were listed in an aspect, but also weren't listed under "only sharing with me", so the total number of contacts was wrong. I also fixed that here.

And since contacts only sharing with the imported user weren't created in the database during the import anymore, I took the contacts from the archive to also send the migration message to them.