### PR TITLE
Update open_graph_reader gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -148,7 +148,7 @@ gem "leaflet-rails",       "1.7.0"
 # Parsing
 
 gem "nokogiri",          "1.11.7"
-gem "open_graph_reader", "0.7.1" # also update User-Agent in features/support/webmock.rb and open_graph_cache_spec.rb
+gem "open_graph_reader", "0.7.2" # also update User-Agent in features/support/webmock.rb and open_graph_cache_spec.rb
 gem "redcarpet",         "3.5.1"
 gem "ruby-oembed",       "0.15.0"
 gem "twitter-text",      "3.1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -456,7 +456,7 @@ GEM
       rack
     omniauth-wordpress (0.2.2)
       omniauth-oauth2 (>= 1.1.0)
-    open_graph_reader (0.7.1)
+    open_graph_reader (0.7.2)
       faraday (>= 0.9.0)
       nokogiri (~> 1.6)
     openid_connect (1.2.0)
@@ -857,7 +857,7 @@ DEPENDENCIES
   omniauth-tumblr (= 1.2)
   omniauth-twitter (= 1.4.0)
   omniauth-wordpress (= 0.2.2)
-  open_graph_reader (= 0.7.1)
+  open_graph_reader (= 0.7.2)
   openid_connect (= 1.2.0)
   pg (= 1.2.3)
   pronto (= 0.11.0)

--- a/features/support/webmock.rb
+++ b/features/support/webmock.rb
@@ -7,7 +7,7 @@ Before do
   stub_request(:head, /.+/).with(
     headers: {
       "Accept"     => "text/html",
-      "User-Agent" => "OpenGraphReader/0.7.1 (+https://github.com/jhass/open_graph_reader)"
+      "User-Agent" => "OpenGraphReader/0.7.2 (+https://github.com/jhass/open_graph_reader)"
     }
   ).to_return(status: 200, body: "", headers: {"Content-Type" => "text/plain"})
 end

--- a/spec/models/open_graph_cache_spec.rb
+++ b/spec/models/open_graph_cache_spec.rb
@@ -63,7 +63,7 @@ describe OpenGraphCache, type: :model do
         stub_request(:head, "http:///wetter.com")
           .with(headers: {
                   "Accept"     => "text/html",
-                  "User-Agent" => "OpenGraphReader/0.7.1 (+https://github.com/jhass/open_graph_reader)"
+                  "User-Agent" => "OpenGraphReader/0.7.2 (+https://github.com/jhass/open_graph_reader)"
                 })
           .to_return(status: 200, body: "", headers:
             {"Set-Cookie" => "Dabgroup=A;path=/;Expires=Thu, 23 May 2019 16:12:01 GMT;httpOnly"})


### PR DESCRIPTION
The previous version had a bug in detecting open graph provides without a valid title property.
Will solve the 'Workers::GatherOpenGraphData' - Errors seen in Sidekiq