### PR TITLE
Resend account migration and deletion

### DIFF
--- a/app/models/account_migration.rb
+++ b/app/models/account_migration.rb
@@ -152,7 +152,7 @@ class AccountMigration < ApplicationRecord
 
   def person_references
     references = Person.reflections.reject {|key, _|
-      %w[profile owner notifications pod account_migration].include?(key)
+      %w[profile owner notifications pod account_deletion account_migration].include?(key)
     }
 
     references.map {|key, value|

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -57,6 +57,7 @@ class Person < ApplicationRecord
 
   has_many :mentions, :dependent => :destroy
 
+  has_one :account_deletion, dependent: :destroy
   has_one :account_migration, foreign_key: :old_person_id, dependent: :nullify, inverse_of: :old_person
 
   validate :owner_xor_pod

--- a/app/workers/receive_base.rb
+++ b/app/workers/receive_base.rb
@@ -26,6 +26,7 @@ module Workers
            DiasporaFederation::Salmon::InvalidEncoding,
            Diaspora::Federation::AuthorIgnored,
            Diaspora::Federation::InvalidAuthor,
+           Diaspora::Federation::RecipientClosed,
            # TODO: deprecated
            DiasporaFederation::Salmon::MissingMagicEnvelope,
            DiasporaFederation::Salmon::MissingAuthor,

--- a/db/migrate/20211024142641_add_signature_to_account_migration.rb
+++ b/db/migrate/20211024142641_add_signature_to_account_migration.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSignatureToAccountMigration < ActiveRecord::Migration[5.2]
+  def change
+    add_column :account_migrations, :signature, :text
+  end
+end

--- a/lib/diaspora/federation.rb
+++ b/lib/diaspora/federation.rb
@@ -9,6 +9,10 @@ module Diaspora
     # Raised, if the author of the existing object doesn't match the received author
     class InvalidAuthor < RuntimeError
     end
+
+    # Raised, if the recipient account is closed already
+    class RecipientClosed < RuntimeError
+    end
   end
 end
 

--- a/lib/diaspora/federation/entities.rb
+++ b/lib/diaspora/federation/entities.rb
@@ -26,8 +26,9 @@ module Diaspora
 
       def self.account_migration(account_migration)
         DiasporaFederation::Entities::AccountMigration.new(
-          author:  account_migration.sender.diaspora_handle,
-          profile: profile(account_migration.new_person.profile)
+          author:    account_migration.sender.diaspora_handle,
+          profile:   profile(account_migration.new_person.profile),
+          signature: account_migration.signature
         )
       end
 

--- a/lib/diaspora/federation/receive.rb
+++ b/lib/diaspora/federation/receive.rb
@@ -9,6 +9,15 @@ module Diaspora
         public_send(Mappings.receiver_for(entity), entity, opts)
       end
 
+      def self.handle_closed_recipient(sender, recipient)
+        return unless recipient.closed_account?
+
+        entity = recipient.person.account_migration || recipient.person.account_deletion
+        Diaspora::Federation::Dispatcher.build(recipient, entity, subscribers: [sender]).dispatch if entity.present?
+
+        raise Diaspora::Federation::RecipientClosed
+      end
+
       def self.account_deletion(entity)
         person = author_of(entity)
         AccountDeletion.create!(person: person) unless AccountDeletion.where(person: person).exists?

--- a/spec/federation_callbacks_spec.rb
+++ b/spec/federation_callbacks_spec.rb
@@ -387,12 +387,13 @@ describe "diaspora federation callbacks" do
     it "receives a entity for a recipient" do
       received = Fabricate(:status_message_entity, author: remote_person.diaspora_handle)
       persisted = FactoryBot.create(:status_message)
-      recipient_id = FactoryBot.create(:user).id
+      recipient = FactoryBot.create(:user)
 
+      expect(Diaspora::Federation::Receive).to receive(:handle_closed_recipient).with(remote_person, recipient)
       expect(Diaspora::Federation::Receive).to receive(:perform).with(received).and_return(persisted)
-      expect(Workers::ReceiveLocal).to receive(:perform_async).with(persisted.class.to_s, persisted.id, [recipient_id])
+      expect(Workers::ReceiveLocal).to receive(:perform_async).with(persisted.class.to_s, persisted.id, [recipient.id])
 
-      DiasporaFederation.callbacks.trigger(:receive_entity, received, received.author, recipient_id)
+      DiasporaFederation.callbacks.trigger(:receive_entity, received, received.author, recipient.id)
     end
 
     it "does not trigger a ReceiveLocal job if Receive.perform returned nil" do

--- a/spec/lib/account_deleter_spec.rb
+++ b/spec/lib/account_deleter_spec.rb
@@ -200,7 +200,7 @@ describe AccountDeleter do
   it "has all person association keys accounted for" do
     ignored_or_special_ar_person_associations = %i[comments likes poll_participations contacts notification_actors
                                                    notifications owner profile pod conversations messages
-                                                   account_migration]
+                                                   account_deletion account_migration]
     all_keys = @account_deletion.normal_ar_person_associates_to_delete + ignored_or_special_ar_person_associations
     expect(all_keys.sort_by(&:to_s)).to eq(Person.reflections.keys.sort_by(&:to_s).map(&:to_sym))
   end

--- a/spec/lib/diaspora/federation/entities_spec.rb
+++ b/spec/lib/diaspora/federation/entities_spec.rb
@@ -18,6 +18,19 @@ describe Diaspora::Federation::Entities do
       expect(federation_entity).to be_instance_of(DiasporaFederation::Entities::AccountMigration)
       expect(federation_entity.author).to eq(diaspora_entity.old_person.diaspora_handle)
       expect(federation_entity.profile.author).to eq(diaspora_entity.new_person.diaspora_handle)
+      expect(federation_entity.signature).to be_nil
+    end
+
+    it "builds an account migration with signature" do
+      diaspora_entity = FactoryBot.build(:account_migration,
+                                         old_person: FactoryBot.create(:user).person,
+                                         signature:  "aa")
+      federation_entity = described_class.build(diaspora_entity)
+
+      expect(federation_entity).to be_instance_of(DiasporaFederation::Entities::AccountMigration)
+      expect(federation_entity.author).to eq(diaspora_entity.old_person.diaspora_handle)
+      expect(federation_entity.profile.author).to eq(diaspora_entity.new_person.diaspora_handle)
+      expect(federation_entity.signature).to eq(diaspora_entity.signature)
     end
 
     it "builds a comment" do


### PR DESCRIPTION
So lets try that again ... this time store signatures of the new person when receiving an `AccountMigration` where the old person is local, so we can resend it when we receive a message for the old person again.

I also changed the logic so it also resends `AccountDeletion` if there is one for the recipient, and if there is both an `AccountDeletion` and and `AccountMigration`, it resends the migration, because a closed account might still be re-imported later and then be migrated.

I ignore the fact, that some migrations which maybe already happened still don't have a signature stored, but these shouldn't be many and it would make `handle_closed_recipient` a lot more complicated if we want to handle that special case and not try to send the `AccountMigration` if there isn't a signature. So lets just try to send it anyway and fail.

This PR contains a migration, but since this table should be almost empty it should be fast enough for a minor release.