### PR TITLE
Use old person private key if relayable author migrated away

### DIFF
--- a/app/serializers/federation_entity_serializer.rb
+++ b/app/serializers/federation_entity_serializer.rb
@@ -5,11 +5,26 @@
 # are used as for federation messages generation.
 class FederationEntitySerializer < ActiveModel::Serializer
   include SerializerPostProcessing
+  include Diaspora::Logging
 
   private
 
   def modify_serializable_object(hash)
     hash.merge(entity.to_json)
+  rescue DiasporaFederation::Entities::Relayable::AuthorPrivateKeyNotFound => e
+    # The author of this relayable probably migrated from this pod to a different pod,
+    # and we neither have the signature nor the new private key to generate a valid signature.
+    # But we can use the private key of the old user to generate the signature it had when this entity was created
+    old_person = AccountMigration.joins(:old_person)
+                                 .where("new_person_id = ? AND people.owner_id IS NOT NULL", object.author_id)
+                                 .first.old_person
+    if old_person
+      logger.info "Using private key of #{old_person.diaspora_handle} to export: #{e.message}"
+      object.author = old_person
+      hash.merge(entity.to_json)
+    else
+      logger.warn "Skip entity for export because #{e.class}: #{e.message}"
+    end
   end
 
   def entity

--- a/spec/serializers/export/others_data_serializer_spec.rb
+++ b/spec/serializers/export/others_data_serializer_spec.rb
@@ -13,9 +13,14 @@ describe Export::OthersDataSerializer do
     serializer.associations
   end
 
-  context "with user's activity" do
-    before do
-      DataGenerator.new(user).activity
+  it "uses old local user private key if the author was migrated away from the pod" do
+    post = DataGenerator.new(user).status_message_with_activity
+
+    old_comment_author = post.comments.first.author
+    AccountMigration.create!(old_person: old_comment_author, new_person: FactoryBot.create(:person)).perform!
+
+    serializer.associations[:relayables].select {|r| r[:entity_type] == "comment" }.each do |comment|
+      expect(comment[:entity_data][:author]).to eq(old_comment_author.diaspora_handle)
     end
   end
 end


### PR DESCRIPTION
We only store signatures for relayables if the author is external, but if the author becomes external through a migration, the signature is missing. Lets just use the old persons private key to still be able to generate a signature for the export.

This fixes the issue found here: https://diasp.org/posts/4cbeca400483013acc58002590c0bfb8

We will have a similar issue on import, where the signature doesn't match the authors diaspora-ID, because the signature was created with an old user, and then the author changed through a migration, so the signature maybe matches a previous account of the author. But that's a different issue and needs to be handled in the importer.