### PR TITLE
Migrate remote_photo_path and cleanup old photo uploads

### DIFF
--- a/app/models/account_migration.rb
+++ b/app/models/account_migration.rb
@@ -97,6 +97,10 @@ class AccountMigration < ApplicationRecord
     old_user && new_user
   end
 
+  def includes_photo_migration?
+    remote_photo_path.present?
+  end
+
   def tombstone_old_user_and_update_all_references
     ActiveRecord::Base.transaction do
       account_deleter.tombstone_person_and_profile
@@ -146,6 +150,7 @@ class AccountMigration < ApplicationRecord
   end
 
   def update_all_references
+    update_remote_photo_path if remotely_initiated? && includes_photo_migration?
     update_person_references
     update_user_references if user_changed_id_locally?
   end
@@ -222,6 +227,20 @@ class AccountMigration < ApplicationRecord
       .joins("INNER JOIN tag_followings as t2 ON (tag_followings.tag_id = t2.tag_id AND"\
         " tag_followings.user_id=#{old_user.id} AND t2.user_id=#{newest_user.id})")
       .destroy_all
+  end
+
+  def update_remote_photo_path
+    Photo.where(author: old_person)
+         .update_all(remote_photo_path: remote_photo_path) # rubocop:disable Rails/SkipsModelValidations
+    return unless user_left_our_pod?
+
+    Photo.where(author: old_person).find_in_batches do |batch|
+      batch.each do |photo|
+        photo.processed_image = nil
+        photo.unprocessed_image = nil
+        logger.warn "Error cleaning up photo #{photo.id}" unless photo.save
+      end
+    end
   end
 
   def update_person_references

--- a/db/migrate/20211027230348_add_remote_photo_path_to_account_migration.rb
+++ b/db/migrate/20211027230348_add_remote_photo_path_to_account_migration.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRemotePhotoPathToAccountMigration < ActiveRecord::Migration[5.2]
+  def change
+    add_column :account_migrations, :remote_photo_path, :text
+  end
+end

--- a/lib/diaspora/federation/receive.rb
+++ b/lib/diaspora/federation/receive.rb
@@ -31,7 +31,11 @@ module Diaspora
         profile = profile(entity.profile, opts)
         return if AccountMigration.exists?(old_person: old_person, new_person: profile.person)
 
-        AccountMigration.create!(old_person: old_person, new_person: profile.person).tap do |migration|
+        AccountMigration.create!(
+          old_person:        old_person,
+          new_person:        profile.person,
+          remote_photo_path: entity.remote_photo_path
+        ).tap do |migration|
           migration.signature = entity.signature if old_person.local?
           migration.save!
         end

--- a/spec/integration/federation/receive_federation_messages_spec.rb
+++ b/spec/integration/federation/receive_federation_messages_spec.rb
@@ -55,7 +55,9 @@ describe "Receive federation messages feature" do
         it "receives account migration correctly" do
           run_migration
           expect(AccountMigration.where(old_person: sender.person, new_person: new_user.person)).to exist
-          expect(AccountMigration.find_by(old_person: sender.person, new_person: new_user.person)).to be_performed
+          account_migration = AccountMigration.find_by(old_person: sender.person, new_person: new_user.person)
+          expect(account_migration).to be_performed
+          expect(account_migration.remote_photo_path).to eq("https://diaspora.example.tld/uploads/images/")
         end
 
         it "doesn't run the same migration for the second time" do

--- a/spec/models/account_migration_spec.rb
+++ b/spec/models/account_migration_spec.rb
@@ -17,7 +17,9 @@ describe AccountMigration, type: :model do
   let(:old_person) { FactoryBot.create(:person) }
   let(:new_person) { FactoryBot.create(:person) }
   let(:account_migration) {
-    AccountMigration.create!(old_person: old_person, new_person: new_person)
+    AccountMigration.create!(old_person:        old_person,
+                             new_person:        new_person,
+                             remote_photo_path: "https://diaspora.example.tld/uploads/images/")
   }
 
   describe "receive" do
@@ -128,6 +130,34 @@ describe AccountMigration, type: :model do
         contact = FactoryBot.create(:contact, person: old_person, sharing: true)
         expect(Diaspora::Federation::Dispatcher).to receive(:defer_dispatch).with(contact.user, contact)
         account_migration.perform!
+      end
+
+      it "cleans up old local photos" do
+        photo = FactoryBot.create(:photo, author: old_person)
+        photo.processed_image.store!(photo.unprocessed_image)
+        photo.save!
+
+        account_migration.perform!
+
+        updated_photo = photo.reload
+        expect(updated_photo.remote_photo_path).to eq("https://diaspora.example.tld/uploads/images/")
+        expect(updated_photo.processed_image.path).to be_nil
+        expect(updated_photo.unprocessed_image.path).to be_nil
+      end
+
+      it "does nothing if migration doesn't contain a new remote_photo_path" do
+        photo = FactoryBot.create(:photo, author: old_person)
+        photo.processed_image.store!(photo.unprocessed_image)
+        photo.save!
+
+        remote_photo_path = photo.remote_photo_path
+
+        AccountMigration.create!(old_person: old_person, new_person: new_person).perform!
+
+        updated_photo = photo.reload
+        expect(updated_photo.remote_photo_path).to eq(remote_photo_path)
+        expect(updated_photo.processed_image.path).not_to be_nil
+        expect(updated_photo.unprocessed_image.path).not_to be_nil
       end
     end
 


### PR DESCRIPTION
If the migration contains a new `remote_photo_path` migrate all photos of the old person to this path. If the person was local before, cleanup old uploaded files of the photos.

This still needs changes in the importer to also send a new `remote_photo_path` which can either be done as part of https://github.com/diaspora/diaspora/pull/8298 or in a separate PR if photo import gets moved out of that PR.