### PR TITLE
Extend short links to full pod links

### DIFF
--- a/app/assets/javascripts/app/helpers/text_formatter.js
+++ b/app/assets/javascripts/app/helpers/text_formatter.js
@@ -30,6 +30,8 @@
     md.use(inlinePlugin, "link_new_window_and_missing_http", "link_open", function (tokens, idx) {
       tokens[idx].attrs.forEach(function(attribute, index, array) {
         if( attribute[0] === "href" ) {
+          let host = window.location.protocol + "//" + window.location.host;
+          array[index][1] = attribute[1].replace(/^\/posts\//, host + "/posts/");
           array[index][1] = attribute[1].replace(/^www\./, "http://www.");
         }
       });


### PR DESCRIPTION
Fixes #8223 

If a short link was given in the text
and it starts with /posts/ff1122...
It will be changed to the full pod address with
hostname and port.

This enables copying the link or bookmark it.