### PR TITLE
Links in open_id views should be disabled

### DIFF
--- a/app/controllers/api/openid_connect/authorizations_controller.rb
+++ b/app/controllers/api/openid_connect/authorizations_controller.rb
@@ -19,6 +19,7 @@ module Api
         handle_params_error("bad_request", e.message)
       end
 
+      before_action :remember_authorization_context, only: [:new]
       before_action :auth_user_unless_prompt_none!
 
       def new
@@ -33,6 +34,10 @@ module Api
         else
           handle_authorization_form(auth)
         end
+      end
+
+      def remember_authorization_context
+        session[:authorization_context] = true
       end
 
       def create
@@ -131,6 +136,7 @@ module Api
         session[:scopes] = scopes_as_space_seperated_values
         session[:state] = params[:state]
         session[:nonce] = params[:nonce]
+        session.delete(:authorization_context)
       end
 
       def scopes_as_space_seperated_values

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -7,9 +7,7 @@ module SessionsHelper
   end
 
   def authorization_context?
-    uri = Addressable::URI.parse(session["user_return_to"])
-    client_id = session["client_id"]
-    uri && uri.path.match("openid_connect").present? || client_id.present?
+    session[:authorization_context]
   end
 
   def display_registration_link?

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -10,6 +10,16 @@ module SessionsHelper
     end
   end
 
+  def open_id_context?
+    uri = Addressable::URI.parse(session["user_return_to"])
+    client_id = session["client_id"]
+    if uri && uri.path.match("openid_connect").present? || client_id.present?
+      true
+    else
+      false
+    end
+  end
+
   def display_registration_link?
     AppConfig.settings.enable_registrations? && controller_name != "registrations"
   end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -3,7 +3,7 @@
 module SessionsHelper
   def prefilled_username
     uri = Addressable::URI.parse(session["user_return_to"])
-    uri.query_values["login_hint"] if uri&.query_values
+    uri&.query_values&.fetch("login_hint")
   end
 
   def authorization_context?

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -3,21 +3,13 @@
 module SessionsHelper
   def prefilled_username
     uri = Addressable::URI.parse(session["user_return_to"])
-    if uri && uri.query_values
-      uri.query_values["username"]
-    else
-      nil
-    end
+    uri.query_values["login_hint"] if uri&.query_values
   end
 
-  def open_id_context?
+  def authorization_context?
     uri = Addressable::URI.parse(session["user_return_to"])
     client_id = session["client_id"]
-    if uri && uri.path.match("openid_connect").present? || client_id.present?
-      true
-    else
-      false
-    end
+    uri && uri.path.match("openid_connect").present? || client_id.present?
   end
 
   def display_registration_link?

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -1,6 +1,6 @@
 %footer.footer
   .container
     .powered-by-diaspora.pull-left
-      = link_to_unless open_id_context?, t("layouts.application.powered_by"), "https://diasporafoundation.org"
+      = link_to_unless authorization_context?, t("layouts.application.powered_by"), "https://diasporafoundation.org"
     %ul#footer_nav.pull-right
       = render partial: "shared/links"

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -1,6 +1,6 @@
 %footer.footer
   .container
     .powered-by-diaspora.pull-left
-      = link_to t("layouts.application.powered_by"), "https://diasporafoundation.org"
+      = link_to_unless open_id_context?, t("layouts.application.powered_by"), "https://diasporafoundation.org"
     %ul#footer_nav.pull-right
       = render partial: "shared/links"

--- a/app/views/layouts/_header.mobile.haml
+++ b/app/views/layouts/_header.mobile.haml
@@ -1,39 +1,45 @@
 .nav.navbar-inverse.navbar-fixed-top#main-nav
   .container-fluid
     .navbar
-      = link_to(image_tag("branding/logos/asterisk_white_mobile.png", class: "img-responsive"),
-          stream_path, class: "navbar-brand header-title")
-
+      - if open_id_context?
+        = image_tag("branding/logos/asterisk_white_mobile.png", class: "img-responsive navbar-brand header-title")
+      - else
+        = link_to(image_tag("branding/logos/asterisk_white_mobile.png", class: "img-responsive"),
+            stream_path, class: "navbar-brand header-title")
       - if user_signed_in?
         %ul.nav.navbar-nav#nav-badges
           -# Notifications
           %li
-            = link_to notifications_path, class: "badge-link", id: "notification-badge" do
-              %i.entypo-bell
-              - if current_user.unread_notifications.size > 0
-                %span.badge.badge-important#notification
-                  = current_user.unread_notifications.size
+            - unless open_id_context?
+              = link_to notifications_path, class: "badge-link", id: "notification-badge" do
+                %i.entypo-bell
+                - unless current_user.unread_notifications.empty?
+                  %span.badge.badge-important#notification
+                    = current_user.unread_notifications.size
 
           -# Conversations
           %li
-            = link_to conversations_path, class: "badge-link", id: "conversations-badge" do
-              %i.entypo-mail
-              - if current_user.unread_message_count > 0
-                %span.badge.badge-important#conversation
-                  = current_user.unread_message_count
+            - unless open_id_context?
+              = link_to conversations_path, class: "badge-link", id: "conversations-badge" do
+                %i.entypo-mail
+                - if current_user.unread_message_count > 0
+                  %span.badge.badge-important#conversation
+                    = current_user.unread_message_count
 
           -# Publisher
           %li
-            = link_to new_status_message_path, class: "badge-link", id: "compose-badge" do
-              %i.diaspora-custom-compose
+            - unless open_id_context?
+              = link_to new_status_message_path, class: "badge-link", id: "compose-badge" do
+                %i.diaspora-custom-compose
 
           -# Menu
-          %li
-            %button.navbar-toggle#menu-badge{type: "button"}
-              %span.sr-only
-              %span.icon-bar
-              %span.icon-bar
-              %span.icon-bar
+          - unless open_id_context?
+            %li
+              %button.navbar-toggle#menu-badge{type: "button"}
+                %span.sr-only
+                %span.icon-bar
+                %span.icon-bar
+                %span.icon-bar
 
       - else
         = render "layouts/header_not_connected"

--- a/app/views/layouts/_header.mobile.haml
+++ b/app/views/layouts/_header.mobile.haml
@@ -1,7 +1,7 @@
 .nav.navbar-inverse.navbar-fixed-top#main-nav
   .container-fluid
     .navbar
-      - if open_id_context?
+      - if authorization_context?
         = image_tag("branding/logos/asterisk_white_mobile.png", class: "img-responsive navbar-brand header-title")
       - else
         = link_to(image_tag("branding/logos/asterisk_white_mobile.png", class: "img-responsive"),
@@ -10,7 +10,7 @@
         %ul.nav.navbar-nav#nav-badges
           -# Notifications
           %li
-            - unless open_id_context?
+            - unless authorization_context?
               = link_to notifications_path, class: "badge-link", id: "notification-badge" do
                 %i.entypo-bell
                 - unless current_user.unread_notifications.empty?
@@ -19,7 +19,7 @@
 
           -# Conversations
           %li
-            - unless open_id_context?
+            - unless authorization_context?
               = link_to conversations_path, class: "badge-link", id: "conversations-badge" do
                 %i.entypo-mail
                 - if current_user.unread_message_count > 0
@@ -28,12 +28,12 @@
 
           -# Publisher
           %li
-            - unless open_id_context?
+            - unless authorization_context?
               = link_to new_status_message_path, class: "badge-link", id: "compose-badge" do
                 %i.diaspora-custom-compose
 
           -# Menu
-          - unless open_id_context?
+          - unless authorization_context?
             %li
               %button.navbar-toggle#menu-badge{type: "button"}
                 %span.sr-only

--- a/app/views/layouts/_header_not_connected.haml
+++ b/app/views/layouts/_header_not_connected.haml
@@ -1,5 +1,6 @@
 %ul.nav.navbar-nav.navbar-right
-  - if display_registration_link? && !current_page?(controller: "/registrations", action: :new)
-    %li= link_to t("devise.shared.links.sign_up"), new_user_registration_path, class: "login"
-  - unless current_page?(controller: "/sessions", action: :new)
-    %li= link_to t("devise.shared.links.sign_in"), new_user_session_path, class: "login"
+  - unless open_id_context?
+    - if display_registration_link? && !current_page?(controller: "/registrations", action: :new)
+      %li= link_to t("devise.shared.links.sign_up"), new_user_registration_path, class: "login"
+    - unless current_page?(controller: "/sessions", action: :new)
+      %li= link_to t("devise.shared.links.sign_in"), new_user_session_path, class: "login"

--- a/app/views/layouts/_header_not_connected.haml
+++ b/app/views/layouts/_header_not_connected.haml
@@ -1,5 +1,5 @@
 %ul.nav.navbar-nav.navbar-right
-  - unless open_id_context?
+  - unless authorization_context?
     - if display_registration_link? && !current_page?(controller: "/registrations", action: :new)
       %li= link_to t("devise.shared.links.sign_up"), new_user_registration_path, class: "login"
     - unless current_page?(controller: "/sessions", action: :new)

--- a/app/views/sessions/_form.haml
+++ b/app/views/sessions/_form.haml
@@ -23,6 +23,7 @@
                    autocapitalize: "none",
                    autocorrect: "off",
                    autofocus: true,
+                   value: prefilled_username,
                    aria: {labelledby: "usernameLabel"}
 
     - if mobile

--- a/app/views/sessions/new.mobile.haml
+++ b/app/views/sessions/new.mobile.haml
@@ -14,7 +14,7 @@
 
 %footer.footer
   %ul
-    - unless open_id_context?
+    - unless authorization_context?
       - if display_password_reset_link?
         %li
           = link_to t("devise.shared.links.forgot_your_password"),

--- a/app/views/sessions/new.mobile.haml
+++ b/app/views/sessions/new.mobile.haml
@@ -14,11 +14,12 @@
 
 %footer.footer
   %ul
-    - if display_password_reset_link?
-      %li
-        = link_to t("devise.shared.links.forgot_your_password"),
-          new_password_path(resource_name),
-          id: "forgot_password_link"
-    - if display_registration_link?
-      %li= link_to t("devise.shared.links.sign_up"), new_registration_path(resource_name)
-    %li= link_to t("layouts.application.switch_to_standard_mode"), toggle_mobile_path
+    - unless open_id_context?
+      - if display_password_reset_link?
+        %li
+          = link_to t("devise.shared.links.forgot_your_password"),
+            new_password_path(resource_name),
+            id: "forgot_password_link"
+      - if display_registration_link?
+        %li= link_to t("devise.shared.links.sign_up"), new_registration_path(resource_name)
+      %li= link_to t("layouts.application.switch_to_standard_mode"), toggle_mobile_path


### PR DESCRIPTION
Fixes #8168

During open_id auth process (for enabling external Apps) in the login view and grants_list all diaspora links are enabled and would mess up the login process if a user tries these out. 
