### PR TITLE
Bump apparition to a commit to avoid warnings while running cucumber

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -274,7 +274,8 @@ group :test do
 
   # Cucumber (integration tests)
 
-  gem "apparition",       "0.6.0"
+  # Switch apparition back to a release when https://github.com/twalpole/apparition/issues/81 will be fixed
+  gem "apparition", github: "twalpole/apparition", ref: "ca86be4d54af835d531dbcd2b86e7b2c77f85f34"
   gem "capybara",         "3.35.3"
   gem "database_cleaner-active_record", "2.0.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/twalpole/apparition.git
+  revision: ca86be4d54af835d531dbcd2b86e7b2c77f85f34
+  ref: ca86be4d54af835d531dbcd2b86e7b2c77f85f34
+  specs:
+    apparition (0.6.0)
+      capybara (~> 3.13, < 4)
+      websocket-driver (>= 0.6.5)
+
 GEM
   remote: https://rubygems.org/
   remote: https://gems.diasporafoundation.org/
@@ -57,9 +66,6 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     aes_key_wrap (1.1.0)
-    apparition (0.6.0)
-      capybara (~> 3.13, < 4)
-      websocket-driver (>= 0.6.5)
     arel (9.0.0)
     asset_sync (2.15.0)
       activemodel (>= 4.1.0)
@@ -804,7 +810,7 @@ DEPENDENCIES
   acts-as-taggable-on (= 8.1.0)
   acts_as_api (= 1.0.1)
   addressable (= 2.8.0)
-  apparition (= 0.6.0)
+  apparition!
   asset_sync (= 2.15.0)
   autoprefixer-rails (= 10.3.3.0)
   bootstrap-sass (= 3.4.1)


### PR DESCRIPTION
Looks like apparition is now a dead project, at least they don't do any release but we want this fix so I'm bumping to a commit. See  https://github.com/twalpole/apparition/issues/81