### PR TITLE
Add yalphabetize for yaml normalisation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,5 @@ jobs:
         run: bin/rake jasmine:ci
         timeout-minutes: 2
         if: matrix.kind == 'other'
+      - name: Run Yalphabetize
+        run: bundle exec yalphabetize

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,4 +62,4 @@ jobs:
         timeout-minutes: 2
         if: matrix.kind == 'other'
       - name: Run Yalphabetize
-        run: bundle exec yalphabetize
+        run: bin/rake yalphabetize:run

--- a/.yalphabetize.yml
+++ b/.yalphabetize.yml
@@ -1,0 +1,2 @@
+only:
+  - config/locales/

--- a/Gemfile
+++ b/Gemfile
@@ -251,7 +251,7 @@ group :development do
   gem "pronto-scss",    "0.11.0", require: false
   gem "rubocop",        "0.93.1", require: false
   gem "rubocop-rails",  "2.9.1", require: false
-  gem "yalphabetize",   "0.6.2", require: false
+  gem "yalphabetize",   "0.6.2"
 
   # Debugging
   gem "pry"

--- a/Gemfile
+++ b/Gemfile
@@ -251,6 +251,7 @@ group :development do
   gem "pronto-scss",    "0.11.0", require: false
   gem "rubocop",        "0.93.1", require: false
   gem "rubocop-rails",  "2.9.1", require: false
+  gem "yalphabetize",   "0.6.2", require: false
 
   # Debugging
   gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -793,6 +793,7 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yajl-ruby (1.4.1)
+    yalphabetize (0.6.2)
     yard (0.9.26)
 
 PLATFORMS
@@ -939,6 +940,7 @@ DEPENDENCIES
   webmock (= 3.14.0)
   will_paginate (= 3.3.1)
   yajl-ruby (= 1.4.1)
+  yalphabetize (= 0.6.2)
 
 BUNDLED WITH
    1.17.3

--- a/config/locales/devise/devise.en.yml
+++ b/config/locales/devise/devise.en.yml
@@ -2,125 +2,105 @@ en:
   devise:
     confirmations:
       confirmed: Your email address has been successfully confirmed.
-      send_instructions: You will receive an email with instructions for how to confirm
-        your email address in a few minutes.
-      send_paranoid_instructions: If your email address exists in our database, you
-        will receive an email with instructions for how to confirm your email address
-        in a few minutes.
       new:
         resend_confirmation: Resend confirmation instructions
+      send_instructions: You will receive an email with instructions for how to confirm your email address in a few minutes.
+      send_paranoid_instructions: If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes.
     failure:
       already_authenticated: You are already signed in.
       inactive: Your account is not activated yet.
       invalid: Invalid %{authentication_keys} or password.
-      locked: Your account is locked.
+      invalid_token: Invalid authentication token.
       last_attempt: You have one more attempt before your account is locked.
+      locked: Your account is locked.
       not_found_in_database: Invalid %{authentication_keys} or password.
       timeout: Your session expired. Please sign in again to continue.
       unauthenticated: You need to sign in or sign up before continuing.
       unconfirmed: You have to confirm your email address before continuing.
-      invalid_token: Invalid authentication token.
+    invitations:
+      invitation_token_invalid: Our apologies! That invitation token is not valid.
+      send_instructions: Your invitation has been sent.
+      updated: Your password was set successfully. You are now signed in.
     mailer:
       confirmation_instructions:
+        confirm: Confirm my account
         subject: Confirmation instructions
         you_can_confirm: 'You can confirm your account through the link below:'
-        confirm: Confirm my account
-      reset_password_instructions:
-        subject: Reset password instructions
-        someone_requested: Someone has requested a link to change your password. If
-          it was you, you can do this through the link below.
-        change: Change my password
-        then_connect: After setting a new password, you will be able to sign into diaspora* again using your username "%{username}" and your new password
-        wont_change: Your password won't change until you access the link above and
-          create a new one.
-        ignore: If you didn't request this, please ignore this email.
-      unlock_instructions:
-        subject: Unlock instructions
-        account_locked: Your account has been locked due to an excessive number of
-          unsuccessful sign in attempts.
-        click_to_unlock: 'Click the link below to unlock your account:'
-        unlock: Unlock my account
-      password_change:
-        subject: Password Changed
-      welcome: Welcome %{username}!
       hello: Hello %{username}!
       inviter:
+        accept_at: at %{url}, you can accept it through the link below.
         has_invited_you: "%{name}"
         have_invited_you: "%{names} have invited you to join diaspora*"
-        accept_at: at %{url}, you can accept it through the link below.
+      password_change:
+        subject: Password Changed
+      reset_password_instructions:
+        change: Change my password
+        ignore: If you didn't request this, please ignore this email.
+        someone_requested: Someone has requested a link to change your password. If it was you, you can do this through the link below.
+        subject: Reset password instructions
+        then_connect: After setting a new password, you will be able to sign into diaspora* again using your username "%{username}" and your new password
+        wont_change: Your password won't change until you access the link above and create a new one.
+      unlock_instructions:
+        account_locked: Your account has been locked due to an excessive number of unsuccessful sign in attempts.
+        click_to_unlock: 'Click the link below to unlock your account:'
+        subject: Unlock instructions
+        unlock: Unlock my account
+      welcome: Welcome %{username}!
     omniauth_callbacks:
       failure: Could not authenticate you from %{kind} because "%{reason}".
       success: Successfully authenticated from %{kind} account.
     passwords:
-      no_token: You can't access this page without coming from a password reset email.
-        If you do come from a password reset email, please make sure you used the
-        full URL provided.
-      send_instructions: You will receive an email with instructions on how to reset
-        your password in a few minutes.
-      send_paranoid_instructions: If your email address exists in our database, you
-        will receive a password recovery link at your email address in a few minutes.
-      updated: Your password has been changed successfully. You are now signed in.
-      updated_not_active: Your password has been changed successfully.
       edit:
         change_password: Change my password
-        new_password: New password
         confirm_password: Confirm password
+        new_password: New password
       new:
+        email: Email address
         forgot_password: Forgot your password?
         reset_password: Reset password
-        email: Email address
         send_password_instructions: Send me reset password instructions
+      no_token: You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided.
+      send_instructions: You will receive an email with instructions on how to reset your password in a few minutes.
+      send_paranoid_instructions: If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes.
+      updated: Your password has been changed successfully. You are now signed in.
+      updated_not_active: Your password has been changed successfully.
     registrations:
-      destroyed: Bye! Your account was successfully deleted. We hope to see you again
-        soon.
-      signed_up: You have signed up successfully. If enabled, a confirmation was sent
-        to your e-mail.
-      signed_up_but_inactive: You have signed up successfully. However, we could not
-        sign you in because your account is not yet activated.
-      signed_up_but_locked: You have signed up successfully. However, we could not
-        sign you in because your account is locked.
-      signed_up_but_unconfirmed: A message with a confirmation link has been sent
-        to your email address. Please follow the link to activate your account.
-      update_needs_confirmation: You updated your account successfully, but we need
-        to verify your new email address. Please check your email and follow the confirm
-        link to confirm your new email address.
+      destroyed: Bye! Your account was successfully deleted. We hope to see you again soon.
+      signed_up: You have signed up successfully. If enabled, a confirmation was sent to your e-mail.
+      signed_up_but_inactive: You have signed up successfully. However, we could not sign you in because your account is not yet activated.
+      signed_up_but_locked: You have signed up successfully. However, we could not sign you in because your account is locked.
+      signed_up_but_unconfirmed: A message with a confirmation link has been sent to your email address. Please follow the link to activate your account.
+      update_needs_confirmation: You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirm link to confirm your new email address.
       updated: Your account has been updated successfully.
     sessions:
-      signed_in: Signed in successfully.
-      signed_out: Signed out successfully.
       already_signed_out: Signed out successfully.
       new:
         login: Log in
-        username: Username
-        password: Password
-        sign_in: Sign in
-        remember_me: Remember me
         modern_browsers: only supports modern browsers.
-    unlocks:
-      send_instructions: You will receive an email with instructions for how to unlock
-        your account in a few minutes.
-      send_paranoid_instructions: If your account exists, you will receive an email
-        with instructions for how to unlock it in a few minutes.
-      unlocked: Your account has been unlocked successfully. Please sign in to continue.
-      new:
-        resend_unlock: Resend unlock instructions
-    invitations:
-      send_instructions: Your invitation has been sent.
-      invitation_token_invalid: Our apologies! That invitation token is not valid.
-      updated: Your password was set successfully. You are now signed in.
+        password: Password
+        remember_me: Remember me
+        sign_in: Sign in
+        username: Username
+      signed_in: Signed in successfully.
+      signed_out: Signed out successfully.
     shared:
       links:
-        sign_in: Sign in
-        sign_up: Create account
-        sign_up_closed: Open signups are closed at this time.
         forgot_your_password: Forgot your password?
         receive_confirmation: Didn't receive confirmation instructions?
         receive_unlock: Didn't receive unlock instructions?
+        sign_in: Sign in
+        sign_up: Create account
+        sign_up_closed: Open signups are closed at this time.
+    unlocks:
+      new:
+        resend_unlock: Resend unlock instructions
+      send_instructions: You will receive an email with instructions for how to unlock your account in a few minutes.
+      send_paranoid_instructions: If your account exists, you will receive an email with instructions for how to unlock it in a few minutes.
+      unlocked: Your account has been unlocked successfully. Please sign in to continue.
   errors:
     messages:
       already_confirmed: was already confirmed, please try signing in
-      confirmation_period_expired: needs to be confirmed within %{period}, please
-        request a new one
+      confirmation_period_expired: needs to be confirmed within %{period}, please request a new one
       expired: has expired, please request a new one
       not_found: not found
       not_locked: was not locked

--- a/config/locales/diaspora/en-AU.yml
+++ b/config/locales/diaspora/en-AU.yml
@@ -1,3 +1,7 @@
+#   Copyright (c) 2010-2011, Diaspora Inc.  This file is
+#   licensed under the Affero General Public License version 3 or later.  See
+#   the COPYRIGHT file.
+
 "en-AU":
   activerecord:
     errors:

--- a/config/locales/diaspora/en-AU.yml
+++ b/config/locales/diaspora/en-AU.yml
@@ -1,36 +1,32 @@
-#   Copyright (c) 2010-2011, Diaspora Inc.  This file is
-#   licensed under the Affero General Public License version 3 or later.  See
-#   the COPYRIGHT file.
-
 "en-AU":
   activerecord:
-      errors:
-          models:
-              user:
-                  attributes:
-                      person:
-                          invalid: "is invalid."
-                      username:
-                          taken: "is already taken."
-                      email:
-                          taken: "is already taken."
-              person:
-                  attributes:
-                      diaspora_handle:
-                          taken: "is already taken."
-              contact:
-                  attributes:
-                      person_id:
-                          taken: "must be unique among this user's contacts."
-              request:
-                  attributes:
-                      from_id:
-                          taken: "is a duplicate of a pre-existing request."
-              poll:
-                  attributes:
-                      poll_answers:
-                          not_enough_poll_answers: "Not enough poll options provided."
-              poll_participation:
-                  attributes:
-                      poll:
-                          already_participated: "You've already participated in this poll!"
+    errors:
+      models:
+        contact:
+          attributes:
+            person_id:
+              taken: "must be unique among this user's contacts."
+        person:
+          attributes:
+            diaspora_handle:
+              taken: "is already taken."
+        poll:
+          attributes:
+            poll_answers:
+              not_enough_poll_answers: "Not enough poll options provided."
+        poll_participation:
+          attributes:
+            poll:
+              already_participated: "You've already participated in this poll!"
+        request:
+          attributes:
+            from_id:
+              taken: "is a duplicate of a pre-existing request."
+        user:
+          attributes:
+            email:
+              taken: "is already taken."
+            person:
+              invalid: "is invalid."
+            username:
+              taken: "is already taken."

--- a/config/locales/diaspora/en-GB.yml
+++ b/config/locales/diaspora/en-GB.yml
@@ -1,3 +1,7 @@
+#   Copyright (c) 2010-2011, Diaspora Inc.  This file is
+#   licensed under the Affero General Public License version 3 or later.  See
+#   the COPYRIGHT file.
+
 "en-GB":
   activerecord:
     errors:

--- a/config/locales/diaspora/en-GB.yml
+++ b/config/locales/diaspora/en-GB.yml
@@ -1,36 +1,32 @@
-#   Copyright (c) 2010-2011, Diaspora Inc.  This file is
-#   licensed under the Affero General Public License version 3 or later.  See
-#   the COPYRIGHT file.
-
 "en-GB":
   activerecord:
-      errors:
-          models:
-              user:
-                  attributes:
-                      person:
-                          invalid: "is invalid."
-                      username:
-                          taken: "is already taken."
-                      email:
-                          taken: "is already taken."
-              person:
-                  attributes:
-                      diaspora_handle:
-                          taken: "is already taken."
-              contact:
-                  attributes:
-                      person_id:
-                          taken: "must be unique among this user's contacts."
-              request:
-                  attributes:
-                      from_id:
-                          taken: "is a duplicate of a pre-existing request."
-              poll:
-                  attributes:
-                      poll_answers:
-                          not_enough_poll_answers: "Not enough poll options provided."
-              poll_participation:
-                  attributes:
-                      poll:
-                          already_participated: "You've already participated in this poll!"
+    errors:
+      models:
+        contact:
+          attributes:
+            person_id:
+              taken: "must be unique among this user's contacts."
+        person:
+          attributes:
+            diaspora_handle:
+              taken: "is already taken."
+        poll:
+          attributes:
+            poll_answers:
+              not_enough_poll_answers: "Not enough poll options provided."
+        poll_participation:
+          attributes:
+            poll:
+              already_participated: "You've already participated in this poll!"
+        request:
+          attributes:
+            from_id:
+              taken: "is a duplicate of a pre-existing request."
+        user:
+          attributes:
+            email:
+              taken: "is already taken."
+            person:
+              invalid: "is invalid."
+            username:
+              taken: "is already taken."

--- a/config/locales/diaspora/en-US.yml
+++ b/config/locales/diaspora/en-US.yml
@@ -1,36 +1,32 @@
-#   Copyright (c) 2010-2011, Diaspora Inc.  This file is
-#   licensed under the Affero General Public License version 3 or later.  See
-#   the COPYRIGHT file.
-
 "en-US":
   activerecord:
-      errors:
-          models:
-              user:
-                  attributes:
-                      person:
-                          invalid: "is invalid."
-                      username:
-                          taken: "is already taken."
-                      email:
-                          taken: "is already taken."
-              person:
-                  attributes:
-                      diaspora_handle:
-                          taken: "is already taken."
-              contact:
-                  attributes:
-                      person_id:
-                          taken: "must be unique among this user's contacts."
-              request:
-                  attributes:
-                      from_id:
-                          taken: "is a duplicate of a pre-existing request."
-              poll:
-                  attributes:
-                      poll_answers:
-                          not_enough_poll_answers: "Not enough poll options provided."
-              poll_participation:
-                  attributes:
-                      poll:
-                          already_participated: "You've already participated in this poll!"
+    errors:
+      models:
+        contact:
+          attributes:
+            person_id:
+              taken: "must be unique among this user's contacts."
+        person:
+          attributes:
+            diaspora_handle:
+              taken: "is already taken."
+        poll:
+          attributes:
+            poll_answers:
+              not_enough_poll_answers: "Not enough poll options provided."
+        poll_participation:
+          attributes:
+            poll:
+              already_participated: "You've already participated in this poll!"
+        request:
+          attributes:
+            from_id:
+              taken: "is a duplicate of a pre-existing request."
+        user:
+          attributes:
+            email:
+              taken: "is already taken."
+            person:
+              invalid: "is invalid."
+            username:
+              taken: "is already taken."

--- a/config/locales/diaspora/en-US.yml
+++ b/config/locales/diaspora/en-US.yml
@@ -1,3 +1,7 @@
+#   Copyright (c) 2010-2011, Diaspora Inc.  This file is
+#   licensed under the Affero General Public License version 3 or later.  See
+#   the COPYRIGHT file.
+
 "en-US":
   activerecord:
     errors:

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -1,66 +1,23 @@
-#   Copyright (c) 2010-2011, Diaspora Inc.  This file is
-#   licensed under the Affero General Public License version 3 or later.  See
-#   the COPYRIGHT file.
-
-# Sample localization file for English. Add more files in this directory for other locales.
-# See http://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
-
 en:
-  settings: "Settings"
-  profile: "Profile"
-  account: "Account"
-  privacy: "Privacy"
-  _services: "Services"
   _applications: "Applications"
-  _help: "Help"
-  ok: "OK"
-  cancel: "Cancel"
-  delete: "Delete"
-  username: "Username"
-  email: "Email"
-  are_you_sure: "Are you sure?"
-  are_you_sure_delete_account: "Are you sure you want to close your account? This can’t be undone!"
-  are_you_sure_ignore_user: "You are going to ignore that user. Are you sure?"
-  fill_me_out: "Fill me out"
-  public: "Public"
-  limited: "Limited"
-  search: "Search"
-  nsfw: "NSFW"
-  find_people: "Find people or #tags"
-  more: "More"
-  all_aspects: "All aspects"
-  no_results: "No results found"
   _contacts: "Contacts"
-  _terms: "Terms"
+  _help: "Help"
   _podmin_mail: "Contact Podmin"
+  _services: "Services"
   _statistics: "Statistics"
-
-  # For reference translation; the real ActiveRecord English transations are actually
-  # in the en-US, en-GB, and en-AU yml files.
+  _terms: "Terms"
+  account: "Account"
   activerecord:
     errors:
       models:
-        user:
-          attributes:
-            person:
-              invalid: "is invalid."
-            username:
-              taken: "is already taken."
-              invalid: "is invalid. We only allow letters, numbers, and underscores."
-            email:
-              taken: "is already taken."
-        person:
-          attributes:
-            diaspora_handle:
-              taken: "is already taken."
         contact:
           attributes:
             person_id:
               taken: "must be unique among this user’s contacts."
-        reshare:
+        person:
           attributes:
-            root_guid:
-              taken: "That good, eh? You've already reshared that post!"
+            diaspora_handle:
+              taken: "is already taken."
         poll:
           attributes:
             poll_answers:
@@ -69,213 +26,302 @@ en:
           attributes:
             poll:
               already_participated: "You’ve already participated in this poll!"
-  # Carrierwave error messages
-  errors:
-    messages:
-      carrierwave_processing_error: failed to be processed
-      carrierwave_integrity_error: is not of an allowed file type
-      carrierwave_download_error: could not be downloaded
-      extension_whitelist_error: "You are not allowed to upload %{extension} files, allowed types: %{allowed_types}"
-      extension_blacklist_error: "You are not allowed to upload %{extension} files, prohibited types: %{prohibited_types}"
-      content_type_whitelist_error: "You are not allowed to upload %{content_type} files"
-      content_type_blacklist_error: "You are not allowed to upload %{content_type} files"
-      rmagick_processing_error: "Failed to manipulate with rmagick, maybe it is not an image?"
-      mini_magick_processing_error: "Failed to manipulate with MiniMagick, maybe it is not an image? Original Error: %{e}"
-      min_size_error: "File size should be greater than %{min_size}"
-      max_size_error: "File size should be less than %{max_size}"
-
-  error_messages:
-    helper:
-      correct_the_following_errors_and_try_again: "Correct the following errors and try again."
-    need_javascript: "This website requires JavaScript to function properly. If you disabled JavaScript, please enable it and refresh this page."
-    csrf_token_fail: "The CSRF token is invalid. Please sign in and try again."
-
+        reshare:
+          attributes:
+            root_guid:
+              taken: "That good, eh? You've already reshared that post!"
+        user:
+          attributes:
+            email:
+              taken: "is already taken."
+            person:
+              invalid: "is invalid."
+            username:
+              invalid: "is invalid. We only allow letters, numbers, and underscores."
+              taken: "is already taken."
   admins:
     admin_bar:
-      pages: "Pages"
       dashboard: "Dashboard"
-      user_search: "User search"
-      weekly_user_stats: "Weekly user stats"
+      pages: "Pages"
+      pod_network: "Pod network"
       pod_stats: "Pod stats"
       report: "Reports"
       sidekiq_monitor: "Sidekiq monitor"
-      pod_network: "Pod network"
+      user_search: "User search"
+      weekly_user_stats: "Weekly user stats"
     dashboard:
-      pod_status: "Pod status"
       fetching_diaspora_version: "Determining latest diaspora* version..."
+      pod_status: "Pod status"
+    pods:
+      pod_desktop_link: "desktop view"
+      pod_desktop_view: "This page is not available on mobile view, please switch to %{desktop_link}."
+      pod_network: "Pod network"
+    stats:
+      2weeks: "2 weeks"
+      50_most: "50 most popular tags"
+      comments:
+        one: "%{count} comment"
+        other: "%{count} comments"
+        zero: "%{count} comments"
+      current_segment: "The current segment is averaging %{post_yest} posts per user, from %{post_day}"
+      daily: "Daily"
+      display_results: "Displaying results from the %{segment} segment"
+      go: "Go"
+      month: "Month"
+      posts:
+        one: "%{count} post"
+        other: "%{count} posts"
+        zero: "%{count} posts"
+      shares:
+        one: "%{count} share"
+        other: "%{count} shares"
+        zero: "%{count} shares"
+      tag_name: "Tag name: %{name_tag} Count: %{count_tag}"
+      usage_statistic: "Usage statistics"
+      users:
+        one: "%{count} user"
+        other: "%{count} users"
+        zero: "%{count} users"
+      week: "Week"
+    user_entry:
+      account_closed: "Account closed"
+      admin: "Admin"
+      current_sign_in_ip: "IP address at current sign in"
+      diaspora_handle: "diaspora* ID"
+      email: "Email"
+      guid: "GUID"
+      id: "ID"
+      invite_token: "Invite token"
+      last_seen: "Last seen"
+      moderator: "Moderator"
+      'no': "No"
+      nsfw: "#nsfw"
+      spotlight: "Spotlight"
+      unknown: "Unknown"
+      'yes': "Yes"
     user_search:
-      you_currently:
-        zero: "You currently have no invites left %{link}"
-        one: "You currently have one invite left %{link}"
-        other: "You currently have %{count} invites left %{link}"
-      view_profile: "View profile"
-      add_invites: "Add invites"
-      close_account: "Close account"
-      lock_account: "Lock account"
-      unlock_account: "Unlock account"
-      are_you_sure: "Are you sure you want to close this account?"
-      are_you_sure_lock_account: "Are you sure you want to lock this account?"
-      are_you_sure_unlock_account: "Are you sure you want to unlock this account?"
       account_closing_scheduled: "The account of %{name} is scheduled to be closed. It will be processed in a few moments..."
       account_locking_scheduled: "The account of %{name} is scheduled to be locked. It will be processed in a few moments..."
       account_unlocking_scheduled: "The account of %{name} is scheduled to be unlocked. It will be processed in a few moments..."
-      make_admin: "Make admin"
-      remove_admin: "Remove as admin"
-      make_moderator: "Make moderator"
-      remove_moderator: "Remove as moderator"
-      make_spotlight: "Add to community spotlight"
-      remove_spotlight: "Remove from community spotlight"
       add_admin: "%{name} has been made an admin."
-      delete_admin: "%{name} has been removed from the list of admins."
+      add_invites: "Add invites"
       add_moderator: "%{name} has been made a moderator."
-      delete_moderator: "%{name} has been removed from the list of moderators."
       add_spotlight: "%{name} has been added to community spotlight."
+      are_you_sure: "Are you sure you want to close this account?"
+      are_you_sure_lock_account: "Are you sure you want to lock this account?"
+      are_you_sure_unlock_account: "Are you sure you want to unlock this account?"
+      close_account: "Close account"
+      delete_admin: "%{name} has been removed from the list of admins."
+      delete_moderator: "%{name} has been removed from the list of moderators."
       delete_spotlight: "%{name} has been removed from community spotlight."
       does_not_exist: "User does not exist!"
-      role_implemented: "%{name} has already been given this role!"
-      role_removal_implemented: "%{name} has already been removed from this role!"
       email_to: "Email to invite"
       invite: "Invite"
+      lock_account: "Lock account"
+      make_admin: "Make admin"
+      make_moderator: "Make moderator"
+      make_spotlight: "Add to community spotlight"
+      remove_admin: "Remove as admin"
+      remove_moderator: "Remove as moderator"
+      remove_spotlight: "Remove from community spotlight"
+      role_implemented: "%{name} has already been given this role!"
+      role_removal_implemented: "%{name} has already been removed from this role!"
       under_13: "Show users that are under 13 (COPPA)"
+      unlock_account: "Unlock account"
       users:
-        zero: "%{count} users found"
         one: "%{count} user found"
         other: "%{count} users found"
-    user_entry:
-      id: "ID"
-      guid: "GUID"
-      email: "Email"
-      diaspora_handle: "diaspora* ID"
-      last_seen: "Last seen"
-      current_sign_in_ip: "IP address at current sign in"
-      account_closed: "Account closed"
-      nsfw: "#nsfw"
-      admin: "Admin"
-      moderator: "Moderator"
-      spotlight: "Spotlight"
-      unknown: "Unknown"
-      invite_token: "Invite token"
-      'yes': "Yes"
-      'no': "No"
+        zero: "%{count} users found"
+      view_profile: "View profile"
+      you_currently:
+        one: "You currently have one invite left %{link}"
+        other: "You currently have %{count} invites left %{link}"
+        zero: "You currently have no invites left %{link}"
     weekly_user_stats:
-      current_server: "Current server date is %{date}"
       amount_of:
-        zero: "Number of new users this week: none"
         one: "Number of new users this week: %{count}"
         other: "Number of new users this week: %{count}"
-    stats:
-      week: "Week"
-      2weeks: "2 weeks"
-      month: "Month"
-      daily: "Daily"
-      usage_statistic: "Usage statistics"
-      go: "Go"
-      display_results: "Displaying results from the %{segment} segment"
-      posts:
-        zero: "%{count} posts"
-        one: "%{count} post"
-        other: "%{count} posts"
-      comments:
-        zero: "%{count} comments"
-        one: "%{count} comment"
-        other: "%{count} comments"
-      shares:
-        zero: "%{count} shares"
-        one: "%{count} share"
-        other: "%{count} shares"
-      users:
-        zero: "%{count} users"
-        one: "%{count} user"
-        other: "%{count} users"
-      current_segment: "The current segment is averaging %{post_yest} posts per user, from %{post_day}"
-      50_most: "50 most popular tags"
-      tag_name: "Tag name: %{name_tag} Count: %{count_tag}"
-    pods:
-      pod_network: "Pod network"
-      pod_desktop_view: "This page is not available on mobile view, please switch to %{desktop_link}."
-      pod_desktop_link: "desktop view"
-  aspects:
-    edit:
-      confirm_remove_aspect: "Are you sure you want to delete this aspect?"
-      rename: "Rename"
-      aspect_list_is_visible: "Contacts in this aspect are able to see each other."
-      aspect_list_is_not_visible: "Contacts in this aspect are not able to see each other."
-      update: "Update"
-      updating: "Updating"
-    no_contacts_message:
-      you_should_add_some_more_contacts: "You should add some more contacts!"
-      try_adding_some_more_contacts: "You can search or %{invite_link} more contacts."
-      invite_link_text: "invite"
-      or_spotlight: "Or you can share with %{link}"
-      community_spotlight: "Community spotlight"
-    aspect_listings:
-      add_an_aspect: "+ Add an aspect"
+        zero: "Number of new users this week: none"
+      current_server: "Current server date is %{date}"
+  all_aspects: "All aspects"
+  api:
+    openid_connect:
+      authorizations:
+        destroy:
+          fail: "The attempt to revoke the authorization with ID %{id} failed"
+        new:
+          access: "%{name} requires access to:"
+          approve: "Approve"
+          bad_request: "Missing client id or redirect URI"
+          client_id_not_found: "No client with client_id %{client_id} with redirect URI %{redirect_uri} found"
+          deny: "Deny"
+          no_requirement: "%{name} requires no permissions"
+          private_contacts_linkage_error: "private:read and private:modify require contacts:read as well"
+          redirection_message: "Are you sure you want to give access to %{redirect_uri}?"
+          unknown_scope: "Unknown scope: %{scope_name}"
+      error_page:
+        contact_developer: "Please contact the application’s developer and include the following detailed error message:"
+        could_not_authorize: "The application could not be authorized"
+        login_required: "You must first login before you can authorize this application"
+        title: "Oh! Something went wrong :("
+      scopes:
+        'contacts:modify':
+          description: "This grants write access to contacts and related data (such as aspects)."
+          name: "Contacts (Write)"
+        'contacts:read':
+          description: "This grants read-only access to contacts and related data (such as aspects)."
+          name: "Contacts (Read-only)"
+        conversations:
+          description: "This grants read and write permission to private messages."
+          name: "Conversations"
+        email:
+          description: "This grants read-only access to your email address."
+          name: "E-Mail"
+        interactions:
+          description: "This grants access to interact with posts, for instance liking or submitting a comment."
+          name: "Interactions"
+        name:
+          description: "This grants read-only access to your full name."
+          name: "Full name"
+        nickname:
+          description: "This grants read-only access to your username."
+          name: "Username"
+        notifications:
+          description: "This grants read and write access to your notifications."
+          name: "Notifications"
+        openid:
+          description: "This grants read-only access to your basic profile information."
+          name: "Basic profile information"
+        picture:
+          description: "This grants read-only access to your profile picture."
+          name: "Profile picture"
+        'private:modify':
+          description: "This grants access to publish private posts."
+          name: "Private Posts (Write)"
+        'private:read':
+          description: "This grants read-only access to your and your contacts’ private posts."
+          name: "Private Posts (Read-only)"
+        profile:
+          description: "This grants read-only access to your extended profile data."
+          name: "Extended profile (Read-only)"
+        'profile:modify':
+          description: "This grants access to update your extended profile data."
+          name: "Extended profile (Write)"
+        'profile:read_private':
+          description: "This grants read-only access to your private profile data."
+          name: "Private profile data (Read-only)"
+        'public:modify':
+          description: "This grants write access to publish public posts and related data (such as votes and attached media)."
+          name: "Public Posts (Write)"
+        'public:read':
+          description: "This grants access to your public posts, including interactions and related data."
+          name: "Public Posts (Read-only)"
+        sub:
+          description: "This grants read-only access to your unique identifier."
+          name: "Unique identifier"
+        'tags:modify':
+          description: "This grants access to change the tags you follow."
+          name: "Tags (Write)"
+        'tags:read':
+          description: "This grants read-only access to your followed tags and tag streams."
+          name: "Tags (Read-only)"
+      user_applications:
+        index:
+          access: "%{name} has access to:"
+          edit_applications: "Applications"
+          no_requirement: "%{name} requires no permissions"
+          title: "Authorized applications"
+        no_applications: "You have no authorized applications"
+        policy: "See the application’s privacy policy"
+        revoke_autorization: "Revoke"
+        tos: "See the application’s terms of service"
+  are_you_sure: "Are you sure?"
+  are_you_sure_delete_account: "Are you sure you want to close your account? This can’t be undone!"
+  are_you_sure_ignore_user: "You are going to ignore that user. Are you sure?"
+  aspect_memberships:
     destroy:
-      success: "%{name} was successfully removed."
-      success_auto_follow_back: "%{name} was successfully removed. You used this aspect to automatically follow back users. Check your user settings to select a new auto follow back aspect."
-      failure: "%{name} could not be removed."
-    update:
-      success: "Your aspect, %{name}, has been successfully edited."
-      failure: "Your aspect, %{name}, had too long name to be saved."
+      failure: "Failed to remove person from aspect."
+      forbidden: "You are not allowed to do that."
+      invalid_statement: "Duplicate record rejected."
+      no_membership: "Could not find the selected person in that aspect."
+      success: "Successfully removed person from aspect."
+  aspects:
     add_to_aspect:
       failure: "Failed to add contact to aspect."
       success: "Successfully added contact to aspect."
-    seed:
-      family: "Family"
-      work: "Work"
-      acquaintances: "Acquaintances"
-      friends: "Friends"
-    index:
-      donate: "Donate"
-      keep_pod_running: "Keep %{pod} running fast and buy servers their coffee fix with a monthly donation!"
-      donate_liberapay: "Donate to liberapay"
-      welcome_to_diaspora: "Welcome to diaspora*, %{name}!"
-      introduce_yourself: "This is your stream. Jump in and introduce yourself."
-
-      new_here:
-        title: "Welcome new users"
-        follow: "Follow %{link} and welcome new users to diaspora*!"
-        learn_more: "Learn more"
-
-      help:
-        need_help: "Need help?"
-        here_to_help: "The diaspora* community is here!"
-        do_you: "Do you:"
-        have_a_question: "... have a %{link}?"
-        tag_question: "question"
-        find_a_bug: "... find a %{link}?"
-        tag_bug: "bug"
-        feature_suggestion: "... have a %{link} suggestion?"
-        tag_feature: "feature"
-        tutorials_and_wiki: "%{faq}, %{tutorial} & %{wiki}: help for your first steps."
-        tutorial_link_text: "Tutorials"
-        support_forum: "You can also join the %{support_forum}."
-        support_forum_link: "support forum"
-        any_problem: "Got a problem?"
-        contact_podmin: "Contact the administrator of your pod!"
-        mail_podmin: "Podmin email"
-      services:
-        heading: "Connect services"
-        content: "You can connect the following services to diaspora*:"
-
+    aspect_listings:
+      add_an_aspect: "+ Add an aspect"
     aspect_stream:
+      make_something: "Make something"
       stay_updated: "Stay updated"
       stay_updated_explanation: "Your main stream is populated with all of your contacts, tags you follow, and posts from some creative members of the community."
-      make_something: "Make something"
-
-  aspect_memberships:
     destroy:
-      success: "Successfully removed person from aspect."
-      failure: "Failed to remove person from aspect."
-      no_membership: "Could not find the selected person in that aspect."
-      forbidden: "You are not allowed to do that."
-      invalid_statement: "Duplicate record rejected."
-
+      failure: "%{name} could not be removed."
+      success: "%{name} was successfully removed."
+      success_auto_follow_back: "%{name} was successfully removed. You used this aspect to automatically follow back users. Check your user settings to select a new auto follow back aspect."
+    edit:
+      aspect_list_is_not_visible: "Contacts in this aspect are not able to see each other."
+      aspect_list_is_visible: "Contacts in this aspect are able to see each other."
+      confirm_remove_aspect: "Are you sure you want to delete this aspect?"
+      rename: "Rename"
+      update: "Update"
+      updating: "Updating"
+    index:
+      donate: "Donate"
+      donate_liberapay: "Donate to liberapay"
+      help:
+        any_problem: "Got a problem?"
+        contact_podmin: "Contact the administrator of your pod!"
+        do_you: "Do you:"
+        feature_suggestion: "... have a %{link} suggestion?"
+        find_a_bug: "... find a %{link}?"
+        have_a_question: "... have a %{link}?"
+        here_to_help: "The diaspora* community is here!"
+        mail_podmin: "Podmin email"
+        need_help: "Need help?"
+        support_forum: "You can also join the %{support_forum}."
+        support_forum_link: "support forum"
+        tag_bug: "bug"
+        tag_feature: "feature"
+        tag_question: "question"
+        tutorial_link_text: "Tutorials"
+        tutorials_and_wiki: "%{faq}, %{tutorial} & %{wiki}: help for your first steps."
+      introduce_yourself: "This is your stream. Jump in and introduce yourself."
+      keep_pod_running: "Keep %{pod} running fast and buy servers their coffee fix with a monthly donation!"
+      new_here:
+        follow: "Follow %{link} and welcome new users to diaspora*!"
+        learn_more: "Learn more"
+        title: "Welcome new users"
+      services:
+        content: "You can connect the following services to diaspora*:"
+        heading: "Connect services"
+      welcome_to_diaspora: "Welcome to diaspora*, %{name}!"
+    no_contacts_message:
+      community_spotlight: "Community spotlight"
+      invite_link_text: "invite"
+      or_spotlight: "Or you can share with %{link}"
+      try_adding_some_more_contacts: "You can search or %{invite_link} more contacts."
+      you_should_add_some_more_contacts: "You should add some more contacts!"
+    seed:
+      acquaintances: "Acquaintances"
+      family: "Family"
+      friends: "Friends"
+      work: "Work"
+    update:
+      failure: "Your aspect, %{name}, had too long name to be saved."
+      success: "Your aspect, %{name}, has been successfully edited."
+  blocks:
+    create:
+      failure: "I couldn’t ignore that user. #evasion"
+      success: "All right, you won’t see that user in your stream again. #silencio!"
+    destroy:
+      failure: "I couldn’t stop ignoring that user. #evasion"
+      success: "Let’s see what they have to say! #sayhello"
   bookmarklet:
+    explanation: "Post to diaspora* from anywhere by bookmarking this link => %{link}."
     heading: "Bookmarklet"
     post_something: "Post to diaspora*"
-    explanation: "Post to diaspora* from anywhere by bookmarking this link => %{link}."
-
+  cancel: "Cancel"
   color_themes:
     dark: "Dark"
     dark_green: "Dark green"
@@ -283,257 +329,145 @@ en:
     magenta: "Magenta"
     original: "Original gray"
     original_white: "Original white background"
-
   comments:
     create:
       error: "Failed to comment."
-    new_comment:
-      comment: "Comment"
-      commenting: "Commenting..."
     create:
       fail: "Comment creation has failed"
     destroy:
-      success: "Comment %{id} has been successfully deleted"
       fail: "Comment deletion has failed"
+      success: "Comment %{id} has been successfully deleted"
+    new_comment:
+      comment: "Comment"
+      commenting: "Commenting..."
     not_found: "Post or comment not found"
-
   contacts:
     index:
+      add_contact: "Add contact"
+      all_contacts: "All contacts"
+      community_spotlight: "Community spotlight"
+      my_contacts: "My contacts"
+      no_contacts: "Looks like you need to add some contacts!"
+      no_contacts_in_aspect: "You don't have any contacts in this aspect yet. Below is a list of your existing contacts which you can add to this aspect."
+      no_contacts_message: "Check out %{community_spotlight}"
+      only_sharing_with_me: "Only sharing with me"
       start_a_conversation: "Start a conversation"
       title: "Contacts"
-      no_contacts: "Looks like you need to add some contacts!"
-      no_contacts_message: "Check out %{community_spotlight}"
-      community_spotlight: "Community spotlight"
-      no_contacts_in_aspect: "You don't have any contacts in this aspect yet. Below is a list of your existing contacts which you can add to this aspect."
-      my_contacts: "My contacts"
-      all_contacts: "All contacts"
-      only_sharing_with_me: "Only sharing with me"
-      add_contact: "Add contact"
       user_search: "Contact search"
     spotlight:
       community_spotlight: "Community spotlight"
-      suggest_member: "Suggest a member"
       no_members: "There are no members yet."
-
+      suggest_member: "Suggest a member"
   conversations:
-    index:
-      conversations_inbox: "Conversations – Inbox"
-      new_conversation: "New conversation"
-      no_messages: "No messages"
-      inbox: "Inbox"
-      no_contacts: "You need to add some contacts before you can start a conversation"
-    show:
-      reply: "Reply"
-      replying: "Replying..."
-      hide: "Hide and mute conversation"
-      delete: "Delete conversation"
-      last_message: "Last message received %{timeago}"
-    new:
-      to: "To"
-      subject: "Subject"
-      subject_default: "No subject"
-      message: "Message"
-      send: "Send"
-      sending: "Sending..."
     create:
+      fail: "Invalid message"
       sent: "Message sent"
-      fail: "Invalid message"
-    new_conversation:
-      fail: "Invalid message"
     destroy:
       delete_success: "Conversation successfully deleted"
       hide_success: "Conversation successfully hidden"
+    index:
+      conversations_inbox: "Conversations – Inbox"
+      inbox: "Inbox"
+      new_conversation: "New conversation"
+      no_contacts: "You need to add some contacts before you can start a conversation"
+      no_messages: "No messages"
+    new:
+      message: "Message"
+      send: "Send"
+      sending: "Sending..."
+      subject: "Subject"
+      subject_default: "No subject"
+      to: "To"
+    new_conversation:
+      fail: "Invalid message"
     not_found: "Conversation not found"
+    show:
+      delete: "Delete conversation"
+      hide: "Hide and mute conversation"
+      last_message: "Last message received %{timeago}"
+      reply: "Reply"
+      replying: "Replying..."
   date:
     formats:
-      fullmonth_day: "%B %d"
       birthday: "%B %d"
       birthday_with_year: "%B %d %Y"
-
+      fullmonth_day: "%B %d"
+  delete: "Delete"
+  email: "Email"
+  error_messages:
+    csrf_token_fail: "The CSRF token is invalid. Please sign in and try again."
+    helper:
+      correct_the_following_errors_and_try_again: "Correct the following errors and try again."
+    need_javascript: "This website requires JavaScript to function properly. If you disabled JavaScript, please enable it and refresh this page."
+  errors:
+    messages:
+      carrierwave_download_error: could not be downloaded
+      carrierwave_integrity_error: is not of an allowed file type
+      carrierwave_processing_error: failed to be processed
+      content_type_blacklist_error: "You are not allowed to upload %{content_type} files"
+      content_type_whitelist_error: "You are not allowed to upload %{content_type} files"
+      extension_blacklist_error: "You are not allowed to upload %{extension} files, prohibited types: %{prohibited_types}"
+      extension_whitelist_error: "You are not allowed to upload %{extension} files, allowed types: %{allowed_types}"
+      max_size_error: "File size should be less than %{max_size}"
+      min_size_error: "File size should be greater than %{min_size}"
+      mini_magick_processing_error: "Failed to manipulate with MiniMagick, maybe it is not an image? Original Error: %{e}"
+      rmagick_processing_error: "Failed to manipulate with rmagick, maybe it is not an image?"
+  fill_me_out: "Fill me out"
+  find_people: "Find people or #tags"
   help:
-    title_header: "Help"
-    tutorials: "tutorials"
-    tutorial: "tutorial"
-    irc: "IRC"
-    wiki: "wiki"
-    faq: "FAQ"
-    markdown: "Markdown"
-    here: "here"
-    foundation_website: "diaspora* foundation website"
-    third_party_tools: "Third-party tools"
-    getting_started_tutorial: "”Getting started” tutorial series"
+    account_and_data_management:
+      close_account_a: "Go to the bottom of your settings page and click the “Close account” button. You will be asked to enter your password to complete the process. Remember, if you close your account, you will <strong>never</strong> be able to re-register your username on that pod."
+      close_account_q: "How do I delete my seed (account)?"
+      data_other_podmins_a: "Once you are sharing with someone on another pod, any posts you share with them and a copy of your profile data are stored (cached) on their pod, and are accessible to that pod’s database administrator. When you delete a post or profile data it is deleted from your pod and a delete request is sent to any other pods where it had previously been stored. Your images are never stored on any pod but your own; only links to them are transmitted to other pods."
+      data_other_podmins_q: "Can the administrators of other pods see my information?"
+      data_visible_to_podmin_a: "In short: everything. Communication between pods is always encrypted (using SSL and diaspora*’s own transport encryption), but the storage of data on pods is not encrypted. If they wanted to, the database administrator for your pod (usually the person running the pod) could access all your profile data and everything that you post (as is the case for most websites that store user data). This is why we give you the choice which pod you sign up to, so you can choose a pod whose admin you are happy to trust with your data. Running your own pod provides more privacy since you then control access to the database."
+      data_visible_to_podmin_q: "How much of my information can my pod administrator see?"
+      download_data_a: "Yes. At the bottom of the Account tab of your settings page you will find two buttons: one for downloading your data and one for downloading your photos."
+      download_data_q: "Can I download a copy of all of my data contained in my seed (account)?"
+      move_pods_a: "Version 0.7.0.0 of diaspora* provides the first stage of account migration: you can now export all your data from the “Account” section of the user settings. Keep your data safely! In a future release you will be able to migrate your whole account, including posts and contacts, to another pod."
+      move_pods_q: "How do I move my seed (account) from one pod to another?"
+      title: "Account and data management"
+    aspects:
+      change_aspect_of_post_a: "No, but you can always make a new post with the same content and post it to a different aspect."
+      change_aspect_of_post_q: "Once I have posted something, can I change the aspect(s) that can see it?"
+      contacts_know_aspect_a: "No. They cannot see the name of the aspect under any circumstances."
+      contacts_know_aspect_q: "Do my contacts know which aspects I have put them in?"
+      delete_aspect_a: "Click “My aspects” in the side-bar from a stream view and click the pencil icon by the aspect you want to delete, or go to your Contacts page and select the relevant aspect. Then click the trash icon in the top right of the page."
+      delete_aspect_q: "How do I delete an aspect?"
+      person_multiple_aspects_a: "Yes. Go to your contacts page and click on “My contacts”. For each contact you can use the menu on the right to add them to (or remove them from) as many aspects as you want. Or you can add them to a new aspect (or remove them from an aspect) by clicking the aspect selector button on their profile page. Or you can even just move the pointer over their name where you see it in the stream, and a “hovercard” will appear. You can change the aspects they are in right there."
+      person_multiple_aspects_q: "Can I add a person to multiple aspects?"
+      post_multiple_aspects_a: "Yes. When you are making a post, use the aspect selector button to select or deselect aspects. “All aspects” is the default setting. Your post will be visible to all the aspects you select. You could also select the aspects you want to post to in the side-bar. When you post, the aspect(s) that you have selected in the list on the left will automatically be selected in the aspect selector when you start to make a new post."
+      post_multiple_aspects_q: "Can I post content to multiple aspects at once?"
+      remove_notification_a: "No. They are also not notified if you add them to more aspects, when you are already sharing with them."
+      remove_notification_q: "If I remove someone from an aspect, or all of my aspects, are they notified of this?"
+      rename_aspect_a: "Click “My aspects” in the side-bar from a stream view and click the pencil icon by the aspect you want to rename, or go to your Contacts page and select the relevant aspect. Then click the edit icon next to the aspect name at the top of this page, change the name and press “Update”."
+      rename_aspect_q: "How do I rename an aspect?"
+      restrict_posts_i_see_a: "Yes. Click “My aspects” in the side-bar and then click individual aspects in the list to select or deselect them. Only the posts by people in the selected aspects will appear in your stream."
+      restrict_posts_i_see_q: "Can I restrict the posts in my stream to just those from certain aspects?"
+      title: "Aspects"
+      what_is_an_aspect_a: "Aspects are the way you group your contacts on diaspora*. An aspect is one of the faces you show to the world. It might be who you are at work, or who you are to your family, or who you are to your friends in a club you belong to."
+      what_is_an_aspect_q: "What is an aspect?"
+      who_sees_post_a: "If you make a limited post, it will only be visible to the people you had placed in that aspect (or aspects, if it is made to multiple aspects) before making the post. Contacts you have who aren’t in the aspect have no way of seeing the post. Limited posts will never be visible to anyone who you haven’t placed into one of your aspects."
+      who_sees_post_q: "When I post to an aspect, who sees it?"
     community_guidelines: "community guidelines"
+    faq: "FAQ"
+    foundation_website: "diaspora* foundation website"
     getting_help:
-      title: "Getting help"
-      getting_started_q: "Help! I need some basic help to get me started!"
-      getting_started_a: "You’re in luck. Try the %{tutorial_series} on our project site. It will take you step-by-step through the registration process and teach you all the basic things you need to know about using diaspora*."
-      get_support_q: "What if my question is not answered in this FAQ? Where else can I get support?"
-      get_support_a_website: "Visit our %{link}"
-      get_support_a_tutorials: "Check out our %{tutorials}"
-      get_support_a_wiki: "Search the %{link}"
-      get_support_a_irc: "Join us on %{irc} (live chat)"
+      get_support_a_discourse: "Search for existing discussions relating to your enquiry or open a new thread in our %{discourse} platform"
       get_support_a_faq: "Read our %{faq} page on wiki"
       get_support_a_hashtag: "Ask in a public post on diaspora* using the %{question} hashtag"
-      get_support_a_discourse: "Search for existing discussions relating to your enquiry or open a new thread in our %{discourse} platform"
-    account_and_data_management:
-      title: "Account and data management"
-      move_pods_q: "How do I move my seed (account) from one pod to another?"
-      move_pods_a: "Version 0.7.0.0 of diaspora* provides the first stage of account migration: you can now export all your data from the “Account” section of the user settings. Keep your data safely! In a future release you will be able to migrate your whole account, including posts and contacts, to another pod."
-      download_data_q: "Can I download a copy of all of my data contained in my seed (account)?"
-      download_data_a: "Yes. At the bottom of the Account tab of your settings page you will find two buttons: one for downloading your data and one for downloading your photos."
-      close_account_q: "How do I delete my seed (account)?"
-      close_account_a: "Go to the bottom of your settings page and click the “Close account” button. You will be asked to enter your password to complete the process. Remember, if you close your account, you will <strong>never</strong> be able to re-register your username on that pod."
-      data_visible_to_podmin_q: "How much of my information can my pod administrator see?"
-      data_visible_to_podmin_a: "In short: everything. Communication between pods is always encrypted (using SSL and diaspora*’s own transport encryption), but the storage of data on pods is not encrypted. If they wanted to, the database administrator for your pod (usually the person running the pod) could access all your profile data and everything that you post (as is the case for most websites that store user data). This is why we give you the choice which pod you sign up to, so you can choose a pod whose admin you are happy to trust with your data. Running your own pod provides more privacy since you then control access to the database."
-      data_other_podmins_q: "Can the administrators of other pods see my information?"
-      data_other_podmins_a: "Once you are sharing with someone on another pod, any posts you share with them and a copy of your profile data are stored (cached) on their pod, and are accessible to that pod’s database administrator. When you delete a post or profile data it is deleted from your pod and a delete request is sent to any other pods where it had previously been stored. Your images are never stored on any pod but your own; only links to them are transmitted to other pods."
-    aspects:
-      title: "Aspects"
-      what_is_an_aspect_q: "What is an aspect?"
-      what_is_an_aspect_a: "Aspects are the way you group your contacts on diaspora*. An aspect is one of the faces you show to the world. It might be who you are at work, or who you are to your family, or who you are to your friends in a club you belong to."
-      who_sees_post_q: "When I post to an aspect, who sees it?"
-      who_sees_post_a: "If you make a limited post, it will only be visible to the people you had placed in that aspect (or aspects, if it is made to multiple aspects) before making the post. Contacts you have who aren’t in the aspect have no way of seeing the post. Limited posts will never be visible to anyone who you haven’t placed into one of your aspects."
-      contacts_know_aspect_q: "Do my contacts know which aspects I have put them in?"
-      contacts_know_aspect_a: "No. They cannot see the name of the aspect under any circumstances."
-      person_multiple_aspects_q: "Can I add a person to multiple aspects?"
-      person_multiple_aspects_a: "Yes. Go to your contacts page and click on “My contacts”. For each contact you can use the menu on the right to add them to (or remove them from) as many aspects as you want. Or you can add them to a new aspect (or remove them from an aspect) by clicking the aspect selector button on their profile page. Or you can even just move the pointer over their name where you see it in the stream, and a “hovercard” will appear. You can change the aspects they are in right there."
-      remove_notification_q: "If I remove someone from an aspect, or all of my aspects, are they notified of this?"
-      remove_notification_a: "No. They are also not notified if you add them to more aspects, when you are already sharing with them."
-      change_aspect_of_post_q: "Once I have posted something, can I change the aspect(s) that can see it?"
-      change_aspect_of_post_a: "No, but you can always make a new post with the same content and post it to a different aspect."
-      post_multiple_aspects_q: "Can I post content to multiple aspects at once?"
-      post_multiple_aspects_a: "Yes. When you are making a post, use the aspect selector button to select or deselect aspects. “All aspects” is the default setting. Your post will be visible to all the aspects you select. You could also select the aspects you want to post to in the side-bar. When you post, the aspect(s) that you have selected in the list on the left will automatically be selected in the aspect selector when you start to make a new post."
-      restrict_posts_i_see_q: "Can I restrict the posts in my stream to just those from certain aspects?"
-      restrict_posts_i_see_a: "Yes. Click “My aspects” in the side-bar and then click individual aspects in the list to select or deselect them. Only the posts by people in the selected aspects will appear in your stream."
-      rename_aspect_q: "How do I rename an aspect?"
-      rename_aspect_a: "Click “My aspects” in the side-bar from a stream view and click the pencil icon by the aspect you want to rename, or go to your Contacts page and select the relevant aspect. Then click the edit icon next to the aspect name at the top of this page, change the name and press “Update”."
-      delete_aspect_q: "How do I delete an aspect?"
-      delete_aspect_a: "Click “My aspects” in the side-bar from a stream view and click the pencil icon by the aspect you want to delete, or go to your Contacts page and select the relevant aspect. Then click the trash icon in the top right of the page."
-    mentions:
-      title: "Mentions"
-      what_is_a_mention_q: "What is a “mention”?"
-      what_is_a_mention_a: "A mention is a link to a person’s profile page that appears in a post. When someone is mentioned they receive a notification that calls their attention to the post."
-      how_to_mention_q: "How do I mention someone when making a post?"
-      how_to_mention_a: "Type the “@” sign and start typing their name. A drop-down menu should appear to let you select them more easily. Note that it is only possible to mention people you have added to an aspect."
-      mention_in_comment_q: "Can I mention someone in a comment?"
-      mention_in_comment_a: "Since version 0.7.0.0, yes! You can mention someone in a comment the same way you would do it in a post, by typing “@” and then start typing their name. Please note that when you comment on a post which is not public, you can only mention users who have already interacted with the post."
-      see_mentions_q: "Is there a way to see the posts in which I have been mentioned?"
-      see_mentions_a: "Yes, click “@Mentions” in the left-hand column on your home page."
-    pods:
-      title: "Pods"
-      what_is_a_pod_q: "What is a pod?"
-      what_is_a_pod_a: "A pod is a server running the diaspora* software and connected to the diaspora* network. “Pod” is a metaphor referring to pods on plants which contain seeds, in the way that a server contains a number of user accounts. There are many different pods. You can add friends from other pods and communicate with them. There’s no need to open an account on different pods! One is enough – in this way, you can think of a diaspora* pod as similar to an email provider. There are public pods, private pods, and with some effort you can even run your own."
-      find_people_q: "I just joined a pod, how can I find people to share with?"
-      find_people_a: "If you want to invite your friends to join diaspora*, use the invitation link or the email link in the side-bar. Follow #tags to discover others who share your interests, and add those who post things that interest you to an aspect. Shout out that you’re #newhere in a public post."
-      use_search_box_q: "How do I use the search box to find particular individuals?"
-      use_search_box_a: "You can search for people by entering their username or their diaspora* name (the name that is shown on their profile). If neither of these methods work, enter their full diaspora* ID (username@podname.org). If your search doesn’t work the first time, it could be due to network latency. Try it again."
-    posts_and_posting:
-      title: "Posts and posting"
-      stream_full_of_posts_q: "Why is my stream full of posts from people I don’t know and don’t share with?"
-      stream_full_of_posts_a1: "Your stream is made up of three types of posts:"
-      stream_full_of_posts_li1: "Posts by people you are sharing with, which come in two types: public posts and limited posts shared with an aspect that you are part of. To remove these posts from your stream, simply stop sharing with the person."
-      stream_full_of_posts_li2: "Public posts containing one of the tags that you follow. To remove these, stop following that tag."
-      stream_full_of_posts_li3: "Public posts by people listed in the community spotlight. These can be removed by unchecking the “Show community spotlight in stream?” option in the Account tab of your Settings."
-      hide_posts_q: "How do I hide a post?"
-      hide_posts_a: "If you point your mouse at the top of a post, an X appears on the right. Click it to hide the post and mute notifications about it. You can still see the post if you visit the profile page of the person who posted it."
-      post_notification_q: "How do I get notifications, or stop getting notifications, about a post?"
-      post_notification_a: "You will find a bell icon next to the X at the top right of a post. Click this to enable or disable notifications for that post."
-      ignore_user_q: "How do I stop someone’s posts from appearing in my stream?"
-      ignore_user_a1: "If you are currently sharing with that person, removing them from your aspects will stop many of their posts from appearing in your stream. A more complete method is to “ignore” that account. This will prevent any of their posts from appearing in your stream, and they will no longer be able to like or comment on your posts. They will, however, still be able to reshare your posts, comment on reshares of your posts, and their comments on posts by other people which appear in your stream will still be visible to you."
-      ignore_user_a2: "To ignore an account, click the “ignore” icon (a circle with a diagonal line through it) at the top right of one of their posts. Their posts will instantly disappear from your stream. Alternatively, go to their profile page and click the ignore icon there. You will still be able to see their posts on their profile page, or by using the single-post view."
-      ignore_user_a3: "A list of people you are ignoring can be found in your account settings under Privacy. To stop ignoring someone, remove them from the list on that page."
-      post_report_q: "How do I report an offensive post?"
-      post_report_a: "Click the alert triangle icon at the top right of the post to report it to your podmin. Enter a reason for reporting this post in the dialog box. Please only report posts that break our %{community_guidelines} or your pod’s terms of service, for example posts containing illegal content, or which are abusive or spam."
-      character_limit_q: "What is the character limit for posts?"
-      character_limit_a: "65,535 characters. That’s 65,395 more characters than you get on Twitter! ;)"
-      char_limit_services_q: "What if I'm sharing my post with a connected service with a smaller character count?"
-      char_limit_services_a: "In that case you should restrict your post to the smaller character count (140 in the case of Twitter; 1000 in the case of Tumblr), and the number of characters you have left to use is displayed when that service’s icon is highlighted. You can still post to these services if your post is longer than their limit, but the text will be truncated on those services with a link to the post on diaspora*."
-      format_text_q: "How can I format the text in my posts (bold, italics, etc.)?"
-      format_text_a: "diaspora* uses a simplified system called %{markdown}. The publisher has buttons to make it easy to format your text. If you want to format your post manually, you can find the full Markdown syntax %{here}. The preview tab means you can see how your message will look before you share it. Remember that you can’t edit it once posted, so use the preview to make sure it’s perfect before pressing Share!"
-      insert_images_q: "How do I insert images into posts?"
-      insert_images_a: "If you want to include an image stored on your computer in your post, click the little camera icon at the bottom of the publisher. You can also drag and drop an image, or multiple images, from your computer onto that icon. If you want to insert an image from the web into your post, click the image button on the top of the publisher, which will create the Markdown code for you."
-      insert_images_comments_q: "Can I insert images into comments?"
-      insert_images_comments_a: "You can use Markdown to insert an image from the web into a comment, just like in posts. However, you cannot upload images from your computer directly into comments. Upload them to an image-hosting service and then insert them using the image button above the publisher."
-      size_of_images_q: "Can I customize the size of images in posts or comments?"
-      size_of_images_a: "No. Images are resized automatically to fit the stream or single-post view. Markdown does not have a code for specifying the size of an image."
-      embed_multimedia_q: "How do I embed a video, audio, or other multimedia content into a post?"
-      embed_multimedia_a: "You can usually just paste the URL (e.g. http://www.youtube.com/watch?v=nnnnnnnnnnn ) into your post and the video or audio will be embedded automatically. The sites supported include: YouTube, Vimeo, SoundCloud, Flickr and a few more. diaspora* uses oEmbed for this feature. If you post a direct link to an audio or video file, diaspora* will embed it using standard HTML5 player. We’re supporting more media sources all the time. Remember to always post simple, full links – no shortened links; no operators after the base URL – and give it a little time before you refresh the page after posting for seeing the preview."
-      post_location_q: "How do I add my location to a post?"
-      post_location_a: "Click the pin icon next to the camera in the publisher. This will insert your location from OpenStreetMap. You can edit your location – you might only want to include the city you’re in rather than the specific street address."
-      post_poll_q: "How do I add a poll to my post?"
-      post_poll_a: "Click the graph icon to generate a poll. Type a question and at least two answers. Don’t forget to make your post public if you want everyone to be able to participate in your poll."
-    private_posts:
-      title: "Private posts"
-      who_sees_post_q: "When I post a message to an aspect (i.e., a private post), who can see it?"
-      who_sees_post_a: "Only logged-in diaspora* users you had placed in that aspect before making the private post can see it."
-      can_comment_q: "Who can comment on or like my private post?"
-      can_comment_a: "Only logged-in diaspora* users you had placed in that aspect before making the private post can comment on or like it."
-      can_reshare_q: "Who can reshare my private post?"
-      can_reshare_a: "Nobody. Private posts are not resharable. Logged-in diaspora* users in that aspect can potentially copy and paste it, however. It’s up to you whether you trust those people!"
-      see_comment_q: "When I comment on or like a private post, who can see it?"
-      see_comment_a: "Only the people that the post was shared with (the people who are in the aspects selected by the original poster) can see its comments and likes. "
-    public_posts:
-      title: "Public posts"
-      who_sees_post_q: "When I post something publicly, who can see it?"
-      who_sees_post_a: "Anyone using the internet can potentially see a post you mark public, so make sure you really do want your post to be public. It’s a great way of reaching out to the world."
-      find_public_post_q: "How can other people find my public post?"
-      find_public_post_a: "Your public posts will appear in the streams of anyone following you. If you included #tags in your public post, anyone following those tags will find your post in their streams. Every public post also has a specific URL that anyone can view, even if they’re not logged in – thus public posts may be linked to directly from Twitter, blogs, etc. Public posts may also be indexed by search engines."
-      can_comment_reshare_like_q: "Who can comment on, reshare, or like my public post?"
-      can_comment_reshare_like_a: "Any logged-in diaspora* user can comment on, reshare, or like your public post. The exception to this is people you have ignored, who won’t be able to like or comment on your posts."
-      see_comment_reshare_like_q: "When I comment on, reshare, or like a public post, who can see it?"
-      see_comment_reshare_like_a: "Comments, likes, and reshares of public posts are also public. Any logged-in diaspora* user and anyone else on the internet can see your interactions with a public post."
-      deselect_aspect_posting_q: "What happens when I deselect one or more aspects in the left-hand column when making a public post?"
-      deselect_aspect_posting_a: "Deselecting aspects does not affect a public post. It will still be public and will appear in the streams of all of your contacts. To make a post visible only to specific aspects, you need to select those aspects from the aspect selector under the publisher."
-    profile:
-      title: "Profile"
-      whats_in_profile_q: "What’s in my profile?"
-      whats_in_profile_a: "Your profile is in two parts: your basic profile and your extended profile. Your basic profile contains your name, the five tags you chose to describe yourself, and your photo. Your extended profile contains your biography, location, gender, and birthday. All this information is optional – it’s up to you whether you provide it, and you can make this profile information as identifiable or anonymous as you like. Your extended profile is displayed in the left-hand column of your profile page, under your profile picture."
-      who_sees_profile_q: "Who sees my profile?"
-      who_sees_profile_a: "Your basic profile (name, profile image and #tags) is public. Your extended profile is private by default, but you can make it all publicly accessible if you want. Only people you are sharing with (meaning, you have added them to one of your aspects) can see your extended profile if you keep it private. Other people will see only your public information. Any profile information you make public can be viewed by anyone using the web, and can be indexed by search engines"
-      what_do_tags_do_q: "What do the tags in my basic profile do?"
-      what_do_tags_do_a: "They help people get to know you. Your profile picture will also appear on the left-hand side of the stream pages of those tags, along with anyone else who has them in their basic profile."
-    resharing_posts:
-      title: "Resharing posts"
-      reshare_public_post_aspects_q: "Can I reshare a public post to selected aspects?"
-      reshare_public_post_aspects_a: "No, when you reshare a public post it automatically becomes one of your public posts. To share it with certain aspects, copy and paste the contents of the post into a new, limited post."
-      reshare_private_post_aspects_q: "Can I reshare a private post to selected aspects?"
-      reshare_private_post_aspects_a: "No, it is not possible to reshare any private post. This is to respect the intentions of the original poster, who shared it only with a particular group of people."
-    sharing:
-      title: "Sharing"
-      add_to_aspect_q: "What happens when I add someone to one of my aspects, or when someone adds me to one of their aspects?"
-      add_to_aspect_a1: "Let’s say that Amy adds Ben to an aspect, but Ben has not (yet) added Amy to an aspect:"
-      add_to_aspect_li1: "Ben will receive a notification that Amy has “started sharing” with Ben."
-      add_to_aspect_li2: "Amy will start to see Ben’s public posts in her stream."
-      add_to_aspect_li3: "Amy will not see any of Ben’s private posts."
-      add_to_aspect_li4: "Ben will not see Amy’s public or private posts in his stream."
-      add_to_aspect_li5: "But if Ben goes to Amy’s profile page, then he will see the private posts that Amy makes to the aspect that she has placed him in (as well as her public posts, which anyone can see there)."
-      add_to_aspect_li6: "Ben will be able to see Amy’s private profile (biography, location, gender, birthday)."
-      add_to_aspect_li7: "Amy will appear under “Only sharing with me” on Ben’s contacts page."
-      add_to_aspect_li8: "Amy will also be able to @mention Ben in a post."
-      add_to_aspect_a2: "This is known as asymmetrical sharing. If and when Ben also adds Amy to an aspect then it would become mutual sharing, with both Amy’s and Ben’s public posts and relevant private posts appearing in each other’s streams, and Amy would be able to view Ben’s private profile. They would then also be able to send each other private messages."
-      sharing_notification_q: "How do I know when someone starts sharing with me?"
-      sharing_notification_a: "You should receive a notification each time someone starts sharing with you."
-      only_sharing_q: "Who are the people listed under “Only sharing with me” on my contacts page?"
-      only_sharing_a: "These are people that have added you to one of their aspects, but who are not (yet) in any of your aspects. In other words, they are sharing with you, but you are not sharing with them: you can think of this as them “following” you. If you add them to an aspect, they will then appear under that aspect and not under “Only sharing with me”. See above."
-      list_not_sharing_q: "Is there a list of people whom I have added to one of my aspects, but who have not added me to one of theirs?"
-      list_not_sharing_a: "No, but you can see whether or not someone is sharing with you by visiting their profile page. If they are, there will be a green tick next to their diaspora* ID. If they are not, there will be a gray circle."
-      see_old_posts_q: "When I add someone to an aspect, can they see older posts that I have already posted to that aspect?"
-      see_old_posts_a: "No. They will only be able to see new posts to that aspect. They (and everyone else) can see your older public posts on your profile page, and they may also see them in their stream."
-    tags:
-      title: "Tags"
-      what_are_tags_for_q: "What are tags for?"
-      what_are_tags_for_a: "Tags are a way to categorize a post, usually by topic. Searching for a tag shows all posts, both public and private, with that tag that you have permission to see. This lets people who are interested in a given topic find public posts about it."
-      tags_in_comments_q: "Can I put tags in comments or just in posts?"
-      tags_in_comments_a: "A tag added to a comment will still appear as a link to that tag’s page, but it will not make that post (or comment) appear on that tag page. This only works for tags in posts."
-      followed_tags_q: "What are “#Followed Tags” and how do I follow a tag?"
-      followed_tags_a: "After searching for a tag you can click the button at the top of the tag’s page to “follow” that tag. It will then appear in your list of followed tags in the left-hand menu. Clicking one of your followed tags takes you to that tag’s page so you can see recent posts containing that tag. Click on #Followed Tags to see a stream of posts that include any one of your followed tags. Posts containing that tag will also be included in your main stream."
-      people_tag_page_q: "Who are the people listed on the left-hand side of a tag page?"
-      people_tag_page_a: "They are people who have listed that tag to describe themselves in their public profile."
-      filter_tags_q: "How can I filter/exclude some tags from my stream?"
-      filter_tags_a: "This is not yet available directly through diaspora*, but some %{third_party_tools} have been written that might provide this."
+      get_support_a_irc: "Join us on %{irc} (live chat)"
+      get_support_a_tutorials: "Check out our %{tutorials}"
+      get_support_a_website: "Visit our %{link}"
+      get_support_a_wiki: "Search the %{link}"
+      get_support_q: "What if my question is not answered in this FAQ? Where else can I get support?"
+      getting_started_a: "You’re in luck. Try the %{tutorial_series} on our project site. It will take you step-by-step through the registration process and teach you all the basic things you need to know about using diaspora*."
+      getting_started_q: "Help! I need some basic help to get me started!"
+      title: "Getting help"
+    getting_started_tutorial: "”Getting started” tutorial series"
+    here: "here"
+    irc: "IRC"
     keyboard_shortcuts:
-      title: "Keyboard shortcuts"
-      keyboard_shortcuts_q: "What keyboard shortcuts are available?"
       keyboard_shortcuts_a1: "In the stream view you can use the following keyboard shortcuts:"
       keyboard_shortcuts_li1: "j – Jump to the next post"
       keyboard_shortcuts_li2: "k – Jump to the previous post"
@@ -543,235 +477,333 @@ en:
       keyboard_shortcuts_li6: "m – Expand the current post"
       keyboard_shortcuts_li7: "o – Open the first link in the current post"
       keyboard_shortcuts_li8: "Ctrl+Enter – Send the message you are writing"
+      keyboard_shortcuts_q: "What keyboard shortcuts are available?"
+      title: "Keyboard shortcuts"
+    markdown: "Markdown"
+    mentions:
+      how_to_mention_a: "Type the “@” sign and start typing their name. A drop-down menu should appear to let you select them more easily. Note that it is only possible to mention people you have added to an aspect."
+      how_to_mention_q: "How do I mention someone when making a post?"
+      mention_in_comment_a: "Since version 0.7.0.0, yes! You can mention someone in a comment the same way you would do it in a post, by typing “@” and then start typing their name. Please note that when you comment on a post which is not public, you can only mention users who have already interacted with the post."
+      mention_in_comment_q: "Can I mention someone in a comment?"
+      see_mentions_a: "Yes, click “@Mentions” in the left-hand column on your home page."
+      see_mentions_q: "Is there a way to see the posts in which I have been mentioned?"
+      title: "Mentions"
+      what_is_a_mention_a: "A mention is a link to a person’s profile page that appears in a post. When someone is mentioned they receive a notification that calls their attention to the post."
+      what_is_a_mention_q: "What is a “mention”?"
     miscellaneous:
-      title: "Miscellaneous"
-      back_to_top_q: "Is there a quick way to go back to the top of a page after I scroll down?"
       back_to_top_a: "Yes. After scrolling down a page, click on the grey arrow that appears in the bottom right-hand corner of your browser window."
-      photo_albums_q: "Are there photo or video albums?"
-      photo_albums_a: "No, not currently. However you can view a person’s uploaded pictures under the Photos tab of their profile page."
-      subscribe_feed_q: "Can I subscribe to someone’s public posts with a feed reader?"
-      subscribe_feed_a: "Yes, but this is still not a polished feature and the formatting of the results is still pretty rough. If you want to try it anyway, go to someone’s profile page and click the feed button in your browser, or you can copy the profile URL (e.g. https://podname.org/people/somenumber) and paste it into a feed reader. The resulting feed address looks like this: https://podname.org/public/username.atom – diaspora* uses Atom rather than RSS."
-      diaspora_app_q: "Is there a diaspora* app for Android or iOS?"
+      back_to_top_q: "Is there a quick way to go back to the top of a page after I scroll down?"
       diaspora_app_a: "There have been several Android apps in development by community members. Some are long-abandoned projects and so do not work well with the current version of diaspora*. Don’t expect much from these apps at the moment. There is currently no app for iOS. The best way to access diaspora* from your mobile device is through a browser, because we’ve designed a mobile version of the site which should work well on all devices, although it does not yet have complete functionality."
-
+      diaspora_app_q: "Is there a diaspora* app for Android or iOS?"
+      photo_albums_a: "No, not currently. However you can view a person’s uploaded pictures under the Photos tab of their profile page."
+      photo_albums_q: "Are there photo or video albums?"
+      subscribe_feed_a: "Yes, but this is still not a polished feature and the formatting of the results is still pretty rough. If you want to try it anyway, go to someone’s profile page and click the feed button in your browser, or you can copy the profile URL (e.g. https://podname.org/people/somenumber) and paste it into a feed reader. The resulting feed address looks like this: https://podname.org/public/username.atom – diaspora* uses Atom rather than RSS."
+      subscribe_feed_q: "Can I subscribe to someone’s public posts with a feed reader?"
+      title: "Miscellaneous"
+    pods:
+      find_people_a: "If you want to invite your friends to join diaspora*, use the invitation link or the email link in the side-bar. Follow #tags to discover others who share your interests, and add those who post things that interest you to an aspect. Shout out that you’re #newhere in a public post."
+      find_people_q: "I just joined a pod, how can I find people to share with?"
+      title: "Pods"
+      use_search_box_a: "You can search for people by entering their username or their diaspora* name (the name that is shown on their profile). If neither of these methods work, enter their full diaspora* ID (username@podname.org). If your search doesn’t work the first time, it could be due to network latency. Try it again."
+      use_search_box_q: "How do I use the search box to find particular individuals?"
+      what_is_a_pod_a: "A pod is a server running the diaspora* software and connected to the diaspora* network. “Pod” is a metaphor referring to pods on plants which contain seeds, in the way that a server contains a number of user accounts. There are many different pods. You can add friends from other pods and communicate with them. There’s no need to open an account on different pods! One is enough – in this way, you can think of a diaspora* pod as similar to an email provider. There are public pods, private pods, and with some effort you can even run your own."
+      what_is_a_pod_q: "What is a pod?"
+    posts_and_posting:
+      char_limit_services_a: "In that case you should restrict your post to the smaller character count (140 in the case of Twitter; 1000 in the case of Tumblr), and the number of characters you have left to use is displayed when that service’s icon is highlighted. You can still post to these services if your post is longer than their limit, but the text will be truncated on those services with a link to the post on diaspora*."
+      char_limit_services_q: "What if I'm sharing my post with a connected service with a smaller character count?"
+      character_limit_a: "65,535 characters. That’s 65,395 more characters than you get on Twitter! ;)"
+      character_limit_q: "What is the character limit for posts?"
+      embed_multimedia_a: "You can usually just paste the URL (e.g. http://www.youtube.com/watch?v=nnnnnnnnnnn ) into your post and the video or audio will be embedded automatically. The sites supported include: YouTube, Vimeo, SoundCloud, Flickr and a few more. diaspora* uses oEmbed for this feature. If you post a direct link to an audio or video file, diaspora* will embed it using standard HTML5 player. We’re supporting more media sources all the time. Remember to always post simple, full links – no shortened links; no operators after the base URL – and give it a little time before you refresh the page after posting for seeing the preview."
+      embed_multimedia_q: "How do I embed a video, audio, or other multimedia content into a post?"
+      format_text_a: "diaspora* uses a simplified system called %{markdown}. The publisher has buttons to make it easy to format your text. If you want to format your post manually, you can find the full Markdown syntax %{here}. The preview tab means you can see how your message will look before you share it. Remember that you can’t edit it once posted, so use the preview to make sure it’s perfect before pressing Share!"
+      format_text_q: "How can I format the text in my posts (bold, italics, etc.)?"
+      hide_posts_a: "If you point your mouse at the top of a post, an X appears on the right. Click it to hide the post and mute notifications about it. You can still see the post if you visit the profile page of the person who posted it."
+      hide_posts_q: "How do I hide a post?"
+      ignore_user_a1: "If you are currently sharing with that person, removing them from your aspects will stop many of their posts from appearing in your stream. A more complete method is to “ignore” that account. This will prevent any of their posts from appearing in your stream, and they will no longer be able to like or comment on your posts. They will, however, still be able to reshare your posts, comment on reshares of your posts, and their comments on posts by other people which appear in your stream will still be visible to you."
+      ignore_user_a2: "To ignore an account, click the “ignore” icon (a circle with a diagonal line through it) at the top right of one of their posts. Their posts will instantly disappear from your stream. Alternatively, go to their profile page and click the ignore icon there. You will still be able to see their posts on their profile page, or by using the single-post view."
+      ignore_user_a3: "A list of people you are ignoring can be found in your account settings under Privacy. To stop ignoring someone, remove them from the list on that page."
+      ignore_user_q: "How do I stop someone’s posts from appearing in my stream?"
+      insert_images_a: "If you want to include an image stored on your computer in your post, click the little camera icon at the bottom of the publisher. You can also drag and drop an image, or multiple images, from your computer onto that icon. If you want to insert an image from the web into your post, click the image button on the top of the publisher, which will create the Markdown code for you."
+      insert_images_comments_a: "You can use Markdown to insert an image from the web into a comment, just like in posts. However, you cannot upload images from your computer directly into comments. Upload them to an image-hosting service and then insert them using the image button above the publisher."
+      insert_images_comments_q: "Can I insert images into comments?"
+      insert_images_q: "How do I insert images into posts?"
+      post_location_a: "Click the pin icon next to the camera in the publisher. This will insert your location from OpenStreetMap. You can edit your location – you might only want to include the city you’re in rather than the specific street address."
+      post_location_q: "How do I add my location to a post?"
+      post_notification_a: "You will find a bell icon next to the X at the top right of a post. Click this to enable or disable notifications for that post."
+      post_notification_q: "How do I get notifications, or stop getting notifications, about a post?"
+      post_poll_a: "Click the graph icon to generate a poll. Type a question and at least two answers. Don’t forget to make your post public if you want everyone to be able to participate in your poll."
+      post_poll_q: "How do I add a poll to my post?"
+      post_report_a: "Click the alert triangle icon at the top right of the post to report it to your podmin. Enter a reason for reporting this post in the dialog box. Please only report posts that break our %{community_guidelines} or your pod’s terms of service, for example posts containing illegal content, or which are abusive or spam."
+      post_report_q: "How do I report an offensive post?"
+      size_of_images_a: "No. Images are resized automatically to fit the stream or single-post view. Markdown does not have a code for specifying the size of an image."
+      size_of_images_q: "Can I customize the size of images in posts or comments?"
+      stream_full_of_posts_a1: "Your stream is made up of three types of posts:"
+      stream_full_of_posts_li1: "Posts by people you are sharing with, which come in two types: public posts and limited posts shared with an aspect that you are part of. To remove these posts from your stream, simply stop sharing with the person."
+      stream_full_of_posts_li2: "Public posts containing one of the tags that you follow. To remove these, stop following that tag."
+      stream_full_of_posts_li3: "Public posts by people listed in the community spotlight. These can be removed by unchecking the “Show community spotlight in stream?” option in the Account tab of your Settings."
+      stream_full_of_posts_q: "Why is my stream full of posts from people I don’t know and don’t share with?"
+      title: "Posts and posting"
+    private_posts:
+      can_comment_a: "Only logged-in diaspora* users you had placed in that aspect before making the private post can comment on or like it."
+      can_comment_q: "Who can comment on or like my private post?"
+      can_reshare_a: "Nobody. Private posts are not resharable. Logged-in diaspora* users in that aspect can potentially copy and paste it, however. It’s up to you whether you trust those people!"
+      can_reshare_q: "Who can reshare my private post?"
+      see_comment_a: "Only the people that the post was shared with (the people who are in the aspects selected by the original poster) can see its comments and likes. "
+      see_comment_q: "When I comment on or like a private post, who can see it?"
+      title: "Private posts"
+      who_sees_post_a: "Only logged-in diaspora* users you had placed in that aspect before making the private post can see it."
+      who_sees_post_q: "When I post a message to an aspect (i.e., a private post), who can see it?"
+    profile:
+      title: "Profile"
+      what_do_tags_do_a: "They help people get to know you. Your profile picture will also appear on the left-hand side of the stream pages of those tags, along with anyone else who has them in their basic profile."
+      what_do_tags_do_q: "What do the tags in my basic profile do?"
+      whats_in_profile_a: "Your profile is in two parts: your basic profile and your extended profile. Your basic profile contains your name, the five tags you chose to describe yourself, and your photo. Your extended profile contains your biography, location, gender, and birthday. All this information is optional – it’s up to you whether you provide it, and you can make this profile information as identifiable or anonymous as you like. Your extended profile is displayed in the left-hand column of your profile page, under your profile picture."
+      whats_in_profile_q: "What’s in my profile?"
+      who_sees_profile_a: "Your basic profile (name, profile image and #tags) is public. Your extended profile is private by default, but you can make it all publicly accessible if you want. Only people you are sharing with (meaning, you have added them to one of your aspects) can see your extended profile if you keep it private. Other people will see only your public information. Any profile information you make public can be viewed by anyone using the web, and can be indexed by search engines"
+      who_sees_profile_q: "Who sees my profile?"
+    public_posts:
+      can_comment_reshare_like_a: "Any logged-in diaspora* user can comment on, reshare, or like your public post. The exception to this is people you have ignored, who won’t be able to like or comment on your posts."
+      can_comment_reshare_like_q: "Who can comment on, reshare, or like my public post?"
+      deselect_aspect_posting_a: "Deselecting aspects does not affect a public post. It will still be public and will appear in the streams of all of your contacts. To make a post visible only to specific aspects, you need to select those aspects from the aspect selector under the publisher."
+      deselect_aspect_posting_q: "What happens when I deselect one or more aspects in the left-hand column when making a public post?"
+      find_public_post_a: "Your public posts will appear in the streams of anyone following you. If you included #tags in your public post, anyone following those tags will find your post in their streams. Every public post also has a specific URL that anyone can view, even if they’re not logged in – thus public posts may be linked to directly from Twitter, blogs, etc. Public posts may also be indexed by search engines."
+      find_public_post_q: "How can other people find my public post?"
+      see_comment_reshare_like_a: "Comments, likes, and reshares of public posts are also public. Any logged-in diaspora* user and anyone else on the internet can see your interactions with a public post."
+      see_comment_reshare_like_q: "When I comment on, reshare, or like a public post, who can see it?"
+      title: "Public posts"
+      who_sees_post_a: "Anyone using the internet can potentially see a post you mark public, so make sure you really do want your post to be public. It’s a great way of reaching out to the world."
+      who_sees_post_q: "When I post something publicly, who can see it?"
+    resharing_posts:
+      reshare_private_post_aspects_a: "No, it is not possible to reshare any private post. This is to respect the intentions of the original poster, who shared it only with a particular group of people."
+      reshare_private_post_aspects_q: "Can I reshare a private post to selected aspects?"
+      reshare_public_post_aspects_a: "No, when you reshare a public post it automatically becomes one of your public posts. To share it with certain aspects, copy and paste the contents of the post into a new, limited post."
+      reshare_public_post_aspects_q: "Can I reshare a public post to selected aspects?"
+      title: "Resharing posts"
+    sharing:
+      add_to_aspect_a1: "Let’s say that Amy adds Ben to an aspect, but Ben has not (yet) added Amy to an aspect:"
+      add_to_aspect_a2: "This is known as asymmetrical sharing. If and when Ben also adds Amy to an aspect then it would become mutual sharing, with both Amy’s and Ben’s public posts and relevant private posts appearing in each other’s streams, and Amy would be able to view Ben’s private profile. They would then also be able to send each other private messages."
+      add_to_aspect_li1: "Ben will receive a notification that Amy has “started sharing” with Ben."
+      add_to_aspect_li2: "Amy will start to see Ben’s public posts in her stream."
+      add_to_aspect_li3: "Amy will not see any of Ben’s private posts."
+      add_to_aspect_li4: "Ben will not see Amy’s public or private posts in his stream."
+      add_to_aspect_li5: "But if Ben goes to Amy’s profile page, then he will see the private posts that Amy makes to the aspect that she has placed him in (as well as her public posts, which anyone can see there)."
+      add_to_aspect_li6: "Ben will be able to see Amy’s private profile (biography, location, gender, birthday)."
+      add_to_aspect_li7: "Amy will appear under “Only sharing with me” on Ben’s contacts page."
+      add_to_aspect_li8: "Amy will also be able to @mention Ben in a post."
+      add_to_aspect_q: "What happens when I add someone to one of my aspects, or when someone adds me to one of their aspects?"
+      list_not_sharing_a: "No, but you can see whether or not someone is sharing with you by visiting their profile page. If they are, there will be a green tick next to their diaspora* ID. If they are not, there will be a gray circle."
+      list_not_sharing_q: "Is there a list of people whom I have added to one of my aspects, but who have not added me to one of theirs?"
+      only_sharing_a: "These are people that have added you to one of their aspects, but who are not (yet) in any of your aspects. In other words, they are sharing with you, but you are not sharing with them: you can think of this as them “following” you. If you add them to an aspect, they will then appear under that aspect and not under “Only sharing with me”. See above."
+      only_sharing_q: "Who are the people listed under “Only sharing with me” on my contacts page?"
+      see_old_posts_a: "No. They will only be able to see new posts to that aspect. They (and everyone else) can see your older public posts on your profile page, and they may also see them in their stream."
+      see_old_posts_q: "When I add someone to an aspect, can they see older posts that I have already posted to that aspect?"
+      sharing_notification_a: "You should receive a notification each time someone starts sharing with you."
+      sharing_notification_q: "How do I know when someone starts sharing with me?"
+      title: "Sharing"
+    tags:
+      filter_tags_a: "This is not yet available directly through diaspora*, but some %{third_party_tools} have been written that might provide this."
+      filter_tags_q: "How can I filter/exclude some tags from my stream?"
+      followed_tags_a: "After searching for a tag you can click the button at the top of the tag’s page to “follow” that tag. It will then appear in your list of followed tags in the left-hand menu. Clicking one of your followed tags takes you to that tag’s page so you can see recent posts containing that tag. Click on #Followed Tags to see a stream of posts that include any one of your followed tags. Posts containing that tag will also be included in your main stream."
+      followed_tags_q: "What are “#Followed Tags” and how do I follow a tag?"
+      people_tag_page_a: "They are people who have listed that tag to describe themselves in their public profile."
+      people_tag_page_q: "Who are the people listed on the left-hand side of a tag page?"
+      tags_in_comments_a: "A tag added to a comment will still appear as a link to that tag’s page, but it will not make that post (or comment) appear on that tag page. This only works for tags in posts."
+      tags_in_comments_q: "Can I put tags in comments or just in posts?"
+      title: "Tags"
+      what_are_tags_for_a: "Tags are a way to categorize a post, usually by topic. Searching for a tag shows all posts, both public and private, with that tag that you have permission to see. This lets people who are interested in a given topic find public posts about it."
+      what_are_tags_for_q: "What are tags for?"
+    third_party_tools: "Third-party tools"
+    title_header: "Help"
+    tutorial: "tutorial"
+    tutorials: "tutorials"
+    wiki: "wiki"
   home:
     default:
-      headline: "Welcome to %{pod_name}"
-      part_of_diaspora: "Part of the %{diaspora_site_link}"
-      diaspora_site_link: "diaspora* federated network"
-      byline: "The online social world where you are in control"
       be_who_you_want_to_be: "Be who you want to be"
       be_who_you_want_to_be_info: "A lot of networks insist that you use your real identity. Not diaspora*. Here you can choose who you want to be, and share as much or as little about yourself as you want. It really is up to you how you want to interact with other people."
+      byline: "The online social world where you are in control"
       choose_your_audience: "Choose your audience"
       choose_your_audience_info: "diaspora*’s aspects allow you to share with just those people you want to. You can be as public or as private as you like. Share a funny photo with the whole world, or a deep secret just with your closest friends. You’re in control."
+      diaspora_site_link: "diaspora* federated network"
+      headline: "Welcome to %{pod_name}"
       own_your_data: "Own your own data"
       own_your_data_info: "Many networks use your data to make money by analysing your interactions and using this information to advertise things to you. diaspora* doesn’t use your data for any purpose other than allowing you to connect and share with others."
+      part_of_diaspora: "Part of the %{diaspora_site_link}"
     podmin:
-      headline: "Welcome, friend."
       byline: "You’re about to change the Internet. Let’s get you set up, shall we?"
-      configure_your_pod: "Configure your pod"
-      create_an_account: "Create an account"
-      make_yourself_an_admin: "Make yourself an admin"
-      update_your_pod: "Update your pod"
-      getting_help: "Getting help"
-      contribute: "Contribute"
       configuration_info: "Open %{database_path} and %{diaspora_path} in your favourite text editor and carefully review them, they are extensively commented."
-      create_an_account_info: "%{sign_up_link} for a new account."
-      make_yourself_an_admin_info: "You can find instructions in the %{wiki}. This should add an “%{admin_dashboard}” link to your user menu in the header when you are logged in. It gives you stuff like user search and stats for your pod."
-      update_your_pod_info: "You can find %{update_instructions}."
-      update_instructions: "update instructions in the diaspora* wiki"
-      getting_help_info: "We listed some %{faq} including some additional tips and tricks and solutions for the most common problems. Also feel free to %{irc}."
-      faq_for_podmins: "FAQ for pod maintainers in our wiki"
+      configure_your_pod: "Configure your pod"
       contact_irc: "contact us on IRC"
+      contribute: "Contribute"
       contribute_info: "Make diaspora* even better! If you find any bugs please %{report_bugs}."
+      create_an_account: "Create an account"
+      create_an_account_info: "%{sign_up_link} for a new account."
+      faq_for_podmins: "FAQ for pod maintainers in our wiki"
+      getting_help: "Getting help"
+      getting_help_info: "We listed some %{faq} including some additional tips and tricks and solutions for the most common problems. Also feel free to %{irc}."
+      headline: "Welcome, friend."
+      make_yourself_an_admin: "Make yourself an admin"
+      make_yourself_an_admin_info: "You can find instructions in the %{wiki}. This should add an “%{admin_dashboard}” link to your user menu in the header when you are logged in. It gives you stuff like user search and stats for your pod."
       report_bugs: "report them"
-
+      update_instructions: "update instructions in the diaspora* wiki"
+      update_your_pod: "Update your pod"
+      update_your_pod_info: "You can find %{update_instructions}."
   invitation_codes:
-    not_valid: "That invite code is no longer valid"
     already_logged_in: "You have been invited by %{inviter} to join this pod but you are already logged in."
-
+    not_valid: "That invite code is no longer valid"
   invitations:
     create:
-      sent: "Invitations have been sent to: %{emails}"
-      rejected: "The following email addresses had problems: %{emails}"
-      no_more: "You have no more invitations."
-      empty: "Please enter at least one email address."
-      note_already_sent: "Invitations have already been sent to: %{emails}"
       closed: "Invitations are closed on this diaspora* pod."
+      empty: "Please enter at least one email address."
+      no_more: "You have no more invitations."
+      note_already_sent: "Invitations have already been sent to: %{emails}"
+      rejected: "The following email addresses had problems: %{emails}"
+      sent: "Invitations have been sent to: %{emails}"
     new:
-      language: "Language"
-      invite_someone_to_join: "Invite someone to join diaspora*!"
-      comma_separated_plz: "You can enter multiple email addresses separated by commas."
-      send_an_invitation: "Send an invitation"
-      sending_invitation: "Sending invitation..."
-      paste_link: "Share this link with your friends to invite them to diaspora*, or email them the link directly."
       codes_left:
-        zero: "No invites left on this code"
         one: "One invite left on this code"
         other: "%{count} invites left on this code"
-
+        zero: "No invites left on this code"
+      comma_separated_plz: "You can enter multiple email addresses separated by commas."
+      invite_someone_to_join: "Invite someone to join diaspora*!"
+      language: "Language"
+      paste_link: "Share this link with your friends to invite them to diaspora*, or email them the link directly."
+      send_an_invitation: "Send an invitation"
+      sending_invitation: "Sending invitation..."
   layouts:
+    application:
+      back_to_top: "Back to top"
+      be_excellent: "Be excellent to each other! ♥"
+      discourse: "Project discussions and support"
+      powered_by: "Powered by diaspora*"
+      public_feed: "Public diaspora* feed for %{name}"
+      source_package: "Download the source code package"
+      statistics_link: "Pod statistics"
+      switch_to_standard_mode: "Switch to standard mode"
+      switch_to_touch_optimized_mode: "Switch to touch-optimized mode"
+      whats_new: "What’s new?"
     header:
+      code: "Code"
+      logout: "Log out"
       profile: "Profile"
       settings: "Settings"
-      logout: "Log out"
-      code: "Code"
       toggle_navigation: "Toggle navigation"
-    application:
-      powered_by: "Powered by diaspora*"
-      whats_new: "What’s new?"
-      statistics_link: "Pod statistics"
-      discourse: "Project discussions and support"
-      switch_to_touch_optimized_mode: "Switch to touch-optimized mode"
-      switch_to_standard_mode: "Switch to standard mode"
-      public_feed: "Public diaspora* feed for %{name}"
-      back_to_top: "Back to top"
-      source_package: "Download the source code package"
-      be_excellent: "Be excellent to each other! ♥"
-
   likes:
     create:
       error: "Failed to like."
       fail: "Like creation has failed"
     destroy:
       error: "Failed to unlike."
-    people_like_this:
-      zero: "No likes"
-      one: "%{count} like"
-      other: "%{count} likes"
-    people_like_this_comment:
-      zero: "No likes"
-      one: "%{count} like"
-      other: "%{count} likes"
+    not_found: "Post or like not found"
     people_dislike_this:
-      zero: "No dislikes"
       one: "%{count} dislike"
       other: "%{count} dislikes"
-    not_found: "Post or like not found"
-
+      zero: "No dislikes"
+    people_like_this:
+      one: "%{count} like"
+      other: "%{count} likes"
+      zero: "No likes"
+    people_like_this_comment:
+      one: "%{count} like"
+      other: "%{count} likes"
+      zero: "No likes"
+  limited: "Limited"
+  more: "More"
+  no_results: "No results found"
   notifications:
-    started_sharing:
-      zero: "%{actors} started sharing with you."
-      one: "%{actors} started sharing with you."
-      other: "%{actors} started sharing with you."
-    private_message:
-      zero: "%{actors} sent you a message."
-      one: "%{actors} sent you a message."
-      other: "%{actors} sent you a message."
-    comment_on_post:
-      zero: "%{actors} commented on your post %{post_link}."
-      one: "%{actors} commented on your post %{post_link}."
-      other: "%{actors} commented on your post %{post_link}."
     also_commented:
-      zero: "%{actors} also commented on %{post_author}’s post %{post_link}."
       one: "%{actors} also commented on %{post_author}’s post %{post_link}."
       other: "%{actors} also commented on %{post_author}’s post %{post_link}."
-    mentioned:
-      one: "%{actors} has mentioned you in the post %{post_link}."
-      other: "%{actors} have mentioned you in the post %{post_link}."
-    mentioned_in_comment:
-      one: "%{actors} has mentioned you in a <a href='%{comment_path}'>comment</a> to the post %{post_link}."
-      other: "%{actors} have mentioned you in a <a href='%{comment_path}'>comment</a> to the post %{post_link}."
-    liked:
-      zero: "%{actors} have liked your post %{post_link}."
-      one: "%{actors} has liked your post %{post_link}."
-      other: "%{actors} have liked your post %{post_link}."
-    reshared:
-      zero: "%{actors} have reshared your post %{post_link}."
-      one: "%{actors} has reshared your post %{post_link}."
-      other: "%{actors} have reshared your post %{post_link}."
-    contacts_birthday:
-      zero: "%{actors} have their birthday on %{date}."
-      one: "%{actors} has their birthday on %{date}."
-      other: "%{actors} have their birthday on %{date}."
+      zero: "%{actors} also commented on %{post_author}’s post %{post_link}."
     also_commented_deleted:
-      zero: "%{actors} commented on a deleted post."
       one: "%{actors} commented on a deleted post."
       other: "%{actors} commented on a deleted post."
-    liked_post_deleted:
-      zero: "%{actors} liked your deleted post."
-      one: "%{actors} liked your deleted post."
-      other: "%{actors} liked your deleted post."
-    reshared_post_deleted:
-      zero: "%{actors} reshared your deleted post."
-      one: "%{actors} reshared your deleted post."
-      other: "%{actors} reshared your deleted post."
-    mentioned_deleted:
-      one: "%{actors} mentioned you in a deleted post."
-      other: "%{actors} mentioned you in a deleted post."
-    mentioned_in_comment_deleted:
-      one: "%{actors} mentioned you in a deleted comment."
-      other: "%{actors} mentioned you in a deleted comment."
+      zero: "%{actors} commented on a deleted post."
+    comment_on_post:
+      one: "%{actors} commented on your post %{post_link}."
+      other: "%{actors} commented on your post %{post_link}."
+      zero: "%{actors} commented on your post %{post_link}."
+    contacts_birthday:
+      one: "%{actors} has their birthday on %{date}."
+      other: "%{actors} have their birthday on %{date}."
+      zero: "%{actors} have their birthday on %{date}."
     index:
-      notifications: "Notifications"
+      all_notifications: "All notifications"
+      also_commented: "Also commented"
+      and: "and"
+      and_others:
+        one: "and one more"
+        other: "and %{count} others"
+        zero: "and nobody else"
+      comment_on_post: "Comment on post"
+      contacts_birthday: "Birthday"
+      liked: "Liked"
       mark_all_as_read: "Mark all as read"
       mark_all_shown_as_read: "Mark all shown as read"
       mark_read: "Mark read"
       mark_unread: "Mark unread"
-      show_all: "Show all"
-      show_unread: "Show unread"
-      all_notifications: "All notifications"
-      also_commented: "Also commented"
-      comment_on_post: "Comment on post"
-      liked: "Liked"
       mentioned: "Mentioned in post"
       mentioned_in_comment: "Mentioned in comment"
-      reshared: "Reshared"
-      started_sharing: "Started sharing"
-      contacts_birthday: "Birthday"
       no_notifications: "You don't have any notifications yet."
-      and_others:
-        zero: "and nobody else"
-        one: "and one more"
-        other: "and %{count} others"
-      and: "and"
-
+      notifications: "Notifications"
+      reshared: "Reshared"
+      show_all: "Show all"
+      show_unread: "Show unread"
+      started_sharing: "Started sharing"
+    liked:
+      one: "%{actors} has liked your post %{post_link}."
+      other: "%{actors} have liked your post %{post_link}."
+      zero: "%{actors} have liked your post %{post_link}."
+    liked_post_deleted:
+      one: "%{actors} liked your deleted post."
+      other: "%{actors} liked your deleted post."
+      zero: "%{actors} liked your deleted post."
+    mentioned:
+      one: "%{actors} has mentioned you in the post %{post_link}."
+      other: "%{actors} have mentioned you in the post %{post_link}."
+    mentioned_deleted:
+      one: "%{actors} mentioned you in a deleted post."
+      other: "%{actors} mentioned you in a deleted post."
+    mentioned_in_comment:
+      one: "%{actors} has mentioned you in a <a href='%{comment_path}'>comment</a> to the post %{post_link}."
+      other: "%{actors} have mentioned you in a <a href='%{comment_path}'>comment</a> to the post %{post_link}."
+    mentioned_in_comment_deleted:
+      one: "%{actors} mentioned you in a deleted comment."
+      other: "%{actors} mentioned you in a deleted comment."
+    private_message:
+      one: "%{actors} sent you a message."
+      other: "%{actors} sent you a message."
+      zero: "%{actors} sent you a message."
+    reshared:
+      one: "%{actors} has reshared your post %{post_link}."
+      other: "%{actors} have reshared your post %{post_link}."
+      zero: "%{actors} have reshared your post %{post_link}."
+    reshared_post_deleted:
+      one: "%{actors} reshared your deleted post."
+      other: "%{actors} reshared your deleted post."
+      zero: "%{actors} reshared your deleted post."
+    started_sharing:
+      one: "%{actors} started sharing with you."
+      other: "%{actors} started sharing with you."
+      zero: "%{actors} started sharing with you."
   notifier:
+    a_limited_post_comment: "There’s a new comment on a limited post in diaspora* for you to check out."
     a_post_you_shared: "a post."
     a_private_message: "There’s a new private message in diaspora* for you to check out."
-    a_limited_post_comment: "There’s a new comment on a limited post in diaspora* for you to check out."
-    email_sent_by_diaspora: "This email was sent by %{pod_name}. If you'd like to stop getting emails like this,"
-    click_here: "Click here"
-    hello: "Hello %{name}!"
-    thanks: "Thanks,"
-    to_change_your_notification_settings: "to change your notification settings"
-    single_admin:
-        subject: "A message about your diaspora* account:"
-        admin: "Your diaspora* administrator"
-    started_sharing:
-        subject: "%{name} started sharing with you on diaspora*"
-        sharing: "has started sharing with you!"
-        view_profile: "View %{name}’s profile"
-    comment_on_post:
-        limited_subject: "There's a new comment on one of your posts"
-        reply: "Reply or view %{name}’s post >"
     also_commented:
-        limited_subject: "There's a new comment on a post you commented"
-    mentioned:
-        subject: "%{name} has mentioned you on diaspora*"
-        limited_post: "You were mentioned in a limited post."
-    mentioned_in_comment:
-        limited_post: "You were mentioned in a comment to a limited post."
-        reply: "Reply to or view this conversation >"
-    private_message:
-        subject: "There’s a new private message for you"
-        reply_to_or_view: "Reply to or view this conversation >"
-    liked:
-        liked: "%{name} liked your post"
-        limited_post: "%{name} liked your limited post"
-        view_post: "View post >"
-    reshared:
-        reshared: "%{name} reshared your post"
-        view_post: "View post >"
-    contacts_birthday:
-        subject: "%{name} has their birthday today"
-        birthday: "%{name} has their birthday today. Wish them 'Happy Birthday'!"
-        view_profile: "View %{name}’s profile"
+      limited_subject: "There's a new comment on a post you commented"
+    click_here: "Click here"
+    comment_on_post:
+      limited_subject: "There's a new comment on one of your posts"
+      reply: "Reply or view %{name}’s post >"
     confirm_email:
-        subject: "Please activate your new email address %{unconfirmed_email}"
-        click_link: "To activate your new email address %{unconfirmed_email}, please follow this link:"
+      click_link: "To activate your new email address %{unconfirmed_email}, please follow this link:"
+      subject: "Please activate your new email address %{unconfirmed_email}"
+    contacts_birthday:
+      birthday: "%{name} has their birthday today. Wish them 'Happy Birthday'!"
+      subject: "%{name} has their birthday today"
+      view_profile: "View %{name}’s profile"
     csrf_token_fail:
-      subject: "We received an unauthorized request from your account, %{name}"
       body: |-
         Hello %{name},
 
@@ -793,30 +825,9 @@ en:
 
         Thank you,
         The diaspora* email robot!
-    report_email:
-        type:
-          post: "post"
-          comment: "comment"
-        subject: "A new %{type} was marked as offensive"
-        body: |-
-          Hello,
-
-          the %{type} with ID %{id} was marked as offensive.
-
-          Reason: %{reason}
-
-          [%{url}][1]
-
-          Please review as soon as possible!
-
-
-          Cheers,
-
-          The diaspora* email robot!
-
-          [1]: %{url}
+      subject: "We received an unauthorized request from your account, %{name}"
+    email_sent_by_diaspora: "This email was sent by %{pod_name}. If you'd like to stop getting emails like this,"
     export_email:
-      subject: "Your personal data is ready for download, %{name}"
       body: |-
         Hello %{name},
 
@@ -825,8 +836,8 @@ en:
         Cheers,
 
         The diaspora* email robot!
+      subject: "Your personal data is ready for download, %{name}"
     export_failure_email:
-      subject: "We’re sorry, there was an issue with your data, %{name}"
       body: |-
         Hello %{name}
 
@@ -836,8 +847,8 @@ en:
         Sorry,
 
         The diaspora* email robot!
+      subject: "We’re sorry, there was an issue with your data, %{name}"
     export_photos_email:
-      subject: "Your photos are ready for download, %{name}"
       body: |-
         Hello %{name},
 
@@ -846,8 +857,8 @@ en:
         Cheers,
 
         The diaspora* email robot!
+      subject: "Your photos are ready for download, %{name}"
     export_photos_failure_email:
-      subject: "There was an issue with your photos, %{name}"
       body: |-
         Hello %{name}
 
@@ -857,7 +868,8 @@ en:
         Sorry,
 
         The diaspora* email robot!
-    invited_you: "%{name} invited you to diaspora*"
+      subject: "There was an issue with your photos, %{name}"
+    hello: "Hello %{name}!"
     invite:
       message: |-
         Hello!
@@ -879,8 +891,21 @@ en:
 
         [1]: %{invite_url}
         [2]: %{diasporafoundation_url}
+    invited_you: "%{name} invited you to diaspora*"
+    liked:
+      liked: "%{name} liked your post"
+      limited_post: "%{name} liked your limited post"
+      view_post: "View post >"
+    mentioned:
+      limited_post: "You were mentioned in a limited post."
+      subject: "%{name} has mentioned you on diaspora*"
+    mentioned_in_comment:
+      limited_post: "You were mentioned in a comment to a limited post."
+      reply: "Reply to or view this conversation >"
+    private_message:
+      reply_to_or_view: "Reply to or view this conversation >"
+      subject: "There’s a new private message for you"
     remove_old_user:
-      subject: "Your diaspora* account has been flagged for removal due to inactivity"
       body: |-
         Hello,
 
@@ -895,265 +920,197 @@ en:
         Hoping to see you again,
 
         The diaspora* email robot!
-  api:
-    openid_connect:
-      authorizations:
-        new:
-          redirection_message: "Are you sure you want to give access to %{redirect_uri}?"
-          access: "%{name} requires access to:"
-          no_requirement: "%{name} requires no permissions"
-          approve: "Approve"
-          deny: "Deny"
-          bad_request: "Missing client id or redirect URI"
-          client_id_not_found: "No client with client_id %{client_id} with redirect URI %{redirect_uri} found"
-          private_contacts_linkage_error: "private:read and private:modify require contacts:read as well"
-          unknown_scope: "Unknown scope: %{scope_name}"
-        destroy:
-          fail: "The attempt to revoke the authorization with ID %{id} failed"
-      user_applications:
-        index:
-          edit_applications: "Applications"
-          title: "Authorized applications"
-          access: "%{name} has access to:"
-          no_requirement: "%{name} requires no permissions"
-        no_applications: "You have no authorized applications"
-        revoke_autorization: "Revoke"
-        tos: "See the application’s terms of service"
-        policy: "See the application’s privacy policy"
-      scopes:
-        openid:
-          name: "Basic profile information"
-          description: "This grants read-only access to your basic profile information."
-        sub:
-          name: "Unique identifier"
-          description: "This grants read-only access to your unique identifier."
-        name:
-          name: "Full name"
-          description: "This grants read-only access to your full name."
-        nickname:
-          name: "Username"
-          description: "This grants read-only access to your username."
-        picture:
-          name: "Profile picture"
-          description: "This grants read-only access to your profile picture."
-        'contacts:read':
-          name: "Contacts (Read-only)"
-          description: "This grants read-only access to contacts and related data (such as aspects)."
-        'contacts:modify':
-          name: "Contacts (Write)"
-          description: "This grants write access to contacts and related data (such as aspects)."
-        conversations:
-          name: "Conversations"
-          description: "This grants read and write permission to private messages."
-        email:
-          name: "E-Mail"
-          description: "This grants read-only access to your email address."
-        interactions:
-          name: "Interactions"
-          description: "This grants access to interact with posts, for instance liking or submitting a comment."
-        notifications:
-          name: "Notifications"
-          description: "This grants read and write access to your notifications."
-        'private:read':
-          name: "Private Posts (Read-only)"
-          description: "This grants read-only access to your and your contacts’ private posts."
-        'private:modify':
-          name: "Private Posts (Write)"
-          description: "This grants access to publish private posts."
-        'public:read':
-          name: "Public Posts (Read-only)"
-          description: "This grants access to your public posts, including interactions and related data."
-        'public:modify':
-          name: "Public Posts (Write)"
-          description: "This grants write access to publish public posts and related data (such as votes and attached media)."
-        profile:
-          name: "Extended profile (Read-only)"
-          description: "This grants read-only access to your extended profile data."
-        'profile:modify':
-          name: "Extended profile (Write)"
-          description: "This grants access to update your extended profile data."
-        'profile:read_private':
-          name: "Private profile data (Read-only)"
-          description: "This grants read-only access to your private profile data."
-        'tags:read':
-          name: "Tags (Read-only)"
-          description: "This grants read-only access to your followed tags and tag streams."
-        'tags:modify':
-          name: "Tags (Write)"
-          description: "This grants access to change the tags you follow."
-      error_page:
-        title: "Oh! Something went wrong :("
-        contact_developer: "Please contact the application’s developer and include the following detailed error message:"
-        login_required: "You must first login before you can authorize this application"
-        could_not_authorize: "The application could not be authorized"
+      subject: "Your diaspora* account has been flagged for removal due to inactivity"
+    report_email:
+      body: |-
+        Hello,
 
+        the %{type} with ID %{id} was marked as offensive.
+
+        Reason: %{reason}
+
+        [%{url}][1]
+
+        Please review as soon as possible!
+
+
+        Cheers,
+
+        The diaspora* email robot!
+
+        [1]: %{url}
+      subject: "A new %{type} was marked as offensive"
+      type:
+        comment: "comment"
+        post: "post"
+    reshared:
+      reshared: "%{name} reshared your post"
+      view_post: "View post >"
+    single_admin:
+      admin: "Your diaspora* administrator"
+      subject: "A message about your diaspora* account:"
+    started_sharing:
+      sharing: "has started sharing with you!"
+      subject: "%{name} started sharing with you on diaspora*"
+      view_profile: "View %{name}’s profile"
+    thanks: "Thanks,"
+    to_change_your_notification_settings: "to change your notification settings"
+  nsfw: "NSFW"
+  ok: "OK"
   people:
-    person:
-      thats_you: "That’s you!"
-    index:
-      results_for: "Users matching %{search_term}"
-      no_results: "Hey! You need to search for something."
-      couldnt_find_them: "Couldn’t find them?"
-      search_handle: "Use their diaspora* ID (username@pod.tld) to be sure to find your friends."
-      send_invite: "Still nothing? Send an invite!"
-      no_one_found: "...and no one was found."
-      searching: "Searching, please be patient..."
-      looking_for: "Looking for posts tagged %{tag_link}?"
-    show:
-      has_not_shared_with_you_yet: "%{name} has not shared any posts with you yet!"
-      does_not_exist: "Person does not exist!"
-      closed_account: "This account has been closed."
-    profile_sidebar:
-      bio: "Bio"
-      location: "Location"
-      gender: "Gender"
-      born: "Birthday"
     add_contact:
       invited_by: "You were invited by"
-
+    index:
+      couldnt_find_them: "Couldn’t find them?"
+      looking_for: "Looking for posts tagged %{tag_link}?"
+      no_one_found: "...and no one was found."
+      no_results: "Hey! You need to search for something."
+      results_for: "Users matching %{search_term}"
+      search_handle: "Use their diaspora* ID (username@pod.tld) to be sure to find your friends."
+      searching: "Searching, please be patient..."
+      send_invite: "Still nothing? Send an invite!"
+    person:
+      thats_you: "That’s you!"
+    profile_sidebar:
+      bio: "Bio"
+      born: "Birthday"
+      gender: "Gender"
+      location: "Location"
+    show:
+      closed_account: "This account has been closed."
+      does_not_exist: "Person does not exist!"
+      has_not_shared_with_you_yet: "%{name} has not shared any posts with you yet!"
   photos:
     create:
-      runtime_error: "Photo upload failed. Are you sure that your seatbelt is fastened?"
       integrity_error: "Photo upload failed. Are you sure that was an image?"
+      runtime_error: "Photo upload failed. Are you sure that your seatbelt is fastened?"
       type_error: "Photo upload failed. Are you sure an image was added?"
     destroy:
       notice: "Photo deleted."
     new_profile_photo:
       upload: "Upload a new profile photo!"
-
   polls:
     votes:
-      zero: "%{count} votes so far"
       one: "%{count} vote so far"
       other: "%{count} votes so far"
-
+      zero: "%{count} votes so far"
   posts:
     presenter:
       title: "A post from %{name}"
     show:
-      location: "Posted from: %{location}"
       forbidden: "You are not allowed to do that"
+      location: "Posted from: %{location}"
       photos_by:
-        zero: "No photos by %{author}"
         one: "One photo by %{author}"
         other: "%{count} photos by %{author}"
+        zero: "No photos by %{author}"
       reshare_by: "Reshare by %{author}"
-
-  report:
-    title: "Reports overview"
-    post_label: "<strong>Post</strong>: %{content}"
-    comment_label: "<strong>Comment</strong>: %{data}"
-    reported_label: "<strong>Reported by</strong> %{person}"
-    reason_label: "Reason:"
-    review_link: "Mark as reviewed"
-    delete_link: "Delete item"
-    reported_user_details: "Details on reported user"
-    confirm_deletion: "Are you sure to delete the item?"
-    not_found: "The post/comment was not found. It seems that it was deleted by the user!"
-    status:
-      destroyed: "The post was destroyed"
-      failed: "Something went wrong"
-    unreviewed_reports:
-      zero: "There are no unreviewed reports."
-      one: "There is one unreviewed report."
-      other: "There are %{count} unreviewed reports."
-
+  privacy: "Privacy"
+  profile: "Profile"
   profiles:
     edit:
+      allow_search: "Allow for people to search for you within diaspora*"
       basic: "My basic profile"
-      extended: "My extended profile"
-      settings: "Profile settings"
-      extended_visibility_text: "Visibility of your extended profile:"
-      public: "Public"
-      limited: "Limited"
       basic_hint: "Every item in your profile is optional. Your basic profile will always be publicly visible."
+      extended: "My extended profile"
       extended_hint: "Click the switch to set your extended profile data visibility. Public means it is visible to the internet, limited means only people who you share with will see this information."
-      your_name: "Your name"
+      extended_visibility_text: "Visibility of your extended profile:"
       first_name: "First name"
       last_name: "Last name"
-      your_gender: "Your gender"
-      your_birthday: "Your birthday"
-      your_tags: "Describe yourself in 5 words"
-
-      your_tags_placeholder: "Like #movies #kittens #travel #teacher #newyork"
-
-      your_bio: "Your bio"
-      your_location: "Your location"
-      your_photo: "Your photo"
-      update_profile: "Update profile"
-      allow_search: "Allow for people to search for you within diaspora*"
+      limited: "Limited"
+      nsfw_check: "Mark everything I share as NSFW"
       nsfw_explanation: "NSFW (“not safe for work”) is diaspora*’s self-governing community standard for content which may not be suitable to view while at work. If you plan to share such material frequently, please check this option so that everything you share will be hidden from people’s streams unless they choose to view them."
       nsfw_explanation2: "If you choose not to select this option, please add the #nsfw tag each time you share such material."
-      nsfw_check: "Mark everything I share as NSFW"
+      public: "Public"
+      settings: "Profile settings"
+      update_profile: "Update profile"
+      your_bio: "Your bio"
+      your_birthday: "Your birthday"
+      your_gender: "Your gender"
+      your_location: "Your location"
+      your_name: "Your name"
+      your_photo: "Your photo"
+      your_tags: "Describe yourself in 5 words"
+      your_tags_placeholder: "Like #movies #kittens #travel #teacher #newyork"
     update:
-      updated: "Profile updated"
       failed: "Failed to update profile"
-
+      updated: "Profile updated"
+  public: "Public"
   registrations:
+    closed:
+      another_pod: "another pod"
+      closed_pod: "This pod is currently closed to new registrations. However, you can still join the diaspora* network by registering on %{wiki}. Because all pods are interconnected, you will have access to the same content there."
+      find_pods: "There’s a list of pods you can sign up to at %{fediverse_observer}."
+      other_questions: "If you have any other questions regarding choosing a pod, check out our %{wiki}."
+    create:
+      success: "You’ve joined diaspora*!"
+    invalid_invite: "The invite link you provided is no longer valid!"
     new:
+      email: "Email"
       enter_email: "Enter your email address"
-      enter_username: "Pick a username (only letters, numbers, and underscores)"
       enter_password: "Enter a password (six character minimum)"
       enter_password_again: "Enter the same password as before"
-      sign_up: "Create account"
-      email: "Email"
-      username: "Username"
+      enter_username: "Pick a username (only letters, numbers, and underscores)"
       password: "Password"
       password_confirmation: "Password confirmation"
+      sign_up: "Create account"
       submitting: "Submitting..."
       terms: "By creating an account you accept the %{terms_link}."
       terms_link: "terms of service"
-    create:
-      success: "You’ve joined diaspora*!"
-    closed:
-      closed_pod: "This pod is currently closed to new registrations. However, you can still join the diaspora* network by registering on %{wiki}. Because all pods are interconnected, you will have access to the same content there."
-      another_pod: "another pod"
-      find_pods: "There’s a list of pods you can sign up to at %{fediverse_observer}."
-      other_questions: "If you have any other questions regarding choosing a pod, check out our %{wiki}."
-    invalid_invite: "The invite link you provided is no longer valid!"
-
+      username: "Username"
+  report:
+    comment_label: "<strong>Comment</strong>: %{data}"
+    confirm_deletion: "Are you sure to delete the item?"
+    delete_link: "Delete item"
+    not_found: "The post/comment was not found. It seems that it was deleted by the user!"
+    post_label: "<strong>Post</strong>: %{content}"
+    reason_label: "Reason:"
+    reported_label: "<strong>Reported by</strong> %{person}"
+    reported_user_details: "Details on reported user"
+    review_link: "Mark as reviewed"
+    status:
+      destroyed: "The post was destroyed"
+      failed: "Something went wrong"
+    title: "Reports overview"
+    unreviewed_reports:
+      one: "There is one unreviewed report."
+      other: "There are %{count} unreviewed reports."
+      zero: "There are no unreviewed reports."
   reshares:
+    comment_email_subject: "%{resharer}’s reshare of %{author}’s post"
     create:
       error: "Failed to reshare."
     reshare:
-      reshared_via: "Reshared via"
-      reshare_confirmation: "Reshare %{author}’s post?"
       deleted: "Original post deleted by author."
-    comment_email_subject: "%{resharer}’s reshare of %{author}’s post"
+      reshare_confirmation: "Reshare %{author}’s post?"
+      reshared_via: "Reshared via"
+  search: "Search"
   services:
-    provider:
-      tumblr: "Tumblr"
-      twitter: "Twitter"
-      wordpress: "WordPress"
-    index:
-      title: "Manage connected services"
-      connect: "Connect"
-      disconnect: "Disconnect"
-      logged_in_as: "Logged in as %{nickname}."
-      no_services_available: "There are no services available on this pod."
-      not_logged_in: "Currently not logged in."
-      really_disconnect: "Disconnect %{service}?"
-      edit_services: "Edit services"
-      services_explanation: "Connecting to third-party sharing services gives you the ability to publish your posts to them as you write them in diaspora*."
-      share_to: "Share to %{provider}"
     create:
-      success: "Authentication successful."
-      failure: "Authentication failed."
       already_authorized: "A user with diaspora id %{diaspora_id} already authorized that %{service_name} account."
+      failure: "Authentication failed."
       read_only_access: "Access level is read-only, please try to authorize again later"
+      success: "Authentication successful."
     destroy:
       success: "Successfully deleted authentication."
     failure:
       error: "There was an error connecting to that service"
-
-  blocks:
-    create:
-      success: "All right, you won’t see that user in your stream again. #silencio!"
-      failure: "I couldn’t ignore that user. #evasion"
-    destroy:
-      success: "Let’s see what they have to say! #sayhello"
-      failure: "I couldn’t stop ignoring that user. #evasion"
-
+    index:
+      connect: "Connect"
+      disconnect: "Disconnect"
+      edit_services: "Edit services"
+      logged_in_as: "Logged in as %{nickname}."
+      no_services_available: "There are no services available on this pod."
+      not_logged_in: "Currently not logged in."
+      really_disconnect: "Disconnect %{service}?"
+      services_explanation: "Connecting to third-party sharing services gives you the ability to publish your posts to them as you write them in diaspora*."
+      share_to: "Share to %{provider}"
+      title: "Manage connected services"
+    provider:
+      tumblr: "Tumblr"
+      twitter: "Twitter"
+      wordpress: "WordPress"
+  settings: "Settings"
   shared:
     aspect_dropdown:
       mobile_row_checked: "%{name} (remove)"
@@ -1161,280 +1118,249 @@ en:
       toggle:
         one: "In %{count} aspect"
         other: "In %{count} aspects"
-    publisher:
-      formatWithMarkdown: "You can use %{markdown_link} to format your post"
-      posting: "Posting..."
+    invitations:
+      by_email: "Invite people by email"
+      invite_your_friends: "Invite your friends"
+      invites: "Invites"
+      share_this: "Share this link via email, blog, or social networks!"
+    public_explain:
+      atom_feed: "Atom feed"
+      control_your_audience: "Control your audience"
+      logged_in: "Logged in to %{service}"
+      manage: "Manage connected services"
+      new_user_welcome_message: "Use #hashtags to classify your posts and find people who share your interests. Call out awesome people with @Mentions"
+      outside: "Public messages will be available for others outside of diaspora* to see."
       share: "Share"
-      get_location: "Get your location"
-      remove_location: "Remove location"
-      whats_on_your_mind: "What’s on your mind?"
+      title: "Set up connected services"
+      visibility_dropdown: "Use this dropdown to change visibility of your post. (We suggest you make this first one public.)"
+    publisher:
       discard_post: "Discard post"
+      formatWithMarkdown: "You can use %{markdown_link} to format your post"
+      get_location: "Get your location"
       new_user_prefill:
-        newhere: "newhere"
         hello: "Hey everyone, I’m #%{new_user_tag}. "
         i_like: "I’m interested in %{tags}. "
         invited_by: "Thanks for the invite, "
+        newhere: "newhere"
       poll:
         add_a_poll: "Add a poll"
-    invitations:
-      invites: "Invites"
-      invite_your_friends: "Invite your friends"
-      by_email: "Invite people by email"
-      share_this: "Share this link via email, blog, or social networks!"
-    public_explain:
-      control_your_audience: "Control your audience"
-      new_user_welcome_message: "Use #hashtags to classify your posts and find people who share your interests. Call out awesome people with @Mentions"
-      visibility_dropdown: "Use this dropdown to change visibility of your post. (We suggest you make this first one public.)"
-      title: "Set up connected services"
+      posting: "Posting..."
+      remove_location: "Remove location"
       share: "Share"
-      outside: "Public messages will be available for others outside of diaspora* to see."
-      logged_in: "Logged in to %{service}"
-      manage: "Manage connected services"
-      atom_feed: "Atom feed"
+      whats_on_your_mind: "What’s on your mind?"
     stream_element:
       via: "Via %{link}"
       via_mobile: "Via mobile"
+  simple_captcha:
+    label: "Enter the code in the box:"
+    message:
+      default: "The secret code did not match with the image"
+      failed: "Human verification failed"
+      user: "The secret image and code were different"
+    placeholder: "Enter the image value"
+  statistics:
+    active_users_halfyear: "Active users half year"
+    active_users_monthly: "Active users monthly"
+    closed: "Closed"
+    disabled: "Not available"
+    enabled: "Available"
+    local_comments: "Local comments"
+    local_posts: "Local posts"
+    name: "Name"
+    network: "Network"
+    open: "Open"
+    registrations: "Registrations"
+    services: "Services"
+    total_users: "Total users"
+    version: "Version"
   status_messages:
+    bad_aspects: "Provided aspects IDs aren't applicable (non-existent or not owned)"
     new:
       mentioning: "Mentioning: %{person}"
     too_long: "Please make your status message fewer than %{count} characters. Right now it is %{current_length} characters"
-    bad_aspects: "Provided aspects IDs aren't applicable (non-existent or not owned)"
-
   stream_helper:
     no_more_posts: "You have reached the end of the stream."
     no_posts_yet: "There are no posts yet."
-
-  tags:
-    show:
-      tagged_people:
-        zero: "No one tagged with %{tag}"
-        one: "1 person tagged with %{tag}"
-        other: "%{count} people tagged with %{tag}"
-      follow: "Follow #%{tag}"
-      stop_following: "Stop following #%{tag}"
-      none: "The empty tag does not exist!"
-    name_too_long: "Please make your tag name fewer than %{count} characters. Right now it is %{current_length} characters"
-
-  tag_followings:
-    manage:
-      title: "Manage followed tags"
-      no_tags: "You aren't following any tags."
-
   streams:
-    community_spotlight_stream: "Community spotlight"
-    aspects_stream: "Aspects"
-    mentioned_stream: "@Mentions"
-    followed_tags_stream: "#Followed tags"
-
-    mentions:
-      title: "@Mentions"
-
-    comment_stream:
-      title: "Commented posts"
-
-    like_stream:
-      title: "Like stream"
-
-    followed_tag:
-      title: "#Followed tags"
-      add_a_tag: "Add a tag"
-      follow: "Follow"
-      all: "All tags"
-
-    admin:
-      title: "Admin"
-
-    tags:
-      title: "Posts tagged: %{tags}"
-
-    public:
-      title: "Public activity"
-
-    local_public:
-      title: "Local posts"
-
-    multi:
-      title: "Stream"
-
-    aspects:
-      title: "My aspects"
-      all: "All aspects"
-
     activity:
       title: "My activity"
-
-    liked:
-      title: "Liked posts"
-
+    admin:
+      title: "Admin"
+    aspects:
+      all: "All aspects"
+      title: "My aspects"
+    aspects_stream: "Aspects"
+    comment_stream:
+      title: "Commented posts"
     commented:
       title: "Commented posts"
-  users:
-    edit:
-      edit_account: "Edit account"
-      change: "Change"
-      your_handle: "Your diaspora* ID"
-      your_email: "Your email"
-      your_email_private: "Your email will never be seen by other users"
-      change_email: "Change email"
-      email_awaiting_confirmation: "We have sent you an activation link to %{unconfirmed_email}. Until you follow this link and activate the new address, we will continue to use your original address %{email}."
-      change_password: "Change password"
-      new_password: "New password"
-      current_password: "Current password"
-      current_password_expl: "the one you sign in with..."
-      character_minimum_expl: "must be at least six characters"
-      change_language: "Change language"
-      change_color_theme: "Change color theme"
-      close_account_text: "Close account"
-      stream_preferences: "Stream preferences"
-      show_community_spotlight: "Show “community spotlight” in stream"
-      show_getting_started: "Show “getting started” hints"
-      following: "Sharing settings"
-      auto_follow_back: "Automatically share with users who start sharing with you"
-      auto_follow_aspect: "Aspect for users you automatically share with:"
-      default_post_visibility: "Default aspects selected for posting"
-      receive_email_notifications: "Receive email notifications when:"
-      started_sharing: "someone starts sharing with you"
-      someone_reported: "someone sends a report"
-      mentioned: "you are mentioned in a post"
-      mentioned_in_comment: "you are mentioned in a comment"
-      liked: "someone likes your post"
-      reshared: "someone reshares your post"
-      comment_on_post: "someone comments on your post"
-      also_commented: "someone comments on a post you’ve commented on"
-      private_message: "you receive a private message"
-      birthday: "someone has their birthday"
-      download_export: "Download my profile"
-      request_export: "Request my profile data"
-      request_export_update: "Refresh my profile data"
-      export_data: "Export data"
-      export_in_progress: "We are currently processing your data. Please check back in a few moments."
-      last_exported_html: "(Last updated %{timeago})"
-      download_export_photos: "Download my photos"
-      request_export_photos: "Request my photos"
-      request_export_photos_update: "Refresh my photos"
-      export_photos_in_progress: "We are currently processing your photos. Please check back in a few moments."
-
-      close_account:
-        dont_go: "Hey, please don’t go!"
-        make_diaspora_better: "We’d love you to stay and help us make diaspora* better instead of leaving. If you really do want to leave, however, here’s what will happen next:"
-        mr_wiggles: "Mr Wiggles will be sad to see you go"
-        what_we_delete: "We will delete all of your posts and profile data as soon as possible. Your comments on other people’s posts will still appear, but they will be associated with your diaspora* ID rather than your name."
-        locked_out: "You will get signed out and locked out of your account until it has been deleted."
-        lock_username: "Your username will be locked. You will not be able to create a new account on this pod with the same ID."
-        no_turning_back: "There is no turning back! If you’re really sure, enter your password below."
-
-      protocol_handler:
-        title: "web+diaspora:// protocol handler"
-        description: "web+diaspora:// is a new web protocol that we have introduced. Any link to a diaspora* page on an external website that uses this protocol can be opened in the pod on which your diaspora* account is registered. Click the button below to set your browser to use %{pod_url} to recognise external web+diaspora:// links."
-        browser: "This protocol is currently in the experimental stage and the success of interactions using it will depend on your browser. If you want to manage or remove this handler, you will do this via your browser settings. The button below will always be enabled, and you need to set the handler separately in each browser you use."
-        register: "Register web+diaspora:// handler on this browser"
-
-    privacy_settings:
-      title: "Privacy settings"
-      strip_exif: "Strip metadata such as location, author, and camera model from uploaded images (recommended)"
-      ignored_users: "Ignored users"
-      stop_ignoring: "Stop ignoring"
-      no_user_ignored_message: "You are not currently ignoring any other user"
-
-    destroy:
-      success: "Your account has been locked. It may take 20 minutes for us to finish closing your account. Thank you for trying diaspora*."
-      no_password: "Please enter your current password to close your account."
-      wrong_password: "The entered password didn’t match your current password."
-
-    getting_started:
-      well_hello_there: "Well, hello there!"
-      community_welcome: "diaspora*’s community is happy to have you aboard!"
-      awesome_take_me_to_diaspora: "Awesome! Take me to diaspora*"
-      who_are_you: "Who are you?"
-      what_are_you_in_to: "What are you into?"
-      hashtag_explanation: "Hashtags allow you to talk about and follow your interests. They’re also a great way to find new people on diaspora*."
-      hashtag_suggestions: "Try following tags like #art, #movies, #gif, etc."
-
-    update:
-      password_changed: "Password changed. You can now log in with your new password."
-      password_not_changed: "Password change failed"
-
-      language_changed: "Language changed"
-      language_not_changed: "Language change failed"
-
-      settings_updated: "Settings updated"
-      settings_not_updated: "Settings update failed"
-
-      email_notifications_changed: "Email notifications changed"
-      unconfirmed_email_changed: "Email changed. Needs activation."
-      unconfirmed_email_not_changed: "Email change failed"
-      follow_settings_changed: "Follow settings changed"
-      follow_settings_not_changed: "Follow settings change failed."
-      color_theme_changed: "Color theme successfully changed."
-      color_theme_not_changed: "An error occurred while changing the color theme."
+    community_spotlight_stream: "Community spotlight"
+    followed_tag:
+      add_a_tag: "Add a tag"
+      all: "All tags"
+      follow: "Follow"
+      title: "#Followed tags"
+    followed_tags_stream: "#Followed tags"
+    like_stream:
+      title: "Like stream"
+    liked:
+      title: "Liked posts"
+    local_public:
+      title: "Local posts"
+    mentioned_stream: "@Mentions"
+    mentions:
+      title: "@Mentions"
+    multi:
+      title: "Stream"
     public:
-      does_not_exist: "User %{username} does not exist!"
-    confirm_email:
-      email_confirmed: "Email %{email} activated"
-      email_not_confirmed: "Email could not be activated. Wrong link?"
-
+      title: "Public activity"
+    tags:
+      title: "Posts tagged: %{tags}"
+  tag_followings:
+    manage:
+      no_tags: "You aren't following any tags."
+      title: "Manage followed tags"
+  tags:
+    name_too_long: "Please make your tag name fewer than %{count} characters. Right now it is %{current_length} characters"
+    show:
+      follow: "Follow #%{tag}"
+      none: "The empty tag does not exist!"
+      stop_following: "Stop following #%{tag}"
+      tagged_people:
+        one: "1 person tagged with %{tag}"
+        other: "%{count} people tagged with %{tag}"
+        zero: "No one tagged with %{tag}"
   two_factor_auth:
-    title: "Two-factor authentication"
-    explanation: "Two-factor authentication is a powerful way to ensure you are the only one able to sign in to your account. When signing in, you will enter a 6-digit code along with your password to prove your identity. Be careful though: if you lose your phone and the recovery codes created when you activate this feature, access to your diaspora* account will be blocked forever."
     activated:
-      status: "Two-factor authentication activated"
-      change_label: "Deactivate two-factor authentication by entering your password"
       change_button: "Deactivate"
-    deactivated:
-      status: "Two-factor authentication not activated"
-      change_label: "Activate two-factor authentication"
-      change_button: "Activate"
+      change_label: "Deactivate two-factor authentication by entering your password"
+      status: "Two-factor authentication activated"
     confirm:
-      title: "Confirm activation"
-      status: "Two-factor authentication is not fully activated yet, you need to confirm activation with a TOTP token"
-      scan_title: "Scan the QR code"
-      scan_explanation: "Please scan the QR code with a TOTP capable app, such as andOTP (Android), FreeOTP (iOS), SailOTP (SailfishOS)."
+      activate_button: "Confirm and activate"
+      input_explanation: "After scanning or entering the secret, enter the six-digit code you see and confirm the setup."
+      input_title: "Confim with TOTP token"
       manual_explanation: "In case you can’t scan the QR code automatically you can manually enter the secret in your app."
       manual_explanation_cont: "We are using time-based one-time passwords (TOTP) with six-digit tokens. In case your app prompts you for a time interval and algorithm enter 30 seconds and sha1 respectively. <br /> The spaces are just for readability, please enter the code without them."
-      input_title: "Confim with TOTP token"
-      input_explanation: "After scanning or entering the secret, enter the six-digit code you see and confirm the setup."
-      activate_button: "Confirm and activate"
+      scan_explanation: "Please scan the QR code with a TOTP capable app, such as andOTP (Android), FreeOTP (iOS), SailOTP (SailfishOS)."
+      scan_title: "Scan the QR code"
+      status: "Two-factor authentication is not fully activated yet, you need to confirm activation with a TOTP token"
+      title: "Confirm activation"
+    deactivated:
+      change_button: "Activate"
+      change_label: "Activate two-factor authentication"
+      status: "Two-factor authentication not activated"
+    explanation: "Two-factor authentication is a powerful way to ensure you are the only one able to sign in to your account. When signing in, you will enter a 6-digit code along with your password to prove your identity. Be careful though: if you lose your phone and the recovery codes created when you activate this feature, access to your diaspora* account will be blocked forever."
+    flash:
+      error_token: "Token was incorrect or invalid"
+      success_activation: "Successfully activated two-factor authentication"
+      success_deactivation: "Successfully deactivated two-factor authentication"
     input_token:
       label: "Two-factor token"
       placeholder: "six-digit two-factor token"
     recovery:
-      title: "Recovery codes"
-      reminder: "Alternatively, you can use one of the recovery codes."
+      button: "Generate new recovery codes"
       explanation: "If you ever lose access to your phone, you can use one of the recovery codes below to regain access to your account. Keep the recovery codes safe. For example, you may print them and store them with other important documents."
       explanation_short: "Recovery codes allow you to regain access to your account if you lose your phone. Note that you can use each recovery code only once."
       invalidation_notice: "If you've lost your recovery codes, you can regenerate them here. Your old recovery codes will be invalidated."
-      button: "Generate new recovery codes"
-    flash:
-      success_activation: "Successfully activated two-factor authentication"
-      success_deactivation: "Successfully deactivated two-factor authentication"
-      error_token: "Token was incorrect or invalid"
-
+      reminder: "Alternatively, you can use one of the recovery codes."
+      title: "Recovery codes"
+    title: "Two-factor authentication"
+  username: "Username"
+  users:
+    confirm_email:
+      email_confirmed: "Email %{email} activated"
+      email_not_confirmed: "Email could not be activated. Wrong link?"
+    destroy:
+      no_password: "Please enter your current password to close your account."
+      success: "Your account has been locked. It may take 20 minutes for us to finish closing your account. Thank you for trying diaspora*."
+      wrong_password: "The entered password didn’t match your current password."
+    edit:
+      also_commented: "someone comments on a post you’ve commented on"
+      auto_follow_aspect: "Aspect for users you automatically share with:"
+      auto_follow_back: "Automatically share with users who start sharing with you"
+      birthday: "someone has their birthday"
+      change: "Change"
+      change_color_theme: "Change color theme"
+      change_email: "Change email"
+      change_language: "Change language"
+      change_password: "Change password"
+      character_minimum_expl: "must be at least six characters"
+      close_account:
+        dont_go: "Hey, please don’t go!"
+        lock_username: "Your username will be locked. You will not be able to create a new account on this pod with the same ID."
+        locked_out: "You will get signed out and locked out of your account until it has been deleted."
+        make_diaspora_better: "We’d love you to stay and help us make diaspora* better instead of leaving. If you really do want to leave, however, here’s what will happen next:"
+        mr_wiggles: "Mr Wiggles will be sad to see you go"
+        no_turning_back: "There is no turning back! If you’re really sure, enter your password below."
+        what_we_delete: "We will delete all of your posts and profile data as soon as possible. Your comments on other people’s posts will still appear, but they will be associated with your diaspora* ID rather than your name."
+      close_account_text: "Close account"
+      comment_on_post: "someone comments on your post"
+      current_password: "Current password"
+      current_password_expl: "the one you sign in with..."
+      default_post_visibility: "Default aspects selected for posting"
+      download_export: "Download my profile"
+      download_export_photos: "Download my photos"
+      edit_account: "Edit account"
+      email_awaiting_confirmation: "We have sent you an activation link to %{unconfirmed_email}. Until you follow this link and activate the new address, we will continue to use your original address %{email}."
+      export_data: "Export data"
+      export_in_progress: "We are currently processing your data. Please check back in a few moments."
+      export_photos_in_progress: "We are currently processing your photos. Please check back in a few moments."
+      following: "Sharing settings"
+      last_exported_html: "(Last updated %{timeago})"
+      liked: "someone likes your post"
+      mentioned: "you are mentioned in a post"
+      mentioned_in_comment: "you are mentioned in a comment"
+      new_password: "New password"
+      private_message: "you receive a private message"
+      protocol_handler:
+        browser: "This protocol is currently in the experimental stage and the success of interactions using it will depend on your browser. If you want to manage or remove this handler, you will do this via your browser settings. The button below will always be enabled, and you need to set the handler separately in each browser you use."
+        description: "web+diaspora:// is a new web protocol that we have introduced. Any link to a diaspora* page on an external website that uses this protocol can be opened in the pod on which your diaspora* account is registered. Click the button below to set your browser to use %{pod_url} to recognise external web+diaspora:// links."
+        register: "Register web+diaspora:// handler on this browser"
+        title: "web+diaspora:// protocol handler"
+      receive_email_notifications: "Receive email notifications when:"
+      request_export: "Request my profile data"
+      request_export_photos: "Request my photos"
+      request_export_photos_update: "Refresh my photos"
+      request_export_update: "Refresh my profile data"
+      reshared: "someone reshares your post"
+      show_community_spotlight: "Show “community spotlight” in stream"
+      show_getting_started: "Show “getting started” hints"
+      someone_reported: "someone sends a report"
+      started_sharing: "someone starts sharing with you"
+      stream_preferences: "Stream preferences"
+      your_email: "Your email"
+      your_email_private: "Your email will never be seen by other users"
+      your_handle: "Your diaspora* ID"
+    getting_started:
+      awesome_take_me_to_diaspora: "Awesome! Take me to diaspora*"
+      community_welcome: "diaspora*’s community is happy to have you aboard!"
+      hashtag_explanation: "Hashtags allow you to talk about and follow your interests. They’re also a great way to find new people on diaspora*."
+      hashtag_suggestions: "Try following tags like #art, #movies, #gif, etc."
+      well_hello_there: "Well, hello there!"
+      what_are_you_in_to: "What are you into?"
+      who_are_you: "Who are you?"
+    privacy_settings:
+      ignored_users: "Ignored users"
+      no_user_ignored_message: "You are not currently ignoring any other user"
+      stop_ignoring: "Stop ignoring"
+      strip_exif: "Strip metadata such as location, author, and camera model from uploaded images (recommended)"
+      title: "Privacy settings"
+    public:
+      does_not_exist: "User %{username} does not exist!"
+    update:
+      color_theme_changed: "Color theme successfully changed."
+      color_theme_not_changed: "An error occurred while changing the color theme."
+      email_notifications_changed: "Email notifications changed"
+      follow_settings_changed: "Follow settings changed"
+      follow_settings_not_changed: "Follow settings change failed."
+      language_changed: "Language changed"
+      language_not_changed: "Language change failed"
+      password_changed: "Password changed. You can now log in with your new password."
+      password_not_changed: "Password change failed"
+      settings_not_updated: "Settings update failed"
+      settings_updated: "Settings updated"
+      unconfirmed_email_changed: "Email changed. Needs activation."
+      unconfirmed_email_not_changed: "Email change failed"
   will_paginate:
-    previous_label: "&laquo; previous"
     next_label: "next &raquo;"
-
-  simple_captcha:
-    placeholder: "Enter the image value"
-    label: "Enter the code in the box:"
-    message:
-      default: "The secret code did not match with the image"
-      user: "The secret image and code were different"
-      failed: "Human verification failed"
-
-  statistics:
-    name: "Name"
-    network: "Network"
-    services: "Services"
-    total_users: "Total users"
-    active_users_halfyear: "Active users half year"
-    active_users_monthly: "Active users monthly"
-    local_posts: "Local posts"
-    local_comments: "Local comments"
-    version: "Version"
-    registrations: "Registrations"
-    enabled: "Available"
-    disabled: "Not available"
-    open: "Open"
-    closed: "Closed"
-
-
+    previous_label: "&laquo; previous"

--- a/config/locales/inflections/all.yml
+++ b/config/locales/inflections/all.yml
@@ -1,44 +1,38 @@
-
 all:
   i18n:
     inflections:
       gender:
-        f:          "female"
-        m:          "male"
-        n:          "neuter"
-        masculine:  :@m
-        male:       :@m
-        man:        :@m
-        boy:        :@m
-        b:          :@m
-        he:         :@m
-        sir:        :@m
-        mr:         :@m
-        mister:     :@m
-        guy:        :@m
-        dude:       :@m
-        gentleman:  :@m
-        mal:        :@m
-        female:     :@f
-        feminine:   :@f
-        girl:       :@f
-        g:          :@f
-        lady:       :@f
-        she:        :@f
-        miss:       :@f
-        missus:     :@f
-        mrs:        :@f
-        missis:     :@f
-        mistress:   :@f
-        ms:         :@f
-        neuter:     :@n
-        neutral:    :@n
-        it:         :@n
-        they:       :@n
+        b: :@m
+        boy: :@m
+        default: :n
+        dude: :@m
+        f: "female"
+        female: :@f
+        feminine: :@f
+        g: :@f
+        gentleman: :@m
+        girl: :@f
+        guy: :@m
+        he: :@m
         impersonal: :@n
-        default:    :n
-      
-    
-  
-
-
+        it: :@n
+        lady: :@f
+        m: "male"
+        mal: :@m
+        male: :@m
+        man: :@m
+        masculine: :@m
+        miss: :@f
+        missis: :@f
+        missus: :@f
+        mister: :@m
+        mistress: :@f
+        mr: :@m
+        mrs: :@f
+        ms: :@f
+        n: "neuter"
+        neuter: :@n
+        neutral: :@n
+        she: :@f
+        sir: :@m
+        they: :@n

--- a/config/locales/inflections/pl.yml
+++ b/config/locales/inflections/pl.yml
@@ -1,64 +1,59 @@
-
 pl:
   i18n:
     inflections:
       gender:
-        f:          "rodzaj żeński"
-        m:          "rodzaj męski"
-        n:          "rodzaj nijaki"
-        masculine:  :@m
-        facet:      :@m
-        chłop:      :@m
-        chłopak:    :@m
-        chłopek:    :@m
-        chłopiec:   :@m
+        baba: :@f
+        babka: :@f
+        boj: :@m
+        chłop: :@m
         chłopaczek: :@m
-        mąż:        :@m
-        prawiczek:  :@m
-        prawik:     :@m
-        boj:        :@m
-        woj:        :@m
-        gość:       :@m
-        gostek:     :@m
-        gościu:     :@m
-        samiec:     :@m
-        samczyk:    :@m
-        kawaler:    :@m
-        mężczyzna:  :@m
-        męski:      :@m
-        pani:       :@f
-        kobieta:    :@f
-        k:          :@f
-        kobietka:   :@f
+        chłopak: :@m
+        chłopek: :@m
+        chłopiec: :@m
+        coś: :@n
+        default: :n
+        dziecko: :@n
         dziewczyna: :@f
-        dziewczę:   :@f
-        baba:       :@f
-        babka:      :@f
-        facetka:    :@f
         dziewczynka: :@f
-        dziewica:   :@f
-        niewiasta:  :@f
-        samica:     :@f
-        samiczka:   :@f
-        ona:        :@f
-        panna:      :@f
-        pannica:    :@f
-        panienka:   :@f
-        żeński:     :@f
-        laska:      :@f
-        lasencja:   :@f
-        żona:       :@f
-        dziewoja:   :@f
-        neuter:     :@n
-        to:         :@n
-        ono:        :@n
-        dziecko:    :@n
-        ktoś:       :@n
-        coś:        :@n
+        dziewczę: :@f
+        dziewica: :@f
+        dziewoja: :@f
+        f: "rodzaj żeński"
+        facet: :@m
+        facetka: :@f
+        gostek: :@m
+        gościu: :@m
+        gość: :@m
         impersonal: :@n
-        nijaki:     :@n
-        default:    :n
-      
-    
-  
-
+        k: :@f
+        kawaler: :@m
+        kobieta: :@f
+        kobietka: :@f
+        ktoś: :@n
+        lasencja: :@f
+        laska: :@f
+        m: "rodzaj męski"
+        masculine: :@m
+        mąż: :@m
+        męski: :@m
+        mężczyzna: :@m
+        n: "rodzaj nijaki"
+        neuter: :@n
+        niewiasta: :@f
+        nijaki: :@n
+        ona: :@f
+        ono: :@n
+        pani: :@f
+        panienka: :@f
+        panna: :@f
+        pannica: :@f
+        prawiczek: :@m
+        prawik: :@m
+        samczyk: :@m
+        samica: :@f
+        samiczka: :@f
+        samiec: :@m
+        to: :@n
+        woj: :@m
+        żeński: :@f
+        żona: :@f

--- a/config/locales/javascript/javascript.en.yml
+++ b/config/locales/javascript/javascript.en.yml
@@ -1,341 +1,313 @@
-#   Copyright (c) 2010-2011, Diaspora Inc.  This file is
-#   licensed under the Affero General Public License version 3 or later.  See
-#   the COPYRIGHT file.
-
-
 en:
   javascripts:
-    cancel: "Cancel"
-    confirm_dialog: "Are you sure?"
-    confirm_unload: "Please confirm that you want to leave this page. Data you have entered won’t be saved."
-    create: "Create"
-    delete: "Delete"
-    ignore: "Ignore"
-    report:
-      prompt: "Please enter a reason:"
-      prompt_default: "e.g. offensive content"
-      name: "Report"
-      status:
-        created: "The report has successfully been created"
-        exists: "The report already exists"
-    ignore_user: "Ignore this user?"
-    ignore_failed: "Unable to ignore this user"
-    hide_post: "Hide this post?"
-    hide_post_failed: "Unable to hide this post"
-    remove_post: "Remove this post?"
-    unblock_failed: "Unblocking this user has failed"
-    and: "and"
-    comma: ","
-    edit: "Edit"
-    no_results: "No results found"
-    show_all: "Show all"
-
-    admins:
-      dashboard:
-        up_to_date: "Your pod is up to date!"
-        outdated: "Your pod is outdated."
-        compare_versions: "The latest diaspora* release is <%= latestVersion %>, your pod is running <%= podVersion %>."
-        error: "Unable to determine latest diaspora* version."
     admin:
       pods:
-        pod: "Pod"
-        ssl: "SSL"
-        ssl_enabled: "SSL enabled"
-        ssl_disabled: "SSL disabled"
-        added: "Added"
-        status: "Status"
-        states:
-          unchecked: "Unchecked"
-          no_errors: "OK"
-          dns_failed: "Name resolution (DNS) failed"
-          net_failed: "Connection attempt failed"
-          ssl_failed: "Secure connection (SSL) failed"
-          http_failed: "HTTP connection failed"
-          version_failed: "Unable to retrieve software version"
-          unknown_error: "An unspecified error has happened during the check"
         actions: "Actions"
-        offline_since: "offline since:"
-        last_check: "last check:"
-        more_info: "show more information"
+        added: "Added"
         check: "perform connection test"
-        recheck:
-          success: "The pod was just checked again."
-          failure: "The check was not performed."
-        follow_link: "open link in browser"
-        no_info: "No additional information available at this point"
-        server_software: "Server software:"
-        response_time: "Response time:"
-        ms:
-          one: "<%= count %>ms"
-          other: "<%= count %>ms"
-        unknown: "unknown"
-        not_available: "not available"
-        unchecked:
-          one: "There is still one pod that hasn't been checked at all."
-          other: "There are still <%= count %> pods that haven't been checked at all."
-        version_failed:
-          one: "There is one pod that has no version (old pod, no NodeInfo)."
-          other: "There are <%= count %> pods that have no version (old pods, no NodeInfo)."
         errors:
           one: "The connection test returned an error for one pod."
           other: "The connection test returned an error for <%= count %> pods."
-
+        follow_link: "open link in browser"
+        last_check: "last check:"
+        more_info: "show more information"
+        ms:
+          one: "<%= count %>ms"
+          other: "<%= count %>ms"
+        no_info: "No additional information available at this point"
+        not_available: "not available"
+        offline_since: "offline since:"
+        pod: "Pod"
+        recheck:
+          failure: "The check was not performed."
+          success: "The pod was just checked again."
+        response_time: "Response time:"
+        server_software: "Server software:"
+        ssl: "SSL"
+        ssl_disabled: "SSL disabled"
+        ssl_enabled: "SSL enabled"
+        states:
+          dns_failed: "Name resolution (DNS) failed"
+          http_failed: "HTTP connection failed"
+          net_failed: "Connection attempt failed"
+          no_errors: "OK"
+          ssl_failed: "Secure connection (SSL) failed"
+          unchecked: "Unchecked"
+          unknown_error: "An unspecified error has happened during the check"
+          version_failed: "Unable to retrieve software version"
+        status: "Status"
+        unchecked:
+          one: "There is still one pod that hasn't been checked at all."
+          other: "There are still <%= count %> pods that haven't been checked at all."
+        unknown: "unknown"
+        version_failed:
+          one: "There is one pod that has no version (old pod, no NodeInfo)."
+          other: "There are <%= count %> pods that have no version (old pods, no NodeInfo)."
+    admins:
+      dashboard:
+        compare_versions: "The latest diaspora* release is <%= latestVersion %>, your pod is running <%= podVersion %>."
+        error: "Unable to determine latest diaspora* version."
+        outdated: "Your pod is outdated."
+        up_to_date: "Your pod is up to date!"
+    and: "and"
+    aspect_dropdown:
+      add_to_aspect: "Add contact"
+      all_aspects: "All aspects"
+      error: "Couldn’t start sharing with <%= name %>. Are you ignoring them?"
+      error_remove: "Couldn’t remove <%= name %> from the aspect :("
+      mobile_row_checked: "<%= name %> (remove)"
+      mobile_row_unchecked: "<%= name %> (add)"
+      select_aspects: "Select aspects"
+      started_sharing_with: "You have started sharing with <%= name %>!"
+      stopped_sharing_with: "You have stopped sharing with <%= name %>."
+      toggle:
+        one: "In <%= count %> aspect"
+        other: "In <%= count %> aspects"
+      updating: "updating..."
+    aspect_navigation:
+      add_an_aspect: "+ Add an aspect"
+      deselect_all: "Deselect all"
+      no_aspects: "No aspects selected"
+      select_all: "Select all"
     aspects:
-      name: "Name"
       create:
         add_a_new_aspect: "Add a new aspect"
-        success: "Your new aspect <%= name %> was created"
         failure: "Aspect creation failed."
-
-    errors:
-      connection: "Unable to connect to the server."
-
-    timeago:
-      prefixAgo: ""
-      prefixFromNow: ""
-      suffixAgo: "ago"
-      suffixFromNow: "from now"
-      inPast: "any moment now"
-      seconds: "less than a minute"
-      minute: "about a minute"
-      minutes:
-        one: "1 minute"
-        other: "%d minutes"
-      hour: "about an hour"
-      hours:
-        one: "about 1 hour"
-        other: "about %d hours"
-      day: "a day"
-      days:
-        one: "1 day"
-        other: "%d days"
-      month: "about a month"
-      months:
-        one: "1 month"
-        other: "%d months"
-      year: "about a year"
-      years:
-        one: "1 year"
-        other: "%d years"
-      wordSeparator: " "
-
-    contacts:
-      add_contact: "Add contact"
-      remove_contact: "Remove contact"
-      error_add: "Couldn’t add <%= name %> to the aspect :("
-      error_remove: "Couldn’t remove <%= name %> from the aspect :("
-      search_no_results: "No contacts found"
-
-    my_activity: "My activity"
-    my_stream: "Stream"
-    my_aspects: "My aspects"
-
-    publisher:
-      near_from: "Posted from: <%= location %>"
-      option: "Answer"
-      add_option: "Add an answer"
-      question: "Question"
-      markdown_editor:
-        preview: "Preview"
-        write: "Write"
-        tooltips:
-          bold: "Bold"
-          italic: "Italic"
-          heading: "Heading"
-          insert_link: "Insert link"
-          insert_image: "Insert image"
-          insert_ordered_list: "Insert ordered list"
-          insert_unordered_list: "Insert unordered list"
-          preview: "Preview message"
-          write: "Edit message"
-          cancel: "Cancel message"
-          quote: "Insert quotation"
-          code: "Insert code"
-        texts:
-          strong: "strong text"
-          italic: "italic text"
-          heading: "heading text"
-          insert_link_description_text: "enter link description here"
-          insert_link_help_text: "Insert link here"
-          insert_image_description_text: "enter image description here"
-          insert_image_help_text: "Insert image link here"
-          insert_image_title: "enter image title here"
-          list: "list text here"
-          quote: "quotation text here"
-          code: "code here"
-      mention_success: "Successfully mentioned: <%= names %>"
-
+        success: "Your new aspect <%= name %> was created"
+      name: "Name"
     bookmarklet:
       post_something: "Post to diaspora*"
       post_submit: "Submitting post..."
       post_success: "Posted! Closing popup window..."
-    aspect_dropdown:
-      add_to_aspect: "Add contact"
-      select_aspects: "Select aspects"
-      all_aspects: "All aspects"
-      updating: "updating..."
-      mobile_row_checked: "<%= name %> (remove)"
-      mobile_row_unchecked: "<%= name %> (add)"
-      stopped_sharing_with: "You have stopped sharing with <%= name %>."
-      started_sharing_with: "You have started sharing with <%= name %>!"
-      error: "Couldn’t start sharing with <%= name %>. Are you ignoring them?"
-      error_remove: "Couldn’t remove <%= name %> from the aspect :("
-      toggle:
-        one: "In <%= count %> aspect"
-        other: "In <%= count %> aspects"
-    show_more: "Show more"
-    failed_to_post_message: "Failed to post message!"
-    failed_to_remove: "Failed to remove the entry!"
+    cancel: "Cancel"
+    comma: ","
     comments:
-      show: "Show all comments"
       hide: "Hide comments"
       no_comments: "There are no comments yet."
-    reshares:
-      successful: "The post was successfully reshared!"
-      post: "Reshare <%= name %>’s post?"
-    aspect_navigation:
-      select_all: "Select all"
-      deselect_all: "Deselect all"
-      no_aspects: "No aspects selected"
-      add_an_aspect: "+ Add an aspect"
-    getting_started:
-      hey: "Hey, <%= name %>!"
-      no_tags: "Hey, you haven’t followed any tags! Continue anyway?"
-      alright_ill_wait: "All right, I’ll wait."
-      preparing_your_stream: "Preparing your personalized stream..."
-    photo_uploader:
-      upload_photos: "Upload photos"
-      looking_good: "OMG, you look awesome!"
-      completed: "<%= file %> completed"
-      error: "A problem occurred while uploading file <%= file %>"
-      invalid_ext: "{file} has invalid extension. Only {extensions} are allowed."
-      size_error: "{file} is too large, maximum file size is {sizeLimit}."
-      empty: "{file} is empty, please select files again without it."
-    tags:
-      wasnt_that_interesting: "OK, I suppose #<%= tagName %> wasn’t all that interesting..."
-    people:
-      not_found: "... and no one was found"
-      mention: "Mention"
-      message: "Message"
-      edit_my_profile: "Edit my profile"
-      stop_ignoring: "Stop ignoring"
-      helper:
-        is_sharing: "<%= name %> is sharing with you"
-        is_not_sharing: "<%= name %> is not sharing with you"
-    profile:
-      edit: "Edit"
-      add_some: "Add some"
-      you_have_no_tags: "You have no tags!"
-      bio: "Bio"
-      location: "Location"
-      gender: "Gender"
-      born: "Birthday"
-      photos: "Photos"
-      posts: "Posts"
-
+      show: "Show all comments"
+    confirm_dialog: "Are you sure?"
+    confirm_unload: "Please confirm that you want to leave this page. Data you have entered won’t be saved."
+    contacts:
+      add_contact: "Add contact"
+      error_add: "Couldn’t add <%= name %> to the aspect :("
+      error_remove: "Couldn’t remove <%= name %> from the aspect :("
+      remove_contact: "Remove contact"
+      search_no_results: "No contacts found"
     conversation:
       create:
         no_recipient: "Hey, you need to add a recipient first!"
       new:
         no_contacts: "You need to add some contacts before you can start a conversation."
-
+    create: "Create"
+    delete: "Delete"
+    edit: "Edit"
+    errors:
+      connection: "Unable to connect to the server."
+    failed_to_post_message: "Failed to post message!"
+    failed_to_remove: "Failed to remove the entry!"
+    getting_started:
+      alright_ill_wait: "All right, I’ll wait."
+      hey: "Hey, <%= name %>!"
+      no_tags: "Hey, you haven’t followed any tags! Continue anyway?"
+      preparing_your_stream: "Preparing your personalized stream..."
+    header:
+      admin: "Admin"
+      close: "Close"
+      contacts: "Contacts"
+      conversations: "Conversations"
+      help: "Help"
+      home: "Home"
+      log_out: "Log out"
+      mark_all_as_read: "Mark all as read"
+      moderator: "Moderator"
+      notifications: "Notifications"
+      profile: "Profile"
+      recent_notifications: "Recent notifications"
+      search: "Search"
+      settings: "Settings"
+      switch_to_touch_optimized_mode: "Switch to touch-optimized mode"
+      toggle_navigation: "Toggle navigation"
+      view_all: "View all"
+    hide_post: "Hide this post?"
+    hide_post_failed: "Unable to hide this post"
+    ignore: "Ignore"
+    ignore_failed: "Unable to ignore this user"
+    ignore_user: "Ignore this user?"
+    my_activity: "My activity"
+    my_aspects: "My aspects"
+    my_stream: "Stream"
+    no_results: "No results found"
     notifications:
       mark_read: "Mark read"
       mark_unread: "Mark unread"
       new_notifications:
         one: "You have <%= count %> unread notification"
         other: "You have <%= count %> unread notifications"
-
-    stream:
-      hide: "Hide"
-      public: "Public"
-      limited: "Limited"
-      like: "Like"
-      unlike: "Unlike"
-      reshare: "Reshare"
-      comment: "Comment"
-      original_post_deleted: "Original post deleted by author"
-      show_nsfw_post: "Show post"
-      show_nsfw_posts: "Show all"
-      hide_nsfw_posts: "Hide #nsfw posts"
-      follow: "Follow"
-      unfollow: "Unfollow"
-      enable_post_notifications: "Enable notifications for this post"
-      disable_post_notifications: "Disable notifications for this post"
-      permalink: "Permalink"
-      via: "via <%= provider %>"
-      no_posts_yet: "There are no posts to display here yet."
-
-      likes:
-        zero: "<%= count %> Likes"
-        one: "<%= count %> Like"
-        other: "<%= count %> Likes"
-
-      reshares:
-        zero: "<%= count %> Reshares"
-        one: "<%= count %> Reshare"
-        other: "<%= count %> Reshares"
-
-      comments:
-        zero: "<%= count %> comments"
-        one: "<%= count %> comment"
-        other: "<%= count %> comments"
-
-      more_comments:
-        zero: "Show <%= count %> more comments"
-        one: "Show <%= count %> more comment"
-        other: "Show <%= count %> more comments"
-
-      followed_tag:
-        title: "#Followed tags"
-        add_a_tag: "Add a tag"
-        follow: "Follow"
-
-      tags:
-        follow: "Follow #<%= tag %>"
-        following: "Following #<%= tag %>"
-        stop_following: "Stop following #<%= tag %>"
-        stop_following_confirm: "Stop following #<%= tag %>?"
-        follow_error: "Couldn’t follow #<%= tag %> :("
-        stop_following_error: "Couldn’t stop following #<%= tag %> :("
-
-    header:
-      home: "Home"
-      profile: "Profile"
-      contacts: "Contacts"
-      settings: "Settings"
-      help: "Help"
-      admin: "Admin"
-      moderator: "Moderator"
-      log_out: "Log out"
-      toggle_navigation: "Toggle navigation"
-      switch_to_touch_optimized_mode: "Switch to touch-optimized mode"
-
-      notifications: "Notifications"
-      conversations: "Conversations"
-
-      search: "Search"
-
-      recent_notifications: "Recent notifications"
-      mark_all_as_read: "Mark all as read"
-      view_all: "View all"
-      close: "Close"
-
-    viewer:
-      reshared: "Reshared"
-
+    people:
+      edit_my_profile: "Edit my profile"
+      helper:
+        is_not_sharing: "<%= name %> is not sharing with you"
+        is_sharing: "<%= name %> is sharing with you"
+      mention: "Mention"
+      message: "Message"
+      not_found: "... and no one was found"
+      stop_ignoring: "Stop ignoring"
+    photo_uploader:
+      completed: "<%= file %> completed"
+      empty: "{file} is empty, please select files again without it."
+      error: "A problem occurred while uploading file <%= file %>"
+      invalid_ext: "{file} has invalid extension. Only {extensions} are allowed."
+      looking_good: "OMG, you look awesome!"
+      size_error: "{file} is too large, maximum file size is {sizeLimit}."
+      upload_photos: "Upload photos"
     poll:
-      vote: "Vote"
-      go_to_original_post: "You can participate in this poll on the <%= original_post_link %>."
-      original_post: "original post"
-      result: "Result"
+      answer_count:
+        one: "1 vote"
+        other: "<%=count%> votes"
+        zero: "0 votes"
+      close_result: "Hide result"
       count:
         one: "1 vote so far"
         other: "<%=count%> votes so far"
-      answer_count:
-        zero: "0 votes"
-        one: "1 vote"
-        other: "<%=count%> votes"
+      go_to_original_post: "You can participate in this poll on the <%= original_post_link %>."
+      original_post: "original post"
+      result: "Result"
       show_result: "Show result"
-      close_result: "Hide result"
+      vote: "Vote"
       your_vote: "Your vote"
+    profile:
+      add_some: "Add some"
+      bio: "Bio"
+      born: "Birthday"
+      edit: "Edit"
+      gender: "Gender"
+      location: "Location"
+      photos: "Photos"
+      posts: "Posts"
+      you_have_no_tags: "You have no tags!"
+    publisher:
+      add_option: "Add an answer"
+      markdown_editor:
+        preview: "Preview"
+        texts:
+          code: "code here"
+          heading: "heading text"
+          insert_image_description_text: "enter image description here"
+          insert_image_help_text: "Insert image link here"
+          insert_image_title: "enter image title here"
+          insert_link_description_text: "enter link description here"
+          insert_link_help_text: "Insert link here"
+          italic: "italic text"
+          list: "list text here"
+          quote: "quotation text here"
+          strong: "strong text"
+        tooltips:
+          bold: "Bold"
+          cancel: "Cancel message"
+          code: "Insert code"
+          heading: "Heading"
+          insert_image: "Insert image"
+          insert_link: "Insert link"
+          insert_ordered_list: "Insert ordered list"
+          insert_unordered_list: "Insert unordered list"
+          italic: "Italic"
+          preview: "Preview message"
+          quote: "Insert quotation"
+          write: "Edit message"
+        write: "Write"
+      mention_success: "Successfully mentioned: <%= names %>"
+      near_from: "Posted from: <%= location %>"
+      option: "Answer"
+      question: "Question"
+    remove_post: "Remove this post?"
+    report:
+      name: "Report"
+      prompt: "Please enter a reason:"
+      prompt_default: "e.g. offensive content"
+      status:
+        created: "The report has successfully been created"
+        exists: "The report already exists"
+    reshares:
+      post: "Reshare <%= name %>’s post?"
+      successful: "The post was successfully reshared!"
+    show_all: "Show all"
+    show_more: "Show more"
+    stream:
+      comment: "Comment"
+      comments:
+        one: "<%= count %> comment"
+        other: "<%= count %> comments"
+        zero: "<%= count %> comments"
+      disable_post_notifications: "Disable notifications for this post"
+      enable_post_notifications: "Enable notifications for this post"
+      follow: "Follow"
+      followed_tag:
+        add_a_tag: "Add a tag"
+        follow: "Follow"
+        title: "#Followed tags"
+      hide: "Hide"
+      hide_nsfw_posts: "Hide #nsfw posts"
+      like: "Like"
+      likes:
+        one: "<%= count %> Like"
+        other: "<%= count %> Likes"
+        zero: "<%= count %> Likes"
+      limited: "Limited"
+      more_comments:
+        one: "Show <%= count %> more comment"
+        other: "Show <%= count %> more comments"
+        zero: "Show <%= count %> more comments"
+      no_posts_yet: "There are no posts to display here yet."
+      original_post_deleted: "Original post deleted by author"
+      permalink: "Permalink"
+      public: "Public"
+      reshare: "Reshare"
+      reshares:
+        one: "<%= count %> Reshare"
+        other: "<%= count %> Reshares"
+        zero: "<%= count %> Reshares"
+      show_nsfw_post: "Show post"
+      show_nsfw_posts: "Show all"
+      tags:
+        follow: "Follow #<%= tag %>"
+        follow_error: "Couldn’t follow #<%= tag %> :("
+        following: "Following #<%= tag %>"
+        stop_following: "Stop following #<%= tag %>"
+        stop_following_confirm: "Stop following #<%= tag %>?"
+        stop_following_error: "Couldn’t stop following #<%= tag %> :("
+      unfollow: "Unfollow"
+      unlike: "Unlike"
+      via: "via <%= provider %>"
+    tags:
+      wasnt_that_interesting: "OK, I suppose #<%= tagName %> wasn’t all that interesting..."
+    timeago:
+      day: "a day"
+      days:
+        one: "1 day"
+        other: "%d days"
+      hour: "about an hour"
+      hours:
+        one: "about 1 hour"
+        other: "about %d hours"
+      inPast: "any moment now"
+      minute: "about a minute"
+      minutes:
+        one: "1 minute"
+        other: "%d minutes"
+      month: "about a month"
+      months:
+        one: "1 month"
+        other: "%d months"
+      prefixAgo: ""
+      prefixFromNow: ""
+      seconds: "less than a minute"
+      suffixAgo: "ago"
+      suffixFromNow: "from now"
+      wordSeparator: " "
+      year: "about a year"
+      years:
+        one: "1 year"
+        other: "%d years"
+    unblock_failed: "Unblocking this user has failed"
+    viewer:
+      reshared: "Reshared"

--- a/lib/tasks/yalphabetize.rake
+++ b/lib/tasks/yalphabetize.rake
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'yalphabetize'
+
 namespace :yalphabetize do
   task run: :environment do
     Yalphabetize::Yalphabetizer.call

--- a/lib/tasks/yalphabetize.rake
+++ b/lib/tasks/yalphabetize.rake
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'yalphabetize'
+require "yalphabetize"
 
 namespace :yalphabetize do
   task run: :environment do

--- a/lib/tasks/yalphabetize.rake
+++ b/lib/tasks/yalphabetize.rake
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 namespace :yalphabetize do
-  task :run do
+  task run: :environment do
     Yalphabetize::Yalphabetizer.call
   end
 end

--- a/lib/tasks/yalphabetize.rake
+++ b/lib/tasks/yalphabetize.rake
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+namespace :yalphabetize do
+  task :run do
+    Yalphabetize::Yalphabetizer.call
+  end
+end


### PR DESCRIPTION
This PR introduces [yalphabetize](https://github.com/samrjenkins/yalphabetize) to the project. I would love to hear your thoughts/feedback.

It provides us with the ability to quickly normalise/alphabetise YAML files such as locales and to maintain this normalisation into the future.

Advantages of alphabetising YAML include:
- easier to locate specific keys in large files
- easier to spot duplicate keys
- easier to compare equivalent locale YAMLs for different languages

Yalphabetize can also be integrated into CI to ensure that future PRs maintain the alphabetisation of locale files.

I am slightly unsure how to handle alphabetisation of each language because the contribution guidelines state that the translations are maintained via a 3rd party. Is it ok to normalise the 8 locales I have touched in this PR?