### PR TITLE
Add dedicated SECURITY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ Everyone interacting in diaspora’s codebases, issue trackers, chat rooms, the 
 
 ## Security
 
-Found a security issue? Please disclose it responsibly. We have a team of developers listening to [security@diasporafoundation.org](mailto:security@diasporafoundation.org). The PGP fingerprint is [AB0D AB02 0FC5 D398 03AB 3CE1 6F70 243F 27AD 886A](https://pgp.mit.edu/pks/lookup?op=get&search=0x6F70243F27AD886A).
+See [`SECURITY.md`](/SECURITY.md) for instructions on how to responsibly report a security vulnerability.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Supported Versions
+
+We support the latest stable release, as well as the current state of the `next-minor` and `develop` branches. Security issues for older releases are out of scope.
+
+## Reporting a Vulnerability
+
+Found a security issue? Please disclose it responsibly. We have a team of developers listening to [security@diasporafoundation.org](mailto:security@diasporafoundation.org). The PGP fingerprint is [AB0D AB02 0FC5 D398 03AB 3CE1 6F70 243F 27AD 886A](https://pgp.mit.edu/pks/lookup?op=get&search=0x6F70243F27AD886A).


### PR DESCRIPTION
We had this information in `README.md` already, but it's generally considered best-practice on GitHub to have a dedicated `SECURITY.md` for that.