### PR TITLE
Manually stringify keys to fix sidekiq 7.0 deprecation warning

### DIFF
--- a/app/workers/deferred_dispatch.rb
+++ b/app/workers/deferred_dispatch.rb
@@ -11,9 +11,8 @@ module Workers
     def perform(user_id, object_class_name, object_id, opts)
       user = User.find(user_id)
       object = object_class_name.constantize.find(object_id)
-      opts = ActiveSupport::HashWithIndifferentAccess.new(opts)
 
-      Diaspora::Federation::Dispatcher.build(user, object, opts).dispatch
+      Diaspora::Federation::Dispatcher.build(user, object, opts.deep_symbolize_keys).dispatch
     rescue ActiveRecord::RecordNotFound # The target got deleted before the job was run
     end
   end

--- a/app/workers/deferred_retraction.rb
+++ b/app/workers/deferred_retraction.rb
@@ -12,9 +12,8 @@ module Workers
       user = User.find(user_id)
       subscribers = Person.where(id: recipient_ids)
       object = retraction_class.constantize.new(retraction_data.deep_symbolize_keys, subscribers)
-      opts = ActiveSupport::HashWithIndifferentAccess.new(opts)
 
-      Diaspora::Federation::Dispatcher.build(user, object, opts).dispatch
+      Diaspora::Federation::Dispatcher.build(user, object, opts.deep_symbolize_keys).dispatch
     end
   end
 end

--- a/app/workers/delete_post_from_service.rb
+++ b/app/workers/delete_post_from_service.rb
@@ -10,8 +10,7 @@ module Workers
 
     def perform(service_id, opts)
       service = Service.find_by_id(service_id)
-      opts = ActiveSupport::HashWithIndifferentAccess.new(opts)
-      service.delete_from_service(opts)
+      service.delete_from_service(opts.deep_symbolize_keys)
     end
   end
 end

--- a/lib/diaspora/federated/retraction.rb
+++ b/lib/diaspora/federated/retraction.rb
@@ -36,7 +36,8 @@ class Retraction
 
   def defer_dispatch(user, include_target_author=true)
     subscribers = dispatch_subscribers(include_target_author)
-    Workers::DeferredRetraction.perform_async(user.id, self.class.to_s, data, subscribers.map(&:id), service_opts(user))
+    Workers::DeferredRetraction.perform_async(user.id, self.class.to_s, data.deep_stringify_keys,
+                                              subscribers.map(&:id), service_opts(user).deep_stringify_keys)
   end
 
   def perform

--- a/lib/diaspora/federation/dispatcher.rb
+++ b/lib/diaspora/federation/dispatcher.rb
@@ -21,7 +21,7 @@ module Diaspora
       end
 
       def self.defer_dispatch(sender, object, opts={})
-        Workers::DeferredDispatch.perform_async(sender.id, object.class.to_s, object.id, opts)
+        Workers::DeferredDispatch.perform_async(sender.id, object.class.to_s, object.id, opts.deep_stringify_keys)
       end
 
       def dispatch
@@ -69,7 +69,7 @@ module Diaspora
         when StatusMessage
           each_service {|service| Workers::PostToService.perform_async(service.id, object.id, opts[:url]) }
         when Retraction
-          each_service {|service| Workers::DeletePostFromService.perform_async(service.id, opts) }
+          each_service {|service| Workers::DeletePostFromService.perform_async(service.id, opts.deep_stringify_keys) }
         end
       end
 

--- a/spec/integration/receiving_spec.rb
+++ b/spec/integration/receiving_spec.rb
@@ -28,7 +28,7 @@ describe 'a user receives a post', :type => :request do
       bob.aspects.reload
       bob.add_to_streams(sm, [@bobs_aspect])
       queue.drain_all
-      bob.dispatch_post(sm, :to => @bobs_aspect)
+      bob.dispatch_post(sm)
     end
 
     expect(alice.visible_shareables(Post).count(:all)).to eq(1)

--- a/spec/lib/diaspora/federated/contact_retraction_spec.rb
+++ b/spec/lib/diaspora/federated/contact_retraction_spec.rb
@@ -53,7 +53,7 @@ describe ContactRetraction do
       federation_retraction_data = Diaspora::Federation::Entities.contact(contact).to_h
 
       expect(Workers::DeferredRetraction).to receive(:perform_async).with(
-        local_luke.id, "ContactRetraction", federation_retraction_data, [remote_raphael.id], {}
+        local_luke.id, "ContactRetraction", federation_retraction_data.deep_stringify_keys, [remote_raphael.id], {}
       )
 
       retraction.defer_dispatch(local_luke)

--- a/spec/lib/diaspora/federated/retraction_spec.rb
+++ b/spec/lib/diaspora/federated/retraction_spec.rb
@@ -70,7 +70,8 @@ describe Retraction do
       federation_retraction = Diaspora::Federation::Entities.retraction(retraction)
 
       expect(Workers::DeferredRetraction).to receive(:perform_async).with(
-        local_luke.id, "Retraction", federation_retraction.to_h, [remote_raphael.id], service_types: []
+        local_luke.id, "Retraction", federation_retraction.to_h.deep_stringify_keys, [remote_raphael.id],
+        "service_types" => []
       )
 
       retraction.defer_dispatch(local_luke)
@@ -85,7 +86,8 @@ describe Retraction do
       federation_retraction = Diaspora::Federation::Entities.retraction(retraction)
 
       expect(Workers::DeferredRetraction).to receive(:perform_async).with(
-        alice.id, "Retraction", federation_retraction.to_h, [], service_types: ["Services::Twitter"], tweet_id: "123"
+        alice.id, "Retraction", federation_retraction.to_h.deep_stringify_keys, [],
+        "service_types" => ["Services::Twitter"], "tweet_id" => "123"
       )
 
       retraction.defer_dispatch(alice)
@@ -96,7 +98,7 @@ describe Retraction do
       federation_retraction = Diaspora::Federation::Entities.retraction(retraction)
 
       expect(Workers::DeferredRetraction).to receive(:perform_async).with(
-        alice.id, "Retraction", federation_retraction.to_h, [], service_types: []
+        alice.id, "Retraction", federation_retraction.to_h.deep_stringify_keys, [], "service_types" => []
       )
 
       retraction.defer_dispatch(alice)
@@ -109,7 +111,7 @@ describe Retraction do
       federation_retraction = Diaspora::Federation::Entities.retraction(retraction)
 
       expect(Workers::DeferredRetraction).to receive(:perform_async).with(
-        local_luke.id, "Retraction", federation_retraction.to_h, [remote_raphael.id], {}
+        local_luke.id, "Retraction", federation_retraction.to_h.deep_stringify_keys, [remote_raphael.id], {}
       )
 
       retraction.defer_dispatch(local_luke)
@@ -124,7 +126,7 @@ describe Retraction do
         federation_retraction = Diaspora::Federation::Entities.retraction(retraction)
 
         expect(Workers::DeferredRetraction).to receive(:perform_async).with(
-          local_luke.id, "Retraction", federation_retraction.to_h, [remote_raphael.id], {}
+          local_luke.id, "Retraction", federation_retraction.to_h.deep_stringify_keys, [remote_raphael.id], {}
         )
 
         retraction.defer_dispatch(local_luke)
@@ -135,7 +137,7 @@ describe Retraction do
         federation_retraction = Diaspora::Federation::Entities.retraction(retraction)
 
         expect(Workers::DeferredRetraction).to receive(:perform_async).with(
-          local_luke.id, "Retraction", federation_retraction.to_h, [], {}
+          local_luke.id, "Retraction", federation_retraction.to_h.deep_stringify_keys, [], {}
         )
 
         retraction.defer_dispatch(local_luke, false)

--- a/spec/lib/diaspora/federation/dispatcher_spec.rb
+++ b/spec/lib/diaspora/federation/dispatcher_spec.rb
@@ -57,7 +57,8 @@ describe Diaspora::Federation::Dispatcher do
 
   describe ".defer_dispatch" do
     it "queues a job for dispatch" do
-      expect(Workers::DeferredDispatch).to receive(:perform_async).with(alice.id, "StatusMessage", post.id, opts)
+      expect(Workers::DeferredDispatch)
+        .to receive(:perform_async).with(alice.id, "StatusMessage", post.id, opts.deep_stringify_keys)
       described_class.defer_dispatch(alice, post, opts)
     end
   end

--- a/spec/shared_behaviors/dispatcher.rb
+++ b/spec/shared_behaviors/dispatcher.rb
@@ -17,7 +17,7 @@ shared_examples "a dispatcher" do
 
       it "delivers a Retraction of a Post to specified services" do
         opts = {service_types: "Services::Twitter", tweet_id: "123"}
-        expect(Workers::DeletePostFromService).to receive(:perform_async).with(twitter.id, opts)
+        expect(Workers::DeletePostFromService).to receive(:perform_async).with(twitter.id, opts.deep_stringify_keys)
 
         retraction = Retraction.for(post)
         Diaspora::Federation::Dispatcher.build(alice, retraction, opts).dispatch

--- a/spec/support/user_methods.rb
+++ b/spec/support/user_methods.rb
@@ -32,12 +32,7 @@ class User
 
       if p.save!
         self.aspects.reload
-
-        dispatch_opts = {
-          url: Rails.application.routes.url_helpers.post_url(p, host: AppConfig.pod_uri.to_s),
-          to:  opts[:to]
-        }
-        dispatch_post(p, dispatch_opts)
+        dispatch_post(p, url: Rails.application.routes.url_helpers.post_url(p, host: AppConfig.pod_uri.to_s))
       end
       unless opts[:created_at]
         p.created_at = Time.now - 1


### PR DESCRIPTION
"WARN: Job arguments to Workers::DeferredDispatch do not serialize to JSON safely. This will raise an error in
Sidekiq 7.0. See https://github.com/mperham/sidekiq/wiki/Best-Practices or raise an error today by calling `Sidekiq.strict_args!` during Sidekiq initialization."