### PR TITLE
API: update Search endpoint to be aware of ignored users

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -87,11 +87,9 @@ module Api
       end
 
       def posts_query
-        if private_read?
-          Stream::Tag.new(current_user, params.require(:tag)).posts
-        else
-          Stream::Tag.new(nil, params.require(:tag)).posts
-        end
+        opts = {}
+        opts[:public_only] = !private_read?
+        Stream::Tag.new(current_user, params.require(:tag), opts).stream_posts
       end
 
       def tags_query

--- a/lib/stream/tag.rb
+++ b/lib/stream/tag.rb
@@ -5,12 +5,13 @@
 #   the COPYRIGHT file.
 
 class Stream::Tag < Stream::Base
-  attr_accessor :tag_name, :people_page , :people_per_page
+  attr_accessor :tag_name, :people_page , :people_per_page, :public_only
 
   def initialize(user, tag_name, opts={})
     self.tag_name = tag_name
     self.people_page = opts[:page] || 1
     self.people_per_page = 15
+    self.public_only = opts[:public_only] || false
     super(user, opts)
   end
 
@@ -31,11 +32,12 @@ class Stream::Tag < Stream::Base
   end
 
   def posts
-    @posts ||= if user
-                 StatusMessage.user_tag_stream(user, tag.id)
-               else
-                 StatusMessage.public_tag_stream(tag.id)
-               end
+    return @posts unless @posts.nil?
+
+    if public_only || user.blank?
+      return @posts = StatusMessage.public_tag_stream(tag.id)
+    end
+    @posts = StatusMessage.user_tag_stream(user, tag.id)
   end
 
   def stream_posts

--- a/spec/integration/api/search_controller_spec.rb
+++ b/spec/integration/api/search_controller_spec.rb
@@ -460,6 +460,41 @@ describe Api::V1::SearchController do
       )
       expect(response.status).to eq(401)
     end
+
+    context 'when the author is blocked' do
+      before do
+        FactoryBot.create(
+          :block,
+          user: auth_public_only_read_only.user,
+          person: eve.person
+        )
+        FactoryBot.create(
+          :block,
+          user: auth.user,
+          person: eve.person
+        )
+      end
+
+      it "hides the blocked author's posts in with public only scopes" do
+        get(
+          "/api/v1/search/posts",
+          params: {tag: "tag2", access_token: access_token_public_only_read_only}
+        )
+        expect(response.status).to eq(200)
+        posts = response_body_data(response)
+        expect(posts.length).to eq(1)
+      end
+
+      it "hides the blocked author's posts in with default scopes" do
+        get(
+          "/api/v1/search/posts",
+          params: {tag: "tag2", access_token: access_token}
+        )
+        expect(response.status).to eq(200)
+        posts = response_body_data(response)
+        expect(posts.length).to eq(1)
+      end
+    end
   end
 
   describe "tag_index" do


### PR DESCRIPTION
While I was using insporation I noticed that when I was looking up posts by the tag name it showed up posts by the people I block. It didn't happen in the same case for the web app.

So in this PR I fixed that.

@tclaus looks like I changed the same files as you did in https://github.com/diaspora/diaspora/pull/8284. It means whatever gets shipped first will create conflicts for the other. I'll try to review your PRs, especially the one I referenced.