### PR TITLE
Don't eager load active storage in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -15,6 +15,11 @@ Rails.application.configure do
   config.eager_load = true
   config.eager_load_paths += %W[#{config.root}/lib]
 
+  # diaspora* does not use ActiveStroage. But eager loading then loads active_storage/blob.rb,
+  # which then fails if there isn't a config/storage.yml
+  # This can be removed if we ever want to use ActiveStorage and a storage.yml exists
+  config.eager_load_namespaces.delete(ActiveStorage::Engine)
+
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true


### PR DESCRIPTION
We don't use active storage, but eager loading it tries to read the `config/storage.yml`, which doesn't exist, because we don't need it.

replacement for #8370 :smiley: 