### PR TITLE
Disable export_concurrent to prevent segfault during precompile

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -16,3 +16,9 @@ Rails.application.config.assets.paths << Rails.root.join("node_modules")
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
 
 Rails.application.config.public_file_server.enabled = AppConfig.environment.assets.serve?
+
+# assets:precompile can sometimes fail with a Segmentation fault.
+# Disabling export_concurrent is a workaround. See: https://github.com/sass/sassc-ruby/issues/207
+Rails.application.config.assets.configure do |env|
+  env.export_concurrent = false
+end


### PR DESCRIPTION
See https://github.com/sass/sassc-ruby/issues/207