### PR TITLE
Add dummy param to receive workers

### DIFF
--- a/app/workers/receive_private.rb
+++ b/app/workers/receive_private.rb
@@ -6,7 +6,7 @@
 
 module Workers
   class ReceivePrivate < ReceiveBase
-    def perform(user_id, data)
+    def perform(user_id, data, _dummy=nil)
       filter_errors_for_retry do
         user_private_key = User.where(id: user_id).pluck(:serialized_private_key).first
         rsa_key = OpenSSL::PKey::RSA.new(user_private_key)

--- a/app/workers/receive_public.rb
+++ b/app/workers/receive_public.rb
@@ -6,7 +6,7 @@
 
 module Workers
   class ReceivePublic < ReceiveBase
-    def perform(data)
+    def perform(data, _dummy=nil)
       filter_errors_for_retry do
         DiasporaFederation::Federation::Receiver.receive_public(data)
       end


### PR DESCRIPTION
it looks like something still schedules jobs with an additional parameter which breaks incoming federation. Lets add a dummy parameter to till be able to consume the jobs until I know what's going wrong here.

If I understand this correctly the jobs should be scheduled without this parameter (line 93 and 100):

https://github.com/diaspora/diaspora/blob/975afe03bbc9406de5998f91f32aae9ba58a54b4/config/initializers/diaspora_federation.rb#L92-L102