### PR TITLE
Disable the default CSRF protection.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -39,6 +39,11 @@ module Diaspora
     # Enable escaping HTML in JSON.
     config.active_support.escape_html_entities_in_json = true
 
+    # We specify CSRF protection manually in ApplicationController with
+    # protect_from_forgery - having it enabled anywhere by default breaks
+    # federation.
+    config.action_controller.default_protect_from_forgery = false
+
     # Enable the asset pipeline
     config.assets.enabled = true
 


### PR DESCRIPTION
This was added [in Rails 5.2 defaults](https://github.com/rails/rails/commit/ec4a836919c021c0a5cf9ebeebb4db5e02104a55), but we upgraded from 5.1 defaults to 6.1, so we didn't notice until now.