### PR TITLE
Add dummy host meta

### DIFF
--- a/app/controllers/node_info_controller.rb
+++ b/app/controllers/node_info_controller.rb
@@ -20,4 +20,14 @@ class NodeInfoController < ApplicationController
       format.all { @statistics = NodeInfoPresenter.new("1.0") }
     end
   end
+
+  # TODO: this is only a dummy endpoint, because old versions of the ConnectionTester (<= 0.7.17.0)
+  #  checked for this endpoint. Remove this endpoint again once most pods are updated to >= 0.7.18.0
+  def host_meta
+    render xml: <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <XRD xmlns="http://docs.oasis-open.org/ns/xri/xrd-1.0">
+      </XRD>
+    XML
+  end
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -11,7 +11,6 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     origins "*"
     resource "/api/*", methods: :any
-    resource "/.well-known/host-meta"
     resource "/.well-known/webfinger"
     resource "/.well-known/openid-configuration"
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -213,6 +213,7 @@ Rails.application.routes.draw do
   get ".well-known/nodeinfo", to: "node_info#jrd"
   get "nodeinfo/:version",    to: "node_info#document", as: "node_info", constraints: {version: /\d+\.\d+/}
   get "statistics",           to: "node_info#statistics"
+  get ".well-known/host-meta", to: "node_info#host_meta"
 
   # Terms
   if AppConfig.settings.terms.enable? || Rails.env.test?

--- a/spec/integration/migration_service_spec.rb
+++ b/spec/integration/migration_service_spec.rb
@@ -438,8 +438,6 @@ describe MigrationService do
         expect(DiasporaFederation::Discovery::Discovery).to receive(:new).with(archive_author).and_call_original
         stub_request(:get, "https://#{old_pod_hostname}/.well-known/webfinger?resource=acct:#{archive_author}")
           .to_return(status: 404)
-        stub_request(:get, %r{https*://#{old_pod_hostname}/\.well-known/host-meta})
-          .to_return(status: 404)
 
         expect_relayable_parent_fetch(archive_author, existing_subscription_guid)
           .and_raise(DiasporaFederation::Federation::Fetcher::NotFetchable)

--- a/spec/lib/archive_importer/post_importer_spec.rb
+++ b/spec/lib/archive_importer/post_importer_spec.rb
@@ -87,8 +87,6 @@ describe ArchiveImporter::PostImporter do
             :get,
             %r{https*://old_pod\.nowhere/\.well-known/webfinger\?resource=acct:old_id@old_pod\.nowhere}
           ).to_return(status: 404, body: "", headers: {})
-          stub_request(:get, %r{https*://old_pod\.nowhere/\.well-known/host-meta})
-            .to_return(status: 404, body: "", headers: {})
 
           expect {
             instance.import

--- a/spec/lib/archive_importer_spec.rb
+++ b/spec/lib/archive_importer_spec.rb
@@ -95,8 +95,6 @@ describe ArchiveImporter do
       before do
         stub_request(:get, %r{https*://old_pod\.nowhere/\.well-known/webfinger\?resource=acct:old_id@old_pod\.nowhere})
           .to_return(status: 404, body: "", headers: {})
-        stub_request(:get, %r{https*://old_pod\.nowhere/\.well-known/host-meta})
-          .to_return(status: 404, body: "", headers: {})
       end
 
       it "doesn't fail" do

--- a/spec/lib/archive_validator/author_private_key_validator_spec.rb
+++ b/spec/lib/archive_validator/author_private_key_validator_spec.rb
@@ -56,8 +56,6 @@ describe ArchiveValidator::AuthorPrivateKeyValidator do
     before do
       stub_request(:get, %r{https*://old_pod\.nowhere/\.well-known/webfinger\?resource=acct:old_id@old_pod\.nowhere})
         .to_return(status: 404, body: "", headers: {})
-      stub_request(:get, %r{https*://old_pod\.nowhere/\.well-known/host-meta})
-        .to_return(status: 404, body: "", headers: {})
     end
 
     include_examples "validation result is valid"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -108,10 +108,6 @@ RSpec.configure do |config|
       :get,
       "https://example.com/.well-known/webfinger?resource=acct:bob@example.com"
     )
-    stub_request(
-      :get,
-      "https://example.com/.well-known/host-meta"
-    )
     $process_queue = false
   end
 


### PR DESCRIPTION
This was removed from the `diaspora_federation` gem (https://github.com/diaspora/diaspora_federation/pull/122), since it's not used for the federation/discovery anymore since a long time. But old versions of the `ConnectionTester` up to version 0.7.17 still check if this route exist or else they mark the pod as offline. So lets add a dummy host-meta with an empty response back, so the `ConnectionTester` is happy again until we can remove this workaround again when most pods are updated (see #8377).

Also cleanup some other leftover of `/.well-known/host-meta` in the tests, which also isn't needed anymore, because the `diaspora_federation` gem doesn't try to access this anymore.