### PR TITLE
Add NodeInfo 2.1 and parse the newest available version

### DIFF
--- a/app/assets/templates/pod_table_entry_tpl.jst.hbs
+++ b/app/assets/templates/pod_table_entry_tpl.jst.hbs
@@ -1,5 +1,5 @@
 
-<td class="ssl-status"">
+<td class="ssl-status">
   {{#if ssl}}
     <i title="{{t 'admin.pods.ssl_enabled'}}" class="entypo-check">
   {{else}}
@@ -14,6 +14,7 @@
 <td>
   {{#if has_no_errors}}
     <i title="{{status_text}}" class="glyphicon glyphicon-ok"></i>
+    {{software}}
   {{else}}
     {{status_text}}
   {{/if}}

--- a/app/presenters/node_info_presenter.rb
+++ b/app/presenters/node_info_presenter.rb
@@ -29,6 +29,8 @@ class NodeInfoPresenter
 
   def add_static_data(doc)
     doc.software.name = "diaspora"
+    doc.software.repository = "https://github.com/diaspora/diaspora"
+    doc.software.homepage = "https://diasporafoundation.org/"
     doc.protocols.protocols << "diaspora"
   end
 

--- a/lib/node_info.rb
+++ b/lib/node_info.rb
@@ -6,7 +6,7 @@ require "json-schema"
 module NodeInfo
   VERSIONS = %w[1.0 2.0 2.1].freeze
   SCHEMAS = {} # rubocop:disable Style/MutableConstant
-  private_constant :VERSIONS, :SCHEMAS
+  private_constant :SCHEMAS
 
   Document = Struct.new(:version, :software, :protocols, :services, :open_registrations, :usage, :metadata) do
     # rubocop:disable Lint/ConstantDefinitionInBlock

--- a/lib/node_info.rb
+++ b/lib/node_info.rb
@@ -4,13 +4,13 @@ require "pathname"
 require "json-schema"
 
 module NodeInfo
-  VERSIONS = %w(1.0 2.0).freeze
-  SCHEMAS = {}
+  VERSIONS = %w[1.0 2.0 2.1].freeze
+  SCHEMAS = {} # rubocop:disable Style/MutableConstant
   private_constant :VERSIONS, :SCHEMAS
 
-  # rubocop:disable Metrics/BlockLength
   Document = Struct.new(:version, :software, :protocols, :services, :open_registrations, :usage, :metadata) do
-    Software = Struct.new(:name, :version) do
+    # rubocop:disable Lint/ConstantDefinitionInBlock
+    Software = Struct.new(:name, :version, :repository, :homepage) do
       def initialize(name=nil, version=nil)
         super(name, version)
       end
@@ -20,6 +20,13 @@ module NodeInfo
           "name"    => name,
           "version" => version
         }
+      end
+
+      def version_21_hash
+        version_10_hash.merge(
+          "repository" => repository,
+          "homepage"   => homepage
+        )
       end
     end
 
@@ -80,6 +87,7 @@ module NodeInfo
         }
       end
     end
+    # rubocop:enable Lint/ConstantDefinitionInBlock
 
     def self.build
       new.tap do |doc|
@@ -98,6 +106,8 @@ module NodeInfo
         version_10_hash
       when "2.0"
         version_20_hash
+      when "2.1"
+        version_21_hash
       end
     end
 
@@ -144,6 +154,18 @@ module NodeInfo
       )
     end
 
+    def version_21_hash
+      deep_compact(
+        "version"           => "2.1",
+        "software"          => software.version_21_hash,
+        "protocols"         => protocols.version_20_array,
+        "services"          => services.version_10_hash,
+        "openRegistrations" => open_registrations,
+        "usage"             => usage.version_10_hash,
+        "metadata"          => metadata
+      )
+    end
+
     def deep_compact(hash)
       hash.tap do |hash|
         hash.reject! {|_, value|
@@ -153,7 +175,6 @@ module NodeInfo
       end
     end
   end
-  # rubocop:enable Metrics/BlockLength
 
   def self.schema(version)
     SCHEMAS[version] ||= JSON.parse(

--- a/spec/controllers/node_info_controller_spec.rb
+++ b/spec/controllers/node_info_controller_spec.rb
@@ -20,6 +20,9 @@ describe NodeInfoController do
       }, {
         "rel"  => "http://nodeinfo.diaspora.software/ns/schema/2.0",
         "href" => node_info_url("2.0")
+      }, {
+        "rel"  => "http://nodeinfo.diaspora.software/ns/schema/2.1",
+        "href" => node_info_url("2.1")
       }]
     end
   end
@@ -33,7 +36,7 @@ describe NodeInfoController do
       end
     end
 
-    %w(1.0 2.0).each do |version|
+    %w[1.0 2.0 2.1].each do |version|
       context "version #{version}" do
         it "responds to JSON" do
           get :document, params: {version: version}, format: :json

--- a/spec/lib/connection_tester_spec.rb
+++ b/spec/lib/connection_tester_spec.rb
@@ -106,23 +106,59 @@ describe ConnectionTester do
   end
 
   describe "#nodeinfo" do
-    let(:ni_wellknown) { {links: [{rel: ConnectionTester::NODEINFO_SCHEMA, href: "/nodeinfo"}]} }
-
-    it "reads the version from the nodeinfo document" do
-      ni_document = NodeInfo.build do |doc|
-        doc.version = "1.0"
+    def build_ni_document(version)
+      NodeInfo.build do |doc|
+        doc.version = version
         doc.open_registrations = true
         doc.protocols.protocols << "diaspora"
         doc.software.name = "diaspora"
         doc.software.version = "a.b.c.d"
       end
+    end
+
+    NodeInfo::VERSIONS.each do |version|
+      context "with version #{version}" do
+        let(:ni_wellknown) {
+          {links: [{rel: "http://nodeinfo.diaspora.software/ns/schema/#{version}", href: "/nodeinfo/#{version}"}]}
+        }
+
+        it "reads the version from the nodeinfo document" do
+          ni_document = build_ni_document(version)
+
+          stub_request(:get, "#{url}#{ConnectionTester::NODEINFO_FRAGMENT}")
+            .to_return(status: 200, body: JSON.generate(ni_wellknown))
+          stub_request(:get, "#{url}/nodeinfo/#{version}")
+            .to_return(status: 200, body: JSON.generate(ni_document.as_json))
+
+          tester.nodeinfo
+          expect(result.software_version).to eq("diaspora a.b.c.d")
+        end
+      end
+    end
+
+    it "uses the latest commonly supported version" do
+      ni_wellknown = {links: [
+        {rel: "http://nodeinfo.diaspora.software/ns/schema/1.0", href: "/nodeinfo/1.0"},
+        {rel: "http://nodeinfo.diaspora.software/ns/schema/1.1", href: "/nodeinfo/1.1"},
+        {rel: "http://nodeinfo.diaspora.software/ns/schema/2.0", href: "/nodeinfo/2.0"},
+        {rel: "http://nodeinfo.diaspora.software/ns/schema/9.0", href: "/nodeinfo/9.0"}
+      ]}
+
+      ni_document = build_ni_document("2.0")
 
       stub_request(:get, "#{url}#{ConnectionTester::NODEINFO_FRAGMENT}")
         .to_return(status: 200, body: JSON.generate(ni_wellknown))
-      stub_request(:get, "#{url}/nodeinfo").to_return(status: 200, body: JSON.generate(ni_document.as_json))
+      stub_request(:get, "#{url}/nodeinfo/2.0").to_return(status: 200, body: JSON.generate(ni_document.as_json))
 
       tester.nodeinfo
       expect(result.software_version).to eq("diaspora a.b.c.d")
+    end
+
+    it "handles no common version gracefully" do
+      ni_wellknown = {links: [{rel: "http://nodeinfo.diaspora.software/ns/schema/1.1", href: "/nodeinfo/1.1"}]}
+      stub_request(:get, "#{url}#{ConnectionTester::NODEINFO_FRAGMENT}")
+        .to_return(status: 200, body: JSON.generate(ni_wellknown))
+      expect { tester.nodeinfo }.to raise_error(ConnectionTester::NodeInfoFailure)
     end
 
     it "fails the nodeinfo document is missing" do
@@ -137,16 +173,17 @@ describe ConnectionTester do
     end
 
     it "handles a invalid jrd document gracefully" do
-      invalid_wellknown = {links: {rel: ConnectionTester::NODEINFO_SCHEMA, href: "/nodeinfo"}}
+      invalid_wellknown = {links: {rel: "http://nodeinfo.diaspora.software/ns/schema/1.0", href: "/nodeinfo/1.0"}}
       stub_request(:get, "#{url}#{ConnectionTester::NODEINFO_FRAGMENT}")
         .to_return(status: 200, body: JSON.generate(invalid_wellknown))
       expect { tester.nodeinfo }.to raise_error(ConnectionTester::NodeInfoFailure)
     end
 
     it "handles a invalid nodeinfo document gracefully" do
+      ni_wellknown = {links: [{rel: "http://nodeinfo.diaspora.software/ns/schema/1.0", href: "/nodeinfo/1.0"}]}
       stub_request(:get, "#{url}#{ConnectionTester::NODEINFO_FRAGMENT}")
         .to_return(status: 200, body: JSON.generate(ni_wellknown))
-      stub_request(:get, "#{url}/nodeinfo").to_return(status: 200, body: '{"software": "invalid nodeinfo"}')
+      stub_request(:get, "#{url}/nodeinfo/1.0").to_return(status: 200, body: '{"software": "invalid nodeinfo"}')
       expect { tester.nodeinfo }.to raise_error(ConnectionTester::NodeInfoFailure)
     end
   end

--- a/spec/presenters/node_info_presenter_spec.rb
+++ b/spec/presenters/node_info_presenter_spec.rb
@@ -171,5 +171,36 @@ describe NodeInfoPresenter do
         )
       end
     end
+
+    context "version 2.1" do
+      it "provides generic pod data in json" do
+        expect(NodeInfoPresenter.new("2.1").as_json.as_json).to eq(
+          "version"           => "2.1",
+          "software"          => {
+            "name"       => "diaspora",
+            "version"    => AppConfig.version_string,
+            "repository" => "https://github.com/diaspora/diaspora",
+            "homepage"   => "https://diasporafoundation.org/"
+          },
+          "protocols"         => ["diaspora"],
+          "services"          => {
+            "inbound"  => [],
+            "outbound" => AppConfig.configured_services.map(&:to_s)
+          },
+          "openRegistrations" => AppConfig.settings.enable_registrations?,
+          "usage"             => {
+            "users" => {}
+          },
+          "metadata"          => {
+            "nodeName" => AppConfig.settings.pod_name,
+            "camo"     => {
+              "markdown"   => AppConfig.privacy.camo.proxy_markdown_images?,
+              "opengraph"  => AppConfig.privacy.camo.proxy_opengraph_thumbnails?,
+              "remotePods" => AppConfig.privacy.camo.proxy_remote_pod_images?
+            }
+          }
+        )
+      end
+    end
   end
 end

--- a/vendor/nodeinfo/schemas/2.1.json
+++ b/vendor/nodeinfo/schemas/2.1.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "http://nodeinfo.diaspora.software/ns/schema/2.0#",
-  "description": "NodeInfo schema version 2.0.",
+  "id": "http://nodeinfo.diaspora.software/ns/schema/2.1#",
+  "description": "NodeInfo schema version 2.1.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -15,9 +15,9 @@
   ],
   "properties": {
     "version": {
-      "description": "The schema version, must be 2.0.",
+      "description": "The schema version, must be 2.1.",
       "enum": [
-        "2.0"
+        "2.1"
       ]
     },
     "software": {
@@ -36,6 +36,14 @@
         },
         "version": {
           "description": "The version of this server software.",
+          "type": "string"
+        },
+        "repository": {
+          "description": "The url of the source code repository of this server software.",
+          "type": "string"
+        },
+        "homepage": {
+          "description": "The url of the homepage of this server software.",
           "type": "string"
         }
       }


### PR DESCRIPTION
Add NodeInfo 2.1 with URL to the repo and homepage.

Also add parsing of version 2.0 and 2.1. This allows us to parse NodeInfo from other software which can't have a valid 1.0, but has a valid 2.x. It always chooses the newest version both servers support.

I also added the software version directly to the table of there weren't any errors, this allows to see easier which versions are used at the moment. It would also be cool to have a toggle to hide all pods which are offline for more than 14 days (which is also when we stop federating to that pod), probably with inactive pods hidden by default, so the list is less overloaded with offline pods ... but my frontend knowledge isn't good enough to do that myself at the moment.