### PR TITLE
Prepare the backend for generating a list of active pods

### DIFF
--- a/app/assets/javascripts/app/pages/admin_pods.js
+++ b/app/assets/javascripts/app/pages/admin_pods.js
@@ -29,6 +29,25 @@ app.pages.AdminPods = app.views.Base.extend({
 
   _showMessages: function() {
     var msgs = document.createDocumentFragment();
+    if (gon.totalCount && gon.totalCount > 0) {
+      let totalPods = $("<div class='alert alert-info' role='alert' />")
+        .append(Diaspora.I18n.t("admin.pods.total", {count: gon.totalCount}));
+      if (gon.activeCount) {
+        if (gon.activeCount === 0) {
+          totalPods
+            .append(" " + Diaspora.I18n.t("admin.pods.none_active"));
+        }
+        if (gon.activeCount === gon.totalCount) {
+          totalPods
+            .append(" " + Diaspora.I18n.t("admin.pods.all_active"));
+        } else {
+          totalPods
+            .append(" " + Diaspora.I18n.t("admin.pods.active", {count: gon.activeCount}));
+        }
+      }
+      msgs.appendChild(totalPods[0]);
+    }
+
     if( gon.uncheckedCount && gon.uncheckedCount > 0 ) {
       var unchecked = $("<div class='alert alert-info' role='alert' />")
         .append(Diaspora.I18n.t("admin.pods.unchecked", {count: gon.uncheckedCount}));

--- a/app/controllers/admin/pods_controller.rb
+++ b/app/controllers/admin/pods_controller.rb
@@ -14,7 +14,8 @@ module Admin
           gon.unchecked_count = Pod.unchecked.count
           gon.version_failed_count = Pod.version_failed.count
           gon.error_count = Pod.check_failed.count
-
+          gon.active_count = Pod.active.count
+          gon.total_count = Pod.count
           render "admins/pods"
         end
         format.mobile { render "admins/pods" }

--- a/app/models/pod.rb
+++ b/app/models/pod.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Pod < ApplicationRecord
+  # a pod is active if it is online or was online less than 14 days ago
+  ACTIVE_DAYS = 14.days
+
   enum status: %i(
     unchecked
     no_errors
@@ -39,6 +42,10 @@ class Pod < ApplicationRecord
     where(arel_table[:status].gt(Pod.statuses[:no_errors])).where.not(status: Pod.statuses[:version_failed])
   }
 
+  scope :active, -> {
+    where(["offline_since is null or offline_since > ?", DateTime.now.utc - ACTIVE_DAYS])
+  }
+
   validate :not_own_pod
 
   class << self
@@ -73,9 +80,9 @@ class Pod < ApplicationRecord
     Pod.offline_statuses.include?(Pod.statuses[status])
   end
 
-  # a pod is active if it is online or was online less than 14 days ago
+  # a pod is active if it is online or was online recently
   def active?
-    !offline? || offline_since.try {|date| date > DateTime.now.utc - 14.days }
+    !offline? || offline_since.try {|date| date > DateTime.now.utc - ACTIVE_DAYS }
   end
 
   def to_s

--- a/app/presenters/pod_presenter.rb
+++ b/app/presenters/pod_presenter.rb
@@ -10,6 +10,7 @@ class PodPresenter < BasePresenter
       status:        status,
       checked_at:    checked_at,
       response_time: response_time,
+      active:        active?,
       offline:       offline?,
       offline_since: offline_since,
       created_at:    created_at,

--- a/config/locales/javascript/javascript.en.yml
+++ b/config/locales/javascript/javascript.en.yml
@@ -70,9 +70,17 @@ en:
           other: "<%= count %>ms"
         unknown: "unknown"
         not_available: "not available"
+        total:
+          one: "There is only one known pod."
+          other: "There are <%= count %> known pods in total."
         unchecked:
           one: "There is still one pod that hasn't been checked at all."
           other: "There are still <%= count %> pods that haven't been checked at all."
+        active:
+          one: "One pod was active recently."
+          other: "<%= count %> pods were active recently."
+        none_active: "None of them were active recently."
+        all_active: "All of them were active recently."
         version_failed:
           one: "There is one pod that has no version (old pod, no NodeInfo)."
           other: "There are <%= count %> pods that have no version (old pods, no NodeInfo)."


### PR DESCRIPTION
I've heard that pods that are offline longer than 14 days should be filtered out from admin view.