### PR TITLE
Make inline code inside links show the link color.

### DIFF
--- a/app/assets/stylesheets/code.scss
+++ b/app/assets/stylesheets/code.scss
@@ -5,3 +5,12 @@ pre {
   white-space: pre;
   code { white-space: pre; }
 }
+
+// For inline-code inside links, let's force the color to the default link
+// color to make them be recognizable as links.
+p a {
+  code,
+  pre {
+    color: $link-color;
+  }
+}


### PR DESCRIPTION
Fixes #8386.

The linked issue has a screenshot of The Before. Here is what it looks with this PR in light mode:

<img width="796" alt="Screenshot 2022-08-26 at 19 45 29" src="https://user-images.githubusercontent.com/344777/186963024-f8e3f2b8-5d97-46d3-b135-384d870a7948.png">

and dark mode:

<img width="798" alt="Screenshot 2022-08-26 at 19 45 50" src="https://user-images.githubusercontent.com/344777/186963049-d1d11e57-893c-427d-8f32-50ac5ce55aa9.png">

You can't actually link around or inside multi-line code blocks, so this is enough.