### PR TITLE
Update next major to 1.0.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-# 0.8.0.0
+# 1.0.0 (unreleased)
 
 ## New configuration file!
 
@@ -6,7 +6,7 @@ We already recommended you to move to our new TOML based configuration file. Wit
 
 ## API!
 
-With the release of diaspora\* Version 0.8.0.0, we now officially support building applications on top of the diaspora\* API! Please check out [the official API documentation](https://diaspora.github.io/api-documentation/) for instructions, and please do file bugs if you notice something that could be improved!
+With the release of diaspora\* Version 1.0, we now officially support building applications on top of the diaspora\* API! Please check out [the official API documentation](https://diaspora.github.io/api-documentation/) for instructions, and please do file bugs if you notice something that could be improved!
 
 We are looking forward to seeing many creative applications!
 

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -4,7 +4,7 @@
 
 defaults:
   version:
-    number: "0.7.99.0" # Do not touch unless doing a release, do not backport the version number that's in master
+    number: "1.0.0-dev" # Do not touch unless doing a release, do not backport the version number that's in master
   heroku: false
   environment:
     url: "http://localhost:3000/"

--- a/config/load_config.rb
+++ b/config/load_config.rb
@@ -42,7 +42,7 @@ AppConfig ||= Configurate::Settings.create do
                  File.join(config_dir, "diaspora.toml"),
                  namespace: "configuration", required: false
   else
-    warn "WARNING: diaspora.yml is deprecated and will no longer be read in diaspora 0.9."
+    warn "WARNING: diaspora.yml is deprecated and will no longer be read in diaspora 2.0."
     warn "         Please copy over diaspora.toml.example to diaspora.toml and migrate your settings from diaspora.yml."
 
     add_provider Configurate::Provider::YAML,


### PR DESCRIPTION
As [it is official now](https://blog.diasporafoundation.org/74-diaspora-s-10-years-in-community-hands) that the next major release will be 1.0, I changed the changelog to that version. I also added an "unreleased" note next to it, as I have seen similar things in other projects and I like it, as it makes clear that these changes aren't in any official release yet.

I also changed the deprecation warning for the `diaspora.yml` to 2.0, as this will be the next major release now, where support for the old config will be removed.

I also changed the milestone on GitHub to [1.0.0](https://github.com/diaspora/diaspora/milestone/35)