### PR TITLE
Fixes for two date-related spec breakages

### DIFF
--- a/spec/workers/queue_users_for_removal_spec.rb
+++ b/spec/workers/queue_users_for_removal_spec.rb
@@ -22,7 +22,7 @@ describe Workers::QueueUsersForRemoval do
       user = FactoryBot.create(:user, last_seen: Time.zone.now - 732.days, sign_in_count: 5)
       Workers::QueueUsersForRemoval.new.perform
       user.reload
-      expect(user.remove_after.to_i).to eq(removal_date.utc.to_i)
+      expect(user.remove_after.to_i).to be_within(1.day).of(removal_date.utc.to_i)
       expect(ActionMailer::Base.deliveries.count).to eq(1)
     end
 
@@ -31,7 +31,7 @@ describe Workers::QueueUsersForRemoval do
       user = FactoryBot.create(:user, last_seen: Time.zone.now - 735.days, sign_in_count: 0)
       Workers::QueueUsersForRemoval.new.perform
       user.reload
-      expect(user.remove_after.to_i).to eq(removal_date.utc.to_i)
+      expect(user.remove_after.to_i).to be_within(1.day).of(removal_date.utc.to_i)
       expect(ActionMailer::Base.deliveries.count).to eq(0) # no email sent
     end
 


### PR DESCRIPTION
Two fixes,

1. an adjustment to `queue_users_for_removal_spec.rb` that doesn't check exact dates, but allows for a bit of tolerance (1 day). This is to accord for the timespan where the spec runs before a DST shift, but the "30 days" in the future is already after the DST switch. In those cases, the difference has been 30 days + 1 hour, and thus the test fails. Checking with 1 day of tolerance is what we do in `pod_spec.rb`, so it seems appropriate.
2. A change to `check_birthday_spec.rb` to no longer use the 9th of September as a fixed birthday, causing the specs to fail on that specific date. This fixes #8394.