### PR TITLE
Fix docker development setup after switch to puma

### DIFF
--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7-slim-bullseye
+FROM amd64/ruby:2.7-slim-bullseye
 
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update && \

--- a/docker/develop/docker-compose.yml
+++ b/docker/develop/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - ${DIASPORA_DOCKER_PORT:-3000}:3000
     environment:
       - ENVIRONMENT_REDIS=redis://redis
+      - SERVER_LISTEN=tcp://0.0.0.0:3000
     depends_on:
       - "${DIASPORA_DOCKER_DB}"
       - redis

--- a/docker/develop/docker-compose.yml
+++ b/docker/develop/docker-compose.yml
@@ -1,6 +1,7 @@
 version: "3.4"
 
 volumes:
+  redis_data:
   postgresql_data:
   mysql_data:
   dia_data_tmp:
@@ -21,8 +22,17 @@ services:
       - dia_data_bundle:/diaspora/vendor/bundle
     ports:
       - ${DIASPORA_DOCKER_PORT:-3000}:3000
+    environment:
+      - ENVIRONMENT_REDIS=redis://redis
     depends_on:
       - "${DIASPORA_DOCKER_DB}"
+      - redis
+
+  redis:
+    image: redis:7
+    command: redis-server --save 60 1 --loglevel warning
+    volumes:
+      - redis_data:/data
 
   postgresql:
     image: postgres:10.3

--- a/script/diaspora-dev
+++ b/script/diaspora-dev
@@ -208,6 +208,11 @@ dia_is_db_running() {
   dia_docker_compose ps --services --filter status=running | grep -qx $DIASPORA_DOCKER_DB
 }
 
+dia_is_redis_running() {
+  # Check if redis container is running
+  dia_docker_compose ps --services --filter status=running | grep -qx redis
+}
+
 dia_get_db() {
   # Get currently configured or assumed db type
   grep -q '^  <<: \*mysql' "$DIASPORA_CONFIG_DB" 2>/dev/null && echo mysql || echo postgresql
@@ -324,13 +329,14 @@ dia_exec() {
     # Use a running container
     dia_docker_compose exec $detach diaspora /exec-entrypoint.sh "$@"
   else
-    if ! dia_is_db_running; then not_running=1; fi
+    # stop db/redis if it was not running before
+    if ! dia_is_db_running; then stopdb="dia_docker_compose stop $DIASPORA_DOCKER_DB"; fi
+    if ! dia_is_redis_running; then stopredis="dia_docker_compose stop redis"; fi
     # Start a new container
     echo "No running instance found, starting new one for command execution ..."
     dia_docker_compose run --rm $detach --service-ports diaspora "$@"
-    if [ ! -z $not_running ]; then
-      dia_docker_compose stop $DIASPORA_DOCKER_DB
-    fi
+    $stopdb
+    $stopredis
   fi
 }
 
@@ -449,24 +455,28 @@ dia_setup() {
 
 dia_setup_rails() {
   # Prepare rails, install dependencies, migrate database, ...
-  # stop db if it was not running before
   echo "Setting up environment for tests ..."
+  # stop db/redis if it was not running before
   if ! dia_is_db_running; then stopdb="dia_docker_compose stop $DIASPORA_DOCKER_DB"; fi
+  if ! dia_is_redis_running; then stopredis="dia_docker_compose stop redis"; fi
   dia_docker_compose run --rm diaspora bin/setup
   $stopdb
+  $stopredis
 }
 
 dia_setup_tests() {
   # Prepare all possible tests
-  # stop db if it was not running before
   echo "Setting up environment for tests ..."
+  # stop db/redis if it was not running before
   if ! dia_is_db_running; then stopdb="dia_docker_compose stop $DIASPORA_DOCKER_DB"; fi
+  if ! dia_is_redis_running; then stopredis="dia_docker_compose stop redis"; fi
   dia_docker_compose run \
     --rm \
     -e RAILS_ENV=test \
     diaspora \
     bin/rake db:create db:migrate tests:generate_fixtures assets:generate_error_pages
   $stopdb
+  $stopredis
 }
 
 dia_start() {

--- a/script/diaspora-dev
+++ b/script/diaspora-dev
@@ -44,6 +44,10 @@ print_usage() {
       print_usage_header "clean [options]" \
         "    --config    Delete configuration files as well"
       ;;
+    docker-compose)
+      echo; echo "Run docker-compose commands with the required environment variables"
+      print_usage_header "docker-compose [options]"
+      ;;
   # test & development
     cucumber)
       echo; echo "Run cucumber tests"
@@ -136,30 +140,31 @@ print_usage_full() {
   print_usage_header "$SCRIPT_NAME COMMAND"
   echo
   echo "Management Commands:"
-  echo "  setup         Prepare diaspora* to run for development"
-  echo "  start         Start diaspora*"
-  echo "  stop          Stop diaspora*"
-  echo "  restart       Restart of diaspora*"
-  echo "  logs          Follow log output of diaspora*"
-  echo "  status        Show current instance status of diaspora*"
-  echo "  clean         Reset diaspora* instance"
+  echo "  setup            Prepare diaspora* to run for development"
+  echo "  start            Start diaspora*"
+  echo "  stop             Stop diaspora*"
+  echo "  restart          Restart of diaspora*"
+  echo "  logs             Follow log output of diaspora*"
+  echo "  status           Show current instance status of diaspora*"
+  echo "  clean            Reset diaspora* instance"
+  echo "  docker-compose   Run docker-compose commands"
   echo
   echo "Test and Development Commands:"
-  echo "  cucumber      Run cucumber tests"
-  echo "  jasmine       Run jasmine tests"
-  echo "  rspec         Run rspec tests"
-  echo "  pronto        Run pronto checks"
-  echo "  migrate       Execute pending migrations"
+  echo "  cucumber         Run cucumber tests"
+  echo "  jasmine          Run jasmine tests"
+  echo "  rspec            Run rspec tests"
+  echo "  pronto           Run pronto checks"
+  echo "  migrate          Execute pending migrations"
   echo
   echo "Misc. Commands:"
-  echo "  build         Build basic diaspora* environment"
-  echo "  bundle        (Re-)Install gems for diaspora*"
-  echo "  yarn          (Re-)Install frontend dependencies for diaspora*"
-  echo "  config        Configure diaspora*"
-  echo "  exec          Execute a command in the run environment (advanced)"
-  echo "  help          Show help for commands"
-  echo "  setup-rails   Prepare diaspora* development environment (install dependencies, migrate db)"
-  echo "  setup-tests   Prepare diaspora* test environment"
+  echo "  build            Build basic diaspora* environment"
+  echo "  bundle           (Re-)Install gems for diaspora*"
+  echo "  yarn             (Re-)Install frontend dependencies for diaspora*"
+  echo "  config           Configure diaspora*"
+  echo "  exec             Execute a command in the run environment (advanced)"
+  echo "  help             Show help for commands"
+  echo "  setup-rails      Prepare diaspora* development environment (install dependencies, migrate db)"
+  echo "  setup-tests      Prepare diaspora* test environment"
   echo
   echo "Run '$SCRIPT_NAME help COMMAND' for more information on a command."
 }
@@ -555,6 +560,9 @@ case "$dia_command" in
     ;;
   cucumber)
     dia_cucumber "$@"
+    ;;
+  docker-compose)
+    dia_docker_compose "$@"
     ;;
   exec)
     dia_exec "$@"


### PR DESCRIPTION
* #8392 removed `single_process_mode`, which means it now requires a redis instance for development setups. This wasn't the case yet in our docker setup, so it failed to start because it didn't find redis. I added a redis container to our docker-compose setup.
* #8392 also changed the default `listen` configuration for development to only listen on localhost. While this is a good default for normal development setups to not expose a port, it also broke our docker setup because the port now couldn't be forwarded outside of the docker container anymore. So I change this back to the old default when used with docker.
* I also exposed the `docker-compose` command outside of the `diaspora-dev` script, so I'm able to run normal `docker-compose` commands directly without needing to manually set the correct environment variable that are required by our `docker-compose.yml`.

For the configurations for `redis` and `listen`, I overwrite the values set in the `diaspora.toml` as environment variables in the `docker-compose.yml`, as otherwise everybody would need to ensure that the configure the correct settings themselves in their `diaspora.toml`. That way it ensures that you can't break the docker-setup with a wrong setting, but can still set different settings in the `diaspora.toml` when running without docker.