### PR TITLE
Escape mentions before parsing message with markdown for mobile UI

### DIFF
--- a/lib/diaspora/mentionable.rb
+++ b/lib/diaspora/mentionable.rb
@@ -71,6 +71,16 @@ module Diaspora::Mentionable
     }
   end
 
+  # Escapes special chars in mentions to not be parsed as markdown
+  #
+  # @param [String] text containing mentions
+  # @return [String] escaped message
+  def self.escape_for_markdown(msg_text)
+    msg_text.to_s.gsub(REGEX) {|match_str|
+      match_str.gsub("_", "\\_")
+    }
+  end
+
   private_class_method def self.find_or_fetch_person_by_identifier(identifier)
     Person.find_or_fetch_by_identifier(identifier) if Validation::Rule::DiasporaId.new.valid_value?(identifier)
   rescue DiasporaFederation::Discovery::DiscoveryError

--- a/lib/diaspora/message_renderer.rb
+++ b/lib/diaspora/message_renderer.rb
@@ -71,6 +71,10 @@ module Diaspora
         end
       end
 
+      def escape_mentions_for_markdown
+        @message = Diaspora::Mentionable.escape_for_markdown(message)
+      end
+
       def render_mentions
         unless options[:disable_hovercards] || options[:mentioned_people].empty?
           @message = Diaspora::Mentionable.format message, options[:mentioned_people]
@@ -210,6 +214,7 @@ module Diaspora
         normalize
         diaspora_links
         camo_urls if AppConfig.privacy.camo.proxy_markdown_images?
+        escape_mentions_for_markdown
         markdownify
         render_mentions
         render_tags

--- a/spec/lib/diaspora/message_renderer_spec.rb
+++ b/spec/lib/diaspora/message_renderer_spec.rb
@@ -183,6 +183,16 @@ describe Diaspora::MessageRenderer do
         ).to match(/hovercard/)
       end
 
+      it "does not parse mentions as markdown" do
+        new_person = FactoryBot.create(:person, diaspora_handle: "__underscore__@example.org")
+        expect(
+          message(
+            "Hey @{#{new_person.diaspora_handle}}!",
+            mentioned_people: [new_person]
+          ).markdownified
+        ).to match(%r{>#{new_person.name}</a>})
+      end
+
       it 'should process text with both a hashtag and a link' do
         expect(
           message("Test #tag?\nhttps://joindiaspora.com\n").markdownified


### PR DESCRIPTION
Usernames that contained underscores were parsed by markdown first. This broke the diaspora IDs and also added weird html at places where it wasn't needed. Escaping them before sending the message through the markdown parser fixes this issue.

As underscores are the only allowed character that can be used for markdown that is also allowed inside a diaspora ID, this escaping can be kept pretty simple.

Initially I also added `escape_mentions_for_markdown` in the `plain_text_for_json`, which then gets used for the desktop UI. This kind-of fixes the issue also there, but I then decided to revert it again after thinking more about it. I think this is better fixed in the markdown-it parser for the desktop UI directly (so probably with the [`markdown-it-diaspora-mention`](https://github.com/diaspora/markdown-it-diaspora-mention) plugin?). Here are my thoughts about it:
* While fixing it the same way as for mobile worked, it didn't work for the preview. Handling it in `markdown-it-diaspora-mention` would also fix it in the preview.
* Adding it to `plain_text_for_json` would also escape it for the API. While it might be cool that not all clients need to handle that themselves, I don't think it's a good thing to do and this was the main reason I reverted it again. I initially thought, that we could use the escaping in the backend for now, until we have a proper solution in the frontend, but when we then remove the backend-escaping again, that would be a "breaking change" for the API too. Also the escaping only works, if you parse the post through markdown FIRST, before handling the mentions, the other way around the escaping would break the mentions. And I don't know if all clients using the API are doing it in that order. So I think it's better for all clients to handle this themselves, and either also escape it themselves, or do whatever is needed to parse it properly.

Related to #7975 (fixes it for mobile only)