### PR TITLE
Add pull command to diaspora-dev script

### DIFF
--- a/docker/develop/docker-compose.yml
+++ b/docker/develop/docker-compose.yml
@@ -23,8 +23,8 @@ services:
     ports:
       - ${DIASPORA_DOCKER_PORT:-3000}:3000
     environment:
-      - ENVIRONMENT_REDIS=redis://redis
-      - SERVER_LISTEN=tcp://0.0.0.0:3000
+      ENVIRONMENT_REDIS: redis://redis
+      SERVER_LISTEN: tcp://0.0.0.0:3000
     depends_on:
       - "${DIASPORA_DOCKER_DB}"
       - redis
@@ -36,14 +36,16 @@ services:
       - redis_data:/data
 
   postgresql:
-    image: postgres:10.3
+    image: postgres:15
     ports:
       - 55432:5432
     volumes:
       - postgresql_data:/var/lib/postgresql
+    environment:
+      POSTGRES_PASSWORD: postgres
 
   mysql:
-    image: mariadb:10.2
+    image: mariadb:10.9
     ports:
       - 53306:3306
     volumes:

--- a/script/diaspora-dev
+++ b/script/diaspora-dev
@@ -10,7 +10,8 @@ print_usage() {
     setup)
       echo; echo "Set up the environment for diaspora*"
       echo; echo "This command is an alias for the execution of the commands"
-      echo "build, config, bundle, migrate and setup-tests, in that order."
+      echo "build, config, pull, bundle, setup-rails and setup-tests, in that order."
+      echo; echo "This command can also be used to update the environment again."
       print_usage_header "setup [options]" \
         "    --force    Rebuild image without using Docker's cache;" \
         "               overwrite existing configuration" \
@@ -79,6 +80,10 @@ print_usage() {
       echo; echo "(Re-)Build Docker image diaspora:dev-latest"
       print_usage_header "build [options]" \
         "    --no-cache    Rebuild image without using Docker's cache"
+      ;;
+    pull)
+      echo; echo "Pull docker images needed for the development environment"
+      print_usage_header "pull"
       ;;
     bundle)
       echo; echo "Install gems using bundle into $DIASPORA_ROOT"
@@ -158,6 +163,7 @@ print_usage_full() {
   echo
   echo "Misc. Commands:"
   echo "  build            Build basic diaspora* environment"
+  echo "  pull             Update docker images"
   echo "  bundle           (Re-)Install gems for diaspora*"
   echo "  yarn             (Re-)Install frontend dependencies for diaspora*"
   echo "  config           Configure diaspora*"
@@ -228,7 +234,11 @@ dia_get_db() {
 dia_build() {
   if [ $# -gt 0 ] && [ "$1" == "--no-cache" ]; then nocache="--no-cache"; fi
   # Build the diaspora Docker container (diaspora:dev-latest)
-  dia_docker_compose build $nocache diaspora
+  dia_docker_compose build --pull $nocache diaspora
+}
+
+dia_pull() {
+  dia_docker_compose pull redis $(dia_get_db)
 }
 
 dia_bundle() {
@@ -450,6 +460,7 @@ dia_setup() {
     set -e
     dia_build $build
     dia_config $config
+    dia_pull
     dia_bundle
     dia_setup_rails
     dia_setup_tests
@@ -578,6 +589,9 @@ case "$dia_command" in
     ;;
   pronto)
     dia_pronto
+    ;;
+  pull)
+    dia_pull
     ;;
   restart)
     dia_restart "$@"


### PR DESCRIPTION
Before the images were only pulled once and then never updated which lead to really outdated images and OS dependencies. Now all images (including the base image for the diaspora container when it gets built) are pulled when running `setup`. So the idea is to run the `setup` command from time to time to bring everything up to date again.

I also updated to use the latest postgres 10 image. This is currently still supported, but we probably should think about upgrading to newer postgres versions. But as https://github.com/docker-library/postgres/issues/37 is still not fixed, this isn't that easy. I don't know if we could just upgrade to a newer versions and tell devs to start a fresh database (so nothing needs to be migrated), or we we need to provide an upgrade path somehow?

Also, the used mariadb version isn't even supported anymore, but there I know even less about how to handle upgrades (so I didn't touch that for now). Apparently it also requires manually running a command. But as we only have this for the rare case that we need to debug something with it, it might be fine to just force that to a new version and create a fresh database when we need to debug something?