### PR TITLE
Add redirect to mobile-only photo URL when in desktop UI

### DIFF
--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -13,9 +13,17 @@ class PhotosController < ApplicationController
                current_user.photos_from(Person.find_by(guid: params[:person_id])).where(id: params[:id]).first
              else
                Photo.where(id: params[:id], public: true).first
-    end
+             end
 
     raise ActiveRecord::RecordNotFound unless @photo
+
+    respond_to do |format|
+      format.html {
+        post = @photo.status_message
+        redirect_to post ? post_path(post) : @photo.url
+      }
+      format.mobile { render "photos/show" }
+    end
   end
 
   def index

--- a/spec/controllers/photos_controller_spec.rb
+++ b/spec/controllers/photos_controller_spec.rb
@@ -230,6 +230,19 @@ describe PhotosController, :type => :controller do
       expect(response).to be_successful
     end
 
+    it "should redirect to the post of the photo when not on mobile" do
+      alices_post = alice.post(:status_message, text: "Post with photo", to: alice.aspects.first.id, public: false)
+      @alices_photo.update(status_message: alices_post)
+
+      get :show, params: {person_id: alice.person.guid, id: @alices_photo.id}
+      expect(response).to redirect_to(post_path(alices_post))
+    end
+
+    it "should redirect to the photo file when not on mobile and no post exists" do
+      get :show, params: {person_id: alice.person.guid, id: @alices_photo.id}
+      expect(response).to redirect_to(@alices_photo.url)
+    end
+
     it "doesn't leak private photos to the public" do
       sign_out :user
       expect {


### PR DESCRIPTION
This URL is only used in the mobile UI, but when somebody then copies the link and sends it to somebody on the desktop UI, they don't see anything. So lets just redirect to the post containing the photo, so there is at least something to show.

If there is no linked post, just redirect to the image instead.

Fixes #8352