### PR TITLE
Fix running Cucumber in Docker

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -26,7 +26,11 @@ Capybara.server = :webrick
 
 Capybara.register_driver :apparition do |app|
   # Pass headless: false here if you need to see the browser
-  Capybara::Apparition::Driver.new(app, headless: true)
+  Capybara::Apparition::Driver.new(
+    app,
+    headless:        true,
+    browser_options: %i[no_sandbox disable_setuid_sandbox disable_gpu]
+  )
 end
 Capybara.javascript_driver = :apparition
 


### PR DESCRIPTION
After I spent [too much time] yelling at Apparition and monkey-patching their code to add some basic error handling, ... I realized the reason why Cukes don't run in Docker is simply because Chrome's sandbox explodes. [This isn't new or surprising](https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#setting-up-chrome-linux-sandbox), and would have been a 5-minute-task if Apparition bothered to show that Chrome crashes.

Anyway. Since we're only ever running our own code, the security implications of disabling the sandbox are negligible. And since we ship the dev-docker image, I think this is worth it.

~~A second commit replaces `webrick` with `puma`, because it's 2022.~~ Nevermind - switching to Puma for Cukes changes the timing so much that I apparently create a bunch of new heisenbugs. I... I removed that commit and I'll act like I did see nothing.