### PR TITLE
Add info links (the ones in the footer in the desktop version) into the drawer for mobile

### DIFF
--- a/app/assets/stylesheets/mobile/header.scss
+++ b/app/assets/stylesheets/mobile/header.scss
@@ -145,6 +145,9 @@ $mobile-navbar-height: 46px;
     bottom: 0;
     overflow: auto;
     width: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
 
     li {
       font-size: 1.8rem;
@@ -194,6 +197,21 @@ $mobile-navbar-height: 46px;
     list-style: none;
     margin: 0;
     padding: 0;
+  }
+
+  .info-links {
+    li {
+      font-size: 1.2rem;
+      line-height: 1.2;
+    }
+
+    a {
+      padding: 8px 25px;
+    }
+
+    .switch-to-touch {
+      display: none;
+    }
   }
 }
 

--- a/app/views/layouts/_drawer.mobile.haml
+++ b/app/views/layouts/_drawer.mobile.haml
@@ -61,3 +61,6 @@
             = t("admins.admin_bar.report")
       %li= link_to t("layouts.application.switch_to_standard_mode"), toggle_mobile_path
       %li= link_to t("layouts.header.logout"), destroy_user_session_path, method: :delete
+
+    %ul.info-links
+      = render "shared/links"

--- a/app/views/shared/_links.haml
+++ b/app/views/shared/_links.haml
@@ -4,8 +4,8 @@
   source_url.to_s,
   title: t("layouts.application.source_package")
 %li= link_to t("layouts.application.statistics_link"), statistics_path
-%li= link_to t("layouts.application.switch_to_touch_optimized_mode"), toggle_mobile_path
 - if AppConfig.settings.terms.enable?
   %li= link_to t("_terms"), terms_path
 - unless AppConfig.admins.podmin_email.nil?
   %li= mail_to AppConfig.admins.podmin_email, t("_podmin_mail")
+%li.switch-to-touch= link_to t("layouts.application.switch_to_touch_optimized_mode"), toggle_mobile_path


### PR DESCRIPTION
Fixes #7949
![Capture d’écran 2022-10-31 à 12 14 50](https://user-images.githubusercontent.com/930064/198995648-c8c408f7-9dd3-470f-aa05-ffa291703adc.png)

Here is how it looks for a 360x760 phone. For even older phone (360x640), there is no space and the user can scroll:

![image](https://user-images.githubusercontent.com/930064/198995414-48a0204e-1d71-49b6-adb2-425db1272ff4.png)

