### PR TITLE
Do not show the service to the user if it is disabled, fixes #6184

### DIFF
--- a/app/helpers/publisher_helper.rb
+++ b/app/helpers/publisher_helper.rb
@@ -5,6 +5,10 @@
 #   the COPYRIGHT file.
 
 module PublisherHelper
+  def available_services
+    current_user.services.select {|service| AppConfig.configured_services.map(&:to_s).include? service.provider }
+  end
+
   def service_button(service)
     provider_title = I18n.t("services.index.share_to", provider: service.provider.titleize)
     content_tag :div,

--- a/app/views/publisher/_publisher.html.haml
+++ b/app/views/publisher/_publisher.html.haml
@@ -57,7 +57,8 @@
           .btn-toolbar.pull-right#publisher-service-icons
             - if current_user.services
               - current_user.services.each do |service|
-                = service_button(service)
+                - if AppConfig.configured_services.map(&:to_s).include? service.provider
+                  = service_button(service)
             .btn.btn-link.question_mark{title: t("shared.public_explain.manage"),
                            data: {toggle: "modal", target: "#publicExplainModal"}}
               %i.entypo-cog

--- a/app/views/publisher/_publisher.html.haml
+++ b/app/views/publisher/_publisher.html.haml
@@ -55,10 +55,9 @@
             %button.btn.btn-group.btn-primary#submit= t("shared.publisher.share")
 
           .btn-toolbar.pull-right#publisher-service-icons
-            - if current_user.services
-              - current_user.services.each do |service|
-                - if AppConfig.configured_services.map(&:to_s).include? service.provider
-                  = service_button(service)
+            - available_services.each do |service|
+              = service_button(service)
+
             .btn.btn-link.question_mark{title: t("shared.public_explain.manage"),
                            data: {toggle: "modal", target: "#publicExplainModal"}}
               %i.entypo-cog

--- a/app/views/publisher/_publisher.mobile.haml
+++ b/app/views/publisher/_publisher.mobile.haml
@@ -11,11 +11,10 @@
   = hidden_field_tag "aspect_ids[]", "all_aspects"
   .form-group
     %span#publisher-service-icons
-      - if current_user.services
-        - for service in current_user.services
-          = image_tag "social-media-logos/#{service.provider}-32x32.png",
-            title: service.provider.titleize, class: "service_icon dim",
-            id: "#{service.provider}", maxchar: "#{service.class::MAX_CHARACTERS}"
+      - available_services.each do |service|
+        = image_tag "social-media-logos/#{service.provider}-32x32.png",
+                    title: service.provider.titleize, class: "service_icon dim",
+                    id:    service.provider, maxchar: service.class::MAX_CHARACTERS.to_s
 
     .clear
     #publisher-textarea-wrapper

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -202,5 +202,9 @@ test:
       enable: true
       key: 'fake'
       secret: 'sdoigjosdfijg'
+    tumblr:
+      enable: true
+      key: 'fake'
+      secret: 'sdoigjosdfijg'
   mail:
     enable: true

--- a/spec/helpers/publisher_helper_spec.rb
+++ b/spec/helpers/publisher_helper_spec.rb
@@ -1,6 +1,25 @@
 # frozen_string_literal: true
 
 describe PublisherHelper, type: :helper do
+  describe "#available_services" do
+    include Devise::Test::ControllerHelpers
+
+    before do
+      @user = alice
+
+      @user.services << FactoryBot.build(:service, type: "Services::Wordpress", provider: "wordpress")
+      @user.services << FactoryBot.build(:service, type: "Services::Tumblr", provider: "tumblr")
+
+      def current_user
+        @user
+      end
+    end
+
+    it "returns only the connected and enabled services" do
+      expect(available_services.map(&:provider)).to eq(%w[tumblr])
+    end
+  end
+
   describe "#public_selected?" do
     it "returns true when the selected_aspects contains 'public'" do
       expect(helper.public_selected?(["public"])).to be_truthy


### PR DESCRIPTION
I was wondering if we should disconnect all users if we detect that the podmin changed the config to disable the service, but first of all config change isn't easy to detect, and second I think that if the podmin then re-enables it it would be a shame to ask all users to reconnect.