### PR TITLE
Tell users that there is no help in mobile version, allow to switch to desktop

### DIFF
--- a/app/views/help/faq.mobile.haml
+++ b/app/views/help/faq.mobile.haml
@@ -1,5 +1,4 @@
-%h2
-  = t(".pod_network")
+%h1= t("_help")
 
 .alert.alert-warning
   != t("error_messages.mobile_not_available",

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -89,6 +89,8 @@ en:
       correct_the_following_errors_and_try_again: "Correct the following errors and try again."
     need_javascript: "This website requires JavaScript to function properly. If you disabled JavaScript, please enable it and refresh this page."
     csrf_token_fail: "The CSRF token is invalid. Please sign in and try again."
+    mobile_not_available: "This page is not available on mobile view, please switch to %{desktop_link}."
+    desktop_view_link: "desktop view"
 
   admins:
     admin_bar:
@@ -192,8 +194,6 @@ en:
       tag_name: "Tag name: %{name_tag} Count: %{count_tag}"
     pods:
       pod_network: "Pod network"
-      pod_desktop_view: "This page is not available on mobile view, please switch to %{desktop_link}."
-      pod_desktop_link: "desktop view"
   aspects:
     edit:
       confirm_remove_aspect: "Are you sure you want to delete this aspect?"

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -7,10 +7,9 @@ describe HelpController, type: :controller do
       expect(response).to be_successful
     end
 
-    it "fails on mobile" do
-      expect {
-        get :faq, format: :mobile
-      }.to raise_error ActionController::UnknownFormat
+    it "succeeds on mobile" do
+      get :faq, format: :mobile
+      expect(response).to be_successful
     end
   end
 end


### PR DESCRIPTION
Fixes #4821

Here is how it looks:

![image](https://user-images.githubusercontent.com/930064/199129337-7436a98a-4956-40e7-b4b9-2792acf5c0d9.png)
