### PR TITLE
Add app smart banner to web site when using an iOS device

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,6 +13,14 @@ module ApplicationHelper
     AppConfig.version.number
   end
 
+  def uri_with_username
+    if user_signed_in?
+      AppConfig.pod_uri + "?username=#{current_user.username}"
+    else
+      AppConfig.pod_uri
+    end
+  end
+
   def changelog_url
     return AppConfig.settings.changelog_url.get if AppConfig.settings.changelog_url.present?
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,6 +6,7 @@
 %html{lang: I18n.locale.to_s, dir: (rtl? ? "rtl" : "ltr")}
   %head{prefix: og_prefix}
     %meta{name: "viewport", content: "width=device-width, initial-scale=1"}/
+    %meta{name: "apple-itunes-app", content: "app-id=1538074832, app-argument=#{uri_with_username}"}
 
     - content_for :javascript do
       = javascript_include_tag :main

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -165,4 +165,34 @@ describe ApplicationHelper, :type => :helper do
       expect(pod_version).to match "0.0.1.0"
     end
   end
+
+  describe "#uri_with_username" do
+    attr_reader :current_user
+
+    before do
+      @current_user = alice
+      def user_signed_in?
+        true
+      end
+    end
+
+    it "displays the pod uri and username if logged in" do
+      allow(AppConfig).to receive(:pod_uri) { "https://diaspora.social" }
+      expect(uri_with_username).to match "https://diaspora.social?username=alice"
+    end
+  end
+
+  describe "#uri_with_username without logged in user" do
+    before do
+      @current_user = alice
+      def user_signed_in?
+        false
+      end
+    end
+
+    it "displays the pod uri" do
+      allow(AppConfig).to receive(:pod_uri) { "https://diaspora.social" }
+      expect(uri_with_username).to match "https://diaspora.social"
+    end
+  end
 end


### PR DESCRIPTION
As Inspiration App looms on the horizon, an app smart banner would help iOS user to find the app in the store and to inform them that there is an app. 

A app smart banner is shown in the header of the web site if it is open on an iOS device.
The user is then informed that an app exists for diaspora and can be redirected directly to the store.
When a user ever discarded the message its never shown again. Has the user the app already installed, the "install" button changes to "open app". 

It helps spreading the information that there is an official app for diaspora. 