### PR TITLE
Allow DOCKER_HOST env var for diaspora-dev docker setup

### DIFF
--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/ruby:2.7-slim-bullseye
+FROM docker.io/amd64/ruby:2.7-slim-bullseye
 
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update && \

--- a/script/diaspora-dev
+++ b/script/diaspora-dev
@@ -179,8 +179,10 @@ print_usage_full() {
 # ----- Helper functions -----
 
 dia_docker_compose() {
+  local docker_socket="${DOCKER_HOST:-"unix:///var/run/docker.sock"}"
+  docker_socket="${docker_socket#unix://}"
   # Check permissions of docker socket and use sudo if needed
-  if [ -r "/var/run/docker.sock" ] && [ -w "/var/run/docker.sock" ]; then
+  if [ -r "${docker_socket}" ] && [ -w "${docker_socket}" ]; then
     docker-compose "$@"
   else
     echo "Attention: Docker socket not writable, using sudo for the docker command. You might be asked for your password now." >&2


### PR DESCRIPTION
This allows to use rootless podman (which doesn't require sudo) instead of docker.