### PR TITLE
Cleanup unicode emojis from email headers

### DIFF
--- a/app/mailers/notification_mailers/base.rb
+++ b/app/mailers/notification_mailers/base.rb
@@ -36,13 +36,21 @@ module NotificationMailers
 
     def default_headers
       from_name = AppConfig.settings.pod_name
-      from_name += " (#{@sender.profile.full_name.empty? ? @sender.username : @sender.name})" if @sender.present?
+      from_name += " (#{person_name(@sender)})" if @sender.present?
 
       {
         from:          name_and_address(from_name, AppConfig.mail.sender_address),
-        to:            name_and_address(@recipient.name, @recipient.email),
+        to:            name_and_address(person_name(@recipient), @recipient.email),
         template_name: self.class.name.demodulize.underscore
       }
+    end
+
+    def person_name(person)
+      if person.profile.full_name.empty?
+        person.username
+      else
+        person.name.gsub(/\p{Emoji}\uFE0F\u20E3?|\p{Emoji_Presentation}/, "").strip
+      end
     end
 
     def with_recipient_locale(&block)

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -262,6 +262,11 @@ describe Notifier, type: :mailer do
       expect(@mail["From"].to_s).to eq("\"#{pod_name} (#{@cnv.author.name})\" <#{AppConfig.mail.sender_address}>")
     end
 
+    it "FROM: removes emojis from sender's name" do
+      bob.person.profile.update!(first_name: "1️⃣2️3️⃣ Numbers 123", last_name: "👍✅👍🏻Emojis😀😇❄️")
+      expect(@mail["From"].to_s).to eq("\"#{pod_name} (Numbers 123 Emojis)\" <#{AppConfig.mail.sender_address}>")
+    end
+
     it "should use a generic subject" do
       expect(@mail.subject).to eq(I18n.translate("notifier.private_message.subject"))
     end
@@ -300,6 +305,12 @@ describe Notifier, type: :mailer do
 
       it "FROM: contains the sender's name" do
         expect(comment_mail["From"].to_s).to eq("\"#{pod_name} (#{eve.name})\" <#{AppConfig.mail.sender_address}>")
+      end
+
+      it "FROM: removes emojis from sender's name" do
+        eve.person.profile.update!(first_name: "1️⃣2️3️⃣ Numbers 123", last_name: "👍✅👍🏻Emojis😀😇❄️")
+        expect(comment_mail["From"].to_s)
+          .to eq("\"#{pod_name} (Numbers 123 Emojis)\" <#{AppConfig.mail.sender_address}>")
       end
 
       it "SUBJECT: has a snippet of the post contents, without markdown and without newlines" do
@@ -390,6 +401,11 @@ describe Notifier, type: :mailer do
           expect(mail["From"].to_s).to eq("\"#{pod_name} (#{bob.name})\" <#{AppConfig.mail.sender_address}>")
         end
 
+        it "FROM: removes emojis from sender's name" do
+          bob.person.profile.update!(first_name: "1️⃣2️3️⃣ Numbers 123", last_name: "👍✅👍🏻Emojis😀😇❄️")
+          expect(mail["From"].to_s).to eq("\"#{pod_name} (Numbers 123 Emojis)\" <#{AppConfig.mail.sender_address}>")
+        end
+
         it "SUBJECT: does not show the limited post" do
           expect(mail.subject).not_to include("Limited headline")
         end
@@ -413,6 +429,11 @@ describe Notifier, type: :mailer do
 
         it "FROM: contains the sender's name" do
           expect(mail["From"].to_s).to eq("\"#{pod_name} (#{bob.name})\" <#{AppConfig.mail.sender_address}>")
+        end
+
+        it "FROM: removes emojis from sender's name" do
+          bob.person.profile.update!(first_name: "1️⃣2️3️⃣ Numbers 123", last_name: "👍✅👍🏻Emojis😀😇❄️")
+          expect(mail["From"].to_s).to eq("\"#{pod_name} (Numbers 123 Emojis)\" <#{AppConfig.mail.sender_address}>")
         end
 
         it "SUBJECT: does not show the limited post" do
@@ -444,6 +465,11 @@ describe Notifier, type: :mailer do
 
       it "FROM: contains the sender's name" do
         expect(mail["From"].to_s).to eq("\"#{pod_name} (#{bob.name})\" <#{AppConfig.mail.sender_address}>")
+      end
+
+      it "FROM: removes emojis from sender's name" do
+        bob.person.profile.update!(first_name: "1️⃣2️3️⃣ Numbers 123", last_name: "👍✅👍🏻Emojis😀😇❄️")
+        expect(mail["From"].to_s).to eq("\"#{pod_name} (Numbers 123 Emojis)\" <#{AppConfig.mail.sender_address}>")
       end
 
       it "SUBJECT: does not show the limited post" do


### PR DESCRIPTION
Some email providers (for example gmail) block emails if they have emojis in the from header, as they could be confused with UI elements. So the easy solution is to just filter all emojis from the name.

The normal `\p{Emoji}` selector also matches normal numbers, because of the emoji-version of numbers (1️⃣), but the `\p{Emoji_Presentation}` then doesn't match colored emojis anymore (❄️), so we need a mix of both to find all emojis