### PR TITLE
Use YAML.unsafe_load_file when available in bundler helper

### DIFF
--- a/config/bundler_helper.rb
+++ b/config/bundler_helper.rb
@@ -19,8 +19,19 @@ module BundlerHelper
   end
 
   private_class_method def self.parse_value_from_yaml_file(file, *keys)
+    parse_yaml_file(file).dig(*keys)
+  end
+
+  private_class_method def self.parse_yaml_file(file)
     path = File.join(__dir__, file)
-    YAML.load_file(path).dig(*keys) if File.file?(path)
+
+    return {} unless File.file?(path)
+
+    if YAML.respond_to?(:unsafe_load_file)
+      YAML.unsafe_load_file(path)
+    else
+      YAML.load_file(path)
+    end
   end
 
   private_class_method def self.parse_value_from_toml_file(file, key)


### PR DESCRIPTION
fixes #8424

following https://github.com/rails/rails/blob/f642505479b06fa20d9f717d4770dad4d9ad5893/activesupport/lib/active_support/configuration_file.rb#L21-L32
