### PR TITLE
Bump net-* gems and digest

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,6 +195,7 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
+    date (3.3.3)
     devise (4.8.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -225,7 +226,6 @@ GEM
       fabrication (~> 2.29)
       uuid (~> 2.3, >= 2.3.8)
     diff-lcs (1.5.0)
-    digest (3.0.0)
     docile (1.4.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
@@ -368,7 +368,6 @@ GEM
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
-    io-wait (0.2.0)
     jasmine (3.10.0)
       jasmine-core (~> 3.10.0)
       phantomjs
@@ -439,18 +438,14 @@ GEM
     multipart-post (2.2.3)
     mysql2 (0.5.4)
     naught (1.1.0)
-    net-imap (0.1.1)
-      digest
+    net-imap (0.3.4)
+      date
       net-protocol
-      strscan
-    net-pop (0.1.1)
-      digest
+    net-pop (0.1.2)
       net-protocol
+    net-protocol (0.2.1)
       timeout
-    net-protocol (0.1.1)
-      io-wait
-      timeout
-    net-smtp (0.2.1)
+    net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
     nokogiri (1.13.7)
@@ -706,7 +701,6 @@ GEM
     ssrf_filter (1.1.1)
     state_machines (0.5.0)
     string-direction (1.2.2)
-    strscan (3.0.1)
     swd (1.3.0)
       activesupport (>= 3)
       attr_required (>= 0.0.5)
@@ -724,7 +718,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.10)
     timecop (0.9.5)
-    timeout (0.1.1)
+    timeout (0.3.2)
     timers (4.3.3)
     toml-rb (2.1.2)
       citrus (~> 3.0, > 3.0)


### PR DESCRIPTION
I don't know why it pinned them to older versions when adding them, lets use the latest versions instead.

This is a follow up for #8426 as it looks like in some cases the old `digest` version causes problems with ruby 3.1.