### PR TITLE
[CI] Run Pronto on GitHub Actions.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,62 @@
+## SECURITY WARNING:
+##
+## Do not change this job unless you know what you're doing.
+##
+## This GitHub Action runs on: pull_request_target, which means the jobs run in
+## a context where they have access to a Access Token with write access to the
+## target repo, even if the PR is opened from an external contributor from their
+## fork.
+##
+## This means that if we're not careful, we could be running third-party code
+## within an authenticated scope, which isn't good. To mitigate this, this
+## implementation does:
+##
+##   1. checkout the target branch (i.e. the project's original sources)
+##   2. install the Gems from there, and install them into a directory that's
+##      outside the repository contents.
+##   3. checkout the PRs HEAD
+##   4. restore a bunch of files that would allow code execution from the
+##      project's upstream sources, namely:
+##      - bin/bundle - we'll run that in our Job
+##      - Gemfile/Gemfile.lock - to avoid loading a gem with an identical
+##        version number from a in-repo vendored directory
+
+name: Lint
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+  statuses: write
+  pull-requests: write
+
+jobs:
+  pronto:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install system dependencies
+        run: sudo apt update && sudo apt install -y build-essential curl git gsfonts imagemagick libcurl4-openssl-dev libidn11-dev libmagickwand-dev libssl-dev libxml2-dev libxslt1-dev yarnpkg
+      - name: Checkout Target branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.base_ref }}
+          fetch-depth: 0
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.1"
+          bundler-cache: true
+      - name: Checkout PR HEAD
+        run: |
+          git fetch -q origin +refs/pull/${{ github.event.pull_request.number }}/head:
+          git checkout -qf FETCH_HEAD
+      - name: Restore the bundle binstub and Gemfiles from the target branch
+        run: |
+          git restore -s ${{ github.base_ref }} -- bin/bundle
+          git restore -s ${{ github.base_ref }} -- Gemfile
+          git restore -s ${{ github.base_ref }} -- Gemfile.lock
+      - name: Run Pronto
+        run: bin/bundle exec pronto run -f github_status github_pr_review -c ${{ github.base_ref }}
+        env:
+          PRONTO_PULL_REQUEST_ID: ${{ github.event.pull_request.number }}
+          PRONTO_GITHUB_ACCESS_TOKEN: ${{ github.token }}
+


### PR DESCRIPTION
I'm kinda tired of maintaining our own webhook receiver and pronto runner on the project server. :) Also, sorry, another long essay.

This is surprisingly hard to get right, because GitHub Action's permission system is nearly where I want it to be for this. The default `on: pull_request` trigger works fine for team-internal PRs, but the access token it gets is always read-only for everything if the PR is coming from an external contributor. So this won't fly, especially since Pronto hasn't a good internal fallback to "just silently pass". If we run Pronto with the `github_status` and `github_pr` formatters, then it wants to leave an approving review and set the status to green. If it can't, it explodes.

A possible workaround to this would be to simply run Pronto as you'd run on your local setup, and have it dump the linting errors/warnings to the log and fail with a non-zero status code. This wouldn't require any access token, and just like our test suite, the status would just turn red. However, this means that if the linting fails, you'd have to look into the job log to figure out why. Both me and @SuperTux88 agreed in a side-channel chat that we kinda really like the way that Pronto leaves inline-comments.

A possible solution is to run the action `on: pull_request_target`. What [this does is a bit complicated](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target), but essentially, this runs the job for a PR as if it was triggered from within the repo or from a team member. The good thing is that this allows us to run jobs for an external contributor's PR with elevated permissions, but the bad thing is that this allows us to run jobs for an external contributor's PR with elevated permissions. If you're not careful, a malicious contributor could open a PR that changes `bin/bundle`, for example, with a script that pushes the access token to a malicious webservice and uses that token to do evil stuff or something. In theory, the scope of this security issue is limited [as the token is supposed to expire when the job ends](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret), but in practice, this solves absolutely nothing (as you could just do malicious stuff within your custom patch, or just block the job for a while - timeouts are large).

To avoid running unchecked third-party code with a GitHub Token with write access in scope, this job implementation does a few things. I'm not going to explain them here, the steps this is taking are documented in the workflow definition. Additionally, this repo is set to not run Actions for first-time contributors without approval. This isn't much, but it helps a bit.

I'm not sure if there's a better way to achieve this.

To review this, you have essentially two options:

1. [Here's a screenshot of how a PR run looks](https://github.com/diaspora/diaspora/assets/344777/fce81c24-579b-4028-a2ef-5c1f154bb5a1). Trust me(tm).
2. Create a private fork in your personal account, enable actions, be sure [to match this repo's security settings](https://github.com/diaspora/diaspora/settings/actions), push the PR to main, open a PR and test it yourself.

I'm happy to PR the same change to the Federation repo, but I'll hold off on that until this one is merged, just in case there are revisions! Please take a look, @jhass and @SuperTux88 - both of you, just because more eyes are more better.