### PR TITLE
Add 'faraday-retry' to Gemfile to be used by pronto/octokit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -208,6 +208,8 @@ group :development do
   gem "rubocop",        "1.53.1", require: false
   gem "rubocop-rails",  "2.20.2", require: false
 
+  gem "faraday-retry", require: false # used by pronto/octokit
+
   # Debugging
   gem "pry"
   gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,6 +257,7 @@ GEM
     faraday-follow_redirects (0.3.0)
       faraday (>= 1, < 3)
     faraday-net_http (3.0.2)
+    faraday-retry (1.0.3)
     faraday-typhoeus (1.0.0)
       faraday (~> 2.0)
       typhoeus (~> 1.4)
@@ -812,6 +813,7 @@ DEPENDENCIES
   faraday (= 2.7.7)
   faraday-cookie_jar (= 0.0.7)
   faraday-follow_redirects (= 0.3.0)
+  faraday-retry
   faraday-typhoeus (= 1.0.0)
   fixture_builder (= 0.5.2)
   fog-aws (= 3.19.0)


### PR DESCRIPTION
This prevents a "To use retry middleware with Faraday v2.0+, install `faraday-retry` gem" warning whenever pronto runs.