### PR TITLE
Silence warning about unused callbacks to fix pumactl restart

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -25,6 +25,13 @@ workers 0
 
 preload_app!
 
+# Below callbacks (before_fork and on_worker_boot) are only used when running
+# in cluster mode. Since we're not running in cluster mode by default (see
+# workers above), a warning is written on startup about them not being called
+# in single mode. So lets just silence that warnings, but still keep the
+# callbacks in place in case somebody switches on the cluster mode.
+silence_fork_callback_warning
+
 before_fork do
   # we're preloading app in production, so force-reconenct the DB
   ActiveRecord::Base.connection_pool.disconnect!


### PR DESCRIPTION
The callbacks aren't used in cluster mode, and puma prints a warning about that. This is fine, we don't need the callbacks in single mode, but can still keep it, in case somebody switches on cluster mode.

The problem is, the current puma version has a bug (I opened https://github.com/puma/puma/issues/3186 for that), where pumactl crashes when trying to print these warnings, so lets just silence the warnings. People running in single mode also don't need to care about the warnings anyway.

The alternative would be to remove the callbacks, but they don't do any harm when they aren't used, but are maybe useful when somebody wants to enable cluster mode. So as they are already there (even when we never used cluster mode by default), I think keeping them and silence the warning is the better option?