### PR TITLE
Allow CORS requests to nodeinfo endpoint

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -13,5 +13,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     resource "/api/*", methods: :any
     resource "/.well-known/webfinger"
     resource "/.well-known/openid-configuration"
+    resource "/.well-known/nodeinfo"
+    resource "/nodeinfo/*"
   end
 end


### PR DESCRIPTION
Web applications meant to work with different Fediverse applications need to download `/.well-known/nodeinfo` and `/nodeinfo/2.0` in order to determine what software they are dealing with. Diaspora currently doesn’t allow this to happen on the client side, without CORS headers third-party web pages aren’t allowed to do it. I’ve hit this issue myself when implementing “Share to Fediverse” functionality for my website.

Adding CORS headers is trivial and solves this issue. With the node info being public information, there is no reason why third-party websites shouldn’t have access to it.