### PR TITLE
Ensure image processing gets disabled again, even after exceptions

### DIFF
--- a/spec/models/photo_spec.rb
+++ b/spec/models/photo_spec.rb
@@ -6,9 +6,9 @@
 
 def with_carrierwave_processing(&block)
   UnprocessedImage.enable_processing = true
-  val = yield
+  yield
+ensure
   UnprocessedImage.enable_processing = false
-  val
 end
 
 describe Photo, :type => :model do


### PR DESCRIPTION
Otherwise this leaves it enabled if the processing failed, which then makes other specs fail where they expect the image not being processed (for example still have the initial set dimensions, instead of the one read from image after processing).

This only failed when the new spec from [the 0.7.18.2 hotfix](https://github.com/diaspora/diaspora/commit/42b835f0c018063a76c99f772bdcb8914d94b3e1#diff-7db9c591635919ff02f7a3e1f6faf00632a1fb81a63242b7ce74046b5491a742R268-R283) was the last one using `with_carrierwave_processing` and then [exporter_spec.rb](https://github.com/diaspora/diaspora/blob/bb882daeae0d33bbd86f2de9e78d93902e8df9ba/spec/integration/exporter_spec.rb#L143-L174) ran after that, which expected the dimensions from the unprocessed image entity.