### PR TITLE
Allow fetching comments

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -37,6 +37,12 @@ class Comment < ApplicationRecord
   scope :including_author, -> { includes(:author => :profile) }
   scope :for_a_stream,  -> { including_author.merge(order('created_at ASC')) }
 
+  scope :all_public, -> {
+    where("commentable_type = 'Post' AND EXISTS(
+      SELECT 1 FROM posts WHERE posts.id = commentable_id AND posts.public = true
+    )")
+  }
+
   before_save do
     self.text.strip! unless self.text.nil?
   end

--- a/config/initializers/diaspora_federation.rb
+++ b/config/initializers/diaspora_federation.rb
@@ -120,10 +120,10 @@ DiasporaFederation.configure do |config|
     on :fetch_public_entity do |entity_type, guid|
       entity = Diaspora::Federation::Mappings.model_class_for(entity_type).all_public.find_by(guid: guid)
       case entity
-      when Post
-        Diaspora::Federation::Entities.post(entity)
       when Poll
         Diaspora::Federation::Entities.status_message(entity.status_message)
+      else
+        Diaspora::Federation::Entities.build(entity) if entity
       end
     end
 

--- a/spec/federation_callbacks_spec.rb
+++ b/spec/federation_callbacks_spec.rb
@@ -465,6 +465,33 @@ describe "diaspora federation callbacks" do
         DiasporaFederation.callbacks.trigger(:fetch_public_entity, "Post", "unknown-guid")
       ).to be_nil
     end
+
+    context "comment" do
+      it "fetches a Comment" do
+        post = FactoryBot.create(:status_message, author: alice.person, public: true)
+        comment = FactoryBot.create(:comment, author: alice.person, commentable: post)
+        entity = DiasporaFederation.callbacks.trigger(:fetch_public_entity, "Comment", comment.guid)
+
+        expect(entity.guid).to eq(comment.guid)
+        expect(entity.author).to eq(alice.diaspora_handle)
+        expect(entity.parent.public).to be_truthy
+      end
+
+      it "does not fetch a Comment from a private post" do
+        post = FactoryBot.create(:status_message, author: alice.person, public: false)
+        comment = FactoryBot.create(:comment, author: alice.person, commentable: post)
+
+        expect(
+          DiasporaFederation.callbacks.trigger(:fetch_public_entity, "Comment", comment.guid)
+        ).to be_nil
+      end
+
+      it "returns nil, if the comment is unknown" do
+        expect(
+          DiasporaFederation.callbacks.trigger(:fetch_public_entity, "Comment", "unknown-guid")
+        ).to be_nil
+      end
+    end
   end
 
   describe ":fetch_person_url_to" do


### PR DESCRIPTION
Now with likes on comments, diaspora also tries to fetch comments if it receives a like for a comment it doesn't know yet. So this now also allows to fetch comments with `/fetch/comment/<guid>`.