### PR TITLE
Mark Likes on comment notifications as read when visiting a post

### DIFF
--- a/app/services/post_service.rb
+++ b/app/services/post_service.rb
@@ -104,9 +104,8 @@ class PostService
   end
 
   def mark_like_on_comment_notifications_read(post_id)
-    comment_ids = Comment.where(commentable_id: post_id)
-
-    Notification.where(recipient_id: user.id, target_type: "Comment", target_id: comment_ids, unread: true)
-                .update_all(unread: false) if comment_ids.any?
+    Notification.where(recipient_id: user.id, target_type: "Comment",
+                       target_id: Comment.where(commentable_id: post_id, author_id: user.person.id),
+                       unread: true).update_all(unread: false) # rubocop:disable Rails/SkipsModelValidations
   end
 end

--- a/app/services/post_service.rb
+++ b/app/services/post_service.rb
@@ -33,6 +33,7 @@ class PostService
     return unless user
     mark_comment_reshare_like_notifications_read(post_id)
     mark_mention_notifications_read(post_id)
+    mark_like_on_comment_notifications_read(post_id)
   end
 
   def destroy(post_id, private_allowed=true)
@@ -100,5 +101,12 @@ class PostService
     Mention
       .joins("INNER JOIN comments ON mentions_container_id = comments.id AND mentions_container_type = 'Comment'")
       .where(comments: {commentable_id: post_id, commentable_type: "Post"})
+  end
+
+  def mark_like_on_comment_notifications_read(post_id)
+    comment_ids = Comment.where(commentable_id: post_id)
+
+    Notification.where(recipient_id: user.id, target_type: "Comment", target_id: comment_ids, unread: true)
+                .update_all(unread: false) if comment_ids.any?
   end
 end


### PR DESCRIPTION
So this is fixing the fact that "Like on comment" notification is not marked as read when one visits a post.

Initially, I was thinking about marking it read only when the actual comment is visited, like:  
![image](https://github.com/diaspora/diaspora/assets/930064/1a31d8fa-1dcd-48c8-9a3b-15c80a389b19)

But then I saw in the code that everything is marked as read when a post is visited (mentions in comment too for example) so I kept this consistent.

I need help with rubocop: 
- it asks me to not have a if if it's multilines, but then tell me I should not have a block with if and use a safe guard instead
- it says that I should not use update_all as this skips validation, but that's what is used in the same file above for mentions, and when I [search online](https://stackoverflow.com/questions/39644646/running-validations-when-using-update-all) the other solution  is apparently much slower (create the objects in memory, do one SQL query per update...) What do you think?