### PR TITLE
docker-compose.yml - bump mariadb version

### DIFF
--- a/docker/develop/docker-compose.yml
+++ b/docker/develop/docker-compose.yml
@@ -45,10 +45,11 @@ services:
       POSTGRES_PASSWORD: postgres
 
   mysql:
-    image: mariadb:10.9
+    image: mariadb:lts
     ports:
       - 53306:3306
     volumes:
       - mysql_data:/var/lib/mysql
     environment:
-      MYSQL_ROOT_PASSWORD: mysql
+      MARIADB_ROOT_PASSWORD: mysql
+      MARIADB_AUTO_UPGRADE: 1


### PR DESCRIPTION
Noted its not the primary development environment, but 10.9 is out of support so just keep the the LTS tag.

MARIADB_AUTO_UPGRADE=1 facilitates in place upgrades.