### PR TITLE
Let users report comments below their own posts.

### DIFF
--- a/app/assets/javascripts/app/views/comment_view.js
+++ b/app/assets/javascripts/app/views/comment_view.js
@@ -27,6 +27,7 @@ app.views.Comment = app.views.Content.extend({
   presenter: function() {
     return _.extend(this.defaultPresenter(), {
       canRemove: this.canRemove(),
+      canReport: this.canReport(),
       text: app.helpers.textFormatter(this.model.get("text"), this.model.get("mentioned_people")),
       likesCount: this.model.attributes.likesCount,
       userLike: this.model.interactions.userLike()
@@ -43,6 +44,10 @@ app.views.Comment = app.views.Content.extend({
 
   canRemove: function() {
     return app.currentUser.authenticated() && (this.ownComment() || this.postOwner());
+  },
+
+  canReport: function() {
+    return app.currentUser.authenticated() && !this.ownComment();
   },
 
   toggleLike: function(evt) {

--- a/app/assets/templates/comment_tpl.jst.hbs
+++ b/app/assets/templates/comment_tpl.jst.hbs
@@ -7,17 +7,16 @@
 
   <div class="bd">
     <div class="control-icons">
-    {{#if loggedIn}}
-      {{#if canRemove}}
-        <a href="#" class="delete comment_delete" title="{{t "delete"}}">
-          <i class="entypo-trash"></i>
-        </a>
-      {{else}}
+      {{#if canReport}}
         <a href="#" data-type="Comment" class="comment_report" title="{{t "report.name"}}">
           <i class="entypo-warning"></i>
         </a>
       {{/if}}
-    {{/if}}
+      {{#if canRemove}}
+        <a href="#" class="delete comment_delete" title="{{t "delete"}}">
+          <i class="entypo-trash"></i>
+        </a>
+      {{/if}}
     </div>
 
     <div>


### PR DESCRIPTION
A user just raised this, as they were trying to report spam below their own post and couldn't. I think the motivation behind the current logic here was to hide the report button since the user can just delete the comment, but there's value to reporting spam (for example to make sure a spammer is deleted globally).

The current CSS already handles this nicely:

![Screenshot 2024-10-30 at 22 16 54](https://github.com/user-attachments/assets/5ffa77d4-c41b-451d-956d-2b124c9452c1)

We don't have behavior testing coverage for the comment view AFAICT, so I didn't add any. We [do have unit tests for the `canRemove()` function](https://github.com/diaspora/diaspora/blob/37096d9c8805b4c6f0ea397fff8176d928a526ad/spec/javascripts/app/views/comment_view_spec.js#L49-L77), but to be somewhat direct: they're kinda pointless, they're effectively saying "a function that has been called has indeed been called". I don't see a huge point in writing unit tests for a function that is composing two other functions with test coverage - but of course I'm happy to add some. :)

I also removed the `{{#if loggedIn}}` gate. Both `canRemove()` and `canReport()` already do check if the user is authenticated, so that's not really needed and just adds more noise.