### PR TITLE
Implement issue #8196: Leave on read all notifications involving a blocked person

### DIFF
--- a/app/assets/javascripts/app/models/person.js
+++ b/app/assets/javascripts/app/models/person.js
@@ -39,7 +39,10 @@ app.models.Person = Backbone.Model.extend({
 
     // return the jqXHR with Promise interface
     return block.save()
-      .done(function() { app.events.trigger('person:block:'+self.id); });
+      .done(function() {
+        app.events.trigger("person:block:" + self.id);
+        app.notificationsCollection.fetch();
+      });
   },
 
   unblock: function() {

--- a/app/services/block_service.rb
+++ b/app/services/block_service.rb
@@ -11,6 +11,8 @@ class BlockService
     block = @user.blocks.create!(person: person)
     contact = @user.contact_for(person)
 
+    notification_service.read_all_involving(person)
+
     if contact
       @user.disconnect(contact)
     elsif block.person.remote?
@@ -25,5 +27,11 @@ class BlockService
   def remove_block(block)
     block.destroy
     ContactRetraction.for(block).defer_dispatch(@user)
+  end
+
+  private
+
+  def notification_service
+    NotificationService.new(@user)
   end
 end

--- a/app/services/block_service.rb
+++ b/app/services/block_service.rb
@@ -11,7 +11,7 @@ class BlockService
     block = @user.blocks.create!(person: person)
     contact = @user.contact_for(person)
 
-    notification_service.read_all_involving(person)
+    notification_service.read_all_only_involving(person)
 
     if contact
       @user.disconnect(contact)

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -56,6 +56,17 @@ class NotificationService
     notification_types(object).each {|type| type.notify(object, recipient_user_ids) }
   end
 
+  def read_all_involving(person)
+    Notification
+      .for(@user)
+      .joins(:notification_actors)
+      .where(notification_actors: {person: person})
+      .find_each do |note|
+        note.unread = false
+        note.save
+      end
+  end
+
   private
 
   def notification_types(object)

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -60,7 +60,10 @@ class NotificationService
     Notification
       .for(@user)
       .joins(:notification_actors)
-      .where(notification_actors: {person: person})
+      .where(
+        notification_actors: {person: person},
+        unread:              true
+      )
       .find_each do |note|
         note.unread = false
         note.save

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -56,13 +56,18 @@ class NotificationService
     notification_types(object).each {|type| type.notify(object, recipient_user_ids) }
   end
 
-  def read_all_involving(person)
+  def read_all_only_involving(person)
+    one_actor_notes = Notification
+                      .joins(:notification_actors)
+                      .group("notifications.id")
+                      .having("COUNT(notification_actors.notification_id) = 1")
     Notification
       .for(@user)
       .joins(:notification_actors)
       .where(
         notification_actors: {person: person},
-        unread:              true
+        unread:              true,
+        id:                  one_actor_notes
       )
       .find_each do |note|
         note.unread = false

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -57,21 +57,14 @@ class NotificationService
   end
 
   def read_all_only_involving(person)
-    one_actor_notes = Notification
-                      .joins(:notification_actors)
-                      .group("notifications.id")
-                      .having("COUNT(notification_actors.notification_id) = 1")
     Notification
-      .for(@user)
       .joins(:notification_actors)
-      .where(
-        notification_actors: {person: person},
-        unread:              true,
-        id:                  one_actor_notes
-      )
+      .where(recipient_id: @user.id, unread: true)
+      .group("notifications.id")
+      .having("COUNT(notification_actors.notification_id) = 1")
+      .having("MIN(notification_actors.person_id) = ?", person.id)
       .find_each do |note|
-        note.unread = false
-        note.save
+        note.update!(unread: false)
       end
   end
 

--- a/spec/javascripts/app/models/person_spec.js
+++ b/spec/javascripts/app/models/person_spec.js
@@ -64,6 +64,17 @@ describe("app.models.Person", function() {
       expect(request.method).toEqual("POST");
       expect($.parseJSON(request.params).block.person_id).toEqual(this.sharingContact.id);
     });
+    it("re-fetches the notifications", function(done) {
+      spyOn(app.models.Block.prototype, "save").and.returnValue($.Deferred().resolve());
+
+      app.notificationsCollection = {fetch: $.noop};
+      spyOn(app.notificationsCollection, "fetch");
+
+      this.sharingContact.block().done(function() {
+        expect(app.notificationsCollection.fetch).toHaveBeenCalled();
+        done();
+      });
+    });
   });
 
   context("#unblock", function() {

--- a/spec/services/block_serivce_spec.rb
+++ b/spec/services/block_serivce_spec.rb
@@ -23,5 +23,10 @@ describe BlockService do
       expect(Diaspora::Federation::Dispatcher).not_to receive(:defer_dispatch)
       service.block(eve.person)
     end
+
+    it "marks the notifications of the person as read" do
+      expect_any_instance_of(NotificationService).to receive(:read_all_involving).with(bob.person)
+      service.block(bob.person)
+    end
   end
 end

--- a/spec/services/block_serivce_spec.rb
+++ b/spec/services/block_serivce_spec.rb
@@ -25,7 +25,7 @@ describe BlockService do
     end
 
     it "marks the notifications of the person as read" do
-      expect_any_instance_of(NotificationService).to receive(:read_all_involving).with(bob.person)
+      expect_any_instance_of(NotificationService).to receive(:read_all_only_involving).with(bob.person)
       service.block(bob.person)
     end
   end

--- a/spec/services/notification_service_spec.rb
+++ b/spec/services/notification_service_spec.rb
@@ -130,26 +130,22 @@ describe NotificationService do
       end
     end
 
-    describe "#read_all_involving" do
+    describe "#read_all_only_involving" do
       before do
         @notification_actor = @notification.actors.first
         FactoryBot.create(:notification, recipient: alice, target: @post, actors: [eve.person])
         FactoryBot.create(:notification, recipient: alice, target: @post, actors: [eve.person, @notification_actor])
       end
 
-      it "succeeds with valid person" do
+      it "reads the notifications involving only the provided person" do
         expect {
-          @service.read_all_involving(@notification_actor)
+          @service.read_all_only_involving(@notification_actor)
         }.to change(
           Notification
-            .joins(:notification_actors)
-            .where(
-              recipient:           alice,
-              notification_actors: {person: @notification_actor},
-              unread:              true
-            ),
+            .for(alice)
+            .where({unread: true}),
           :count
-        ).to(0)
+        ).by(-1)
       end
     end
   end

--- a/spec/services/notification_service_spec.rb
+++ b/spec/services/notification_service_spec.rb
@@ -129,5 +129,28 @@ describe NotificationService do
         expect(@notification.reload.unread).to eq(true)
       end
     end
+
+    describe "#read_all_involving" do
+      before do
+        @notification_actor = @notification.actors.first
+        FactoryBot.create(:notification, recipient: alice, target: @post, actors: [eve.person])
+        FactoryBot.create(:notification, recipient: alice, target: @post, actors: [eve.person, @notification_actor])
+      end
+
+      it "succeeds with valid person" do
+        expect {
+          @service.read_all_involving(@notification_actor)
+        }.to change(
+          Notification
+            .joins(:notification_actors)
+            .where(
+              recipient:           alice,
+              notification_actors: {person: @notification_actor},
+              unread:              true
+            ),
+          :count
+        ).to(0)
+      end
+    end
   end
 end


### PR DESCRIPTION
Hi, hope everyone is doing well!

This PR would implement the feature requested in #8196.

I went with the proposed alternative of marking the notifications as read instead of deleting them, because I think that's more trackable in case the notifications contained content that might be of interest to keep, such as proof of harassment, and also because I feel deleting them would be more unexpected for the user.

I didn't use a cuke since I didn't wanna add such a slow and high level test for this comparatively low impact feature, but I can add it if we deem it necessary.

I'll be waiting to hear your thoughts! 😄 


