### PR TITLE
Fix target blank diaspora links - Issue 7907

### DIFF
--- a/app/assets/javascripts/app/helpers/text_formatter.js
+++ b/app/assets/javascripts/app/helpers/text_formatter.js
@@ -30,6 +30,10 @@
     md.use(inlinePlugin, "link_new_window_and_missing_http", "link_open", function (tokens, idx) {
       tokens[idx].attrs.forEach(function(attribute, index, array) {
         if( attribute[0] === "href" ) {
+          if (attribute[1].startsWith("diaspora://")) {
+            // if its a diaspora link do not add _blank and return early
+            return;
+          }
           array[index][1] = attribute[1].replace(/^www\./, "http://www.");
         }
       });

--- a/lib/diaspora/markdownify/html.rb
+++ b/lib/diaspora/markdownify/html.rb
@@ -5,13 +5,13 @@ module Diaspora
     class HTML < Redcarpet::Render::HTML
       include ActionView::Helpers::TextHelper
 
-      def autolink link, type
+      def autolink(link, type)
         Twitter::TwitterText::Autolink.auto_link_urls(
           link,
-          url_target:           "_blank",
-          link_attribute_block: lambda {|_, attr| attr[:rel] += " noopener noreferrer" unless link.start_with?("diaspora://")}
-        )
+          url_target: link.start_with?("diaspora://") ? nil : "_blank",
+          link_attribute_block: lambda { |_, attr|attr[:rel] = "noopener noreferrer" unless link.start_with?("diaspora://")})
       end
+      
     end
   end
 end

--- a/lib/diaspora/markdownify/html.rb
+++ b/lib/diaspora/markdownify/html.rb
@@ -9,7 +9,7 @@ module Diaspora
         Twitter::TwitterText::Autolink.auto_link_urls(
           link,
           url_target:           "_blank",
-          link_attribute_block: lambda {|_, attr| attr[:rel] += " noopener noreferrer" }
+          link_attribute_block: lambda {|_, attr| attr[:rel] += " noopener noreferrer" unless link.start_with?("diaspora://")}
         )
       end
     end


### PR DESCRIPTION
Fixes the issue of diaspora links opening in a new tab as mentioned in Issue 7907.

This was not tested on mobile but was user-tested on an Ubuntu VM. This is for a class project