### PR TITLE
Allow ImageMagick to use 1GiB of disk caches

### DIFF
--- a/config/imagemagick/policy.xml
+++ b/config/imagemagick/policy.xml
@@ -1,6 +1,6 @@
 <policymap>
   <policy domain="resource" name="time" value="30" />
-  <policy domain="resource" name="disk" value="256MiB"/>
+  <policy domain="resource" name="disk" value="1GiB"/>
   <policy domain="resource" name="map" value="256MiB"/>
   <policy domain="resource" name="memory" value="256MiB"/>
 


### PR DESCRIPTION
This matches the ["websafe" upstream preset](https://github.com/ImageMagick/ImageMagick/blob/c7d070ec654573ddd9bc0356909a99fd1a7b07bd/config/policy-websafe.xml#L58), and our current limit is too low for high-noise images (like a scene full of snow).
