### PR TITLE
Update open_graph_reader to 0.9.1 and set new config flag.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,7 +110,7 @@ gem "leaflet-rails", "1.9.4"
 # Parsing
 
 gem "nokogiri",          "1.16.5"
-gem "open_graph_reader", "0.8.0" # also update User-Agent in features/support/webmock.rb and open_graph_cache_spec.rb
+gem "open_graph_reader", "0.9.1" # also update User-Agent in features/support/webmock.rb and open_graph_cache_spec.rb
 gem "redcarpet",         "3.6.0"
 gem "ruby-oembed",       "0.17.0"
 gem "twitter-text",      "3.1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,7 +229,7 @@ GEM
       http-cookie (~> 1.0.0)
     faraday-follow_redirects (0.3.0)
       faraday (>= 1, < 3)
-    faraday-net_http (3.1.0)
+    faraday-net_http (3.1.1)
       net-http
     faraday-retry (2.2.1)
       faraday (~> 2.0)
@@ -390,7 +390,7 @@ GEM
     mime-types-data (3.2024.0507)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.7)
+    mini_portile2 (2.8.9)
     minitest (5.23.1)
     mobile-fu (1.4.0)
       rack-mobile-detect
@@ -402,7 +402,7 @@ GEM
     multipart-post (2.4.1)
     mysql2 (0.5.6)
     naught (1.1.0)
-    net-http (0.4.1)
+    net-http (0.6.0)
       uri
     net-imap (0.4.12)
       date
@@ -454,7 +454,7 @@ GEM
       rack
     omniauth-wordpress (0.2.2)
       omniauth-oauth2 (>= 1.1.0)
-    open_graph_reader (0.8.0)
+    open_graph_reader (0.9.1)
       faraday (>= 0.9.0)
       nokogiri (~> 1.6)
     openid_connect (2.3.0)
@@ -507,7 +507,7 @@ GEM
     puma (6.4.2)
       nio4r (~> 2.0)
     raabro (1.4.0)
-    racc (1.8.0)
+    racc (1.8.1)
     rack (2.2.9)
     rack-attack (6.7.0)
       rack (>= 1.0, < 4)
@@ -732,7 +732,7 @@ GEM
       unf_ext
     unf_ext (0.0.9.1)
     unicode-display_width (2.5.0)
-    uri (0.13.0)
+    uri (1.0.3)
     uuid (2.3.9)
       macaddr (~> 1.0)
     valid (1.2.0)
@@ -832,7 +832,7 @@ DEPENDENCIES
   omniauth-tumblr (= 1.2)
   omniauth-twitter (= 1.4.0)
   omniauth-wordpress (= 0.2.2)
-  open_graph_reader (= 0.8.0)
+  open_graph_reader (= 0.9.1)
   openid_connect (= 2.3.0)
   pg (= 1.5.6)
   pronto (= 0.11.2)

--- a/config/initializers/open_graph_reader.rb
+++ b/config/initializers/open_graph_reader.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 OpenGraphReader.configure do |config|
-  config.synthesize_title      = true
-  config.synthesize_url        = true
-  config.synthesize_full_url   = true
-  config.synthesize_image_url  = true
-  config.guess_datetime_format = true
+  config.synthesize_title          = true
+  config.synthesize_url            = true
+  config.synthesize_full_url       = true
+  config.synthesize_full_image_url = true
+  config.synthesize_image_content  = true
+  config.guess_datetime_format     = true
 end
 
 og_video_urls = []

--- a/features/support/webmock.rb
+++ b/features/support/webmock.rb
@@ -7,7 +7,7 @@ Before do
   stub_request(:head, /.+/).with(
     headers: {
       "Accept"     => "text/html",
-      "User-Agent" => "OpenGraphReader/0.8.0 (+https://github.com/jhass/open_graph_reader)"
+      "User-Agent" => "OpenGraphReader/0.9.1 (+https://github.com/jhass/open_graph_reader)"
     }
   ).to_return(status: 200, body: "", headers: {"Content-Type" => "text/plain"})
 end

--- a/spec/models/open_graph_cache_spec.rb
+++ b/spec/models/open_graph_cache_spec.rb
@@ -63,7 +63,7 @@ describe OpenGraphCache, type: :model do
         stub_request(:head, "http:///wetter.com")
           .with(headers: {
                   "Accept"     => "text/html",
-                  "User-Agent" => "OpenGraphReader/0.8.0 (+https://github.com/jhass/open_graph_reader)"
+                  "User-Agent" => "OpenGraphReader/0.9.1 (+https://github.com/jhass/open_graph_reader)"
                 })
           .to_return(status: 200, body: "", headers:
             {"Set-Cookie" => "Dabgroup=A;path=/;Expires=Thu, 23 May 2019 16:12:01 GMT;httpOnly"})


### PR DESCRIPTION
A Geraspora user reported a case where OpenGraph data was not shown for a specific URL. Turns out that this URL was from PeerTube, and they technically violate the spec (they provide `og:image:url`, but not `og:image`). This resulted in the OpenGraph reader returning `nil` for `.og.image.url`, and by extension, us not showing anything.

I [filed this upstream](https://github.com/jhass/open_graph_reader/issues/13) with @jhass, because despite this being a spec violation, it's easy to work around for compatibility. He immediately jumped to action, implemented it, and released a new version. So let's update our use. :)

Proposed changelog would be "Improved compatibility with non-specification-compliant OpenGraph metadata" or something.