### PR TITLE
Add bluesky to the JSON schema

### DIFF
--- a/vendor/nodeinfo/schemas/2.1.json
+++ b/vendor/nodeinfo/schemas/2.1.json
@@ -83,6 +83,7 @@
           "items": {
             "enum": [
               "atom1.0",
+	      "bluesky",
               "gnusocial",
               "imap",
               "pnut",
@@ -101,6 +102,7 @@
             "enum": [
               "atom1.0",
               "blogger",
+	      "bluesky",
               "buddycloud",
               "diaspora",
               "dreamwidth",


### PR DESCRIPTION
It appears that adding "bluesky" to the JSON Schema allows my Diaspora* pod to resume federating with Friendica pods.  Addresses issue #8472 