### PR TITLE
Update docker to use debian trixie as base image

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,7 +43,7 @@ jobs:
           fetch-depth: 0
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.3"
           bundler-cache: true
       - name: Checkout PR HEAD
         run: |

--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -18,9 +18,10 @@ RUN DEBIAN_FRONTEND=noninteractive \
         libxml2-dev \
         libxslt1-dev \
         nodejs \
+        npm \
         gosu \
-        yarnpkg \
     && \
+    npm install -g yarn@1.22.22 && \
     curl https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb -o ./google-chrome.deb && \
     apt install -y -qq --no-install-recommends ./google-chrome.deb && \
     rm ./google-chrome.deb && \

--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/amd64/ruby:3.3-slim-bullseye
+FROM docker.io/amd64/ruby:3.3-slim-trixie
 
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update && \
@@ -10,7 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
         gsfonts \
         imagemagick \
         libcurl4-openssl-dev \
-        libidn11-dev \
+        libidn-dev \
         libmagickwand-dev \
         libmariadb-dev-compat \
         libpq-dev \
@@ -34,11 +34,9 @@ ENV HOME="/home/diaspora" \
     GEM_HOME="/diaspora/vendor/bundle" \
     OPENSSL_CONF="/etc/ssl/"
 
-RUN addgroup --gid $DIA_GID diaspora && \
-    adduser \
+RUN groupadd --gid $DIA_GID diaspora && \
+    useradd \
         --no-create-home \
-        --disabled-password \
-        --gecos "" \
         --uid $DIA_UID \
         --gid $DIA_GID \
         diaspora \

--- a/docker/develop/docker-compose.yml
+++ b/docker/develop/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 volumes:
   redis_data:
   postgresql_data:

--- a/script/server
+++ b/script/server
@@ -128,7 +128,7 @@ if [ -n "$redis_url" ]
 then
   redis_param="url: '$redis_url'"
 fi
-if [ "$(bin/bundle exec ruby -e "require 'redis'; puts Redis.new($redis_param).ping" 2> /dev/null | grep -vE "is not writable|as your home directory temporarily" )" != "PONG" ]
+if [ "$(bin/bundle exec ruby -e "require 'redis-client'; puts RedisClient.config($redis_param).new_client.call('PING')" 2> /dev/null | grep -vE "is not writable|as your home directory temporarily" )" != "PONG" ]
 then
   fatal "Can't connect to redis. Please check if it's running and if environment.redis is configured correctly in $CONFIG_FILE."
 fi


### PR DESCRIPTION
Also get rid of the docker-compose warning about the version attribute.

And finally, fix `script/server` again, as that was missed in #8475 where the redis gem was removed because sidekiq now uses the redis-client gem.