### PR TITLE
WIP:Allow podmins to block users who did not verify their email address

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,6 +22,7 @@ class ApplicationController < ActionController::Base
   before_action :set_locale
   before_action :set_diaspora_header
   before_action :mobile_switch
+  before_action :require_verified_email
   before_action :gon_set_current_user
   before_action :gon_set_appconfig
   before_action :gon_set_preloads
@@ -132,6 +133,12 @@ class ApplicationController < ActionController::Base
     else
       stream_path
     end
+  end
+
+  def require_verified_email
+    return unless AppConfig.settings.require_email_verification? && user_signed_in?
+
+    redirect_to verify_email_path unless current_user.email_verified?
   end
 
   def gon_set_appconfig

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
   rescue_from ActionController::InvalidAuthenticityToken do
     if user_signed_in?
       logger.warn "#{current_user.diaspora_handle} CSRF token fail. referer: #{request.referer || 'empty'}"
-      Workers::Mail::CsrfTokenFail.perform_async(current_user.id)
+      Workers::Mail::CsrfTokenFail.perform_async(current_user.id) if current_user.email_verified?
       sign_out current_user
     end
     flash[:error] = I18n.t("error_messages.csrf_token_fail")

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -16,7 +16,7 @@ class RegistrationsController < Devise::RegistrationsController
       flash[:notice] = t("registrations.create.success")
       @user.process_invite_acceptence(invite) if invite.present?
       @user.seed_aspects
-      @user.send_welcome_message
+      @user.send_welcome_email
       sign_in_and_redirect(:user, @user)
       logger.info "event=registration status=successful user=#{@user.diaspora_handle}"
     else

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,6 +7,7 @@
 class SessionsController < Devise::SessionsController
   # rubocop:disable Rails/LexicallyScopedActionFilter
   before_action :authenticate_with_2fa, only: :create
+  skip_before_action :require_verified_email
   # rubocop:enable Rails/LexicallyScopedActionFilter
 
   def find_user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,6 +6,7 @@
 
 class UsersController < ApplicationController
   before_action :authenticate_user!, except: %i(new create public)
+  skip_before_action :require_verified_email, only: %i(confirm_email update verify_email resend_verification_email)
   respond_to :html
 
   def edit
@@ -99,6 +100,16 @@ class UsersController < ApplicationController
 
   def download_photos
     redirect_to current_user.exported_photos_file.url
+  end
+
+  def verify_email
+    redirect_to current_user_redirect_path if current_user.email_verified?
+  end
+
+  def resend_verification_email
+    current_user.send_welcome_email
+    flash[:notice] = I18n.t("users.verify_email.resent", email: current_user.email)
+    redirect_to verify_email_path
   end
 
   def confirm_email

--- a/app/mailers/welcome_mailer.rb
+++ b/app/mailers/welcome_mailer.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class WelcomeMailer < ApplicationMailer
+  def send_welcome_email(user)
+    @user = user
+    @podmin_message = podmin_message
+    mail(to: @user.email, reply_to: AppConfig.admins.podmin_email.presence,
+         subject: I18n.t("registrations.welcome_email.subject")) do |format|
+      format.text { render "registrations/welcome_email" }
+      format.html { render "registrations/welcome_email" }
+    end
+  end
+
+  private
+
+  def podmin_message
+    return unless AppConfig.settings.welcome_message.enabled?
+    AppConfig.settings.welcome_message.text.get
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -228,8 +228,17 @@ class User < ApplicationRecord
 
   def confirm_email(token)
     return false if token.blank? || token != confirm_email_token
-    self.email = unconfirmed_email
+
+    self.email = unconfirmed_email if unconfirmed_email.present?
+    self.confirm_email_token = nil
     save
+  end
+
+  # The address is considered verified while no confirmation is pending: both
+  # the welcome email (registration) and the change-email flow set this token
+  # and clear it once the link is followed
+  def email_verified?
+    confirm_email_token.blank?
   end
 
   ######## Posting ########
@@ -351,6 +360,8 @@ class User < ApplicationRecord
   ######### Mailer #######################
   def mail(job, *args)
     return unless job.present?
+    return unless email_verified?
+
     pref = job.to_s.gsub('Workers::Mail::', '').underscore
     if(self.disable_mail == false && !self.user_preferences.exists?(:email_type => pref))
       job.perform_async(*args)
@@ -453,18 +464,9 @@ class User < ApplicationRecord
     aq
   end
 
-  def send_welcome_message
-    return unless AppConfig.settings.welcome_message.enabled? && AppConfig.admins.account?
-    sender_username = AppConfig.admins.account.get
-    sender = User.find_by(username: sender_username)
-    return if sender.nil?
-    conversation = sender.build_conversation(
-      participant_ids: [sender.person.id, person.id],
-      subject:         AppConfig.settings.welcome_message.subject.get,
-      message:         {text: AppConfig.settings.welcome_message.text.get % {username: username}}
-    )
-
-    Diaspora::Federation::Dispatcher.build(sender, conversation).dispatch if conversation.save
+  def send_welcome_email
+    update!(confirm_email_token: SecureRandom.hex(15))
+    WelcomeMailer.send_welcome_email(self).deliver_now
   end
 
   def encryption_key

--- a/app/views/registrations/welcome_email.html.erb
+++ b/app/views/registrations/welcome_email.html.erb
@@ -1,0 +1,70 @@
+<style>
+body {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  background-color: #eee;
+  padding: 1rem;
+}
+main {
+  margin: auto;
+  padding: 2rem;
+  background-color: #fff;
+  max-width: 800px;
+  border-radius: 10px;
+}
+h1 {
+  font-size: 1.4rem;
+  text-align: center;
+  margin-top: 0;
+  margin-bottom: 2rem;
+}
+strong {
+  white-space: nowrap;
+}
+.button-container {
+  text-align: center;
+  margin: 1.5rem;
+}
+.button-container a {
+  border-radius: 5px;
+  color: #fff;
+  background-color: #0088e6;
+  padding: 8px 16px;
+}
+p:last-child {
+  margin-bottom: 0;
+}
+</style>
+
+<main>
+  <h1>
+    <%= t("registrations.welcome_email.member") %>
+  </h1>
+  <p>
+    <% pod_url = AppConfig.pod_uri.site %>
+    <%= t("registrations.welcome_email.part_of_network",
+      pod_url: link_to(pod_url, pod_url), username: content_tag(:strong, @user.username)).html_safe %>
+  </p>
+  <p>
+    <%= t("registrations.welcome_email.your_id", id: content_tag(:strong, @user.person.diaspora_handle)).html_safe %>
+  </p>
+  <p>
+    <%= t("registrations.welcome_email.verify") %>
+  </p>
+  <p class="button-container">
+    <%= link_to t("registrations.welcome_email.verify_link"), confirm_email_url(token: @user.confirm_email_token) %>
+  </p>
+  <% if @podmin_message.present? %>
+  <p>
+    <%= @podmin_message %>
+  </p>
+  <% end %>
+  <p>
+    <%= t("registrations.welcome_email.help",
+      tutorials_link: link_to(
+        t("registrations.welcome_email.tutorials_link_text"), "https://diasporafoundation.org/tutorials")
+    ).html_safe %>
+  </p>
+  <p>
+    <em><%= t("registrations.welcome_email.welcome") %></em>
+  </p>
+</main>

--- a/app/views/registrations/welcome_email.text.erb
+++ b/app/views/registrations/welcome_email.text.erb
@@ -1,0 +1,19 @@
+<%= t("registrations.welcome_email.member") %>
+
+<%= t("registrations.welcome_email.part_of_network", pod_url: AppConfig.pod_uri.site, username: @user.username) %>
+
+<%= t("registrations.welcome_email.your_id", id: @user.person.diaspora_handle) %>
+
+<%= t("registrations.welcome_email.verify") %>
+
+<%= confirm_email_url(token: @user.confirm_email_token) %>
+
+<% if @podmin_message.present? %>
+<%= @podmin_message %>
+<% end %>
+
+<% tutorials_text = t("registrations.welcome_email.tutorials_link_text") %>
+<%= t("registrations.welcome_email.help",
+      tutorials_link: "#{tutorials_text} (https://diasporafoundation.org/tutorials)") %>
+
+<%= t("registrations.welcome_email.welcome") %>

--- a/app/views/users/_edit.haml
+++ b/app/views/users/_edit.haml
@@ -27,7 +27,9 @@
               = f.text_field :email, value: @user.unconfirmed_email || @user.email, class: "form-control"
           .clearfix= f.submit t(".change_email"), class: "btn btn-primary pull-right"
         - if @user.unconfirmed_email.present?
-          %div= t(".email_awaiting_confirmation", email: @user.email, unconfirmed_email: @user.unconfirmed_email)
+          %div= t(".email_awaiting_confirmation", unconfirmed_email: @user.unconfirmed_email)
+        - unless @user.email_verified?
+          %div= t(".email_not_verified")
     %hr
 
     .row

--- a/app/views/users/verify_email.html.erb
+++ b/app/views/users/verify_email.html.erb
@@ -1,0 +1,18 @@
+<div class="modern-design">
+  <main class="small-container">
+    <header>
+      <h1><%= t(".title") %></h1>
+    </header>
+    <section>
+      <p><%= t(".explanation", email: content_tag(:strong, current_user.email)).html_safe %></p>
+      <%= button_to t(".resend"), resend_verification_email_path, class: "btn btn-primary" %>
+    </section>
+    <section>
+      <p><%= t(".wrong_email") %></p>
+      <%= form_for "user", url: edit_user_path, html: {method: :put, class: "form-inline"} do |f| %>
+        <%= f.text_field :email, value: current_user.email, class: "form-control" %>
+        <%= f.submit t("users.edit.change_email"), class: "btn btn-primary" %>
+      <% end %>
+    </section>
+  </main>
+</div>

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -69,6 +69,7 @@ defaults:
   settings:
     pod_name: 'diaspora*'
     enable_registrations: true
+    require_email_verification: false
     enable_local_posts_stream: 'disabled'
     autofollow_on_join: true
     autofollow_on_join_user: 'hq@pod.diaspora.software'

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -74,8 +74,7 @@ defaults:
     autofollow_on_join_user: 'hq@pod.diaspora.software'
     welcome_message:
       enabled: false
-      subject: 'Welcome Message'
-      text: 'Hello %{username}, welcome to diaspora*.'
+      text: 'Welcome to diaspora*.'
     invitations:
       open: true
       count: 25

--- a/config/diaspora.toml.example
+++ b/config/diaspora.toml.example
@@ -327,22 +327,12 @@
 ## Welcome Message settings
 [configuration.settings.welcome_message]
 
-## Welcome Message on registration (default=false)
-## Send a message to new users after registration
-## to tell them about your pod and how things
-## are handled on it.
+## Add your own message to the welcome email (default=false) that new users
+## receive after registration.
 #enabled = false
 
-## Welcome Message subject (default="Welcome Message")
-## The subject of the conversation that is started
-## by your welcome message.
-#subject = "Welcome Message"
-
-## Welcome Message text (default="Hello %{username}, welcome to diaspora*.")
-## The content of your welcome message.
-## The placeholder "%{username}" will be replaced by the username
-## of the new user.
-#text = "Hello %{username}, welcome to diaspora*."
+## Welcome Message text (default="Welcome to diaspora*.")
+#text = "Welcome to diaspora*."
 
 ## Invitation settings
 [configuration.settings.invitations]

--- a/config/diaspora.toml.example
+++ b/config/diaspora.toml.example
@@ -262,6 +262,11 @@
 ## (or commented out) to enable the first registration (you).
 #enable_registrations = true
 
+## Require email verification (default=false)
+## When enabled, users cannot use their account until they have verified
+## their email address by following the link in the welcome email.
+#require_email_verification = false
+
 ## Show local posts stream (default="disabled")
 ## If any other setting than disabled local public posts
 ## created on this pod can be shown.

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -1114,7 +1114,16 @@ en:
       find_pods: "There’s a list of pods you can sign up to at %{fediverse_observer}."
       other_questions: "If you have any other questions regarding choosing a pod, check out our %{wiki}."
     invalid_invite: "The invite link you provided is no longer valid!"
-
+    welcome_email:
+      subject: "Welcome to the diaspora* community!"
+      member: "Congratulations! You now are a member of the diaspora* community!"
+      part_of_network: "You have registered with %{pod_url}, one of the many nodes (called a “pod”) in the diaspora* network. To access the diaspora* network, you will need to sign in to that same pod using your username, %{username}, and password. Once signed in, you will be able to reach the whole diaspora* network, even people registered with other pods."
+      your_id: "Your diaspora* id is %{id}. This includes your home pod name and helps diaspora*'s software to locate you in the network. Share this with everyone you want to connect with in diaspora*."
+      verify: "Please confirm that this is really your email address. Until you do, we won’t send you any notification emails."
+      verify_link: "Verify my email address"
+      help: "If you need any help, have a look at our %{tutorials_link} or the in-app help section, which can be found via the user menu in the header bar. If you don’t find the information you need there, post a public message with the #question tag so that members of our amazing community can help you."
+      tutorials_link_text: "tutorials for new community members"
+      welcome: "Welcome aboard, and enjoy diaspora*!"
   reshares:
     create:
       error: "Failed to reshare."
@@ -1248,7 +1257,8 @@ en:
       your_email: "Your email"
       your_email_private: "Your email will never be seen by other users"
       change_email: "Change email"
-      email_awaiting_confirmation: "We have sent you an activation link to %{unconfirmed_email}. Until you follow this link and activate the new address, we will continue to use your original address %{email}."
+      email_awaiting_confirmation: "We have sent you an activation link to %{unconfirmed_email}. You will not receive any notifications until you follow this link and activate the new address."
+      email_not_verified: "Your email address is not verified. You will not receive notification emails from diaspora* until you verify it."
       change_password: "Change password"
       new_password: "New password"
       current_password: "Current password"

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -1354,6 +1354,12 @@ en:
     confirm_email:
       email_confirmed: "Email %{email} activated"
       email_not_confirmed: "Email could not be activated. Wrong link?"
+    verify_email:
+      title: "Verify your email address"
+      explanation: "We have sent a verification link to %{email}. You need to verify your email address before you can use diaspora*."
+      resend: "Resend verification email"
+      wrong_email: "Wrong email address? Enter it again and we will send you a new link:"
+      resent: "Verification email sent to %{email}."
 
   two_factor_auth:
     title: "Two-factor authentication"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,6 +112,8 @@ Rails.application.routes.draw do
     get "public/:username"          => :public,                  :as => :users_public
     get "getting_started"           => :getting_started,         :as => :getting_started
     get "confirm_email/:token"      => :confirm_email,           :as => :confirm_email
+    get "verify_email"              => :verify_email,            :as => :verify_email
+    post "resend_verification_email" => :resend_verification_email, :as => :resend_verification_email
     get "privacy"                   => :privacy_settings,        :as => :privacy_settings
     put "privacy"                   => :update_privacy_settings, :as => :update_privacy_settings
     get "getting_started_completed" => :getting_started_completed

--- a/db/migrate/20260727000000_consider_existing_emails_verified.rb
+++ b/db/migrate/20260727000000_consider_existing_emails_verified.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Clean all unfinished email verification so no user is blocked
+class ConsiderExistingEmailsVerified < ActiveRecord::Migration[6.1]
+  def up
+    execute "UPDATE users SET confirm_email_token = NULL, unconfirmed_email = NULL " \
+            "WHERE confirm_email_token IS NOT NULL OR unconfirmed_email IS NOT NULL"
+  end
+end

--- a/features/desktop/registrations.feature
+++ b/features/desktop/registrations.feature
@@ -4,12 +4,23 @@ Feature: New user registration
   As a desktop user
   I want to register an account
 
-  Scenario: user signs up and goes to getting started
-    Given I am on the new user registration page
+  Scenario: user signs up, goes to getting started and receives a welcome email verifying their address
+    Given the podmin contact address is "podmin@example.org"
+    And the podmin welcome message is "Welcome to my little pod!"
+    And I am on the new user registration page
     When I fill in the new user form
     And I press "Create account"
     Then I should be on the getting started page
     And I should see the 'getting started' contents
+    And I should have 1 email delivery
+    And "ohai@example.com" should have received an email with subject "Welcome to the diaspora* community!"
+    And I should see "ohai" in the last sent email
+    And I should see "Welcome to my little pod!" in the last sent email
+    And the last sent email should have a plain text and an HTML part
+    And the last sent email should have the reply-to address "podmin@example.org"
+    And my email address should not be verified
+    When I follow the "Verify my email address" link from the last sent email
+    Then my email address should be verified
 
   Scenario: registrations are closed, user is informed
     Given the registrations are closed

--- a/features/desktop/registrations.feature
+++ b/features/desktop/registrations.feature
@@ -22,6 +22,20 @@ Feature: New user registration
     When I follow the "Verify my email address" link from the last sent email
     Then my email address should be verified
 
+  Scenario: with mandatory email verification, a new user cannot use the pod until they verify
+    Given the podmin requires email verification
+    And I am on the new user registration page
+    When I fill in the new user form
+    And I press "Create account"
+    And I go to the stream page
+    Then I should be on the verify email page
+    When I press "Resend verification email"
+    Then I should see "Verification email sent"
+    And I should have 2 email delivery
+    When I follow the "Verify my email address" link from the last sent email
+    And I go to the stream page
+    Then I should be on the stream page
+
   Scenario: registrations are closed, user is informed
     Given the registrations are closed
     When I am on the new user registration page

--- a/features/step_definitions/session_steps.rb
+++ b/features/step_definitions/session_steps.rb
@@ -79,6 +79,15 @@ Given /^the registrations are closed$/ do
   AppConfig.settings.enable_registrations = false
 end
 
+Given /^the podmin contact address is "([^"]*)"$/ do |address|
+  AppConfig.admins.podmin_email = address
+end
+
+Given /^the podmin welcome message is "([^"]*)"$/ do |message|
+  AppConfig.settings.welcome_message.enabled = true
+  AppConfig.settings.welcome_message.text = message
+end
+
 When /^I fill in the new user form$/ do
   fill_in_new_user_form
 end

--- a/features/step_definitions/session_steps.rb
+++ b/features/step_definitions/session_steps.rb
@@ -79,6 +79,10 @@ Given /^the registrations are closed$/ do
   AppConfig.settings.enable_registrations = false
 end
 
+Given /^the podmin requires email verification$/ do
+  AppConfig.settings.require_email_verification = true
+end
+
 Given /^the podmin contact address is "([^"]*)"$/ do |address|
   AppConfig.admins.podmin_email = address
 end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -183,6 +183,25 @@ Then /^"([^"]*)" should have received an email with subject "([^"]*)"$/ do |user
   expect(email.subject).to have_content(subject)
 end
 
+Then /^the last sent email should have a plain text and an HTML part$/ do
+  email = ActionMailer::Base.deliveries.last
+  expect(email.text_part).to be_present
+  expect(email.html_part).to be_present
+end
+
+Then /^the last sent email should have the reply-to address "([^"]*)"$/ do |address|
+  expect(ActionMailer::Base.deliveries.last.reply_to).to include(address)
+end
+
+Then /^my email address should( not)? be verified$/ do |negate|
+  user = User.find_by(username: @username)
+  if negate
+    expect(user).not_to be_email_verified
+  else
+    expect(user).to be_email_verified
+  end
+end
+
 When /^"([^\"]+)" has posted a (public )?status message with a photo$/ do |email, public_status|
   user = User.find_for_database_authentication(username: email)
   post = FactoryBot.create(

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -148,8 +148,8 @@ When /^I post a limited status with the text "([^\"]*)"$/ do |text|
 end
 
 And /^I follow the "([^\"]*)" link from the last sent email$/ do |link_text|
-  email_text = Devise.mailer.deliveries.first.body.to_s
-  email_text = Devise.mailer.deliveries.first.html_part.body.raw_source if email_text.blank?
+  email_text = Devise.mailer.deliveries.last.body.to_s
+  email_text = Devise.mailer.deliveries.last.html_part.body.raw_source if email_text.blank?
   doc = Nokogiri("<div>" + email_text + "</div>")
 
   links = doc.css("a")

--- a/spec/integration/application_spec.rb
+++ b/spec/integration/application_spec.rb
@@ -43,6 +43,13 @@ describe ApplicationController, type: :request do
         put edit_user_path, params: {user: {language: "en"}}
       end
 
+      it "doesn't send an email if the current user's email address is not verified" do
+        alice.update!(confirm_email_token: SecureRandom.hex(15))
+        expect_any_instance_of(UsersController).to receive(:verified_request?).and_return(false)
+        expect(Workers::Mail::CsrfTokenFail).not_to receive(:perform_async)
+        put edit_user_path, params: {user: {language: "en"}}
+      end
+
       it "doesn't sign out users if the token was correct" do
         expect_any_instance_of(UsersController).to receive(:verified_request?).and_return(true)
         put edit_user_path, params: {user: {language: "en"}}

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -817,57 +817,42 @@ describe User, type: :model do
     end
   end
 
-  describe "#send_welcome_message" do
+  describe "#send_welcome_email" do
     let(:user) { FactoryBot.create(:user) }
-    let(:podmin) { FactoryBot.create(:user) }
 
-    context "with welcome message enabled" do
-      before do
-        AppConfig.settings.welcome_message.enabled = true
-      end
-
-      it "should send welcome message from podmin account" do
-        AppConfig.admins.account = podmin.username
-        expect {
-          user.send_welcome_message
-        }.to change(user.conversations, :count).by(1)
-        expect(user.conversations.first.author.owner.username).to eq podmin.username
-      end
-
-      it "should send welcome message text from config" do
-        AppConfig.admins.account = podmin.username
-        AppConfig.settings.welcome_message.text = "Hello %{username}, welcome!" # rubocop:disable Style/FormatStringToken
-        user.send_welcome_message
-        expect(user.conversations.first.messages.first.text).to eq "Hello #{user.username}, welcome!"
-      end
-
-      it "should use subject from config" do
-        AppConfig.settings.welcome_message.subject = "Welcome Message"
-        AppConfig.admins.account = podmin.username
-        user.send_welcome_message
-        expect(user.conversations.first.subject).to eq "Welcome Message"
-      end
-
-      it "should send no welcome message if no podmin is specified" do
-        AppConfig.admins.account = ""
-        user.send_welcome_message
-        expect(user.conversations.count).to eq 0
-      end
-
-      it "should send no welcome message if podmin is invalid" do
-        AppConfig.admins.account = "invalid"
-        user.send_welcome_message
-        expect(user.conversations.count).to eq 0
-      end
+    it "sends the welcome email to the address the user registered with" do
+      expect { user.send_welcome_email }.to change(ActionMailer::Base.deliveries, :count).by(1)
+      expect(ActionMailer::Base.deliveries.last.to).to eq [user.email]
     end
 
-    context "with welcome message disabled" do
-      it "shouldn't send a welcome message" do
-        AppConfig.settings.welcome_message.enabled = false
-        AppConfig.admins.account = podmin.username
-        user.send_welcome_message
-        expect(user.conversations.count).to eq 0
-      end
+    it "leaves the address unverified and holds back notification mails" do
+      user.send_welcome_email
+      expect(user.reload).not_to be_email_verified
+      expect(user.confirm_email_token).to be_present
+      expect(Workers::Mail::Mentioned).not_to receive(:perform_async)
+      user.mail(Workers::Mail::Mentioned, user.id, user.id, user.id)
+    end
+
+    it "verifies the address once the user follows the link, and lets mail through" do
+      user.send_welcome_email
+      expect(user.confirm_email(user.reload.confirm_email_token)).to be true
+      expect(user.reload).to be_email_verified
+      expect(Workers::Mail::Mentioned).to receive(:perform_async)
+      user.mail(Workers::Mail::Mentioned, user.id, user.id, user.id)
+    end
+
+    it "keeps mail blocked when an unverified user requests an email change instead" do
+      user.send_welcome_email
+      user.update!(unconfirmed_email: "changed-but-never-confirmed@example.org")
+      expect(user.reload).not_to be_email_verified
+    end
+
+    it "adds the podmin's message when they configured some" do
+      AppConfig.settings.welcome_message.enabled = true
+      AppConfig.settings.welcome_message.text = "Message from your podmin"
+      user.send_welcome_email
+      expect(ActionMailer::Base.deliveries.last.text_part.body.raw_source)
+        .to include("Message from your podmin")
     end
   end
 


### PR DESCRIPTION
This is still WIP, and https://github.com/diaspora/diaspora/pull/7823 should be merged first.

This PR introduces a new settings allowing to block users who did not verify their address. Basically the option 2 described by @skyschub here: https://github.com/diaspora/diaspora/pull/7823#issuecomment-5096013019

This PR is **not** using Devise `confirmable` as we already add most of the mechanism in place ourselves, however I am happy dropping this custom code and implementing it with Devise instead. One downside of Devise is that it requires more changes (and possibly removing the NOT NULL on `email` property of a user, which has bigger impact on the codebase), and so possible manual actions for podmins. I am not entirely sure as I did not dig that route.

The main question with that work is, what do we do with all the **already registered** users who never received an email to verify, and so never verified their email. To send to all a "verify your address" now sounded super weird, some of them registered 15 years ago. So I decided that all the current users should be considered safe and did... nothing, as we use the `email` property as before. An even trickier case is "What about users who set a new email in the settings, but never actually validated the new one". Until now, this wasn't an issue as we always sent emails to the old address, but https://github.com/diaspora/diaspora/pull/7823/changes/4290b9eb0de1f9b01792fc59deb08973baf8cc50#diff-9802ca3c9c4cf89904fd44bc114e35ebdf2c5dd3d5b645491e2b253e1afef29bR241 is using the presence of the `confirm_email_token` to know if a user is verified or not. That means the previous PR is already stopping sending notifications to someone who started the verification flow from the settings and never finished it. This was already borderline acceptable without a notification, but with this new PR those users would not even be able to log in any more. So I did two things:
1. On the screen telling you that you should verify your email address, their is a button to resend, but also one allowing to correct the address in case you made a typo or did not finish verifying
2. A database migration to clean all the started verification from the settings back as if they never started. After all, at the moment users are still receiving emails on the old address.

What do you think? Is 2 not necessary because we have 1? Is it acceptable to consider that all the email addresses until now are verified?

This is still WIP because I want to play with it more and the design of the new page when blocked is not finished. Also, the header is actually still shown, although clicking on links obvisouly redirect to the "blocked" page. But I guess it would be better not to render notifications etc at all, I have to think about it.